### PR TITLE
fix "after this card is activated"

### DIFF
--- a/c11961740.lua
+++ b/c11961740.lua
@@ -19,8 +19,7 @@ function c11961740.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 		local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,LOCATION_DECK,0,1,1,nil)
 		local tc=g:GetFirst()
-		if tc then
-			Duel.Remove(tc,POS_FACEDOWN,REASON_EFFECT)
+		if tc and Duel.Remove(tc,POS_FACEDOWN,REASON_EFFECT)~=0 and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 			tc:RegisterFlagEffect(11961740,RESET_EVENT+0x1fe0000,0,1)
 			c:CancelToGrave()
 			local e1=Effect.CreateEffect(c)

--- a/c17194258.lua
+++ b/c17194258.lua
@@ -34,6 +34,7 @@ function c17194258.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:GetFirst()
 	if tc and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.ConfirmCards(1-tp,tc)
+		if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD)
 		e1:SetCode(EFFECT_CANNOT_SUMMON)

--- a/c313513.lua
+++ b/c313513.lua
@@ -18,6 +18,7 @@ function c313513.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,c313513.cfilter,tp,LOCATION_ONFIELD,0,3,3,nil)
 	Duel.SendtoGrave(g,REASON_COST)
+	if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_SUMMON)

--- a/c51790181.lua
+++ b/c51790181.lua
@@ -22,7 +22,7 @@ function c51790181.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
 	Duel.SendtoDeck(sg,nil,2,REASON_EFFECT)
-	if e:GetHandler():IsRelateToEffect(e) then
+	if e:GetHandler():IsRelateToEffect(e) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
 	end
 end

--- a/c72537897.lua
+++ b/c72537897.lua
@@ -6,27 +6,12 @@ function c72537897.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCondition(c72537897.condition)
-	e1:SetCost(c72537897.cost)
 	e1:SetTarget(c72537897.target)
 	e1:SetOperation(c72537897.activate)
 	c:RegisterEffect(e1)
 end
 function c72537897.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
-end
-function c72537897.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
-	e1:SetTargetRange(1,0)
-	e1:SetTarget(c72537897.splimit)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e1,tp)
-end
-function c72537897.splimit(e,c)
-	return c:GetRace()~=RACE_BEAST
 end
 function c72537897.spfilter(c,e,tp)
 	return c:IsRace(RACE_BEAST) and c:IsLevelBelow(2) and c:IsType(TYPE_EFFECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
@@ -38,6 +23,17 @@ function c72537897.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,3,tp,LOCATION_DECK)
 end
 function c72537897.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+		e1:SetTargetRange(1,0)
+		e1:SetTarget(c72537897.splimit)
+		e1:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e1,tp)
+	end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=2 then return end
 	local g=Duel.GetMatchingGroup(c72537897.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	if g:GetClassCount(Card.GetCode)>=3 then
@@ -51,7 +47,6 @@ function c72537897.activate(e,tp,eg,ep,ev,re,r,rp)
 		local sg3=g:Select(tp,1,1,nil)
 		sg1:Merge(sg2)
 		sg1:Merge(sg3)
-		local c=e:GetHandler()
 		local fid=c:GetFieldID()
 		local tc=sg1:GetFirst()
 		while tc do
@@ -82,6 +77,9 @@ function c72537897.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.RegisterEffect(e3,tp)
 		Duel.SpecialSummonComplete()
 	end
+end
+function c72537897.splimit(e,c)
+	return c:GetRace()~=RACE_BEAST
 end
 function c72537897.desfilter(c,fid)
 	return c:GetFlagEffectLabel(72537897)==fid

--- a/c75500286.lua
+++ b/c75500286.lua
@@ -19,6 +19,7 @@ function c75500286.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tg=g:GetFirst()
 	if tg==nil then return end
 	Duel.Remove(tg,POS_FACEUP,REASON_EFFECT)
+	if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e1:SetRange(LOCATION_REMOVED)


### PR DESCRIPTION
If the effect of a nomal spell card is activated by the effect of Destiny HERO - Diamond Dude , the treatment of "after this card is activated" will not apply.

eg. http://yugioh-wiki.net/?%A1%D4%C9%F5%B0%F5%A4%CE%B2%AB%B6%E2%DD%A4%A1%D5
Ｑ：《Ｄ－ＨＥＲＯ ダイヤモンドガイ》の効果で墓地のこのカードの効果を発動してカードを除外した場合、手札に加える効果を適用されますか？
Ａ：いいえ、その場合魔法カードの発動にはなりませんので、「発動後～」の効果は適用されません。(13/12/12)