### PR TITLE
fix The Monarchs Erupt

### DIFF
--- a/c48716527.lua
+++ b/c48716527.lua
@@ -1,5 +1,6 @@
 --帝王の溶撃
 function c48716527.initial_effect(c)
+	Duel.EnableGlobalFlag(GLOBALFLAG_SELF_TOGRAVE)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -16,12 +17,10 @@ function c48716527.initial_effect(c)
 	c:RegisterEffect(e2)
 	--
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetCountLimit(1)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_SELF_TOGRAVE)
 	e3:SetRange(LOCATION_SZONE)
 	e3:SetCondition(c48716527.tgcon)
-	e3:SetOperation(c48716527.tgop)
 	c:RegisterEffect(e3)
 end
 function c48716527.cfilter(c)
@@ -34,10 +33,8 @@ end
 function c48716527.distg(e,c)
 	return bit.band(c:GetSummonType(),SUMMON_TYPE_ADVANCE)~=SUMMON_TYPE_ADVANCE
 end
-function c48716527.tgcon(e,tp,eg,ep,ev,re,r,rp)
+function c48716527.tgcon(e)
+	local tp=e:GetHandlerPlayer()
 	return Duel.GetTurnPlayer()==tp
 		and not Duel.IsExistingMatchingCard(c48716527.cfilter,tp,LOCATION_MZONE,0,1,nil)
-end
-function c48716527.tgop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11281&keyword=&tag=-1
 Q.自分のモンスターゾーンにアドバンス召喚されている「風帝ライザー」が表側表示で存在し、自分の魔法＆罠ゾーンに「帝王の溶撃」が表側表示で存在しています。

この状況で、自分のエンドフェイズに自分が「風帝ライザー」をリリースして「ゴッドバードアタック」を発動したことで、自分のモンスターゾーンにアドバンス召喚されているモンスターが存在しなくなった場合、『②：自分エンドフェイズに、アドバンス召喚したモンスターが自分フィールドに存在しない場合にこのカードは墓地へ送られる』効果はいつ適用されますか？
A.質問の状況の場合、「ゴッドバードアタック」を発動し、「風帝ライザー」がリリースされた時点にて、自分のモンスターゾーンにアドバンス召喚されているモンスターが存在しなくなっていますので、「ゴッドバードアタック」の効果処理が行われる前に「帝王の溶撃」は墓地へ送られる事になります。 