### PR TITLE
fix Vylon

### DIFF
--- a/c1281505.lua
+++ b/c1281505.lua
@@ -5,7 +5,7 @@ function c1281505.initial_effect(c)
 	e1:SetDescription(aux.Stringid(1281505,0))
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetCondition(c1281505.eqcon)
 	e1:SetCost(c1281505.eqcost)
@@ -47,12 +47,13 @@ function c1281505.eqop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_EQUIP_LIMIT)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetValue(c1281505.eqlimit)
+		e1:SetLabelObject(tc)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 end
 function c1281505.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+	return c==e:GetLabelObject()
 end
 function c1281505.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c38679204.lua
+++ b/c38679204.lua
@@ -5,7 +5,7 @@ function c38679204.initial_effect(c)
 	e1:SetDescription(aux.Stringid(38679204,0))
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetCondition(c38679204.eqcon)
 	e1:SetCost(c38679204.eqcost)
@@ -49,12 +49,13 @@ function c38679204.eqop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_EQUIP_LIMIT)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetValue(c38679204.eqlimit)
+		e1:SetLabelObject(tc)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 end
 function c38679204.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+	return c==e:GetLabelObject()
 end
 function c38679204.descon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c74064212.lua
+++ b/c74064212.lua
@@ -5,7 +5,7 @@ function c74064212.initial_effect(c)
 	e1:SetDescription(aux.Stringid(74064212,0))
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetCondition(c74064212.eqcon)
 	e1:SetCost(c74064212.eqcost)
@@ -46,12 +46,13 @@ function c74064212.eqop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_EQUIP_LIMIT)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetValue(c74064212.eqlimit)
+		e1:SetLabelObject(tc)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 end
 function c74064212.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+	return c==e:GetLabelObject()
 end
 function c74064212.atkcon(e)
 	local ph=Duel.GetCurrentPhase()

--- a/c75886890.lua
+++ b/c75886890.lua
@@ -5,7 +5,7 @@ function c75886890.initial_effect(c)
 	e1:SetDescription(aux.Stringid(75886890,0))
 	e1:SetCategory(CATEGORY_EQUIP)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetCondition(c75886890.eqcon)
 	e1:SetCost(c75886890.eqcost)
@@ -50,12 +50,13 @@ function c75886890.eqop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_EQUIP_LIMIT)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetValue(c75886890.eqlimit)
+		e1:SetLabelObject(tc)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 end
 function c75886890.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+	return c==e:GetLabelObject()
 end
 function c75886890.eqcost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end


### PR DESCRIPTION
http://yugioh-wiki.net/index.php?%A1%D4%B0%DC%A4%EA%B5%A4%A4%CA%BB%C5%CE%A9%B2%B0%A1%D5#faq
Ｑ：自身の効果で装備カードになった以下のカードを、このカードの効果によって正しい対象となるモンスターに移し替えることはできますか？
《ヴァイロン・スフィア》：移し替えることができません。(15/11/20)
《ヴァイロン・プリズム》：移し替えることができません。(15/11/20)