### PR TITLE
update ritual

### DIFF
--- a/c14094090.lua
+++ b/c14094090.lua
@@ -1,6 +1,6 @@
 --超戦士の儀式
 function c14094090.initial_effect(c)
-	aux.AddRitualProcEqual(c,c14094090.ritual_filter)
+	aux.AddRitualProcEqual(c,8,c14094090.ritual_filter)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)

--- a/c18803791.lua
+++ b/c18803791.lua
@@ -1,6 +1,6 @@
 --黒竜降臨
 function c18803791.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,71408082)
+	aux.AddRitualProcGreaterCode(c,4,71408082)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)

--- a/c23965037.lua
+++ b/c23965037.lua
@@ -1,4 +1,4 @@
 --ドリアードの祈り
 function c23965037.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,99414168)
+	aux.AddRitualProcGreaterCode(c,3,99414168)
 end

--- a/c27383110.lua
+++ b/c27383110.lua
@@ -21,6 +21,7 @@ function c27383110.initial_effect(c)
 	e2:SetLabelObject(e1)
 	c:RegisterEffect(e2)
 end
+c27383110.fit_monster={44665365}
 function c27383110.filter(c,e,tp,m)
 	if not c:IsCode(44665365) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
 	local mg=m:Filter(Card.IsCanBeRitualMaterial,c,c)

--- a/c31066283.lua
+++ b/c31066283.lua
@@ -1,4 +1,4 @@
 --スカルライダーの復活
 function c31066283.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,99721536)
+	aux.AddRitualProcGreaterCode(c,6,99721536)
 end

--- a/c33031674.lua
+++ b/c33031674.lua
@@ -1,4 +1,4 @@
 --灼熱の試練
 function c33031674.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,60258960)
+	aux.AddRitualProcGreaterCode(c,7,60258960)
 end

--- a/c34834619.lua
+++ b/c34834619.lua
@@ -1,6 +1,6 @@
 --光子竜降臨
 function c34834619.initial_effect(c)
-	aux.AddRitualProcEqualCode(c,85346853)
+	aux.AddRitualProcEqualCode(c,4,85346853)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(34834619,0))

--- a/c39399168.lua
+++ b/c39399168.lua
@@ -1,4 +1,4 @@
 --チャクラの復活
 function c39399168.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,65393205)
+	aux.AddRitualProcGreaterCode(c,7,65393205)
 end

--- a/c41182875.lua
+++ b/c41182875.lua
@@ -1,4 +1,4 @@
 --ジャベリンビートルの契約
 function c41182875.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,26932788)
+	aux.AddRitualProcGreaterCode(c,8,26932788)
 end

--- a/c41426869.lua
+++ b/c41426869.lua
@@ -1,4 +1,4 @@
 --イリュージョンの儀式
 function c41426869.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,64631466)
+	aux.AddRitualProcGreaterCode(c,1,64631466)
 end

--- a/c43417563.lua
+++ b/c43417563.lua
@@ -1,4 +1,4 @@
 --踊りによる誘発
 function c43417563.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,4849037)
+	aux.AddRitualProcGreaterCode(c,6,4849037)
 end

--- a/c43694075.lua
+++ b/c43694075.lua
@@ -1,4 +1,4 @@
 --ローの祈り
 function c43694075.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,3627449)
+	aux.AddRitualProcGreaterCode(c,7,3627449)
 end

--- a/c45410988.lua
+++ b/c45410988.lua
@@ -9,6 +9,7 @@ function c45410988.initial_effect(c)
 	e1:SetOperation(c45410988.activate)
 	c:RegisterEffect(e1)
 end
+c45410988.fit_monster={19025379}
 function c45410988.filter(c,e,tp,m1,m2)
 	if not c:IsCode(19025379) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
 	local mg=m1:Filter(Card.IsCanBeRitualMaterial,c,c)

--- a/c52913738.lua
+++ b/c52913738.lua
@@ -1,6 +1,6 @@
 --破滅の儀式
 function c52913738.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,30646525)
+	aux.AddRitualProcGreaterCode(c,7,30646525)
 	--To Deck
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(52913738,0))

--- a/c54539105.lua
+++ b/c54539105.lua
@@ -1,4 +1,4 @@
 --ライオンの儀式
 function c54539105.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,33951077)
+	aux.AddRitualProcGreaterCode(c,7,33951077)
 end

