### PR TITLE
fix EFFECT_DESTROY_REPLACE

### DIFF
--- a/c1580833.lua
+++ b/c1580833.lua
@@ -9,7 +9,6 @@ function c1580833.initial_effect(c)
 	e2:SetRange(LOCATION_PZONE)
 	e2:SetTarget(c1580833.reptg)
 	e2:SetValue(c1580833.repval)
-	e2:SetOperation(c1580833.repop)
 	c:RegisterEffect(e2)
 	--destroy
 	local e3=Effect.CreateEffect(c)
@@ -24,17 +23,17 @@ function c1580833.initial_effect(c)
 end
 function c1580833.filter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_ONFIELD) and c:IsSetCard(0xd8)
-		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp))
+		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp)) and not c:IsReason(REASON_REPLACE)
 end
 function c1580833.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c1580833.filter,1,e:GetHandler(),tp) and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) end
-	return Duel.SelectYesNo(tp,aux.Stringid(1580833,0))
+	if Duel.SelectYesNo(tp,aux.Stringid(1580833,0)) then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
+		return true
+	else return false end
 end
 function c1580833.repval(e,c)
 	return c1580833.filter(c,e:GetHandlerPlayer())
-end
-function c1580833.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
 end
 function c1580833.descon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()

--- a/c37752990.lua
+++ b/c37752990.lua
@@ -9,7 +9,6 @@ function c37752990.initial_effect(c)
 	e2:SetRange(LOCATION_PZONE)
 	e2:SetTarget(c37752990.reptg)
 	e2:SetValue(c37752990.repval)
-	e2:SetOperation(c37752990.repop)
 	c:RegisterEffect(e2)
 	--special summon
 	local e3=Effect.CreateEffect(c)
@@ -22,17 +21,17 @@ function c37752990.initial_effect(c)
 end
 function c37752990.filter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_ONFIELD) and c:IsSetCard(0xd8)
-		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp))
+		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp)) and not c:IsReason(REASON_REPLACE)
 end
 function c37752990.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c37752990.filter,1,e:GetHandler(),tp) and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) end
-	return Duel.SelectYesNo(tp,aux.Stringid(37752990,0))
+	if Duel.SelectYesNo(tp,aux.Stringid(37752990,0)) then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
+		return true
+	else return false end
 end
 function c37752990.repval(e,c)
 	return c37752990.filter(c,e:GetHandlerPlayer())
-end
-function c37752990.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
 end
 function c37752990.cfilter(c)
 	return c:IsFacedown() or c:IsCode(37752990) or not c:IsSetCard(0xd8)

--- a/c43577607.lua
+++ b/c43577607.lua
@@ -24,7 +24,6 @@ function c43577607.initial_effect(c)
 	e3:SetCountLimit(1)
 	e3:SetTarget(c43577607.reptg)
 	e3:SetValue(c43577607.repval)
-	e3:SetOperation(c43577607.repop)
 	e3:SetCondition(c43577607.effcon)
 	e3:SetLabel(3)
 	c:RegisterEffect(e3)
@@ -72,17 +71,17 @@ function c43577607.atktg(e,c)
 	return c:IsSetCard(0x9e)
 end
 function c43577607.repfilter(c,tp)
-	return c:IsFaceup() and c:IsSetCard(0x9e) and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
+	return c:IsFaceup() and c:IsSetCard(0x9e) and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and not c:IsReason(REASON_REPLACE)
 end
 function c43577607.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c43577607.repfilter,1,nil,tp) end
-	return Duel.SelectYesNo(tp,aux.Stringid(43577607,1))
+	if Duel.SelectYesNo(tp,aux.Stringid(43577607,1)) then
+		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
+		return true
+	else return false end
 end
 function c43577607.repval(e,c)
 	return c43577607.repfilter(c,e:GetHandlerPlayer())
-end
-function c43577607.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
 end
 function c43577607.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end

--- a/c5067884.lua
+++ b/c5067884.lua
@@ -9,7 +9,6 @@ function c5067884.initial_effect(c)
 	e1:SetRange(LOCATION_PZONE)
 	e1:SetTarget(c5067884.reptg)
 	e1:SetValue(c5067884.repval)
-	e1:SetOperation(c5067884.repop)
 	c:RegisterEffect(e1)
 	--Attack
 	local e2=Effect.CreateEffect(c)
@@ -23,17 +22,17 @@ function c5067884.initial_effect(c)
 end
 function c5067884.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_ONFIELD) and c:IsSetCard(0xd8)
-		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp))
+		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp)) and not c:IsReason(REASON_REPLACE)
 end
 function c5067884.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c5067884.repfilter,1,e:GetHandler(),tp) and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) end
-	return Duel.SelectYesNo(tp,aux.Stringid(5067884,0))
+	if Duel.SelectYesNo(tp,aux.Stringid(5067884,0)) then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
+		return true
+	else return false end
 end
 function c5067884.repval(e,c)
 	return c5067884.repfilter(c,e:GetHandlerPlayer())
-end
-function c5067884.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
 end
 function c5067884.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()

--- a/c63881033.lua
+++ b/c63881033.lua
@@ -33,7 +33,6 @@ function c63881033.initial_effect(c)
 	e4:SetRange(LOCATION_SZONE)
 	e4:SetTarget(c63881033.reptg)
 	e4:SetValue(c63881033.repval)
