### PR TITLE
fix D/D/D Wave King Caesar

### DIFF
--- a/c3758046.lua
+++ b/c3758046.lua
@@ -52,6 +52,7 @@ function c3758046.spop(e,tp,eg,ep,ev,re,r,rp)
 	if ft<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c3758046.filter,tp,LOCATION_GRAVE,0,ft,ft,nil,e,tp,Duel.GetTurnCount())
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) and g:GetCount()>1 then return end
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 		local e1=Effect.CreateEffect(e:GetHandler())


### PR DESCRIPTION
Fix this: If Blue-Eyes Spirit Dragon is on the field, Special Summon from your Graveyard as many monsters destroyed this turn by Wave King Caesar's effect.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分のモンスターが2体以上破壊され、「DDD怒濤王シーザー」の①の効果を発動しているターンのバトルフェイズ終了時に「青眼の精霊龍」がモンスターゾーンに表側表示で存在する場合、『このターンに破壊されたモンスターをバトルフェイズ終了時に、自分の墓地から可能な限り特殊召喚する』処理はどうなりますか？ 
A. 
「DDD怒濤王シーザー」の『①』の効果は、可能な限りモンスターを特殊召喚する効果となり、特殊召喚するモンスターの数をプレイヤーが任意で決める事はできません。 

そのため、「青眼の精霊龍」の『①』の効果を適用されている状況で、バトルフェイズのエンドステップを迎えた場合、「DDD怒濤王シーザー」の効果で墓地から特殊召喚するモンスターの数が2体以上であれば、1体も特殊召喚されずに効果の適用を終えます。