### PR TITLE
fix Raidraptor - Mimicry Lanius

### DIFF
--- a/c96345188.lua
+++ b/c96345188.lua
@@ -57,7 +57,7 @@ function c96345188.lvop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c96345188.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetTurnID()==Duel.GetTurnCount()
+	return e:GetHandler():GetTurnID()==Duel.GetTurnCount() and not e:GetHandler():IsReason(REASON_RETURN)
 end
 function c96345188.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end


### PR DESCRIPTION
Fix this: If returned Mimicry Lanius to the Graveyard by Burial's effect, Mimicry Lanius can activate the effect.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14858&keyword=&tag=-1
Q.そのターンに墓地へ送られた「RR－ミミクリー・レイニアス」が相手の発動した「D.D.クロウ」の効果によって除外されています。

このターンに「異次元からの埋葬」を発動し、その「RR－ミミクリー・レイニアス」が墓地に戻った場合、『②：このカードが墓地へ送られたターンの自分メインフェイズに、墓地のこのカードを除外して発動できる。デッキから「RR－ミミクリー・レイニアス」以外の「RR」カード１枚を手札に加える』効果を発動する事はできますか？
A.質問の状況のように、除外された「RR－ミミクリー・レイニアス」が「異次元からの埋葬」の効果で墓地へ戻ったとしても、「RR－ミミクリー・レイニアス」の効果を発動する事はできません。
（「異次元からの埋葬」の効果処理によって墓地へ戻ったカードは、『墓地へ送られた』扱いにはなりません。） 