### PR TITLE
fix Outer Entity Azathoth

### DIFF
--- a/c34945480.lua
+++ b/c34945480.lua
@@ -46,7 +46,7 @@ function c34945480.sumsuc(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c34945480.actlimit(e,re,tp)
-	return re:IsActiveType(TYPE_MONSTER)
+	return re:IsActiveType(TYPE_MONSTER) and not re:GetHandler():IsImmuneToEffect(e)
 end
 function c34945480.condition(e,tp,eg,ep,ev,re,r,rp)
 	local g=e:GetHandler():GetOverlayGroup()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10976&keyword=&tag=-1
Q.相手のモンスターゾーンに「合神竜ティマイオス」が表側表示で存在しています。

この状況で自分が「外神アザトート」をエクシーズ召喚し、『①：このカードがX召喚に成功したターン、相手はモンスターの効果を発動できない』効果が適用されました。

このターンに、「外神アザトート」が相手の「合神竜ティマイオス」を攻撃した場合、相手は「合神竜ティマイオス」の『②：このカードが戦闘を行うダメージ計算時に発動できる。このカードの攻撃力・守備力は、フィールドのモンスターの一番高い攻撃力と同じになる』効果を発動する事はできますか？
A.「合神竜ティマイオス」は『①：このカードは他のカードの効果を受けない』効果を持つモンスターです。

したがって、「外神アザトート」の『相手はモンスターの効果を発動できない』効果が適用されているターンでも、「合神竜ティマイオス」はその「外神アザトート」の効果を受けず、『②：このカードが戦闘を行うダメージ計算時に発動できる。このカードの攻撃力・守備力は、フィールドのモンスターの一番高い攻撃力と同じになる』効果を通常通り発動する事ができます。