### PR TITLE
fix De-Synchro

### DIFF
--- a/c32441317.lua
+++ b/c32441317.lua
@@ -34,7 +34,7 @@ function c32441317.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)~=0 and sumtype==SUMMON_TYPE_SYNCHRO
 		and ct>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
 		and ct<=Duel.GetLocationCount(tp,LOCATION_MZONE)
-		and mg:IsExists(c32441317.mgfilter,1,nil,e,tp,tc)==ct
+		and Duel.GetMatchingGroupCount(c32441317.mgfilter,tp,LOCATION_GRAVE,0,nil,e,tp,tc)==ct
 		and Duel.SelectYesNo(tp,aux.Stringid(32441317,0)) then
 		Duel.BreakEffect()
 		Duel.SpecialSummon(mg,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
fix this: the synchro material monsters can't be summoned