### PR TITLE
fix

### DIFF
--- a/c23187256.lua
+++ b/c23187256.lua
@@ -33,8 +33,14 @@ function c23187256.initial_effect(c)
 	local e4=e3:Clone()
 	e4:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
 	c:RegisterEffect(e4)
+	if not c23187256.xyz_filter then
+		c23187256.xyz_filter=function(mc)
+			return mc:IsType(TYPE_XYZ) and mc:IsSetCard(0x48) and mc:GetOverlayCount()>0 and mc:IsCanBeXyzMaterial(c)
+		end
+	end
 end
 c23187256.xyz_number=93
+c23187256.xyz_count=2
 function c23187256.mfilter(c,xyzc)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsSetCard(0x48) and c:GetOverlayCount()>0 and c:IsCanBeXyzMaterial(xyzc)
 end
@@ -44,32 +50,59 @@ end
 function c23187256.xyzfilter2(c,rk)
 	return c:GetRank()==rk
 end
-function c23187256.xyzcon(e,c,og)
+function c23187256.xyzcon(e,c,og,min,max)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local ct=math.max(1,-ft)
-	local mg=Duel.GetMatchingGroup(c23187256.mfilter,tp,LOCATION_MZONE,0,nil,c)
-	return mg:IsExists(c23187256.xyzfilter1,1,nil,mg,ct)
+	local minc=2
+	local maxc=64
+	if min then
+		minc=math.max(minc,min)
+		maxc=max
+	end
+	local ct=math.max(minc-1,-ft)
+	local mg=nil
+	if og then
+		mg=og:Filter(c23187256.mfilter,nil,c)
+	else
+		mg=Duel.GetMatchingGroup(c23187256.mfilter,tp,LOCATION_MZONE,0,nil,c)
+	end
+	return maxc>=2 and mg:IsExists(c23187256.xyzfilter1,1,nil,mg,ct)
 end
-function c23187256.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local ct=math.max(1,-ft)
-	local mg=Duel.GetMatchingGroup(c23187256.mfilter,tp,LOCATION_MZONE,0,nil,c)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-	local g1=mg:FilterSelect(tp,c23187256.xyzfilter1,1,1,nil,mg,ct)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-	local g2=mg:FilterSelect(tp,c23187256.xyzfilter2,ct,63,g1:GetFirst(),g1:GetFirst():GetRank())
-	g1:Merge(g2)
+function c23187256.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
+	local g=nil
+	if og and not min then
+		g=og
+	else
+		local mg=nil
+		if og then
+			mg=og:Filter(c23187256.mfilter,nil,c)
+		else
+			mg=Duel.GetMatchingGroup(c23187256.mfilter,tp,LOCATION_MZONE,0,nil,c)
+		end
+		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		local minc=2
+		local maxc=64
+		if min then
+			minc=math.max(minc,min)
+			maxc=max
+		end
+		local ct=math.max(minc-1,-ft)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+		g=mg:FilterSelect(tp,c23187256.xyzfilter1,1,1,nil,mg,ct)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+		local g2=mg:FilterSelect(tp,c23187256.xyzfilter2,ct,maxc-1,g:GetFirst(),g:GetFirst():GetRank())
+		g:Merge(g2)
+	end
 	local sg=Group.CreateGroup()
-	local tc=g1:GetFirst()
+	local tc=g:GetFirst()
 	while tc do
 		sg:Merge(tc:GetOverlayGroup())
-		tc=g1:GetNext()
+		tc=g:GetNext()
 	end
 	Duel.SendtoGrave(sg,REASON_RULE)
-	c:SetMaterial(g1)
-	Duel.Overlay(c,g1)
+	c:SetMaterial(g)
+	Duel.Overlay(c,g)
 end
 function c23187256.filter(c,e,tp)
 	return c:IsRankBelow(9) and c:IsAttackBelow(3000) and c:IsSetCard(0x48)

--- a/c57707471.lua
+++ b/c57707471.lua
@@ -8,6 +8,7 @@ function c57707471.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
 	e1:SetRange(LOCATION_EXTRA)
 	e1:SetCondition(c57707471.xyzcon)
+	e1:SetTarget(c57707471.xyztg)
 	e1:SetOperation(c57707471.xyzop)
 	e1:SetValue(SUMMON_TYPE_XYZ)
 	c:RegisterEffect(e1)
@@ -39,27 +40,45 @@ function c57707471.ovfilter(c,tp,xyzc)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:GetRank()==5 and c:IsCanBeXyzMaterial(xyzc)
 		and c:CheckRemoveOverlayCard(tp,1,REASON_COST)
 end
