### PR TITLE
move 1+N fusion procedure to Utility.lua

### DIFF
--- a/c11039171.lua
+++ b/c11039171.lua
@@ -2,19 +2,13 @@
 function c11039171.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_FUSION_MATERIAL)
-	e1:SetCondition(c11039171.fscon)
-	e1:SetOperation(c11039171.fsop)
-	c:RegisterEffect(e1)
+	aux.AddFusionProcCodeFunRep(c,30068120,aux.FilterBoolFunction(Card.IsSetCard,0xa9),1,63,false,false)
 	--spsummon condition
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e2:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e2:SetValue(c11039171.splimit)
+	e2:SetValue(aux.fuslimit)
 	c:RegisterEffect(e2)
 	--multi
 	local e3=Effect.CreateEffect(c)
@@ -22,27 +16,6 @@ function c11039171.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e3:SetOperation(c11039171.atkop)
 	c:RegisterEffect(e3)
-end
-c11039171.material_count=1
-c11039171.material={30068120}
-function c11039171.splimit(e,se,sp,st)
-	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
-end
-function c11039171.mfilter(c,mg)
-	return c:IsCode(30068120) and mg:IsExists(Card.IsSetCard,1,c,0xa9)
-end
-function c11039171.fscon(e,mg,gc)
-	if mg==nil then return false end
-	if gc then return false end
-	return mg:IsExists(c11039171.mfilter,1,nil,mg)
-end
-function c11039171.fsop(e,tp,eg,ep,ev,re,r,rp,gc)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g1=eg:FilterSelect(tp,c11039171.mfilter,1,1,nil,eg)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g2=eg:FilterSelect(tp,Card.IsSetCard,1,63,g1:GetFirst(),0xa9)
-	g1:Merge(g2)
-	Duel.SetFusionMaterial(g1)
 end
 function c11039171.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c464362.lua
+++ b/c464362.lua
@@ -3,13 +3,7 @@ function c464362.initial_effect(c)
 	c:SetUniqueOnField(1,0,464362)
 	--fusion material
 	c:EnableReviveLimit()
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_FUSION_MATERIAL)
-	e1:SetCondition(c464362.fscon)
-	e1:SetOperation(c464362.fsop)
-	c:RegisterEffect(e1)
+	aux.AddFusionProcCodeFunRep(c,30068120,aux.FilterBoolFunction(Card.IsSetCard,0xa9),1,63,true,true)
 	--destroy
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_DESTROY)
@@ -29,31 +23,6 @@ function c464362.initial_effect(c)
 	e3:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0xad))
 	e3:SetValue(c464362.atkval)
 	c:RegisterEffect(e3)
-end
-c464362.material_count=1
-c464362.material={30068120}
-function c464362.mfilter(c,mg)
-	return (c:IsCode(30068120) or c:IsHasEffect(EFFECT_FUSION_SUBSTITUTE)) and mg:IsExists(Card.IsSetCard,1,c,0xa9)
-end
-function c464362.fscon(e,mg,gc)
-	if mg==nil then return true end
-	if gc then return (gc:IsCode(30068120) or gc:IsHasEffect(EFFECT_FUSION_SUBSTITUTE))
-		and mg:IsExists(Card.IsSetCard,1,gc,0xa9) end
-	return mg:IsExists(c464362.mfilter,1,nil,mg)
-end
-function c464362.fsop(e,tp,eg,ep,ev,re,r,rp,gc)
-	if gc then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-		local g1=eg:FilterSelect(tp,Card.IsSetCard,1,63,nil,0xa9)
-		Duel.SetFusionMaterial(g1)
-		return
-	end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g1=eg:FilterSelect(tp,c464362.mfilter,1,1,nil,eg)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g2=eg:FilterSelect(tp,Card.IsSetCard,1,63,g1:GetFirst(),0xa9)
-	g1:Merge(g2)
-	Duel.SetFusionMaterial(g1)
 end
 function c464362.descon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION

--- a/c64599569.lua
+++ b/c64599569.lua
@@ -2,13 +2,7 @@
 function c64599569.initial_effect(c)
 	c:EnableReviveLimit()
 	--fusion material
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_FUSION_MATERIAL)
-	e1:SetCondition(c64599569.fscondition)
-	e1:SetOperation(c64599569.fsoperation)
-	c:RegisterEffect(e1)
+	aux.AddFusionProcCodeFunRep(c,70095154,aux.FilterBoolFunction(Card.IsRace,RACE_MACHINE),1,63,true,true)
 	--spsummon condition
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
@@ -27,25 +21,6 @@ function c64599569.initial_effect(c)
 	e4:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e4:SetOperation(c64599569.tgop)
 	c:RegisterEffect(e4)
