### PR TITLE
fix Shield & Sword

### DIFF
--- a/c52097679.lua
+++ b/c52097679.lua
@@ -10,10 +10,16 @@ function c52097679.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c52097679.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	Duel.SetTargetCard(g)
+end
+function c52097679.filter(c,e)
+	return c:IsFaceup() and c:IsRelateToEffect(e) and not c:IsImmuneToEffect(e)
 end
 function c52097679.activate(e,tp,eg,ep,ev,re,r,rp)
-	local sg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local sg=Duel.GetMatchingGroup(c52097679.filter,tp,LOCATION_MZONE,0,nil,e)
 	local c=e:GetHandler()
 	local tc=sg:GetFirst()
 	while tc do


### PR DESCRIPTION
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「D－HERO ダイヤモンドガイ」の効果で墓地へ送った「右手に盾を左手に剣を」を発動できますか？ 
A. 
「右手に盾を左手に剣を」は、カードの発動時に存在するモンスターの数値を入れ替える効果となり、「D－HERO ダイヤモンドガイ」で墓地に送り、次のメインフェイズを迎えた場合には、「右手に盾を左手に剣を」の効果の発動を行う事はできません。