### PR TITLE
fix Kickfire

### DIFF
--- a/c11501629.lua
+++ b/c11501629.lua
@@ -36,7 +36,7 @@ end
 function c11501629.ctcon(e,tp,eg,ep,ev,re,r,rp)
 	local ct=eg:FilterCount(c11501629.ctfilter,nil,tp)
 	e:SetLabel(ct)
-	return ct>0
+	return ct>0 and e:GetHandler():IsCanAddCounter(0x2d,ct)
 end
 function c11501629.ctop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetHandler():AddCounter(0x2d,e:GetLabel())


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10340&keyword=&tag=-1
...（炎属性モンスターがカードの効果で破壊された場合でも、「キックファイア」の効果を適用した事にはなりません。）
したがって、そのターンにて「ゲート・ブロッカー」が戦闘やカードの効果で破壊される等によってその効果の適用がなくなった後に、自分のモンスターゾーンに表側表示で存在する炎属性モンスターがカードの効果で破壊されたのであれば、その際には「キックファイア」の『その破壊されたモンスターの数だけこのカードにカウンターを置く』効果が適用される事になります。