### PR TITLE
fix Uni-Zombie

### DIFF
--- a/c49959355.lua
+++ b/c49959355.lua
@@ -69,7 +69,7 @@ function c49959355.lvop2(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,c49959355.tgfilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()==0 or Duel.SendtoGrave(g,REASON_EFFECT)==0 then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and g:GetFirst():IsLocation(LOCATION_GRAVE) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_LEVEL)


### PR DESCRIPTION
if the monster is not sent to the grave for the second effect the level shouldn't raise (but currently it does so)

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14413&keyword=&tag=-1
 Question
「マクロコスモス」が適用されている場合、「ユニゾンビ」の『①：フィールドのモンスター１体を対象として発動できる。手札を１枚捨て、対象のモンスターのレベルを１つ上げる』効果や、『②：フィールドのモンスター１体を対象として発動できる。デッキからアンデット族モンスター１体を墓地へ送り、対象のモンスターのレベルを１つ上げる。この効果の発動後、ターン終了時までアンデット族以外の自分のモンスターは攻撃できない』効果を発動する事はできますか？
Answer
「マクロコスモス」の効果が適用されている場合でも、「ユニゾンビ」のそれぞれの効果を発動する事はできます。

「マクロコスモス」の適用中に、「ユニゾンビ」の『①：フィールドのモンスター１体を対象として発動できる。手札を１枚捨て、対象のモンスターのレベルを１つ上げる』効果を発動した場合、効果処理にて捨てた手札は除外される事になりますが、通常通り対象のモンスターのレベルは１つ上がります。

また、「マクロコスモス」の適用中に、『②：フィールドのモンスター１体を対象として発動できる。デッキからアンデット族モンスター１体を墓地へ送り、対象のモンスターのレベルを１つ上げる。この効果の発動後、ターン終了時までアンデット族以外の自分のモンスターは攻撃できない』効果を発動した場合、デッキから選んだアンデット族モンスターは除外される事になります。
その場合、デッキからアンデット族モンスターが墓地へ送られていませんので、対象のモンスターのレベルは上がりません。 