### PR TITLE
fix Time-Space Trap Hole

### DIFF
--- a/c2055403.lua
+++ b/c2055403.lua
@@ -23,12 +23,16 @@ end
 function c2055403.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=eg:Filter(c2055403.filter,nil,tp):Filter(Card.IsRelateToEffect,nil,e)
 	if g:GetCount()>0 then
-		local ct=Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
-		Duel.BreakEffect()
-		if Duel.GetLP(tp)>=ct*1000 then
-			Duel.SetLP(tp,Duel.GetLP(tp)-ct*1000)
-		else
-			Duel.SetLP(tp,0)
+		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
+		local og=Duel.GetOperatedGroup()
+		local ct=og:FilterCount(Card.IsLocation,nil,LOCATION_DECK)
+		if ct>0 then
+			Duel.BreakEffect()
+			if Duel.GetLP(tp)>=ct*1000 then
+				Duel.SetLP(tp,Duel.GetLP(tp)-ct*1000)
+			else
+				Duel.SetLP(tp,0)
+			end
 		end
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9468&keyword=&tag=-1
この時、「混沌の黒魔術師」はデッキに戻っていませんので、「時空の落とし穴」の『その後、自分は戻したモンスターの数×１０００LPを失う』処理にて、「混沌の黒魔術師」の分のライフポイントを失う事はありません。 