### PR TITLE
fix Performapal Monkeyboard

### DIFF
--- a/c17330916.lua
+++ b/c17330916.lua
@@ -74,7 +74,7 @@ function c17330916.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(e:GetHandler(),REASON_DISCARD)
 end
 function c17330916.filter(c)
-	return (c:IsSetCard(0x9f) or c:IsSetCard(0x99)) and c:IsType(TYPE_MONSTER)
+	return (c:IsSetCard(0x9f) or c:IsSetCard(0x99)) and c:IsType(TYPE_MONSTER) and c:IsLevelAbove(2)
 end
 function c17330916.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c17330916.filter,tp,LOCATION_HAND,0,1,e:GetHandler()) end


### PR DESCRIPTION
Fix this: You can reveal Performapal Odd-Eyes Unicorn in your hand.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12111
■『手札の「EM」モンスターまたは「オッドアイズ」モンスター１体を相手に見せる』効果処理にて、レベル1のモンスターを見せる事はできません。 