### PR TITLE
fix Jiaotu, Darkness of the Yang Zing

### DIFF
--- a/c25935625.lua
+++ b/c25935625.lua
@@ -64,7 +64,7 @@ function c25935625.spfilter2(c,e,tp)
 	return c:IsSetCard(0x9e) and c:GetDefence()==0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c25935625.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>2
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1
 		and Duel.IsExistingMatchingCard(c25935625.spfilter1,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
 end


### PR DESCRIPTION
If this is the only Monster on your side and Ground Collaps is activate you can't use the effect to summon 2 monsters. Adjust the field count check.