### PR TITLE
fix Clear Wing Synchro Dragon

### DIFF
--- a/c82044279.lua
+++ b/c82044279.lua
@@ -42,7 +42,7 @@ function c82044279.condition2(e,tp,eg,ep,ev,re,r,rp)
 	if not g or g:GetCount()~=1 then return false end
 	local tc=g:GetFirst()
 	local c=e:GetHandler()
-	return re:IsActiveType(TYPE_MONSTER) and tc:IsLevelAbove(5) and tc:IsLocation(LOCATION_MZONE)
+	return re:IsActiveType(TYPE_MONSTER) and tc:IsFaceup() and tc:IsLevelAbove(5) and tc:IsLocation(LOCATION_MZONE)
 		and not c:IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)
 end
 function c82044279.target(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11721
（対象を取る効果ではありません。フィールドのに表側表示で存在するレベル５以上のモンスター１体のみを対象として発動したモンスターの効果に直接チェーンして発動します。また、ダメージステップでも発動する事ができます。）