### PR TITLE
解放之阿里阿德涅（98301564）的预备

### DIFF
--- a/c29735721.lua
+++ b/c29735721.lua
@@ -15,6 +15,7 @@ function c29735721.condition(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
 end
 function c29735721.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if Duel.IsPlayerAffectedByEffect(tp,98301564) then return true end
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,2,e:GetHandler()) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,2,2,REASON_COST+REASON_DISCARD)
 end

--- a/c49010598.lua
+++ b/c49010598.lua
@@ -15,6 +15,7 @@ function c49010598.condition(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev)
 end
 function c49010598.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if Duel.IsPlayerAffectedByEffect(tp,98301564) then return true end
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
 end

--- a/c55256016.lua
+++ b/c55256016.lua
@@ -21,6 +21,7 @@ function c55256016.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ex and tg~=nil and tc+tg:FilterCount(c55256016.cfilter,nil)-tg:GetCount()>0
 end
 function c55256016.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if Duel.IsPlayerAffectedByEffect(tp,98301564) then return true end
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
 end

--- a/c56993276.lua
+++ b/c56993276.lua
@@ -21,6 +21,7 @@ function c56993276.cfilter(c)
 	return c:IsSetCard(0xe) and c:IsType(TYPE_MONSTER) and c:IsDiscardable()
 end
 function c56993276.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if Duel.IsPlayerAffectedByEffect(tp,98301564) then return true end
 	if chk==0 then return Duel.IsExistingMatchingCard(c56993276.cfilter,tp,LOCATION_HAND,0,1,nil) end
 	Duel.DiscardHand(tp,c56993276.cfilter,1,1,REASON_COST+REASON_DISCARD,nil)
 end

--- a/c58851034.lua
+++ b/c58851034.lua
@@ -18,6 +18,7 @@ function c58851034.cfilter(c)
 	return c:IsType(TYPE_SPELL) and c:IsDiscardable()
 end
 function c58851034.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if Duel.IsPlayerAffectedByEffect(tp,98301564) then return true end
 	if chk==0 then return Duel.IsExistingMatchingCard(c58851034.cfilter,tp,LOCATION_HAND,0,1,nil) end
 	Duel.DiscardHand(tp,c58851034.cfilter,1,1,REASON_COST+REASON_DISCARD,nil)
 end

--- a/c77414722.lua
+++ b/c77414722.lua
@@ -15,6 +15,7 @@ function c77414722.condition(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
 end
 function c77414722.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if Duel.IsPlayerAffectedByEffect(tp,98301564) then return true end
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
 end

--- a/c98956134.lua
+++ b/c98956134.lua
@@ -17,6 +17,7 @@ function c98956134.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ex and tg~=nil and tc+tg:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)-tg:GetCount()>0
 end
 function c98956134.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if Duel.IsPlayerAffectedByEffect(tp,98301564) then return true end
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
 end


### PR DESCRIPTION
给所有需要丢弃手卡发动的反击陷阱卡的cost添加了这样一句话。那张卡只需要添加一个对tp作用的code为98301564的对玩家永续效果即可处理了。