### PR TITLE
fix Electromagnetic Bagworm, Double Magical Arm Bind

### DIFF
--- a/c72621670.lua
+++ b/c72621670.lua
@@ -53,8 +53,11 @@ function c72621670.activate(e,tp,eg,ep,ev,re,r,rp)
 		dg:Clear()
 	end
 	local tc=sg:GetFirst()
+	local tct=1
+	if Duel.GetTurnPlayer()~=tp then tct=2
+	elseif Duel.GetCurrentPhase()==PHASE_END then tct=3 end
 	while tc do
-		Duel.GetControl(tc,tp,PHASE_END+RESET_SELF_TURN,1)
+		Duel.GetControl(tc,tp,PHASE_END+RESET_SELF_TURN,tct)
 		tc=sg:GetNext()
 	end
 	if dg:GetCount()>0 then Duel.Destroy(dg,REASON_RULE) end

--- a/c7914843.lua
+++ b/c7914843.lua
@@ -30,7 +30,10 @@ function c7914843.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c7914843.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and not Duel.GetControl(tc,tp,PHASE_END+RESET_SELF_TURN,1) then
+	local tct=1
+	if Duel.GetTurnPlayer()~=tp then tct=2
+	elseif Duel.GetCurrentPhase()==PHASE_END then tct=3 end
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and not Duel.GetControl(tc,tp,PHASE_END,tct) then
 		if not tc:IsImmuneToEffect(e) and tc:IsAbleToChangeControler() then
 			Duel.Destroy(tc,REASON_EFFECT)
 		end


### PR DESCRIPTION
Fix this: If you activated Electromagnetic Bagworm's flip effect during your End Phase,  shift control to its owner during the End Phase.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分エンドフェイズにリバースした「電磁ミノ虫」の効果で相手の「キメラテック・オーバー・ドラゴン」のコントロールを得た場合どのタイミングで「キメラテック・オーバー・ドラゴン」のコントロールは戻りますか？ 
A. 
ご質問の状況の場合、「キメラテック・オーバー・ドラゴン」のコントロールは、「電磁ミノ虫」が『①』の効果を発動したエンドフェイズ中までではなく、次の自分のターンのエンドフェイズまでコントロールを得ます。