### PR TITLE
fix Ryuu Ookami

### DIFF
--- a/c63737050.lua
+++ b/c63737050.lua
@@ -16,11 +16,11 @@ function c63737050.cfilter(c,tp)
 	return c:GetSummonPlayer()~=tp
 end
 function c63737050.condition(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c63737050.cfilter,1,nil,tp)
+	return not eg:IsContains(e:GetHandler()) and eg:IsExists(c63737050.cfilter,1,nil,tp)
 end
 function c63737050.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_EXTRA)
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,1-tp,LOCATION_EXTRA)
 end
 function c63737050.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetMatchingGroup(Card.IsAbleToGrave,tp,0,LOCATION_EXTRA,nil)


### PR DESCRIPTION
Fix this: If Ryuu Ookami Special Summon by Give and Take from your Graveyard to your opponent's side of the field, Ryuu Ookami activate.

Q. 
「ギブ＆テイク」の効果で「龍大神」を自分の墓地から相手フィールドに特殊召喚した時、「龍大神」自身の特殊召喚に対して効果は発動されますか？  
A. 
ご質問の場合、「龍大神」の効果を発動する事はできません。