### PR TITLE
fix Junk Destroyer

### DIFF
--- a/c74860293.lua
+++ b/c74860293.lua
@@ -24,7 +24,8 @@ function c74860293.con(e,tp,eg,ep,ev,re,r,rp)
 end
 function c74860293.tg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsDestructable() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsDestructable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsDestructable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
+		and e:GetHandler():GetMaterialCount()>1 end
 	local mc=e:GetHandler():GetMaterialCount()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,Card.IsDestructable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,mc-1,nil)


### PR DESCRIPTION
fix this: if you summon Junk Destroyer as Summon Type Synchro without using materials (Harmony of the King's Soul) you can target an infinite amount of cards to destroy.