### PR TITLE
Update c72714392.lua

### DIFF
--- a/c72714392.lua
+++ b/c72714392.lua
@@ -14,7 +14,7 @@ function c72714392.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_CANNOT_BE_SYNCHRO_MATERIAL)
-	e2:SetValue(aux.TRUE)
+	e2:SetValue(c72714392.smlimit)
 	c:RegisterEffect(e2)
 end
 function c72714392.filter(c,e,tp)
@@ -56,4 +56,7 @@ function c72714392.operation(e,tp,eg,ep,ev,re,r,rp)
 			sc:RegisterEffect(e2)
 		end
 	end
+end
+function c72714392.smlimit(e,c)
+	return not e:GetHandler():IsLocation(LOCATION_MZONE)
 end


### PR DESCRIPTION
(1)：このカードはモンスターゾーンに存在する限り、Ｓ素材にできない。
(1)：When this card is on LOCATION_MZONE, this card cannot be used as Synchro Material. 