### PR TITLE
fix DDD怒濤王シーザー

### DIFF
--- a/c3758046.lua
+++ b/c3758046.lua
@@ -5,16 +5,19 @@ function c3758046.initial_effect(c)
 	c:EnableReviveLimit()
 	--special summon
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(3758046,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,3758046)
+	e1:SetCondition(c3758046.con)
 	e1:SetCost(c3758046.cost)
 	e1:SetOperation(c3758046.operation)
 	c:RegisterEffect(e1)
 	--search
 	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(3758046,1))
 	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_TO_GRAVE)
@@ -24,6 +27,9 @@ function c3758046.initial_effect(c)
 	e2:SetTarget(c3758046.thtg)
 	e2:SetOperation(c3758046.thop)
 	c:RegisterEffect(e2)
+end
+function c3758046.con(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsAbleToEnterBP() or Duel.GetCurrentPhase()==PHASE_BATTLE
 end
 function c3758046.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
@@ -49,6 +55,7 @@ function c3758046.spop(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetDescription(aux.Stringid(3758046,2))
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
 		e1:SetCountLimit(1)


### PR DESCRIPTION
1.效果1不应在主阶段2和结束阶段发动
2.效果1发动后的下一个回合的准备阶段，如果这张卡有素材在场上，无法判断是选择受到伤害还是发动效果