--- a/c55761792.lua
+++ b/c55761792.lua
@@ -1,4 +1,4 @@
 --カオスの儀式
 function c55761792.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,5405694)
+	aux.AddRitualProcGreaterCode(c,8,5405694)
 end

--- a/c60234913.lua
+++ b/c60234913.lua
@@ -1,6 +1,6 @@
 --救世の儀式
 function c60234913.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,61757117)
+	aux.AddRitualProcGreaterCode(c,7,61757117)
 	--untargetable
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(60234913,0))

--- a/c60365591.lua
+++ b/c60365591.lua
@@ -1,4 +1,4 @@
 --奇跡の方舟
 function c60365591.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,86327225)
+	aux.AddRitualProcGreaterCode(c,8,86327225)
 end

--- a/c60369732.lua
+++ b/c60369732.lua
@@ -1,4 +1,4 @@
 --大邪神の儀式
 function c60369732.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,62420419)
+	aux.AddRitualProcGreaterCode(c,8,62420419)
 end

--- a/c62835876.lua
+++ b/c62835876.lua
@@ -1,6 +1,6 @@
 --善悪の彼岸
 function c62835876.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,35330871)
+	aux.AddRitualProcGreaterCode(c,6,35330871)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)

--- a/c72446038.lua
+++ b/c72446038.lua
@@ -1,4 +1,4 @@
 --合成魔術
 function c72446038.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,84385264)
+	aux.AddRitualProcGreaterCode(c,6,84385264)
 end

--- a/c76792184.lua
+++ b/c76792184.lua
@@ -1,4 +1,4 @@
 --カオス－黒魔術の儀式
 function c76792184.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,30208479)
+	aux.AddRitualProcGreaterCode(c,8,30208479)
 end

--- a/c76806714.lua
+++ b/c76806714.lua
@@ -1,4 +1,4 @@
 --亀の誓い
 function c76806714.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,91782219)
+	aux.AddRitualProcGreaterCode(c,8,91782219)
 end

--- a/c77454922.lua
+++ b/c77454922.lua
@@ -1,4 +1,4 @@
 --要塞クジラの誓い
 function c77454922.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,62337487)
+	aux.AddRitualProcGreaterCode(c,7,62337487)
 end

--- a/c78577570.lua
+++ b/c78577570.lua
@@ -1,4 +1,4 @@
 --ガルマソードの誓い
 function c78577570.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,90844184)
+	aux.AddRitualProcGreaterCode(c,7,90844184)
 end

--- a/c79306385.lua
+++ b/c79306385.lua
@@ -9,6 +9,7 @@ function c79306385.initial_effect(c)
 	e1:SetOperation(c79306385.activate)
 	c:RegisterEffect(e1)
 end
+c79306385.fit_monster={48546368}
 function c79306385.filter(c,e,tp,m)
 	if not c:IsCode(48546368) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
 	local mg=m:Filter(Card.IsCanBeRitualMaterial,c,c)

--- a/c80566312.lua
+++ b/c80566312.lua
@@ -1,6 +1,6 @@
 --祝祷の聖歌
 function c80566312.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,56350972)
+	aux.AddRitualProcGreaterCode(c,6,56350972)
 	--destroy replace
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c80811661.lua
+++ b/c80811661.lua
@@ -1,4 +1,4 @@
 --ハンバーガーのレシピ
 function c80811661.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,30243636)
+	aux.AddRitualProcGreaterCode(c,6,30243636)
 end

--- a/c81756897.lua
+++ b/c81756897.lua
@@ -1,4 +1,4 @@
 --ゼラの儀式
 function c81756897.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,69123138)
+	aux.AddRitualProcGreaterCode(c,8,69123138)
 end

--- a/c81933259.lua
+++ b/c81933259.lua
@@ -1,4 +1,4 @@
 --悪魔鏡の儀式
 function c81933259.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,31890399)
+	aux.AddRitualProcGreaterCode(c,6,31890399)
 end

--- a/c94377247.lua
+++ b/c94377247.lua
@@ -1,4 +1,4 @@
 --仮面魔獣の儀式
 function c94377247.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,49064413)
+	aux.AddRitualProcGreaterCode(c,8,49064413)
 end

--- a/c96420087.lua
+++ b/c96420087.lua
@@ -1,4 +1,4 @@
 --闇の支配者との契約
 function c96420087.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,97642679)
