### PR TITLE
Update c52352005.lua

### DIFF
--- a/c52352005.lua
+++ b/c52352005.lua
@@ -1,7 +1,7 @@
 --XX－セイバー ガトムズ
 function c52352005.initial_effect(c)
 	--synchro summon
-	aux.AddSynchroProcedure(c,nil,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_EARTH),1)
+	aux.AddSynchroProcedure(c,nil,c52352005.matfilter,1)
 	c:EnableReviveLimit()
 	--handes
 	local e1=Effect.CreateEffect(c)
@@ -13,6 +13,9 @@ function c52352005.initial_effect(c)
 	e1:SetTarget(c52352005.target)
 	e1:SetOperation(c52352005.operation)
 	c:RegisterEffect(e1)
+end
+function c52352005.matfilter(c)
+	return not c:IsHasEffect(EFFECT_SYNCHRO_MATERIAL_CUSTOM) and c:IsAttribute(ATTRIBUTE_EARTH)
 end
 function c52352005.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsSetCard,1,nil,0x100d) end


### PR DESCRIPTION
「废铁士兵」（65503206）可以作为「XX-剑士 加特姆士」除第一只调整以外的同调素材。
「废铁士兵」有这样一句话：『把这张卡作为同调素材的场合，不是名字带有「废铁」的怪兽的同调召唤不能使用。』因此毫无疑问他不能用来同调召唤「XX-剑士 加特姆士」。

我认为这种方法可以简单地排除「废铁士兵」。