### PR TITLE
fix ChangeAttackTarget

### DIFF
--- a/c21558682.lua
+++ b/c21558682.lua
@@ -49,7 +49,7 @@ end
 function c21558682.atkop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
 		Duel.ChangeAttackTarget(tc)
 	end
 end

--- a/c42256406.lua
+++ b/c42256406.lua
@@ -48,7 +48,10 @@ function c42256406.cbcon(e,tp,eg,ep,ev,re,r,rp)
 	return r~=REASON_REPLACE and c~=bt and bt:IsFaceup() and bt:GetControler()==c:GetControler()
 end
 function c42256406.cbop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.ChangeAttackTarget(e:GetHandler())
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
+		Duel.ChangeAttackTarget(c)
+	end
 end
 function c42256406.defcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeckAsCost(tp,1) end

--- a/c59170782.lua
+++ b/c59170782.lua
@@ -72,7 +72,7 @@ function c59170782.tgcon2(e,tp,eg,ep,ev,re,r,rp)
 end
 function c59170782.tgop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
 		Duel.ChangeAttackTarget(c)
 	end
 end

--- a/c59560625.lua
+++ b/c59560625.lua
@@ -37,7 +37,7 @@ function c59560625.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c59560625.activate1(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
 		Duel.ChangeAttackTarget(tc)
 	end
 end

--- a/c59965151.lua
+++ b/c59965151.lua
@@ -26,7 +26,10 @@ function c59965151.cbcon(e,tp,eg,ep,ev,re,r,rp)
 	return c~=bt and bt:IsFaceup() and bt:GetControler()==c:GetControler()
 end
 function c59965151.cbop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.ChangeAttackTarget(e:GetHandler())
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
+		Duel.ChangeAttackTarget(c)
+	end
 end
 function c59965151.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsReason(REASON_DESTROY)

--- a/c69937550.lua
+++ b/c69937550.lua
@@ -39,5 +39,8 @@ function c69937550.cbcondition(e,tp,eg,ep,ev,re,r,rp)
 	return r~=REASON_REPLACE and c~=bt and bt:IsFaceup() and bt:IsSetCard(0x1034) and bt:GetControler()==c:GetControler()
 end
 function c69937550.cboperation(e,tp,eg,ep,ev,re,r,rp)
-	Duel.ChangeAttackTarget(e:GetHandler())
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
+		Duel.ChangeAttackTarget(c)
+	end
 end

--- a/c79473793.lua
+++ b/c79473793.lua
@@ -57,5 +57,8 @@ function c79473793.cbcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(g,REASON_COST)
 end
 function c79473793.cbop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.ChangeAttackTarget(e:GetHandler())
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
+		Duel.ChangeAttackTarget(c)
+	end
 end

--- a/c81983656.lua
+++ b/c81983656.lua
@@ -68,7 +68,7 @@ function c81983656.cbtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c81983656.cbop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and not Duel.GetAttacker():IsImmuneToEffect(e) then
 		Duel.ChangeAttackTarget(tc)
 	end
 end


### PR DESCRIPTION
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「BF T－漆黒のホーク・ジョー」を攻撃対象に「星態龍」が攻撃宣言した場合「BF T－漆黒のホーク・ジョー」の②の効果を発動できますか？ 
A. 
ご質問の場合、「BF T－漆黒のホーク・ジョー」の『②』の効果を発動する事はできますが、「星態龍」はカードの効果を受けないため攻撃対象を変更する事はできません。

Q. 
「カードガンナー」を攻撃対象に「星態龍」が攻撃宣言した場合「カードブロッカー」の『自分フィールド上に表側表示で存在するモンスターが攻撃対象に選択された時、このカードに攻撃対象を変更する事ができる』の効果を発動できますか？ 
A. 
「星態龍」が攻撃宣言を行った場合、自身の永続効果が適用される事で、自身以外のカードの効果を受けなくなります。 
そのため、ご質問の状況において「カードブロッカー」の効果を発動する事はできますが、『このカードに攻撃対象を変更する事ができる。』効果を、「星態龍」が受けない為、最終的に「星態龍」が一番最初に攻撃対象に選択したモンスターに攻撃を行う事になります。