### PR TITLE
fix Zaborg the Mega Monarch

### DIFF
--- a/c87602890.lua
+++ b/c87602890.lua
@@ -51,7 +51,7 @@ function c87602890.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c87602890.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsDestructable() end
-	if chk==0 then return true end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsDestructable,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,Card.IsDestructable,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)


### PR DESCRIPTION
fix: if there are only monsters on the field that can't be targeted (e.g. Zaborg itself with March) you can activate the effect, this shouldn't be possible