### PR TITLE
fix Gateway to Chaos, Kyoutou Waterfront

### DIFF
--- a/c40089744.lua
+++ b/c40089744.lua
@@ -49,9 +49,11 @@ function c40089744.cfilter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsPreviousLocation(LOCATION_HAND+LOCATION_ONFIELD)
 end
 function c40089744.acop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
 	local ct=eg:FilterCount(c40089744.cfilter,nil)
-	if ct>0 then
-		e:GetHandler():AddCounter(0x3001,ct)
+	local cct=math.min(6-c:GetCounter(0x3001),ct)
+	if cct>0 then
+		c:AddCounter(0x3001,cct)
 	end
 end
 function c40089744.thcost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c56111151.lua
+++ b/c56111151.lua
@@ -33,13 +33,12 @@ function c56111151.initial_effect(c)
 	e4:SetOperation(c56111151.desrepop)
 	c:RegisterEffect(e4)
 end
-function c56111151.cfilter(c)
-	return c:IsPreviousLocation(LOCATION_ONFIELD)
-end
 function c56111151.counter(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
 	local ct=eg:FilterCount(c56111151.cfilter,nil)
-	if ct>0 then
-		e:GetHandler():AddCounter(0x37+COUNTER_NEED_ENABLE,ct)
+	local cct=math.min(5-c:GetCounter(0x37),ct)
+	if cct>0 then
+		c:AddCounter(0x37+COUNTER_NEED_ENABLE,cct)
 	end
 end
 function c56111151.thfilter(c)

--- a/c56111151.lua
+++ b/c56111151.lua
@@ -35,7 +35,7 @@ function c56111151.initial_effect(c)
 end
 function c56111151.counter(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local ct=eg:FilterCount(c56111151.cfilter,nil)
+	local ct=eg:FilterCount(Card.IsPreviousLocation,nil,LOCATION_ONFIELD)
 	local cct=math.min(5-c:GetCounter(0x37),ct)
 	if cct>0 then
 		c:AddCounter(0x37+COUNTER_NEED_ENABLE,cct)


### PR DESCRIPTION
Fix this: If 3 or more monsters were sent to graveyard while 4 counters are on Gateway to Chaos or Kyoutou Waterfront, Gateway to Chaos and Kyoutou Waterfront doesn't put counter.

Konamis Answer:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「混沌の場」に魔力カウンターが5つ置かれている状態で「融合」を発動し、手札の「暗黒騎士ガイア」と「カース・オブ・ドラゴン」を墓地へ送り、「竜騎士ガイア」を融合召喚した場合、「混沌の場」に魔力カウンターは置かれますか？ 
A. 
ご質問の状況の場合でも、魔力カウンターは置きます。 
なお、「混沌の場」に置ける魔力カウンターは最大で6つまでのため、6つ目は置きますが、7つ目の魔力カウンターを置く事はありません。