-function c57707471.xyzcon(e,c,og)
+function c57707471.xyzcon(e,c,og,min,max)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local ct=-ft
 	if 2<=ct then return false end
+	if min and (min>2 or max<2) then return false end
 	if ct<1 and not og and Duel.IsExistingMatchingCard(c57707471.ovfilter,tp,LOCATION_MZONE,0,1,nil,tp,c) then
 		return true
 	end
 	return Duel.CheckXyzMaterial(c,nil,6,2,2,og)
 end
-function c57707471.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og)
-	if og then
+function c57707471.xyztg(e,tp,eg,ep,ev,re,r,rp,chk,c,og,min,max)
+	if og and not min then
+		return true
+	end
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local ct=-ft
+	local b1=Duel.CheckXyzMaterial(c,nil,6,2,2,og)
+	local b2=ct<1 and not og and Duel.IsExistingMatchingCard(c57707471.ovfilter,tp,LOCATION_MZONE,0,1,nil)
+	if b2 and (not b1 or Duel.SelectYesNo(tp,aux.Stringid(57707471,0))) then
+		e:SetLabel(1)
+		return true
+	else
+		e:SetLabel(0)
+		local g=Duel.SelectXyzMaterial(tp,c,nil,6,2,2,og)
+		if g then
+			g:KeepAlive()
+			e:SetLabelObject(g)
+			return true
+		else return false end
+	end
+end
+function c57707471.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
+	if og and not min then
 		c:SetMaterial(og)
 		Duel.Overlay(c,og)
 	else
-		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-		local ct=-ft
-		local b1=Duel.CheckXyzMaterial(c,nil,6,2,2,og)
-		local b2=ct<1 and Duel.IsExistingMatchingCard(c57707471.ovfilter,tp,LOCATION_MZONE,0,1,nil,tp,c)
-		if b2 and (not b1 or Duel.SelectYesNo(tp,aux.Stringid(57707471,0))) then
+		if e:GetLabel()==1 then
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
 			local mg=Duel.SelectMatchingCard(tp,c57707471.ovfilter,tp,LOCATION_MZONE,0,1,1,nil,tp,c)
 			mg:GetFirst():RemoveOverlayCard(tp,1,1,REASON_COST)
@@ -70,9 +89,10 @@ function c57707471.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og)
 			c:SetMaterial(mg)
 			Duel.Overlay(c,mg)
 		else
-			local mg=Duel.SelectXyzMaterial(tp,c,nil,6,2,2)
+			local mg=e:GetLabelObject()
 			c:SetMaterial(mg)
 			Duel.Overlay(c,mg)
+			mg:DeleteGroup()
 		end
 	end
 end

--- a/c65305468.lua
+++ b/c65305468.lua
@@ -59,7 +59,7 @@ end
 function c65305468.xyzfilter2(c,rk)
 	return c:GetRank()==rk
 end
-function c65305468.xyzcon(e,c,og)
+function c65305468.xyzcon(e,c,og,min,max)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=nil
@@ -69,12 +69,13 @@ function c65305468.xyzcon(e,c,og)
 		mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil,c)
 	end
 	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and (not min or min<=2 and max>=2)
 		and mg:IsExists(c65305468.xyzfilter1,1,nil,mg)
 end
-function c65305468.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og)
+function c65305468.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
 	local g=nil
 	local sg=Group.CreateGroup()
-	if og then
+	if og and not min then
 		g=og
 		local tc=og:GetFirst()
 		while tc do
@@ -82,7 +83,12 @@ function c65305468.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og)
 			tc=og:GetNext()
 		end
 	else
-		local mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil)
+		local mg=nil
+		if og then
+			mg=og:Filter(c65305468.mfilter,nil,c)
+		else
+			mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil,c)
+		end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
 		g=mg:FilterSelect(tp,c65305468.xyzfilter1,1,1,nil,mg)
 		local tc1=g:GetFirst()


### PR DESCRIPTION
SNo.0 can be special summoned by 輝望道
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17941&keyword=&tag=-1
....墓地の「No.39 希望皇ホープ」、「CNo.39 希望皇ホープレイ」、「SNo.39 希望皇ホープONE」を選択しました。...
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17938&keyword=&tag=-1
.....「SNo.0 ホープ・ゼアル」のように、『①：このカードのX召喚は無効化されない』効果を持つエクシーズモンスターがエクシーズ召喚される場合には、「ライオウ」の効果によって無効にする事はできません....

xyz_filter and xyz_count seems unnecessary now.