### PR TITLE
fix Cursed Bamboo Sword

### DIFF
--- a/c42199039.lua
+++ b/c42199039.lua
@@ -65,13 +65,14 @@ function c42199039.dtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 then
+	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.ConfirmCards(1-tp,tc)
+		local ec=c:GetEquipTarget()
 		local e1=Effect.CreateEffect(c)
-		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_DIRECT_ATTACK)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
-		c:RegisterEffect(e1)
+		ec:RegisterEffect(e1)
 	end
 end
 function c42199039.thfilter(c)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10226&keyword=&tag=-1
...対象とした自分フィールドの「竹光」と名のついたカードを手札に戻した時に、『装備モンスターはこのターン相手に直接攻撃できる』効果も既に適用されています。

したがって、その後に「妖刀竹光」が破壊された場合でも、効果が適用される際に「妖刀竹光」を装備していたモンスターは、このターンに直接攻撃を行う事ができます。