-end
-c64599569.material_count=1
-c64599569.material={70095154}
-function c64599569.spfilter(c,mg)
-	return (c:IsCode(70095154) or c:IsHasEffect(EFFECT_FUSION_SUBSTITUTE))
-		and mg:IsExists(Card.IsRace,1,c,RACE_MACHINE)
-end
-function c64599569.fscondition(e,mg,gc)
-	if mg==nil then return false end
-	if gc then return false end
-	return mg:IsExists(c64599569.spfilter,1,nil,mg)
-end
-function c64599569.fsoperation(e,tp,eg,ep,ev,re,r,rp,gc)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g1=eg:FilterSelect(tp,c64599569.spfilter,1,1,nil,eg)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g2=eg:FilterSelect(tp,Card.IsRace,1,63,g1:GetFirst(),RACE_MACHINE)
-	g1:Merge(g2)
-	Duel.SetFusionMaterial(g1)
 end
 function c64599569.sucop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c80889750.lua
+++ b/c80889750.lua
@@ -2,13 +2,7 @@
 function c80889750.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_FUSION_MATERIAL)
-	e1:SetCondition(c80889750.fscon)
-	e1:SetOperation(c80889750.fsop)
-	c:RegisterEffect(e1)
+	aux.AddFusionProcFunFunRep(c,c80889750.mfilter1,c80889750.mfilter2,1,63,true)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -36,24 +30,11 @@ function c80889750.initial_effect(c)
 	e4:SetOperation(c80889750.indop)
 	c:RegisterEffect(e4)
 end
-function c80889750.mfilter1(c,mg)
-	return c:IsSetCard(0xad) and c:IsType(TYPE_FUSION) and mg:IsExists(c80889750.mfilter2,1,c)
+function c80889750.mfilter1(c)
+	return c:IsSetCard(0xad) and c:IsType(TYPE_FUSION)
 end
 function c80889750.mfilter2(c)
 	return c:IsSetCard(0xa9) or c:IsSetCard(0xc3)
-end
-function c80889750.fscon(e,mg,gc)
-	if mg==nil then return true end
-	if gc then return false end
-	return mg:IsExists(c80889750.mfilter1,1,nil,mg)
-end
-function c80889750.fsop(e,tp,eg,ep,ev,re,r,rp,gc)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g1=eg:FilterSelect(tp,c80889750.mfilter1,1,1,nil,eg)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g2=eg:FilterSelect(tp,c80889750.mfilter2,1,63,g1:GetFirst())
-	g1:Merge(g2)
-	Duel.SetFusionMaterial(g1)
 end
 function c80889750.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION

--- a/utility.lua
+++ b/utility.lua
@@ -1017,14 +1017,14 @@ function Auxiliary.FConditionFilterCFR(c,code,sub,f,mg,minc)
 	return (c:IsCode(code) or (sub and c:IsHasEffect(EFFECT_FUSION_SUBSTITUTE))) and mg:IsExists(f,minc,c)
 end
 function Auxiliary.FConditionCodeFunRep(code,f,minc,maxc,sub,insf)
-	return	function(e,g,gc,chkf)
-			if g==nil then return insf end
-			local mg=g:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+	return	function(e,eg,gc,chkf)
+			if eg==nil then return insf end
+			local g=eg:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
 			if gc then return (gc:IsCode(code) or sub and gc:IsHasEffect(EFFECT_FUSION_SUBSTITUTE))
-				and mg:IsExists(f,minc,gc)
+				and g:IsExists(f,minc,gc)
 			end
-			local mg1=mg:Filter(aux.FConditionFilterCFR,nil,code,sub,f,mg,minc)
-			local mg2=mg:Filter(f,nil,minc)
+			local mg1=g:Filter(aux.FConditionFilterCFR,nil,code,sub,f,g,minc)
+			local mg2=g:Filter(f,nil)
 			if chkf~=PLAYER_NONE then return mg1:GetCount()>=1
 				and mg1:FilterCount(Card.IsOnField,nil)+mg2:FilterCount(Card.IsOnField,nil)~=0
 			else return mg1:GetCount()>=1 end
