### PR TITLE
fix アモルファスP

### DIFF
--- a/c23160024.lua
+++ b/c23160024.lua
@@ -23,7 +23,6 @@ function c23160024.initial_effect(c)
 	e4:SetRange(LOCATION_FZONE)
 	e4:SetCode(EVENT_RELEASE)
 	e4:SetProperty(EFFECT_FLAG_DELAY)
-	e4:SetCountLimit(2)
 	e4:SetCondition(c23160024.drcon)
 	e4:SetOperation(c23160024.drop)
 	c:RegisterEffect(e4)
@@ -41,11 +40,12 @@ function c23160024.cfilter(c,tp)
 	return c:IsPreviousSetCard(0xe0) and c:IsReason(REASON_RELEASE) and c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousControler()==tp
 end
 function c23160024.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c23160024.cfilter,1,nil,tp)
+	return e:GetHandler():GetFlagEffect(23160024)<2 and eg:IsExists(c23160024.cfilter,1,nil,tp)
 end
 function c23160024.drop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,e:GetHandler():GetCode())
 	Duel.Draw(tp,1,REASON_EFFECT)
+	e:GetHandler():RegisterFlagEffect(23160024,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 end
 function c23160024.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end


### PR DESCRIPTION
> Q. 
相手のモンスターゾーンに「マジック・キャンセラー」が表側表示で存在し、『このカードがフィールド上に表側表示で存在する限り魔法カードは発動できず、全てのフィールド上魔法カードの効果は無効になる』モンスター効果が適用されています。 
この状況で、自分のモンスターゾーンの「アモルファージ」と名のついたモンスターが2度リリースされた場合、自分の「アモルファスP」の『②：このカードがフィールドゾーンに存在する限り、自分フィールドの「アモルファージ」モンスターがリリースされる度に自分はデッキから１枚ドローする。この効果は１ターンに２度まで適用できる』効果は適用されますか？ 
その後、「マジック・キャンセラー」のモンスター効果の適用がなくなった状態で、自分のモンスターゾーンに存在する「アモルファージ」と名のついたモンスターがリリースされた際には、「アモルファスP」の効果が適用される事はできませんか？ 
A. 
「マジック・キャンセラー」の効果が適用されている間は、「アモルファスP」の効果も無効化されます。 
そのため、「アモルファージ」と名のつくモンスターがリリースされる度にドローできる機会はあっても、その効果が無効化されますので、結果的にドローする事はできず、効果を適用した扱いにはなりませんし、『この効果は１ターンに２度まで適用できる』にも当てはまりません。 
また、「マジック・キャンセラー」が存在しなくなった後、再び「アモルファスP」の効果は適用されますので、「マジック・キャンセラー」が存在しなくなってから「アモルファージ」と名のつくモンスターがリリースされた際には、デッキからカードをドローする事ができます。 

If this card was disabled, its effect didn't "適用", so it shouldn't be included in the count limit.