### PR TITLE
fix HSR快刀乱破ズール

### DIFF
--- a/c86943389.lua
+++ b/c86943389.lua
@@ -49,7 +49,8 @@ function c86943389.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c86943389.regcon(e,tp,eg,ep,ev,re,r,rp)
-	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and bit.band(c:GetSummonType(),SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO
 end
 function c86943389.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
it shouldn't be able to active the return to hand effect if the synchro summon was disabled.