### PR TITLE
Update c38331564.lua

### DIFF
--- a/c38331564.lua
+++ b/c38331564.lua
@@ -68,15 +68,15 @@ function c38331564.descon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c38331564.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsDestructable() and chkc~=e:GetHandler() end
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,1)
-		and Duel.IsExistingTarget(Card.IsDestructable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsDestructable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,Card.IsDestructable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function c38331564.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 and Duel.IsPlayerCanDraw(tp,1)
+		and Duel.SelectYesNo(tp,aux.Stringid(38331564,2)) then
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Q. 「光天使セプター」をエクシーズ召喚の素材として使用したモンスターが、『●』の効果を発動し、フィールドのカードを破壊しました。 その後、自分はデッキから１枚ドローしないもよろしいですか? 
A. ご質問の場合、「光天使セプター」によって得た効果によってカードを破壊した自分は、その後カードをドローしないと選択する事もできます。 

光天使棍子破坏后可以选择不抽卡，但lua里写作必须抽。

这样修改后，需要添加aux.Stringid(38331564,2)为“是否抽卡？”。