### PR TITLE
fix Red Dragon Archfiend

### DIFF
--- a/c70902743.lua
+++ b/c70902743.lua
@@ -83,6 +83,7 @@ function c70902743.target2(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c70902743.operation2(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end
 	local g=Duel.GetMatchingGroup(c70902743.filter2,tp,LOCATION_MZONE,0,e:GetHandler())
 	Duel.Destroy(g,REASON_EFFECT)
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12943&keyword=&tag=-1
 Q.「レッド・デーモンズ・ドラゴン」の『②：自分エンドフェイズに発動する。このカードがフィールドに表側表示で存在する場合、このカード以外のこのターン攻撃宣言をしていない自分フィールドのモンスターを全て破壊する』効果の発動にチェーンして「月の書」が発動し、効果を発動した「レッド・デーモンズ・ドラゴン」自身が裏側守備表示になりました。

この場合、効果処理はどうなりますか？
A.エンドフェイズに効果を発動した「レッド・デーモンズ・ドラゴン」自身が、その効果処理時に「月の書」の効果で裏側守備表示になっている場合には、『このカード以外のこのターン攻撃宣言をしていない自分フィールドのモンスターを全て破壊する』処理は適用されません。 