### PR TITLE
fix No.38

### DIFF
--- a/c63767246.lua
+++ b/c63767246.lua
@@ -30,7 +30,7 @@ function c63767246.initial_effect(c)
 	e3:SetDescription(aux.Stringid(63767246,2))
 	e3:SetCategory(CATEGORY_ATKCHANGE)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
 	e3:SetCode(EVENT_DESTROYED)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCondition(c63767246.atkcon)
@@ -52,6 +52,7 @@ function c63767246.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
 	if c:IsRelateToEffect(e) and rc:IsRelateToEffect(re) then
+		rc:CancelToGrave()
 		Duel.Overlay(c,Group.FromCards(rc))
 	end
 end


### PR DESCRIPTION
Fix: The spell card negated by it will go to Overlay and then go to grave.
Fix: The atk up effect will miss timing.