### PR TITLE
fix Fusion Tag

### DIFF
--- a/c59432181.lua
+++ b/c59432181.lua
@@ -21,7 +21,7 @@ function c59432181.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c59432181.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) then return end
+	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
 	local cg=Duel.SelectMatchingCard(tp,c59432181.filter,tp,LOCATION_EXTRA,0,1,1,nil)
 	if cg:GetCount()==0 then return end


### PR DESCRIPTION
Fix this: If target monster is face-down, Fusion Tags effect apply.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18075&keyword=&tag=-1
Q.自分のモンスターゾーンの「E・HERO スパークマン」を対象に「融合識別」を発動しました。
その発動にチェーンして「月の書」が発動し、対象の「E・HERO スパークマン」が裏側守備表示になった場合、「融合識別」の『①：自分フィールドのモンスター１体を対象として発動できる。エクストラデッキの融合モンスター１体を相手に見せる。このターン、対象のモンスターを融合素材とする場合、その見せたモンスターの同名カードとして融合素材にできる』処理はどうなりますか？
A.「融合識別」の効果の対象となったモンスターが効果処理時に裏側守備表示になっている場合、効果処理は適用されません。
（エクストラデッキの融合モンスターを相手に見せる処理も行いません。）