@@ -1041,17 +1041,17 @@ function Auxiliary.FOperationCodeFunRep(code,f,minc,maxc,sub,insf)
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 			local mg1=eg:FilterSelect(tp,aux.FConditionFilterCFR,1,1,nil,code,sub,f,eg,minc)
 			local g2=eg:Filter(f,mg1:GetFirst())
-			local offset=false
+			local offset=0
 			if chkf~=PLAYER_NONE and not mg1:GetFirst():IsOnField() then
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 				local mg3=g2:FilterSelect(tp,Card.IsOnField,1,1,nil)
 				mg1:Merge(mg3)
 				g2:Sub(mg3)
-				offset=true
+				offset=-1
 			end
-			if offset and (maxc-1<1 or minc-1<1 and not Duel.SelectYesNo(tp,93)) then return end
+			if offset~=0 and (maxc-1<1 or minc-1<1 and not Duel.SelectYesNo(tp,93)) then return end
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-			local mg2=g2:Select(tp,minc-1,maxc-1,nil)
+			local mg2=g2:Select(tp,minc+offset,maxc+offset,nil)
 			mg1:Merge(mg2)
 			Duel.SetFusionMaterial(mg1)
 		end
@@ -1071,12 +1071,12 @@ function Auxiliary.FConditionFilterFFR(c,f1,f2,mg,minc)
 	return f1(c) and mg:IsExists(f2,minc,c)
 end
 function Auxiliary.FConditionFunFunRep(f1,f2,minc,maxc,insf)
-	return	function(e,g,gc,chkf)
-			if g==nil then return insf end
-			local mg=g:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
-			if gc then return f1(gc) and mg:IsExists(f2,minc,gc) end
-			local mg1=mg:Filter(aux.FConditionFilterFFR,nil,f1,f2,mg,minc)
-			local mg2=mg:Filter(f2,nil,minc)
+	return	function(e,eg,gc,chkf)
+			if eg==nil then return insf end
+			local g=eg:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+			if gc then return f1(gc) and g:IsExists(f2,minc,gc) end
+			local mg1=g:Filter(aux.FConditionFilterFFR,nil,f1,f2,g,minc)
+			local mg2=g:Filter(f2,nil)
 			if chkf~=PLAYER_NONE then return mg1:GetCount()>=1
 				and mg1:FilterCount(Card.IsOnField,nil)+mg2:FilterCount(Card.IsOnField,nil)~=0
 			else return mg1:GetCount()>=1 end
@@ -1093,17 +1093,17 @@ function Auxiliary.FOperationFunFunRep(f1,f2,minc,maxc,insf)
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 			local mg1=eg:FilterSelect(tp,aux.FConditionFilterFFR,1,1,nil,f1,f2,eg,minc)
 			local g2=eg:Filter(f2,mg1:GetFirst())
-			local offset=false
+			local offset=0
 			if chkf~=PLAYER_NONE and not mg1:GetFirst():IsOnField() then
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 				local mg3=g2:FilterSelect(tp,Card.IsOnField,1,1,nil)
 				mg1:Merge(mg3)
 				g2:Sub(mg3)
-				offset=true
+				offset=-1
 			end
-			if offset and (maxc-1<1 or minc-1<1 and not Duel.SelectYesNo(tp,93)) then return end
+			if offset~=0 and (maxc-1<1 or minc-1<1 and not Duel.SelectYesNo(tp,93)) then return end
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-			local mg2=g2:Select(tp,minc-1,maxc-1,nil)
+			local mg2=g2:Select(tp,minc+offset,maxc+offset,nil)
 			mg1:Merge(mg2)
 			Duel.SetFusionMaterial(mg1)
 		end


### PR DESCRIPTION
在utility.lua添加了两个函数：
aux.AddFusionProcCodeFunRep & aux.AddFusionProcFunFunRep

首先，1+N的融合怪兽的数量其实开始增大了，最初只有「嵌合超载龙」1只，但随后「魔玩具」系列一口气出了3只，略微担心将来会不会有更多，先放进utility.lua里做好预备。

第二，其实1+N的融合怪兽在这以前，独立素材手续其实有个BUG：比如「魔玩具·剪刀虎」，自己场上有1只「锋利小鬼·剪刀」以及4只「毛绒动物」怪兽，自己手卡有1只「锋利小鬼·剪刀」以及若干「毛绒动物」怪兽，发动「融合」，可以只使用手牌的怪兽为素材，导致在把融合素材送去墓地后，自己没有怪兽区域而融合召唤失败。其实这里也顺便修了一下。

因为以上两点，希望能通过。