### PR TITLE
fix Cosmic Fortress Gol'gar

### DIFF
--- a/c68319538.lua
+++ b/c68319538.lua
@@ -40,10 +40,10 @@ end
 function c68319538.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local rg=tg:Filter(Card.IsRelateToEffect,nil,e)
-	local ct=Duel.SendtoHand(rg,nil,REASON_EFFECT)
-	if ct==0 then return end
+	Duel.SendtoHand(rg,nil,REASON_EFFECT)
+	local ct=rg:FilterCount(Card.IsLocation,nil,LOCATION_HAND)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	if g:GetCount()==0 then return end
+	if ct==0 or g:GetCount()==0 then return end
 	for i=1,ct do
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(68319538,2))
 		local sg=g:Select(tp,1,1,nil)


### PR DESCRIPTION
FIx this: If Fusion, Synchro or Xyz Monster returned to deck by Gol'gar effect, you can put A-Counter.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7949&keyword=&tag=-1
Q.「宇宙砦ゴルガー」の『１ターンに１度、自分のメインフェイズ時に発動できる。フィールド上に表側表示で存在する魔法・罠カードを任意の枚数選択して持ち主の手札に戻し、その後手札に戻したカードの数だけAカウンターをフィールド上に表側表示で存在するモンスターに置く』効果の対象として、「サクリファイス」の『①：１ターンに１度、相手フィールドのモンスター１体を対象として発動できる。その相手モンスターを装備カード扱いとしてこのカードに装備する（１体のみ装備可能）』の効果によって装備カード扱いとなっている融合・シンクロ・エクシーズモンスターを選択した場合、処理はどうなりますか？
A.「宇宙砦ゴルガー」の効果で手札に戻す対象として、装備カード扱いとなっている融合モンスター等を選択する事はできます。
その場合、対象の融合モンスター等は持ち主の手札には戻らず、持ち主のエクストラデッキに戻りますので、『その後手札に戻したカードの数だけAカウンターをフィールド上に表側表示で存在するモンスターに置く』処理の際に、その融合モンスター等の枚数分は含まれません。