### PR TITLE
fix Constellar Meteor, Dust Storm of Gusto

### DIFF
--- a/c63545861.lua
+++ b/c63545861.lua
@@ -4,8 +4,12 @@ function c63545861.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c63545861.target)
 	e1:SetOperation(c63545861.regop)
 	c:RegisterEffect(e1)
+end
+function c63545861.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) end
 end
 function c63545861.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c8414337.lua
+++ b/c8414337.lua
@@ -5,11 +5,15 @@ function c8414337.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCondition(c8414337.condition)
+	e1:SetTarget(c8414337.target)
 	e1:SetOperation(c8414337.activate)
 	c:RegisterEffect(e1)
 end
 function c8414337.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()<=PHASE_BATTLE
+end
+function c8414337.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) end
 end
 function c8414337.activate(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())


### PR DESCRIPTION
Fix this: You can banish Dust Storm of Gusto and Constellar Meteor to activate Junk Collector's effect.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「セイクリッドの流星」や「ガスタの風塵」を除外して「ジャンク・コレクター」の効果を発動できますか？ 
A. 
「ジャンク・コレクター」によって「セイクリッドの流星」や「ガスタの風塵」を除外し効果を発動する事はできません。