### PR TITLE
fix Graverobber

### DIFF
--- a/c61705417.lua
+++ b/c61705417.lua
@@ -44,12 +44,20 @@ function c61705417.activate(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e2)
 		local e3=Effect.CreateEffect(e:GetHandler())
 		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		e3:SetCode(EVENT_CHAIN_SOLVED)
+		e3:SetCode(EVENT_CHAINING)
 		e3:SetCondition(c61705417.actcon)
 		e3:SetOperation(c61705417.actop)
 		e3:SetLabelObject(tc)
 		e3:SetReset(RESET_PHASE+PHASE_END)
 		Duel.RegisterEffect(e3,tp)
+		local e4=Effect.CreateEffect(e:GetHandler())
+		e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e4:SetCode(EVENT_CHAIN_SOLVED)
+		e4:SetCondition(c61705417.damcon)
+		e4:SetOperation(c61705417.damop)
+		e4:SetLabelObject(tc)
+		e4:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e4,tp)
 	end
 end
 function c61705417.tgcon(e,tp,eg,ep,ev,re,r,rp)
@@ -62,8 +70,8 @@ function c61705417.tgop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c61705417.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsReason(REASON_COST) and c:GetControler()~=c:GetOwner()
-		and not c:IsStatus(STATUS_CHAINING+STATUS_ACTIVATED) end
+	if chk==0 then return c:IsReason(REASON_COST) and c:GetControler()~=c:GetOwner() end
+	c:ResetFlagEffect(61705418)
 	Duel.Damage(c:GetControler(),2000,REASON_EFFECT)
 	return false
 end
@@ -71,6 +79,14 @@ function c61705417.actcon(e,tp,eg,ep,ev,re,r,rp)
 	return rp==tp and re:GetHandler()==e:GetLabelObject() and re:GetHandler():GetFlagEffect(61705417)~=0
 end
 function c61705417.actop(e,tp,eg,ep,ev,re,r,rp)
+	re:GetHandler():RegisterFlagEffect(61705418,RESET_CHAIN,0,1)
+	e:Reset()
+end
+function c61705417.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return rp==tp and re:GetHandler()==e:GetLabelObject() and re:GetHandler():GetFlagEffect(61705418)~=0
+end
+function c61705417.damop(e,tp,eg,ep,ev,re,r,rp)
+	re:GetHandler():ResetFlagEffect(61705418)
 	Duel.Damage(tp,2000,REASON_EFFECT)
 	e:Reset()
 end


### PR DESCRIPTION
Fix this: If you sended the card that added by Graverobber's effect to activate Emergency Provisions, you don't take damage.
http://yugioh-wiki.net/index.php?%A1%D4%CA%E8%B9%D3%A4%E9%A4%B7%A1%D5#faq
Ｑ：《墓荒らし》の効果で手札に加えた魔法カードを発動し、チェーンして《非常食》のコストとした場合、２回ダメージを受けますか？
Ａ：ご質問の状況の場合、《非常食》の発動コストとして墓地へ送った時点の1回のみ、《墓荒らし》の効果で2000のダメージを受けます。（15/05/01）