### PR TITLE
fix Destiny Hero - Dogma

### DIFF
--- a/c17132130.lua
+++ b/c17132130.lua
@@ -14,7 +14,6 @@ function c17132130.initial_effect(c)
 	e2:SetCode(EFFECT_SPSUMMON_PROC)
 	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
 	e2:SetRange(LOCATION_HAND)
-	e2:SetValue(1)
 	e2:SetCondition(c17132130.spcon)
 	e2:SetOperation(c17132130.spop)
 	c:RegisterEffect(e2)
@@ -45,7 +44,7 @@ function c17132130.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.Release(sg2,REASON_COST)
 end
 function c17132130.lp(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL+1
+	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL
 end
 function c17132130.lpop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
fix: the effect to halve the opponents lp should happen in the SP after the summon, no matter the way it is special summoned (thus also after being special summoned by something like "A Wild Monster Appears!" which it doesn't at the moment)