+	aux.AddRitualProcGreaterCode(c,8,97642679)
 end

--- a/c9786492.lua
+++ b/c9786492.lua
@@ -1,4 +1,4 @@
 --白竜降臨
 function c9786492.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,73398797)
+	aux.AddRitualProcGreaterCode(c,4,73398797)
 end

--- a/c9845733.lua
+++ b/c9845733.lua
@@ -1,4 +1,4 @@
 --覚醒の証
 function c9845733.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,10789972)
+	aux.AddRitualProcGreaterCode(c,4,10789972)
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1158,39 +1158,39 @@ function Auxiliary.AddFusionProcCodeFunRep(c,code1,f,minc,maxc,sub,insf)
 	c:RegisterEffect(e1)
 end
 --Ritual Summon, geq fixed lv
-function Auxiliary.AddRitualProcGreater(c,filter)
+function Auxiliary.AddRitualProcGreater(c,lv,filter)
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetTarget(Auxiliary.RPGTarget(filter))
-	e1:SetOperation(Auxiliary.RPGOperation(filter))
+	e1:SetTarget(Auxiliary.RPGTarget(lv,filter))
+	e1:SetOperation(Auxiliary.RPGOperation(lv,filter))
 	c:RegisterEffect(e1)
 end
-function Auxiliary.RPGFilter(c,filter,e,tp,m)
+function Auxiliary.RPGFilter(c,lv,filter,e,tp,m)
 	if (filter and not filter(c)) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
 	local mg=m:Filter(Card.IsCanBeRitualMaterial,c,c)
-	return mg:CheckWithSumGreater(Card.GetRitualLevel,c:GetOriginalLevel(),c)
+	return mg:CheckWithSumGreater(Card.GetRitualLevel,lv,c)
 end
-function Auxiliary.RPGTarget(filter)
+function Auxiliary.RPGTarget(lv,filter)
 	return	function(e,tp,eg,ep,ev,re,r,rp,chk)
 				if chk==0 then
 					local mg=Duel.GetRitualMaterial(tp)
-					return Duel.IsExistingMatchingCard(Auxiliary.RPGFilter,tp,LOCATION_HAND,0,1,nil,filter,e,tp,mg)
+					return Duel.IsExistingMatchingCard(Auxiliary.RPGFilter,tp,LOCATION_HAND,0,1,nil,lv,filter,e,tp,mg)
 				end
 				Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 			end
 end
-function Auxiliary.RPGOperation(filter)
+function Auxiliary.RPGOperation(lv,filter)
 	return	function(e,tp,eg,ep,ev,re,r,rp)
 				local mg=Duel.GetRitualMaterial(tp)
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-				local tg=Duel.SelectMatchingCard(tp,Auxiliary.RPGFilter,tp,LOCATION_HAND,0,1,1,nil,filter,e,tp,mg)
+				local tg=Duel.SelectMatchingCard(tp,Auxiliary.RPGFilter,tp,LOCATION_HAND,0,1,1,nil,lv,filter,e,tp,mg)
 				local tc=tg:GetFirst()
 				if tc then
 					mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
 					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-					local mat=mg:SelectWithSumGreater(tp,Card.GetRitualLevel,tc:GetOriginalLevel(),tc)
+					local mat=mg:SelectWithSumGreater(tp,Card.GetRitualLevel,lv,tc)
 					tc:SetMaterial(mat)
 					Duel.ReleaseRitualMaterial(mat)
 					Duel.BreakEffect()
@@ -1199,48 +1199,48 @@ function Auxiliary.RPGOperation(filter)
 				end
 			end
 end
-function Auxiliary.AddRitualProcGreaterCode(c,code1)
+function Auxiliary.AddRitualProcGreaterCode(c,lv,code1)
 	if c.fit_monster==nil then
 		local code=c:GetOriginalCode()
 		local mt=_G["c" .. code]
 		mt.fit_monster={code1}
 	end
-	Auxiliary.AddRitualProcGreater(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1))
+	Auxiliary.AddRitualProcGreater(c,lv,Auxiliary.FilterBoolFunction(Card.IsCode,code1))
 end
 --Ritual Summon, equal to fixed lv
-function Auxiliary.AddRitualProcEqual(c,filter)
+function Auxiliary.AddRitualProcEqual(c,lv,filter)
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetTarget(Auxiliary.RPETarget(filter))
-	e1:SetOperation(Auxiliary.RPEOperation(filter))
+	e1:SetTarget(Auxiliary.RPETarget(lv,filter))
+	e1:SetOperation(Auxiliary.RPEOperation(lv,filter))
 	c:RegisterEffect(e1)
 end
