### PR TITLE
Fix Chaofeng, Phantom of the Yang Zing

### DIFF
--- a/c19048328.lua
+++ b/c19048328.lua
@@ -64,7 +64,7 @@ end
 function c19048328.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsReason(REASON_DESTROY) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
-		and c:GetSummonType()==SUMMON_TYPE_SYNCHRO
+		and c:IsPreviousLocation(LOCATION_MZONE) and c:GetSummonType()==SUMMON_TYPE_SYNCHRO
 end
 function c19048328.thfilter(c)
 	return c:IsType(TYPE_TUNER) and c:IsAbleToHand()


### PR DESCRIPTION
If the synchro summon of Chaofeng is negated you are still able to search. That shouldn't happen since it's not properly synchro summoned. Add a check for previous location MZONE.