### PR TITLE
fix D/D/D Oblivion King Abyss Ragnarok

### DIFF
--- a/c74069667.lua
+++ b/c74069667.lua
@@ -60,8 +60,9 @@ end
 function c74069667.spop1(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+	if tc:IsRelateToEffect(e) and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		Duel.Damage(tp,1000,REASON_EFFECT)
+		Duel.SpecialSummonComplete()
 	end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)


### PR DESCRIPTION
fix: you don't gain life points, you should take damage if you summon D/D/D Oracle King d'Ark with the pendulum effect of D/D/D Oblivion King Abyss Ragnarok
https://ygorganization.com/ocg-021816/#more-14105

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13506&keyword=&tag=-1
 Question
「DDD壊薙王アビス・ラグナロク」の『①：自分が「DD」モンスターを特殊召喚した場合、自分の墓地の「DD」モンスター１体を対象として発動できる。そのモンスターを特殊召喚し、自分は１０００ダメージを受ける。このターン、相手が受ける戦闘ダメージは半分になる』ペンデュラム効果によって、「DDD神託王ダルク」を特殊召喚した場合、効果処理はどうなりますか？
Answer
「DDD壊薙王アビス・ラグナロク」のペンデュラム効果は『そのモンスターを特殊召喚し』の処理と、『自分は１０００ダメージを受ける』処理が同時に行われる扱いとなります。（『このターン、相手が受ける戦闘ダメージは半分になる』効果も適用されます。）

「DDD神託王ダルク」の『①：このカードがモンスターゾーンに存在する限り、自分にダメージを与える効果は、自分のLPを回復する効果になる』モンスター効果は永続効果ですので、質問の状況の場合、「DDD神託王ダルク」が特殊召喚に成功した後に適用される事になります。

したがって、この場合、「DDD壊薙王アビス・ラグナロク」のペンデュラム効果によって『自分は１０００ダメージを受ける』処理は通常通り、ダメージとして処理を行う事になります。（「DDD神託王ダルク」のモンスター効果によって回復する事はありません。） 