### PR TITLE
fix Stellarknight Alpha

### DIFF
--- a/c81810441.lua
+++ b/c81810441.lua
@@ -57,7 +57,7 @@ function c81810441.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c81810441.eqlimit(e,c)
-	return c:IsSetCard(0x9c)
+	return c:IsSetCard(0x9c) and c:GetControler()==e:GetHandler():GetControler()
 end
 function c81810441.efilter(e,re)
 	return e:GetHandlerPlayer()~=re:GetOwnerPlayer()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11266
■「星輝士の因子」は自分フィールドの「テラナイト」モンスターにのみ装備できます。装備モンスターのコントロールが相手に移る場合には、「星輝士の因子」は破壊されます。