### PR TITLE
fix Necrovalley

### DIFF
--- a/c47355498.lua
+++ b/c47355498.lua
@@ -80,7 +80,12 @@ function c47355498.discheck(ev,category,re,im0,im1,targets)
 	if not ex then return false end
 	if tg and tg:GetCount()>0 then
 		if targets then
-			return tg:IsExists(c47355498.disfilter1,1,nil,im0,im1,targets)
+			if targets:GetCount()==1 then
+				local tc=targets:GetFirst()
+				return tc:IsHasEffect(EFFECT_NECRO_VALLEY) and tc~=re:GetHandler() and tc:GetLocation()==LOCATION_GRAVE
+			else
+				return tg:IsExists(c47355498.disfilter1,1,nil,im0,im1,targets)
+			end 
 		else
 			return tg:IsExists(c47355498.disfilter2,1,re:GetHandler(),im0,im1)
 		end


### PR DESCRIPTION
fix this:
If you activate a monster effect that can target 1 card out of a group of itself and other cards (e.g. Trick clown, Redox, Inzector Giga-Weevil, Beast of the Pharaoh, Colossal Fighter) it is currently negated by Necrovalley even if it targets itself.