### PR TITLE
Update c98301564.lua

### DIFF
--- a/c98301564.lua
+++ b/c98301564.lua
@@ -42,7 +42,8 @@ function c98301564.cfilter(c)
 	return c:IsType(TYPE_TRAP) and c:IsType(TYPE_COUNTER) and c:IsAbleToHand()
 end
 function c98301564.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c98301564.cfilter,tp,LOCATION_DECK,0,3,nil) end
+	if chk==0 then return not e:GetHandler():IsLocation(LOCATION_DECK)
+		and Duel.IsExistingMatchingCard(c98301564.cfilter,tp,LOCATION_DECK,0,3,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,0,LOCATION_DECK)
 end
 function c98301564.regop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Q. 「グレイヴ・キーパー」の効果の適用中、「解放のアリアドネ」が戦闘で破壊され、デッキに戻られました。この場合、デッキにあるその「解放のアリアドネ」は、そのモンスター効果を発動できますか？ 
A. 戦闘で破壊された「解放のアリアドネ」が、「グレイヴ・キーパー」の効果によってデッキへ戻った場合、その「解放のアリアドネ」のモンスター効果を発動する事はできません。 

「墓场看守者」在场，「解放之阿里阿德涅」被战斗破坏送回卡组，不能从卡组发动怪兽效果。