### PR TITLE
fix Carrot Human

### DIFF
--- a/c44928016.lua
+++ b/c44928016.lua
@@ -16,13 +16,15 @@ function c44928016.cfilter(c)
 	return c:IsRace(RACE_PLANT) and (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and not c:IsCode(44928016) and c:IsAbleToGraveAsCost()
 end
 function c44928016.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c44928016.cfilter,tp,LOCATION_MZONE+LOCATION_HAND,0,1,nil) end
+	local loc=LOCATION_MZONE+LOCATION_HAND
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then loc=LOCATION_MZONE end
+	if chk==0 then return Duel.IsExistingMatchingCard(c44928016.cfilter,tp,loc,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g=Duel.SelectMatchingCard(tp,c44928016.cfilter,tp,LOCATION_MZONE+LOCATION_HAND,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c44928016.cfilter,tp,loc,0,1,1,nil)
 	Duel.SendtoGrave(g,REASON_COST)
 end
 function c44928016.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end


### PR DESCRIPTION
Fix this: If you control 5 monsters and you control 1 or more Plant-Type monsters, Carrot Human cannot activate.