### PR TITLE
fix Magical Hats

### DIFF
--- a/c81210420.lua
+++ b/c81210420.lua
@@ -1,5 +1,4 @@
 --マジカルシルクハット
---destroy is not fully implemented
 function c81210420.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -100,4 +99,5 @@ function c81210420.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=g:Filter(c81210420.desfilter,nil,fid)
 	g:DeleteGroup()
 	Duel.Destroy(tg,REASON_EFFECT)
+	Duel.SendtoGrave(tg,REASON_EFFECT)
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17264&keyword=&tag=-1
また、「マジカルシルクハット」の効果でモンスターカード扱いとなった「忍法」と名のついたカードが表側表示になっている状態にて、バトルフェイズ終了時を迎えた場合には、『この効果でデッキから特殊召喚した２枚のカードはバトルフェイズ終了時に破壊される』処理によってその「忍法」と名のついたカードは破壊されずに**墓地へ送られる事になります**。