-function Auxiliary.RPEFilter(c,filter,e,tp,m)
+function Auxiliary.RPEFilter(c,lv,filter,e,tp,m)
 	if (filter and not filter(c)) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
 	local mg=m:Filter(Card.IsCanBeRitualMaterial,c,c)
-	return mg:CheckWithSumEqual(Card.GetRitualLevel,c:GetOriginalLevel(),1,99,c)
+	return mg:CheckWithSumEqual(Card.GetRitualLevel,lv,1,99,c)
 end
-function Auxiliary.RPETarget(filter)
+function Auxiliary.RPETarget(lv,filter)
 	return	function(e,tp,eg,ep,ev,re,r,rp,chk)
 				if chk==0 then
 					local mg=Duel.GetRitualMaterial(tp)
-					return Duel.IsExistingMatchingCard(Auxiliary.RPEFilter,tp,LOCATION_HAND,0,1,nil,filter,e,tp,mg)
+					return Duel.IsExistingMatchingCard(Auxiliary.RPEFilter,tp,LOCATION_HAND,0,1,nil,lv,filter,e,tp,mg)
 				end
 				Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 			end
 end
-function Auxiliary.RPEOperation(filter)
+function Auxiliary.RPEOperation(lv,filter)
 	return	function(e,tp,eg,ep,ev,re,r,rp)
 				local mg=Duel.GetRitualMaterial(tp)
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-				local tg=Duel.SelectMatchingCard(tp,Auxiliary.RPEFilter,tp,LOCATION_HAND,0,1,1,nil,filter,e,tp,mg)
+				local tg=Duel.SelectMatchingCard(tp,Auxiliary.RPEFilter,tp,LOCATION_HAND,0,1,1,nil,lv,filter,e,tp,mg)
 				local tc=tg:GetFirst()
 				if tc then
 					mg=mg:Filter(Card.IsCanBeRitualMaterial,tc,tc)
 					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-					local mat=mg:SelectWithSumEqual(tp,Card.GetRitualLevel,tc:GetOriginalLevel(),1,99,tc)
+					local mat=mg:SelectWithSumEqual(tp,Card.GetRitualLevel,lv,1,99,tc)
 					tc:SetMaterial(mat)
 					Duel.ReleaseRitualMaterial(mat)
 					Duel.BreakEffect()
@@ -1249,13 +1249,13 @@ function Auxiliary.RPEOperation(filter)
 				end
 			end
 end
-function Auxiliary.AddRitualProcEqualCode(c,code1)
+function Auxiliary.AddRitualProcEqualCode(c,lv,code1)
 	if c.fit_monster==nil then
 		local code=c:GetOriginalCode()
 		local mt=_G["c" .. code]
 		mt.fit_monster={code1}
 	end
-	Auxiliary.AddRitualProcEqual(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1))
+	Auxiliary.AddRitualProcEqual(c,lv,Auxiliary.FilterBoolFunction(Card.IsCode,code1))
 end
 --Ritual Summon, equal to monster lv
 function Auxiliary.AddRitualProcEqual2(c,filter)
@@ -1313,7 +1313,10 @@ function Auxiliary.AddRitualProcEqual2Code2(c,code1,code2)
 		local mt=_G["c" .. code]
 		mt.fit_monster={code1,code2}
 	end
-	Auxiliary.AddRitualProcEqual2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1,code2))
+	Auxiliary.AddRitualProcEqual2(c,Auxiliary.RitualProcCode2Filter(code1,code2))
+end
+function Auxiliary.RitualProcCode2Filter(c,code1,code2)
+	return c:IsCode(code1) or c:IsCode(code2)
 end
 --add procedure to Pendulum monster, also allows registeration of activation effect
 function Auxiliary.EnablePendulumAttribute(c,reg)


### PR DESCRIPTION
「超戦士の儀式」 said tribute level 8 to ritual summon Chaos Soldier, if there was a level 6 Chaos Soldier, it needs level 8 to ritual summon by 「超戦士の儀式」 too. So I think a fixed level should be given by ritual spell cards. 

also, c27383110.lua, c45410988.lua, c79306385.lua needs c???.fit_monster={}. 