### PR TITLE
fix Assault Revival

### DIFF
--- a/c56252810.lua
+++ b/c56252810.lua
@@ -35,7 +35,7 @@ function c56252810.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c56252810.activate(e,tp,eg,ep,ev,re,r,rp)
 	local dg=Duel.GetMatchingGroup(Card.IsDestructable,tp,LOCATION_MZONE,0,nil)
-	Duel.Destroy(dg,REASON_EFFECT)
+	if Duel.Destroy(dg,REASON_EFFECT)~=dg:GetCount() then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local tc=Duel.GetFirstTarget()
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix this: If you didn't destroy all monsters by Assault Revival's effect, that target monster Special Summon.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7996&keyword=&tag=-1
Q.「Re－BUSTER」の効果の処理を行う際に、自分フィールド上のモンスターを破壊できなかった場合、「／バスター」と名のついたモンスターを特殊召喚する効果は適用されますか？
また、自分フィールド上に複数体のモンスターが存在し、そのうち1体が魔法カードの効果を受けない「ホルスの黒炎竜 LV６」等だった場合、自分フィールド上のモンスターを全て破壊する事ができませんが、その場合でも「／バスター」と名のついたモンスターを特殊召喚する効果は適用されますか？
A.「Re－BUSTER」の効果の処理を行う際に、自分フィールド上のモンスターを破壊できなかった場合、特殊召喚する効果は適用されません。
また、魔法カードの効果を受けない「ホルスの黒炎竜 LV６」が存在する場合、「ホルスの黒炎竜 LV６」以外の、他のモンスターが破壊されますが、全てのモンスターを破壊していない為、墓地から「／バスター」と名のついたモンスターを特殊召喚する事はできません。 