### PR TITLE
fix Gogogo Aristera & Dexia

### DIFF
--- a/c91718579.lua
+++ b/c91718579.lua
@@ -80,7 +80,7 @@ function c91718579.posop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SET_DEFENCE_FINAL)
-	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
 	e1:SetValue(0)
 	tc:RegisterEffect(e1)
 end


### PR DESCRIPTION
Fix this: During the End Phase, a monster affected by Gogogo Aristera & Dexia's effect returns to the original DEF.