### PR TITLE
fix Damage = Reptile

### DIFF
--- a/c44584775.lua
+++ b/c44584775.lua
@@ -4,6 +4,11 @@ function c44584775.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetHintTiming(TIMING_DAMAGE)
+	e1:SetCondition(c44584775.condition1)
+	e1:SetTarget(c44584775.target1)
+	e1:SetOperation(c44584775.activate)
 	c:RegisterEffect(e1)
 	--special summon
 	local e2=Effect.CreateEffect(c)
@@ -14,14 +19,45 @@ function c44584775.initial_effect(c)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCountLimit(1)
 	e2:SetCondition(c44584775.condition)
+	e2:SetCost(c44584775.cost)
 	e2:SetTarget(c44584775.target)
 	e2:SetOperation(c44584775.activate)
 	c:RegisterEffect(e2)
+end
+function c44584775.condition1(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetCurrentPhase()~=PHASE_DAMAGE then return true end
+	local res,teg,tep,tev,tre,tr,trp=Duel.CheckEvent(EVENT_BATTLE_DAMAGE,true)
+	local a=Duel.GetAttacker()
+	local d=Duel.GetAttackTarget()
+	return res and tep==tp and (a:IsRace(RACE_REPTILE) or (d and d:IsRace(RACE_REPTILE)))
+end
+function c44584775.target1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local res,teg,tep,tev,tre,tr,trp=Duel.CheckEvent(EVENT_BATTLE_DAMAGE,true)
+	local a=Duel.GetAttacker()
+	local d=Duel.GetAttackTarget()
+	if Duel.GetCurrentPhase()==PHASE_DAMAGE
+		or (res and tep==tp
+		and (a:IsRace(RACE_REPTILE) or (d and d:IsRace(RACE_REPTILE)))
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c44584775.filter,tp,LOCATION_DECK,0,1,nil,e,tp,tev)
+		and Duel.SelectYesNo(tp,94)) then
+		e:SetCategory(CATEGORY_SPECIAL_SUMMON)
+		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+		e:GetHandler():RegisterFlagEffect(44584775,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+		e:GetHandler():RegisterFlagEffect(0,RESET_CHAIN,EFFECT_FLAG_CLIENT_HINT,1,0,65)
+	else
+		e:SetCategory(0)
+	end
 end
 function c44584775.condition(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()
 	local d=Duel.GetAttackTarget()
 	return ep==tp and (a:IsRace(RACE_REPTILE) or (d and d:IsRace(RACE_REPTILE)))
+end
+function c44584775.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(44584775)==0 end
+	e:GetHandler():RegisterFlagEffect(44584775,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 end
 function c44584775.filter(c,e,tp,dam)
 	return c:IsAttackBelow(dam) and c:IsRace(RACE_REPTILE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
@@ -32,6 +68,7 @@ function c44584775.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c44584775.activate(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():GetFlagEffect(44584775)==0 then return end
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
Fix this: Damage = Reptile cannot activate in Damage Step.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7167
■同一のチェーンブロックにて効果の発動も行うのであれば、「ダメージ＝レプトル」のカードの発動をダメージ計算後に行う事はできます。