### PR TITLE
fix Hot Red Dragon Archfiend King Calamity

### DIFF
--- a/c62242678.lua
+++ b/c62242678.lua
@@ -47,7 +47,7 @@ function c62242678.matfilter1(c,syncard)
 	return c:IsType(TYPE_TUNER) and (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsCanBeSynchroMaterial(syncard)
 end
 function c62242678.matfilter2(c,syncard)
-	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSynchroMaterial(syncard)
+	return c:IsNotTuner() and c:IsFaceup() and c:IsRace(RACE_DRAGON) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSynchroMaterial(syncard)
 end
 function c62242678.synfilter1(c,syncard,lv,g1,g2,g3)
 	local tlv=c:GetSynchroLevel(syncard)


### PR DESCRIPTION
Fix this: You can Synchro Summon Hot Red Dragon Archfiend King Calamity using a Tuner DARK Dragon-Type Synchro Monster.