### PR TITLE
fix Buster Dragon

### DIFF
--- a/c11790356.lua
+++ b/c11790356.lua
@@ -71,6 +71,7 @@ function c11790356.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and Duel.IsExistingMatchingCard(c11790356.filter2,tp,LOCATION_GRAVE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,c11790356.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,nil,1,tp,LOCATION_GRAVE)
 end
 function c11790356.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
@@ -78,7 +79,7 @@ function c11790356.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local sg=Duel.SelectMatchingCard(tp,c11790356.filter2,tp,LOCATION_GRAVE,0,1,1,nil)
 	local sc=sg:GetFirst()
-	if sc and not sc:IsHasEffect(EFFECT_NECRO_VALLEY) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if sc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		if not Duel.Equip(tp,sc,tc,true) then return end
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c11790356.lua
+++ b/c11790356.lua
@@ -78,7 +78,7 @@ function c11790356.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local sg=Duel.SelectMatchingCard(tp,c11790356.filter2,tp,LOCATION_GRAVE,0,1,1,nil)
 	local sc=sg:GetFirst()
-	if sc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if sc and not sc:IsHasEffect(EFFECT_NECRO_VALLEY) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		if not Duel.Equip(tp,sc,tc,true) then return end
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
Fix this: If Necrovalley is on the field, Buster Dragon's equipping effect apply.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「王家の眠る谷－ネクロバレー」が存在する場合に「破戒蛮竜－バスター・ドラゴン」の③の効果を発動できますか？ 
A. 
ご質問の状況の場合でも、「破戒蛮竜－バスター・ドラゴン」の『③』の効果を発動はできますが、その効果は「王家の眠る谷－ネクロバレー」の効果で無効化されます。