### PR TITLE
fix Ritual Beast Ulti and so on

### DIFF
--- a/c11502550.lua
+++ b/c11502550.lua
@@ -49,7 +49,7 @@ function c11502550.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c11502550.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c11502550.spcon(e,c)
 	if c==nil then return true end 

--- a/c12678870.lua
+++ b/c12678870.lua
@@ -40,11 +40,11 @@ function c12678870.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c12678870.spfilter1(c,tp)
-	return c:IsSetCard(0x10b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
+	return c:IsFusionSetCard(0x10b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
 		and Duel.IsExistingMatchingCard(c12678870.spfilter2,tp,LOCATION_MZONE,0,1,c)
 end
 function c12678870.spfilter2(c)
-	return c:IsSetCard(0x20b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
+	return c:IsFusionSetCard(0x20b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
 end
 function c12678870.sprcon(e,c)
 	if c==nil then return true end

--- a/c17032740.lua
+++ b/c17032740.lua
@@ -52,7 +52,7 @@ function c17032740.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c17032740.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c17032740.spcon(e,c)
 	if c==nil then return true end 

--- a/c2111707.lua
+++ b/c2111707.lua
@@ -35,7 +35,7 @@ function c2111707.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA+LOCATION_GRAVE)
 end
 function c2111707.spfilter(c,code)
-	return c:IsCode(code) and c:IsAbleToRemoveAsCost()
+	return c:IsFusionCode(code) and c:IsAbleToRemoveAsCost()
 end
 function c2111707.spcon(e,c)
 	if c==nil then return true end 

--- a/c2129638.lua
+++ b/c2129638.lua
@@ -61,7 +61,7 @@ function c2129638.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
 end
 function c2129638.spfilter(c,fc)
-	return c:IsCode(89631139) and c:IsCanBeFusionMaterial(fc) and c:IsAbleToGraveAsCost()
+	return c:IsFusionCode(89631139) and c:IsCanBeFusionMaterial(fc) and c:IsAbleToGraveAsCost()
 end
 function c2129638.spcon(e,c)
 	if c==nil then return true end

--- a/c22638495.lua
+++ b/c22638495.lua
@@ -49,7 +49,7 @@ function c22638495.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c22638495.spfilter1(c,tp,fc)
-	return c:IsSetCard(0xc7) and c:IsType(TYPE_PENDULUM) and c:IsCanBeFusionMaterial(fc)
+	return c:IsFusionSetCard(0xc7) and c:IsType(TYPE_PENDULUM) and c:IsCanBeFusionMaterial(fc)
 		and Duel.CheckReleaseGroup(tp,c22638495.spfilter2,1,c,fc)
 end
 function c22638495.spfilter2(c,fc)

--- a/c25119460.lua
+++ b/c25119460.lua
@@ -35,7 +35,7 @@ function c25119460.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA+LOCATION_GRAVE)
 end
 function c25119460.spfilter(c,code)
-	return c:IsCode(code) and c:IsAbleToRemoveAsCost()
+	return c:IsFusionCode(code) and c:IsAbleToRemoveAsCost()
 end
 function c25119460.spcon(e,c)
 	if c==nil then return true end 

--- a/c27346636.lua
+++ b/c27346636.lua
@@ -38,11 +38,11 @@ function c27346636.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c27346636.spfilter1(c,tp)
-	return c:IsCode(78868776) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
+	return c:IsFusionCode(78868776) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 		and Duel.IsExistingMatchingCard(c27346636.spfilter2,tp,LOCATION_MZONE,0,2,c)
 end
 function c27346636.spfilter2(c)
-	return c:IsSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
+	return c:IsFusionSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
 end
 function c27346636.sprcon(e,c)
 	if c==nil then return true end 

--- a/c28677304.lua
+++ b/c28677304.lua
@@ -52,7 +52,7 @@ function c28677304.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c28677304.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c28677304.spcon(e,c)
 	if c==nil then return true end 

--- a/c29357956.lua
+++ b/c29357956.lua
@@ -52,7 +52,7 @@ function c29357956.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c29357956.spfilter(c)
-	return c:IsSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
+	return c:IsFusionSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
 end
 function c29357956.sprcon(e,c)
 	if c==nil then return true end

--- a/c43378048.lua
+++ b/c43378048.lua
@@ -39,7 +39,7 @@ function c43378048.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c43378048.spfilter(c,code)
-	return c:IsFaceup() and c:IsCode(code) and c:IsAbleToRemoveAsCost() 
+	return c:IsFaceup() and c:IsFusionCode(code) and c:IsAbleToRemoveAsCost() 
 end
 function c43378048.spcon(e,c)
 	if c==nil then return true end 

--- a/c48063985.lua
+++ b/c48063985.lua
@@ -44,11 +44,11 @@ function c48063985.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c48063985.spfilter1(c,tp)
-	return c:IsSetCard(0x10b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
+	return c:IsFusionSetCard(0x10b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
 		and Duel.IsExistingMatchingCard(c48063985.spfilter2,tp,LOCATION_MZONE,0,1,c)
 end
 function c48063985.spfilter2(c)
-	return c:IsSetCard(0x20b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
+	return c:IsFusionSetCard(0x20b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
 end
 function c48063985.sprcon(e,c)
 	if c==nil then return true end

--- a/c48156348.lua
+++ b/c48156348.lua
@@ -46,11 +46,11 @@ function c48156348.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c48156348.spfilter1(c,tp)
-	return c:IsCode(41470137) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
+	return c:IsFusionCode(41470137) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 		and Duel.IsExistingMatchingCard(c48156348.spfilter2,tp,LOCATION_MZONE,0,1,c)
 end
 function c48156348.spfilter2(c)
-	return c:IsSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
+	return c:IsFusionSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
 end
 function c48156348.sprcon(e,c)
 	if c==nil then return true end 

--- a/c48996569.lua
+++ b/c48996569.lua
@@ -52,7 +52,7 @@ function c48996569.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c48996569.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c48996569.spcon(e,c)
 	if c==nil then return true end 

--- a/c49352945.lua
+++ b/c49352945.lua
@@ -60,7 +60,7 @@ function c49352945.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c49352945.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c49352945.spcon(e,c)
 	if c==nil then return true end 

--- a/c5128859.lua
+++ b/c5128859.lua
@@ -34,10 +34,10 @@ function c5128859.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c5128859.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c5128859.spfilter2(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:GetOriginalCode()==code
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c5128859.spcon(e,c)
 	if c==nil then return true end 

--- a/c53315891.lua
+++ b/c53315891.lua
@@ -46,7 +46,7 @@ function c53315891.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c53315891.sprfilter(c,code)
-	return c:IsCode(code) and c:IsAbleToGraveAsCost()
+	return c:IsFusionCode(code) and c:IsAbleToGraveAsCost()
 end
 function c53315891.sprcon(e,c)
 	if c==nil then return true end 

--- a/c55171412.lua
+++ b/c55171412.lua
@@ -52,7 +52,7 @@ function c55171412.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c55171412.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c55171412.spcon(e,c)
 	if c==nil then return true end 

--- a/c56655675.lua
+++ b/c56655675.lua
@@ -26,30 +26,24 @@ function c56655675.initial_effect(c)
 	e3:SetOperation(c56655675.operation)
 	c:RegisterEffect(e3)
 end
-function c56655675.spfilter1(c)
-	return c:IsSetCard(0x40b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
-end
-function c56655675.spfilter2(c)
-	return c:IsSetCard(0x10b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
-end
-function c56655675.spfilter3(c)
-	return c:IsSetCard(0x20b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
+function c56655675.spfilter(c,setcode)
+	return c:IsFusionSetCard(setcode) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
 end
 function c56655675.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-2
-		and Duel.IsExistingMatchingCard(c56655675.spfilter1,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.IsExistingMatchingCard(c56655675.spfilter2,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.IsExistingMatchingCard(c56655675.spfilter3,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c56655675.spfilter,tp,LOCATION_MZONE,0,1,nil,0x40b5)
+		and Duel.IsExistingMatchingCard(c56655675.spfilter,tp,LOCATION_MZONE,0,1,nil,0x10b5)
+		and Duel.IsExistingMatchingCard(c56655675.spfilter,tp,LOCATION_MZONE,0,1,nil,0x20b5)
 end
 function c56655675.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g1=Duel.SelectMatchingCard(tp,c56655675.spfilter1,tp,LOCATION_MZONE,0,1,1,nil)
+	local g1=Duel.SelectMatchingCard(tp,c56655675.spfilter,tp,LOCATION_MZONE,0,1,1,nil,0x40b5)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g2=Duel.SelectMatchingCard(tp,c56655675.spfilter2,tp,LOCATION_MZONE,0,1,1,nil)
+	local g2=Duel.SelectMatchingCard(tp,c56655675.spfilter,tp,LOCATION_MZONE,0,1,1,nil,0x10b5)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g3=Duel.SelectMatchingCard(tp,c56655675.spfilter3,tp,LOCATION_MZONE,0,1,1,nil)
+	local g3=Duel.SelectMatchingCard(tp,c56655675.spfilter,tp,LOCATION_MZONE,0,1,1,nil,0x20b5)
 	g1:Merge(g2)
 	g1:Merge(g3)
 	c:SetMaterial(g1)

--- a/c58859575.lua
+++ b/c58859575.lua
@@ -35,7 +35,7 @@ function c58859575.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c58859575.spfilter(c,code)
-	return c:IsCode(code) and c:IsAbleToRemoveAsCost()
+	return c:IsFusionCode(code) and c:IsAbleToRemoveAsCost()
 end
 function c58859575.spcon(e,c)
 	if c==nil then return true end 

--- a/c73285669.lua
+++ b/c73285669.lua
@@ -24,7 +24,7 @@ function c73285669.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c73285669.spfilter(c)
-	return c:IsSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
+	return c:IsFusionSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
 end
 function c73285669.sprcon(e,c)
 	if c==nil then return true end 

--- a/c78512663.lua
+++ b/c78512663.lua
@@ -58,7 +58,7 @@ function c78512663.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c78512663.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c78512663.spcon(e,c)
 	if c==nil then return true end 

--- a/c79229522.lua
+++ b/c79229522.lua
@@ -31,7 +31,7 @@ function c79229522.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c79229522.spfilter1(c,tp,ft)
-	if c:IsCode(70095154) and c:IsAbleToGraveAsCost() and c:IsCanBeFusionMaterial(nil,true) and (c:IsControler(tp) or c:IsFaceup()) then
+	if c:IsFusionCode(70095154) and c:IsAbleToGraveAsCost() and c:IsCanBeFusionMaterial(nil,true) and (c:IsControler(tp) or c:IsFaceup()) then
 		if ft>0 or (c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)) then
 			return Duel.IsExistingMatchingCard(c79229522.spfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,c,tp)
 		else

--- a/c81566151.lua
+++ b/c81566151.lua
@@ -49,7 +49,7 @@ function c81566151.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c81566151.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c81566151.spcon(e,c)
 	if c==nil then return true end 

--- a/c84243274.lua
+++ b/c84243274.lua
@@ -45,7 +45,7 @@ function c84243274.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c84243274.spfilter(c,code)
-	return c:IsCode(code) and c:IsAbleToRemoveAsCost()
+	return c:IsFusionCode(code) and c:IsAbleToRemoveAsCost()
 end
 function c84243274.spcon(e,c)
 	if c==nil then return true end 

--- a/c85507811.lua
+++ b/c85507811.lua
@@ -53,7 +53,7 @@ function c85507811.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function c85507811.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsCode(code)
+	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
 end
 function c85507811.spcon(e,c)
 	if c==nil then return true end 

--- a/c86274272.lua
+++ b/c86274272.lua
@@ -38,11 +38,11 @@ function c86274272.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c86274272.spfilter1(c,tp)
-	return c:IsSetCard(0x10b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
+	return c:IsFusionSetCard(0x10b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
 		and Duel.IsExistingMatchingCard(c86274272.spfilter2,tp,LOCATION_MZONE,0,1,c)
 end
 function c86274272.spfilter2(c)
-	return c:IsSetCard(0x20b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
+	return c:IsFusionSetCard(0x20b5) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial()
 end
 function c86274272.sprcon(e,c)
 	if c==nil then return true end

--- a/c90957527.lua
+++ b/c90957527.lua
@@ -47,11 +47,11 @@ function c90957527.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
 end
 function c90957527.spfilter1(c,tp)
-	return c:IsCode(79580323) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
+	return c:IsFusionCode(79580323) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 		and Duel.IsExistingMatchingCard(c90957527.spfilter2,tp,LOCATION_MZONE,0,1,c)
 end
 function c90957527.spfilter2(c)
-	return c:IsSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
+	return c:IsFusionSetCard(0x19) and c:IsCanBeFusionMaterial() and c:IsAbleToDeckOrExtraAsCost()
 end
 function c90957527.sprcon(e,c)
 	if c==nil then return true end 

--- a/c91998119.lua
+++ b/c91998119.lua
@@ -35,7 +35,7 @@ function c91998119.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA+LOCATION_GRAVE)
 end
 function c91998119.spfilter(c,code)
-	return c:IsCode(code) and c:IsAbleToRemoveAsCost()
+	return c:IsFusionCode(code) and c:IsAbleToRemoveAsCost()
 end
 function c91998119.spcon(e,c)
 	if c==nil then return true end 

--- a/c99724761.lua
+++ b/c99724761.lua
@@ -35,7 +35,7 @@ function c99724761.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA+LOCATION_GRAVE)
 end
 function c99724761.spfilter(c,code)
-	return c:IsCode(code) and c:IsAbleToRemoveAsCost()
+	return c:IsFusionCode(code) and c:IsAbleToRemoveAsCost()
 end
 function c99724761.spcon(e,c)
 	if c==nil then return true end 


### PR DESCRIPTION
Fix this: If a monster have EFFECT_ADD_FUSION_CODE or EFFECT_ADD_FUSION_SETCODE, Ritual Beast Ulti monster and so on don't use Fuson Material.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18081&keyword=&tag=-1
また、「イグナイト・キャリバー」を対象として「融合識別」を発動した状況の場合、その「イグナイト・キャリバー」はそのターン、「剛竜剣士ダイナスターP」として融合素材に使用する事はできます。
「イグナイト・キャリバー」はペンデュラムモンスターですので、「剛竜剣士ダイナスターP」を特殊召喚する際に必要な、「竜剣士」と名のついたペンデュラムモンスターとして使用する事もできますし、もう1体のペンデュラムモンスターとして使用する事もできます。

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18073&keyword=&tag=-1
したがって、「E・HERO ネオス」と、「N・マリン・ドルフィン」として扱う「E・HERO バブルマン」をデッキに戻し、「E・HERO マリン・ネオス」をエクストラデッキから特殊召喚する事もできますし、、「E・HERO ネオス」と、「N・アクア・ドルフィン」として扱う「E・HERO バブルマン」をデッキに戻し、「E・HERO アクア・ネオス」をエクストラデッキから特殊召喚する事もできます。