### PR TITLE
fix Xyz Universe

### DIFF
--- a/c11109820.lua
+++ b/c11109820.lua
@@ -28,7 +28,8 @@ end
 function c11109820.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if chk==0 then return Duel.IsExistingTarget(c11109820.filter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,e,tp,ft) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and Duel.IsExistingTarget(c11109820.filter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,e,tp,ft) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g1=Duel.SelectTarget(tp,c11109820.filter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,e,tp,ft)
 	local tc=g1:GetFirst()
@@ -40,8 +41,9 @@ function c11109820.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c11109820.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
 	--change damage
-	local e1=Effect.CreateEffect(e:GetHandler())
+	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CHANGE_DAMAGE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
@@ -54,7 +56,6 @@ function c11109820.operation(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e2,tp)
 	--sp_summon
-	local c=e:GetHandler()
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local tc1=g:GetFirst()
 	local tc2=g:GetNext()


### PR DESCRIPTION
Fix this: You can banish Xyz Universe to activate Junk Collector's effect.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「エクシーズ・ユニバース」を除外して「ジャンク・コレクター」の効果を発動した場合そのターンに相手が受ける全てのダメージは０になりますか？ 
A. 
「ジャンク・コレクター」の墓地から除外する発動コストの罠カードに、墓地の「エクシーズ・ユニバース」を選ぶ事自体ができません。 
よって、「ジャンク・コレクター」の効果が、「エクシーズ・ユニバース」と同じ効果になる事がありません。