### PR TITLE
fix Satellarknight Betelgeuse

### DIFF
--- a/c26057276.lua
+++ b/c26057276.lua
@@ -6,7 +6,7 @@ function c26057276.initial_effect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_SUMMON_SUCCESS)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
 	e1:SetCountLimit(1,26057276)
 	e1:SetTarget(c26057276.target)
 	e1:SetOperation(c26057276.operation)
@@ -30,7 +30,7 @@ function c26057276.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c26057276.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and Duel.SendtoGrave(c,REASON_EFFECT)~=0 then
+	if c:IsRelateToEffect(e) and Duel.SendtoGrave(c,REASON_EFFECT)~=0 and c:IsLocation(LOCATION_GRAVE) then
 		local tc=Duel.GetFirstTarget()
 		if tc:IsRelateToEffect(e) then
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)


### PR DESCRIPTION
Fix this: If Satellarknight Betelgeuse banished, you add that target to your hand.

遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「星因士 ベテルギウス」の効果の発動にチェーンして相手が「マクロコスモス」を発動した場合どうなりますか？ 
A. 
ご質問の状況の場合、効果を発動した「星因士 ベテルギウス」自身が墓地へ送る代わりに「マクロコスモス」の効果により墓地へ送られずに除外されるため、『対象のカードを手札に加える』効果処理を行う事はできません。