### PR TITLE
fix D.D. Jet Iron

### DIFF
--- a/c15574615.lua
+++ b/c15574615.lua
@@ -22,54 +22,119 @@ function c15574615.initial_effect(c)
 	e2:SetOperation(c15574615.operation)
 	c:RegisterEffect(e2)
 end
-function c15574615.spfilter(c,code)
+function c15574615.spfilter1(c,code,tp)
+	return c:IsFaceup() and c:IsCode(code) and c:IsControler(tp) and c:IsAbleToGraveAsCost()
+end
+function c15574615.spfilter2(c,code)
 	return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsCode(code) and c:IsAbleToGraveAsCost()
+end
+function c15574615.spfilter3(c,tp)
+	return (c:IsCode(80208158) or c:IsCode(16796157) or c:IsCode(43791861) or c:IsCode(79185500)) and c:IsControler(tp)
 end
 function c15574615.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	return Duel.GetLocationCount(tp,LOCATION_MZONE,0)~=0
-		and Duel.IsExistingMatchingCard(c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,80208158)
-		and Duel.IsExistingMatchingCard(c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,16796157)
-		and Duel.IsExistingMatchingCard(c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,43791861)
-		and Duel.IsExistingMatchingCard(c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,79185500)
+	local ct=0
+	if Duel.IsExistingMatchingCard(c15574615.spfilter1,tp,LOCATION_MZONE,0,1,nil,80208158,tp) then ct=ct-1 end
+	if Duel.IsExistingMatchingCard(c15574615.spfilter1,tp,LOCATION_MZONE,0,1,nil,16796157,tp) then ct=ct-1 end
+	if Duel.IsExistingMatchingCard(c15574615.spfilter1,tp,LOCATION_MZONE,0,1,nil,43791861,tp) then ct=ct-1 end
+	if Duel.IsExistingMatchingCard(c15574615.spfilter1,tp,LOCATION_MZONE,0,1,nil,79185500,tp) then ct=ct-1 end
+	return Duel.GetLocationCount(tp,LOCATION_MZONE)>ct
+		and Duel.IsExistingMatchingCard(c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,80208158)
+		and Duel.IsExistingMatchingCard(c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,16796157)
+		and Duel.IsExistingMatchingCard(c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,43791861)
+		and Duel.IsExistingMatchingCard(c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,nil,79185500)
 end
 function c15574615.spop(e,tp,eg,ep,ev,re,r,rp,c)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g1=Duel.SelectMatchingCard(tp,c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,80208158)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g2=Duel.SelectMatchingCard(tp,c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,16796157)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g3=Duel.SelectMatchingCard(tp,c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,43791861)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g4=Duel.SelectMatchingCard(tp,c15574615.spfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,79185500)
-	g1:Merge(g2)
-	g1:Merge(g3)
-	g1:Merge(g4)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local g1=nil
+	local g2=nil
+	local g3=nil
+	local g4=nil
+	if ft>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g1=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,80208158)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g2=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,16796157)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g3=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,43791861)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g4=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,79185500)
+		g1:Merge(g2)
+		g1:Merge(g3)
+		g1:Merge(g4)
+	elseif ft==0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g1=Duel.SelectReleaseGroup(tp,c15574615.spfilter3,1,1,nil,tp)
+		if g1:GetFirst():IsCode(80208158) then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g2=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,16796157)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g3=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,43791861)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g4=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,79185500)
+		elseif g1:GetFirst():IsCode(16796157) then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g2=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,80208158)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g3=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,43791861)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g4=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,79185500)
+		elseif g1:GetFirst():IsCode(43791861) then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g2=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,80208158)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g3=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,16796157)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g4=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,79185500)
+		else
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g2=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,80208158)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g3=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,16796157)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+			g4=Duel.SelectMatchingCard(tp,c15574615.spfilter2,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,nil,43791861)
+		end
+		g1:Merge(g2)
+		g1:Merge(g3)
+		g1:Merge(g4)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g1=Duel.SelectMatchingCard(tp,c15574615.spfilter1,tp,LOCATION_ONFIELD,0,1,1,nil,80208158,tp)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g2=Duel.SelectMatchingCard(tp,c15574615.spfilter1,tp,LOCATION_ONFIELD,0,1,1,nil,16796157,tp)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g3=Duel.SelectMatchingCard(tp,c15574615.spfilter1,tp,LOCATION_ONFIELD,0,1,1,nil,43791861,tp)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		g4=Duel.SelectMatchingCard(tp,c15574615.spfilter1,tp,LOCATION_ONFIELD,0,1,1,nil,79185500,tp)
+		g1:Merge(g2)
+		g1:Merge(g3)
+		g1:Merge(g4)
+	end
 	Duel.SendtoGrave(g1,REASON_COST)
 end
 function c15574615.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsReleasable() end
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
-function c15574615.spfilter2(c,e,tp,code)
+function c15574615.spfilter4(c,e,tp,code)
 	return c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c15574615.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>=3
-		and Duel.IsExistingTarget(c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,nil,e,tp,80208158)
-		and Duel.IsExistingTarget(c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,nil,e,tp,16796157)
-		and Duel.IsExistingTarget(c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,nil,e,tp,43791861)
-		and Duel.IsExistingTarget(c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,nil,e,tp,79185500) end
+		and Duel.IsExistingTarget(c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,nil,e,tp,80208158)
+		and Duel.IsExistingTarget(c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,nil,e,tp,16796157)
+		and Duel.IsExistingTarget(c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,nil,e,tp,43791861)
+		and Duel.IsExistingTarget(c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,nil,e,tp,79185500) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g1=Duel.SelectTarget(tp,c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,80208158)
+	local g1=Duel.SelectTarget(tp,c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,80208158)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g2=Duel.SelectTarget(tp,c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,16796157)
+	local g2=Duel.SelectTarget(tp,c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,16796157)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g3=Duel.SelectTarget(tp,c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,43791861)
+	local g3=Duel.SelectTarget(tp,c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,43791861)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g4=Duel.SelectTarget(tp,c15574615.spfilter2,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,79185500)
+	local g4=Duel.SelectTarget(tp,c15574615.spfilter4,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,79185500)
 	g1:Merge(g2)
 	g1:Merge(g3)
 	g1:Merge(g4)


### PR DESCRIPTION
Fix this: If you control 5 monsters and you control Esper Star Sparrow, Beast-Warrior Puma, Phoenix Beast Gairuda or Ironhammer the Giant, D.D. Jet Iron cannot Special Summon.