-	e4:SetOperation(c63881033.repop)
 	c:RegisterEffect(e4)
 	--tohand
 	local e5=Effect.CreateEffect(c)
@@ -95,13 +94,13 @@ function c63881033.repfilter(c,tp)
 end
 function c63881033.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c63881033.repfilter,1,nil,tp) end
-	return Duel.SelectYesNo(tp,aux.Stringid(63881033,2))
+	if Duel.SelectYesNo(tp,aux.Stringid(63881033,2)) then
+		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
+		return true
+	else return false end
 end
 function c63881033.repval(e,c)
 	return c63881033.repfilter(c,e:GetHandlerPlayer())
-end
-function c63881033.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
 end
 function c63881033.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)

--- a/c64973287.lua
+++ b/c64973287.lua
@@ -9,7 +9,6 @@ function c64973287.initial_effect(c)
 	e2:SetRange(LOCATION_PZONE)
 	e2:SetTarget(c64973287.reptg)
 	e2:SetValue(c64973287.repval)
-	e2:SetOperation(c64973287.repop)
 	c:RegisterEffect(e2)
 	--search
 	local e3=Effect.CreateEffect(c)
@@ -24,17 +23,17 @@ function c64973287.initial_effect(c)
 end
 function c64973287.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_ONFIELD) and c:IsSetCard(0xd8)
-		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp))
+		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp)) and not c:IsReason(REASON_REPLACE)
 end
 function c64973287.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c64973287.repfilter,1,e:GetHandler(),tp) and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) end
-	return Duel.SelectYesNo(tp,aux.Stringid(64973287,0))
+	if Duel.SelectYesNo(tp,aux.Stringid(64973287,0)) then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
+		return true
+	else return false end
 end
 function c64973287.repval(e,c)
 	return c64973287.repfilter(c,e:GetHandlerPlayer())
-end
-function c64973287.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
 end
 function c64973287.filter(c)
 	return c:IsSetCard(0xd8) and c:IsAbleToHand()

--- a/c65025250.lua
+++ b/c65025250.lua
@@ -9,7 +9,6 @@ function c65025250.initial_effect(c)
 	e2:SetRange(LOCATION_PZONE)
 	e2:SetTarget(c65025250.reptg)
 	e2:SetValue(c65025250.repval)
-	e2:SetOperation(c65025250.repop)
 	c:RegisterEffect(e2)
 	--to defence
 	local e3=Effect.CreateEffect(c)
@@ -36,13 +35,13 @@ function c65025250.filter(c,tp)
 end
 function c65025250.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c65025250.filter,1,nil,tp) and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) end
-	return Duel.SelectYesNo(tp,aux.Stringid(65025250,1))
+	if Duel.SelectYesNo(tp,aux.Stringid(65025250,1)) then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
+		return true
+	else return false end
 end
 function c65025250.repval(e,c)
 	return c65025250.filter(c,e:GetHandlerPlayer())
-end
-function c65025250.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
 end
 function c65025250.postg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAttackPos() end

--- a/c66835946.lua
+++ b/c66835946.lua
@@ -22,7 +22,6 @@ function c66835946.initial_effect(c)
 	e3:SetCountLimit(1)
 	e3:SetTarget(c66835946.destg)
 	e3:SetValue(1)
-	e3:SetOperation(c66835946.desop)
 	c:RegisterEffect(e3)
 end
 function c66835946.val(e,c)
@@ -33,8 +32,8 @@ function c66835946.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 		local tc=eg:GetFirst()
 		return eg:GetCount()==1 and tc:IsLocation(LOCATION_MZONE) and tc:IsControler(tp) and tc:IsFaceup() and tc:IsRace(RACE_ZOMBIE)
 	end
-	return Duel.SelectYesNo(tp,aux.Stringid(66835946,0))
-end
-function c66835946.desop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
+	if Duel.SelectYesNo(tp,aux.Stringid(66835946,0)) then
+		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
+		return true
+	else return false end
 end

--- a/c6853254.lua
+++ b/c6853254.lua
@@ -16,7 +16,6 @@ function c6853254.initial_effect(c)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetTarget(c6853254.reptg)
 	e2:SetValue(c6853254.repval)
-	e2:SetOperation(c6853254.repop)
 	c:RegisterEffect(e2)
 end
 function c6853254.filter(c,e,tp)
@@ -38,15 +37,15 @@ function c6853254.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c6853254.repfilter(c,tp)
 	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and c:IsLocation(LOCATION_MZONE)
-		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
+		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function c6853254.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(c6853254.repfilter,1,nil,tp) end
-	return Duel.SelectYesNo(tp,aux.Stringid(6853254,0))
+	if Duel.SelectYesNo(tp,aux.Stringid(6853254,0)) then
+		Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+		return true
+	else return false end
 end
 function c6853254.repval(e,c)
 	return c6853254.repfilter(c,e:GetHandlerPlayer())
-end
-function c6853254.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
 end


### PR DESCRIPTION
Fix this: If a Blue-Eyes White Dragon you control would be destroyed by Dreadnought Dunker's effect when Blue-Eyes White Dragon would be destroyed by battle with Dreadnought Dunker, you can banish 1 Gospel of Revival instead.