### PR TITLE
fix Destiny Board

### DIFF
--- a/c94212438.lua
+++ b/c94212438.lua
@@ -29,50 +29,54 @@ function c94212438.initial_effect(c)
 	e4:SetCode(EVENT_LEAVE_FIELD)
 	e4:SetOperation(c94212438.tgop)
 	c:RegisterEffect(e4)
+	--win
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_CHAIN_SOLVING)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_DELAY)
+	e5:SetOperation(c94212438.winop)
+	c:RegisterEffect(e5)
 end
 function c94212438.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
-end
-function c94212438.cfilter1(c,code)
-	return c:IsFaceup() and c:IsCode(code)
+	return Duel.GetTurnPlayer()~=tp and e:GetHandler():GetFlagEffect(94212438)<4
 end
 function c94212438.operation(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
-	if not Duel.IsExistingMatchingCard(c94212438.cfilter1,tp,LOCATION_SZONE,0,1,nil,31893528) then
+	if c:GetFlagEffect(94212438)==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
 		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,31893528)
 		if g:GetCount()>0 then
 			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 		end
-	elseif not Duel.IsExistingMatchingCard(c94212438.cfilter1,tp,LOCATION_SZONE,0,1,nil,67287533) then
+	elseif c:GetFlagEffect(94212438)==1 then
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
 		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,67287533)
 		if g:GetCount()>0 then
 			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 		end
-	elseif not Duel.IsExistingMatchingCard(c94212438.cfilter1,tp,LOCATION_SZONE,0,1,nil,94772232) then
+	elseif c:GetFlagEffect(94212438)==2 then
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
 		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,94772232)
 		if g:GetCount()>0 then
 			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 		end
-	elseif not Duel.IsExistingMatchingCard(c94212438.cfilter1,tp,LOCATION_SZONE,0,1,nil,30170981) then
+	elseif c:GetFlagEffect(94212438)==3 then
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
 		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,30170981)
 		if g:GetCount()>0 then
 			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-			Duel.Win(tp,0x15)
 		end
 	end
+	c:RegisterFlagEffect(94212438,RESET_EVENT+0x1fe0000,0,0)
 end
 function c94212438.cfilter2(c,tp)
-	local code=c:GetCode()
-	return (code==94212438 or code==31893528 or code==67287533 or code==94772232 or code==30170981) and c:IsControler(tp)
+	return c:IsCode(94212438,31893528,67287533,94772232,30170981) and c:IsControler(tp)
 end
 function c94212438.cfilter3(c)
-	local code=c:GetCode()
-	return c:IsFaceup() and (code==94212438 or code==31893528 or code==67287533 or code==94772232 or code==30170981)
+	return c:IsFaceup() and c:IsCode(94212438,31893528,67287533,94772232,30170981)
 end
 function c94212438.tgcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c94212438.cfilter2,1,nil,tp)
@@ -81,3 +85,15 @@ function c94212438.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c94212438.cfilter3,tp,LOCATION_SZONE,0,nil)
 	Duel.SendtoGrave(g,REASON_EFFECT)
 end
+function c94212438.cfilter1(c,code)
+	return c:IsFaceup() and c:IsCode(code)
+end
+function c94212438.winop(e,tp,eg,ep,ev,re,r,rp)
+	local WIN_REASON_DESTINY_BOARD=0x15
+	local c=e:GetHandler()
+	local g=Duel.GetFieldGroup(tp,LOCATION_SZONE,0)
+	if g:IsExists(c94212438.cfilter1,1,nil,94212438) and g:IsExists(c94212438.cfilter1,1,nil,31893528) and g:IsExists(c94212438.cfilter1,1,nil,67287533)
+		 and g:IsExists(c94212438.cfilter1,1,nil,94772232) and g:IsExists(c94212438.cfilter1,1,nil,30170981) then
+		Duel.Win(tp,WIN_REASON_DESTINY_BOARD)
+ 	end
+ end

--- a/c94212438.lua
+++ b/c94212438.lua
@@ -82,7 +82,7 @@ function c94212438.tgcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c94212438.cfilter2,1,nil,tp)
 end
 function c94212438.tgop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c94212438.cfilter3,tp,LOCATION_SZONE,0,nil)
+	local g=Duel.GetMatchingGroup(c94212438.cfilter3,tp,LOCATION_ONFIELD,0,nil)
 	Duel.SendtoGrave(g,REASON_EFFECT)
 end
 function c94212438.cfilter1(c,code)
@@ -91,7 +91,7 @@ end
 function c94212438.winop(e,tp,eg,ep,ev,re,r,rp)
 	local WIN_REASON_DESTINY_BOARD=0x15
 	local c=e:GetHandler()
-	local g=Duel.GetFieldGroup(tp,LOCATION_SZONE,0)
+	local g=Duel.GetFieldGroup(tp,LOCATION_ONFIELD,0)
 	if g:IsExists(c94212438.cfilter1,1,nil,94212438) and g:IsExists(c94212438.cfilter1,1,nil,31893528) and g:IsExists(c94212438.cfilter1,1,nil,67287533)
 		 and g:IsExists(c94212438.cfilter1,1,nil,94772232) and g:IsExists(c94212438.cfilter1,1,nil,30170981) then
 		Duel.Win(tp,WIN_REASON_DESTINY_BOARD)


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12728&keyword=&tag=-1
なお、その後に、「王宮のお触れ」の適用がなくなったのであれば、「ウィジャ盤」の『相手のエンドフェイズ毎に、手札・デッキから「死のメッセージ」カード１枚を「E」「A」「T」「H」の順番で魔法＆罠カードゾーンに出す』効果は発動しますが、次に出す「死のメッセージ」と名のついたカードは順番通り「死のメッセージ「T」」になります。