### PR TITLE
fix Stardust and Stardust assault

### DIFF
--- a/c44508094.lua
+++ b/c44508094.lua
@@ -47,11 +47,12 @@ function c44508094.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c44508094.operation(e,tp,eg,ep,ev,re,r,rp)
-	Duel.NegateActivation(ev)
+	if Duel.NegateActivation(ev) then
+		e:GetHandler():RegisterFlagEffect(44508094,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,0)
+	end
 	if re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
-	e:GetHandler():RegisterFlagEffect(44508094,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,0)
 end
 function c44508094.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c61257789.lua
+++ b/c61257789.lua
@@ -59,11 +59,12 @@ function c61257789.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c61257789.negop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.NegateActivation(ev)
+	if Duel.NegateActivation(ev) then
+		e:GetHandler():RegisterFlagEffect(61257789,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,0)
+	end
 	if re:GetHandler():IsRelateToEffect(re)then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
-	e:GetHandler():RegisterFlagEffect(61257789,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,0)
 end
 function c61257789.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()


### PR DESCRIPTION
fix this: if Stardust fails to negate without his effect being negated (e.g. the monster is immune like Burgesstoma) it still can be special summoned, which shouldn't happen