### PR TITLE
fix A Deal with Dark Ruler

### DIFF
--- a/c6850209.lua
+++ b/c6850209.lua
@@ -27,7 +27,7 @@ end
 function c6850209.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
 	while tc do
-		if tc:IsLevelAbove(8) and tc:IsPreviousLocation(LOCATION_ONFIELD) then
+		if tc:IsLevelAbove(8) and tc:IsPreviousLocation(LOCATION_MZONE) then
 			c6850209[tc:GetPreviousControler()]=true
 		end
 		tc=eg:GetNext()


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12700&keyword=&tag=-1
装備カード扱いとなっているレベル8以上のモンスターが墓地へ送られている場合には、「デーモンとの駆け引き」を発動する事はできません。