### PR TITLE
Chimeratech and Glad Beast Fusions

### DIFF
--- a/c27346636.lua
+++ b/c27346636.lua
@@ -38,7 +38,7 @@ function c27346636.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c27346636.spfilter1(c,tp)
-	return c:IsCode(78868776) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
+	return c:IsCode(78868776) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
 		and Duel.IsExistingMatchingCard(c27346636.spfilter2,tp,LOCATION_MZONE,0,2,c)
 end
 function c27346636.spfilter2(c)

--- a/c48156348.lua
+++ b/c48156348.lua
@@ -46,7 +46,7 @@ function c48156348.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c48156348.spfilter1(c,tp)
-	return c:IsCode(41470137) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
+	return c:IsCode(41470137) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
 		and Duel.IsExistingMatchingCard(c48156348.spfilter2,tp,LOCATION_MZONE,0,1,c)
 end
 function c48156348.spfilter2(c)

--- a/c79229522.lua
+++ b/c79229522.lua
@@ -31,7 +31,7 @@ function c79229522.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c79229522.spfilter1(c,tp,ft)
-	if c:IsCode(70095154) and c:IsAbleToGraveAsCost() and c:IsCanBeFusionMaterial(nil,true) and (c:IsControler(tp) or c:IsFaceup()) then
+	if c:IsCode(70095154) and c:IsAbleToGraveAsCost() and c:IsCanBeFusionMaterial() and (c:IsControler(tp) or c:IsFaceup()) then
 		if ft>0 or (c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)) then
 			return Duel.IsExistingMatchingCard(c79229522.spfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,c,tp)
 		else

--- a/c90957527.lua
+++ b/c90957527.lua
@@ -47,7 +47,7 @@ function c90957527.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c90957527.spfilter1(c,tp)
-	return c:IsCode(79580323) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
+	return c:IsCode(79580323) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
 		and Duel.IsExistingMatchingCard(c90957527.spfilter2,tp,LOCATION_MZONE,0,1,c)
 end
 function c90957527.spfilter2(c)


### PR DESCRIPTION
After our last update we noticed that Chimeratech is not able to be summoned anymore. When localy testing I found this: http://imgur.com/PBkkpLF
After a little investigation and finding this commit 
https://github.com/Fluorohydride/ygopro-scripts/commit/a91364e2a90e4b21a6fc7f0f0ffdf7daed400093
I also checked the 3 Gladiator Beast Fusions edited there and they are also not be able to be summoned anymore.

Removing the parameters from the IsCanBeFusionMaterial function solves the problem. Not sure why they were there in the first place, if anyone could enlighten me please, would be very much apprechiated^^
If those are necassary I have no idea what card the function expects to be there. I've already tried inserting one or another possible card there, but then it shows another error that 2 parameters are needed, despite 2 being there.
(Side note: not sure if the other files in that commit are also causing problems, wasn't able to test that yet)