### PR TITLE
fix The Agent of Judgment - Saturn

### DIFF
--- a/c91345518.lua
+++ b/c91345518.lua
@@ -29,7 +29,7 @@ function c91345518.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
 end
 function c91345518.damop(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsEnvironment(56433456) then return end
+	if not Duel.IsEnvironment(56433456,tp) then return end
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	local val=Duel.GetLP(1-p)-Duel.GetLP(p)
 	if val>0 then


### PR DESCRIPTION
この効果は自分フィールド上に「天空の聖域」が表側表示で存在しなければ適用できない。