### PR TITLE
fix Assault Blackwing - Raikiri the Rain Shower

### DIFF
--- a/c16051717.lua
+++ b/c16051717.lua
@@ -6,6 +6,7 @@ function c16051717.initial_effect(c)
 	--add type
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetCondition(c16051717.tncon)
 	e1:SetOperation(c16051717.tnop)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16495
 Q.「スキルドレイン」の適用中に、「BF」と名のついたモンスター1体以上をシンクロ素材として「A BF－驟雨のライキリ」をシンクロ召喚した場合、チューナーとして扱われますか？
A.「スキルドレイン」の適用中に「A BF－驟雨のライキリ」がシンクロ召喚された場合でも、『①：「BF」モンスターを素材としてS召喚したこのカードはチューナーとして扱う』効果は適用され、チューナーとして扱われます。