### PR TITLE
fix Raidraptor - Avenge Vulture

### DIFF
--- a/c10194329.lua
+++ b/c10194329.lua
@@ -8,27 +8,12 @@ function c10194329.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCondition(c10194329.condition)
-	e1:SetCost(c10194329.cost)
 	e1:SetTarget(c10194329.target)
 	e1:SetOperation(c10194329.operation)
 	c:RegisterEffect(e1)
 end
 function c10194329.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and bit.band(r,REASON_BATTLE+REASON_EFFECT)~=0
-end
-function c10194329.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
-	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
-	e1:SetTargetRange(1,0)
-	e1:SetTarget(c10194329.splimit)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e1,tp)
-end
-function c10194329.splimit(e,c,sump,sumtype,sumpos,targetp,se)
-	return not c:IsSetCard(0xba) and c:IsLocation(LOCATION_EXTRA)
 end
 function c10194329.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -40,4 +25,15 @@ function c10194329.operation(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsRelateToEffect(e) then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 	end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c10194329.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c10194329.splimit(e,c,sump,sumtype,sumpos,targetp,se)
+	return not c:IsSetCard(0xba) and c:IsLocation(LOCATION_EXTRA)
 end


### PR DESCRIPTION
Fix this: Avenge Vulture's "you cannot Special Summon monsters from the Extra Deck for the rest of this turn, except "Raidraptor" monsters" is not effect.