### PR TITLE
fix Yang Zing Unleashed

### DIFF
--- a/c16825874.lua
+++ b/c16825874.lua
@@ -17,6 +17,12 @@ function c16825874.initial_effect(c)
 	e2:SetCondition(c16825874.ccon)
 	e2:SetOperation(c16825874.cop)
 	c:RegisterEffect(e2)
+	--hand synchro for double tuner
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetCode(55863245)
+	c:RegisterEffect(e3)
 end
 c16825874.tuner_filter=aux.FALSE
 function c16825874.filter(c,syncard,tuner,f,lv)

--- a/c77783947.lua
+++ b/c77783947.lua
@@ -41,7 +41,10 @@ function c77783947.sccon(e,tp,eg,ep,ev,re,r,rp)
 	return ph==PHASE_MAIN1 or ph==PHASE_BATTLE or ph==PHASE_MAIN2
 end
 function c77783947.mfilter(c)
-	return c:IsSetCard(0x9e)
+	return c:IsSetCard(0x9e) and c:IsType(TYPE_MONSTER)
+end
+function c77783947.mfilter2(c)
+	return c:IsHasEffect(55863245)
 end
 function c77783947.cfilter(c,syn)
 	return syn:IsSynchroSummonable(c)
@@ -56,12 +59,24 @@ end
 function c77783947.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_MZONE,0,nil)
+		local exg=Duel.GetMatchingGroup(c77783947.mfilter2,tp,LOCATION_MZONE,0,nil)
+		if exg:GetCount()>0 then
+			local mg2=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_HAND,0,nil)
+			mg:Merge(exg)
+			mg:Merge(mg2)
+		end
 		return Duel.IsExistingMatchingCard(c77783947.spfilter,tp,LOCATION_EXTRA,0,1,nil,mg)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c77783947.scop(e,tp,eg,ep,ev,re,r,rp)
 	local mg=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_MZONE,0,nil)
+	local exg=Duel.GetMatchingGroup(c77783947.mfilter2,tp,LOCATION_MZONE,0,nil)
+	if exg:GetCount()>0 then
+		local mg2=Duel.GetMatchingGroup(c77783947.mfilter,tp,LOCATION_HAND,0,nil)
+		mg:Merge(exg)
+		mg:Merge(mg2)
+	end
 	local g=Duel.GetMatchingGroup(c77783947.spfilter,tp,LOCATION_EXTRA,0,nil,mg)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10197
Q.
自分のモンスターゾーンに「エキセントリック・ボーイ」が1体のみ表側表示で存在し、自分の魔法＆罠ゾーンに「竜星の極み」が表側表示で存在しています。
また、自分の手札に「炎竜星－シュンゲイ」が存在しています。

この状況で、「竜星の極み」の『②：自分または相手のメインフェイズ及びバトルフェイズに魔法＆罠ゾーンに表側表示で存在するこのカードを墓地へ送ってこの効果を発動できる。「竜星」モンスター１体以上を含むモンスターを素材としてSモンスター１体をS召喚する』効果を発動する事はできますか？
A.
「竜星の極み」の効果を発動する場合、「竜星」と名のついたモンスター1体以上を含むシンクロ素材モンスター一組を揃え、その合計のレベルを持つシンクロモンスターを正しくシンクロ召喚できる状態でなければなりません。

質問の状況の場合、モンスターゾーンのエキセントリック・ボーイ」と手札の「炎竜星－シュンゲイ」をシンクロ素材モンスター一組として、エクストラデッキからレベルのシンクロモンスターをシンクロ召喚できるのであれば、「竜星の極み」の効果を発動する事ができます。

（なお、質問の状況では、モンスターゾーンに「竜星」と名のついたモンスターが表側表示で存在していませんので、手札に「竜星」と名のついたモンスターが存在しないような場合であれば、「竜星の極み」の効果を発動する事自体ができません。） 