### PR TITLE
fix Majester Paladin, Majespecter Cat

### DIFF
--- a/c5506791.lua
+++ b/c5506791.lua
@@ -9,6 +9,7 @@ function c5506791.initial_effect(c)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e2:SetCountLimit(1,5506791)
+	e2:SetTarget(c5506791.regtg)
 	e2:SetOperation(c5506791.regop)
 	c:RegisterEffect(e2)
 	local e3=e2:Clone()
@@ -33,6 +34,9 @@ function c5506791.initial_effect(c)
 end
 function c5506791.thfilter(c)
 	return c:IsSetCard(0xd0) and c:IsAbleToHand()
+end
+function c5506791.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_DECK,0,1,nil,0xd0) end
 end
 function c5506791.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c88722973.lua
+++ b/c88722973.lua
@@ -9,6 +9,7 @@ function c88722973.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetCondition(c88722973.regcon)
+	e1:SetTarget(c88722973.regtg)
 	e1:SetOperation(c88722973.regop)
 	c:RegisterEffect(e1)
 	--spsummon
@@ -24,6 +25,9 @@ function c88722973.initial_effect(c)
 end
 function c88722973.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_XYZ
+end
+function c88722973.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_DECK,0,1,nil,TYPE_PENDULUM) end
 end
 function c88722973.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())


### PR DESCRIPTION
Fix this: If you doesn't have Pendulum Monster or Majespecter card from your Deck, Majester Paladin and Majespecter Cat can activate effect.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
先日お問い合わせいただきました内容につきまして、制作担当部署へのルールの確認ができましたので、下記のとおりご案内申し上げます。 

Q. 
デッキにペンデュラムモンスターが存在しない場合に「昇竜剣士マジェスターP」をエクシーズ召喚した場合「昇竜剣士マジェスターP」の①の効果を発動できますか？ 
Q. 
また、デッキに「マジェスペクター」カードが存在しない場合に「マジェスペクター・キャット」を召喚した場合「マジェスペクター・キャット」の①の効果を発動できますか？ 
A. 
デッキの中にペンデュラムモンスターや「マジェスペクター」と名のついたカードがない場合、「昇竜剣士マジェスターP」や「マジェスペクター・キャット」の『①』の効果を発動する事はできません。