### PR TITLE
fix Odd-Eyes Absolute Dragon

### DIFF
--- a/c16691074.lua
+++ b/c16691074.lua
@@ -48,7 +48,7 @@ function c16691074.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c16691074.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsPreviousLocation(LOCATION_ONFIELD) and bit.band(c:GetSummonType(),SUMMON_TYPE_XYZ)==SUMMON_TYPE_XYZ
+	return c:IsPreviousLocation(LOCATION_MZONE) and bit.band(c:GetSummonType(),SUMMON_TYPE_XYZ)==SUMMON_TYPE_XYZ
 end
 function c16691074.spfilter2(c,e,tp)
 	return c:IsSetCard(0x99) and not c:IsCode(16691074) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%A5%AA%A5%C3%A5%C9%A5%A2%A5%A4%A5%BA%A1%A6%A5%A2%A5%D6%A5%BD%A5%EA%A5%E5%A1%BC%A5%C8%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5#faq
Ｑ：エクシーズ召喚したこのカードが装備カードになった後で墓地へ送られました。
　　(2)の効果は発動できますか？
Ａ：発動できません。(15/07/11)