### PR TITLE
fix A Hero Emerges

### DIFF
--- a/c21597117.lua
+++ b/c21597117.lua
@@ -21,7 +21,7 @@ function c21597117.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		and Duel.IsExistingMatchingCard(c21597117.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
 end
 function c21597117.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or not Duel.IsPlayerCanSpecialSummon(tp) then return end
 	local g=Duel.GetFieldGroup(tp,LOCATION_HAND,0)
 	local sg=g:RandomSelect(1-tp,1)
 	local tc=sg:GetFirst()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8193&keyword=&tag=-1
Q.相手モンスターの攻撃宣言時に、自分が「ヒーロー見参」を発動しました。

その発動にチェーンして相手が「虚無空間」を発動した場合、「ヒーロー見参」の『①：相手モンスターの攻撃宣言時に発動できる。自分の手札１枚を相手がランダムに選ぶ。それがモンスターだった場合、自分フィールドに特殊召喚し、違った場合は墓地へ送る』処理はどうなりますか？
A.質問の状況の場合、「虚無空間」の効果によってモンスターの特殊召喚を行う事ができなくなっていますので、「ヒーロー見参」の効果処理は適用されません。
（『自分の手札１枚を相手がランダムに選ぶ』事も行いません。） 