### PR TITLE
Update c71692913.lua

### DIFF
--- a/c71692913.lua
+++ b/c71692913.lua
@@ -53,7 +53,7 @@ function c71692913.xyzlv(e,c,rc)
 	return c:GetRank()
 end
 function c71692913.disfilter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and not c:IsDisabled()
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsType(TYPE_EFFECT) and not c:IsDisabled()
 end
 function c71692913.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c71692913.disfilter(chkc) end


### PR DESCRIPTION
Q. 「相克の魔術師」のモンスター効果は、「青眼の白龍」に対象として発動する事ができますか？ 
「相克の魔術師」のモンスター効果は、通常モンスター扱いの「E·HERO アナザー·ネオス」に対象として発動する事ができますか？ 
A. 通常モンスターの「青眼の白龍」、または通常モンスター扱いのデュアルモンスターである「E・HERO アナザー・ネオス」を対象に、「相克の魔術師」のモンスター効果を発動する事はできません。 

刚发的邮件，结果出乎意料。我本来以为，不能点通常怪兽就算了，好歹要让我点二重怪兽吧。结果事务局回复我，二重怪兽也不能点-。-