### PR TITLE
fix: Lunalight Cat Dancer 's indestruct effect shouldn't work on uneffected cards

### DIFF
--- a/c26268488.lua
+++ b/c26268488.lua
@@ -45,12 +45,13 @@ function c26268488.initial_effect(c)
 	e4:SetOperation(c26268488.spop)
 	c:RegisterEffect(e4)
 end
-function c26268488.repfilter(c,tp)
-	return c:IsControler(tp) and c:IsOnField() and c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:GetFlagEffect(26268488)==0
+function c26268488.repfilter(c,e,tp)
+	return c:IsControler(tp) and c:IsOnField() and c:IsReason(REASON_BATTLE+REASON_EFFECT)
+		and c:GetFlagEffect(26268488)==0 and not c:IsImmuneToEffect(e)
 end
 function c26268488.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return eg:IsExists(c26268488.repfilter,1,nil,tp) end
-	local g=eg:Filter(c26268488.repfilter,nil,tp)
+	if chk==0 then return eg:IsExists(c26268488.repfilter,1,nil,e,tp) end
+	local g=eg:Filter(c26268488.repfilter,nil,e,tp)
 	local tc=g:GetFirst()
 	while tc do
 		tc:RegisterFlagEffect(26268488,RESET_EVENT+0x1fc0000+RESET_PHASE+PHASE_END,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(26268488,2))

--- a/c51777272.lua
+++ b/c51777272.lua
@@ -58,13 +58,13 @@ function c51777272.operation(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e2)
 	end
 end
-function c51777272.repfilter(c,tp)
+function c51777272.repfilter(c,e,tp)
 	return c:IsFaceup() and c:IsControler(1-tp) and c:IsLocation(LOCATION_MZONE)
-		and c:IsReason(REASON_BATTLE) and c:GetFlagEffect(51777272)==0
+		and c:IsReason(REASON_BATTLE) and c:GetFlagEffect(51777272)==0 and not c:IsImmuneToEffect(e)
 end
 function c51777272.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return eg:IsExists(c51777272.repfilter,1,nil,tp) end
-	local g=eg:Filter(c51777272.repfilter,nil,tp)
+	if chk==0 then return eg:IsExists(c51777272.repfilter,1,nil,e,tp) end
+	local g=eg:Filter(c51777272.repfilter,nil,e,tp)
 	local tc=g:GetFirst()
 	while tc do
 		tc:RegisterFlagEffect(51777272,RESET_EVENT+0x1fc0000+RESET_PHASE+PHASE_END,0,1)

--- a/c79777187.lua
+++ b/c79777187.lua
@@ -29,13 +29,14 @@ end
 function c79777187.target(e,c)
 	return c:IsSetCard(0xc6) or c:IsSetCard(0x9f)
 end
-function c79777187.repfilter(c,tp)
+function c79777187.repfilter(c,e,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
-		and (c:IsSetCard(0xc6) or c:IsSetCard(0x9f)) and c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:GetFlagEffect(79777187)==0
+		and (c:IsSetCard(0xc6) or c:IsSetCard(0x9f)) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
+		and c:GetFlagEffect(79777187)==0 and not c:IsImmuneToEffect(e)
 end
 function c79777187.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return eg:IsExists(c79777187.repfilter,1,nil,tp) end
-	local g=eg:Filter(c79777187.repfilter,nil,tp)
+	if chk==0 then return eg:IsExists(c79777187.repfilter,1,nil,e,tp) end
+	local g=eg:Filter(c79777187.repfilter,nil,e,tp)
 	local tc=g:GetFirst()
 	while tc do
 		tc:RegisterFlagEffect(79777187,RESET_EVENT+0x1fc0000+RESET_PHASE+PHASE_END,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(79777187,0))

--- a/c97165977.lua
+++ b/c97165977.lua
@@ -67,13 +67,13 @@ function c97165977.operation(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e2)
 	end
 end
-function c97165977.repfilter(c,tp)
+function c97165977.repfilter(c,e,tp)
 	return c:IsFaceup() and c:IsControler(1-tp) and c:IsLocation(LOCATION_MZONE)
-		and c:IsReason(REASON_BATTLE) and c:GetFlagEffect(97165977)==0
+		and c:IsReason(REASON_BATTLE) and c:GetFlagEffect(97165977)==0 and not c:IsImmuneToEffect(e)
 end
 function c97165977.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return eg:IsExists(c97165977.repfilter,1,nil,tp) end
-	local g=eg:Filter(c97165977.repfilter,nil,tp)
+	if chk==0 then return eg:IsExists(c97165977.repfilter,1,nil,e,tp) end
+	local g=eg:Filter(c97165977.repfilter,nil,e,tp)
 	local tc=g:GetFirst()
 	while tc do
 		tc:RegisterFlagEffect(97165977,RESET_EVENT+0x1fc0000+RESET_PHASE+PHASE_END,0,1)


### PR DESCRIPTION
> 質問の状況の場合、「ヴェルズ・タナトス」は『このターン、このカードはこのカード以外のモンスターの効果を受けない』効果によって、「月光舞猫姫」の『相手モンスターはそれぞれ１度だけ戦闘では破壊されず』効果を受けません。
したがって、「月光舞猫姫」の攻撃によって「ヴェルズ・タナトス」は通常通り破壊され墓地へ送られる事になります。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18199&keyword=&tag=-1

