### PR TITLE
fix Raidraptor - Last Strix

### DIFF
--- a/c97219708.lua
+++ b/c97219708.lua
@@ -4,7 +4,7 @@ function c97219708.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(97219708,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_RECOVER)
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_QUICK_O)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
 	e1:SetCode(EVENT_PRE_DAMAGE_CALCULATE)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCondition(c97219708.reccon)
@@ -29,7 +29,8 @@ function c97219708.reccon(e,tp,eg,ep,ev,re,r,rp)
 	return (tc:IsControler(tp) and tc:IsSetCard(0xba)) or (at and at:IsControler(tp) and at:IsSetCard(0xba))
 end
 function c97219708.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING) and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and not e:GetHandler():IsStatus(STATUS_CHAINING) and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_ONFIELD+LOCATION_GRAVE,0,1,nil,TYPE_SPELL+TYPE_TRAP) end
 	local ct=Duel.GetMatchingGroupCount(Card.IsType,tp,LOCATION_ONFIELD+LOCATION_GRAVE,0,nil,TYPE_SPELL+TYPE_TRAP)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
@@ -37,12 +38,15 @@ function c97219708.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c97219708.recop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
 		local ct=Duel.GetMatchingGroupCount(Card.IsType,tp,LOCATION_ONFIELD+LOCATION_GRAVE,0,nil,TYPE_SPELL+TYPE_TRAP)
 		if ct>0 then
 			Duel.BreakEffect()
 			Duel.Recover(tp,ct*100,REASON_EFFECT)
 		end
+	elseif Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then
+		Duel.SendtoGrave(c,REASON_EFFECT)
 	end
 end
 function c97219708.spfilter(c,e,tp)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17685&keyword=&tag=-1
...チェーン1にて発動した「RR－ラスト・ストリクス」はモンスターゾーンに空きがなく特殊召喚する事ができませんので、墓地へ送られる事になります。