### PR TITLE
fix Frightfur March

### DIFF
--- a/c74416026.lua
+++ b/c74416026.lua
@@ -52,7 +52,13 @@ function c74416026.activate(e,tp,eg,ep,ev,re,r,rp)
 				e1:SetLabelObject(sc)
 				e1:SetCondition(c74416026.rmcon)
 				e1:SetOperation(c74416026.rmop)
-				e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN)
+				if Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()==PHASE_END then
+					e1:SetLabel(Duel.GetTurnCount())
+					e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,2)
+				else
+					e:SetLabel(0)
+					e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN)
+				end
 				Duel.RegisterEffect(e1,tp)
 				Duel.SpecialSummonComplete()
 				sc:CompleteProcedure()
@@ -63,7 +69,7 @@ function c74416026.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c74416026.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()
-	return Duel.GetTurnPlayer()==tp and tc:GetFlagEffect(74416026)~=0
+	return Duel.GetTurnPlayer()==tp and Duel.GetTurnCount()~=e:GetLabel() and tc:GetFlagEffect(74416026)~=0
 end
 function c74416026.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16545&keyword=&tag=-1
また、「デストーイ・マーチ」を自分のターンのエンドフェイズや相手のターンに発動した場合には、その次の自分のターンのエンドフェイズにて『この効果で特殊召喚したモンスターは、次の自分エンドフェイズに除外される』処理が適用されます。