### PR TITLE
fix Dinomist Rex

### DIFF
--- a/c63251695.lua
+++ b/c63251695.lua
@@ -48,9 +48,10 @@ function c63251695.effcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c63251695.efftg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local b1=e:GetHandler():IsChainAttackable(2,true)
+	local c=e:GetHandler()
+	local b1=c:IsChainAttackable(2,true)
 	local b2=Duel.IsExistingMatchingCard(Card.IsAbleToDeck,tp,0,LOCATION_ONFIELD+LOCATION_HAND,1,nil)
-	if chk==0 then return b1 or b2 end
+	if chk==0 then return (b1 or b2) and c:IsRelateToEffect(e) end
 	local opt=0
 	if b1 and b2 then
 		opt=Duel.SelectOption(tp,aux.Stringid(63251695,2),aux.Stringid(63251695,3))


### PR DESCRIPTION
Fix this: If Dinomist Rex destroyed by battle while Dinomist Rex is attacking, Dinomist Rex can activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17428&keyword=&tag=-1
Q.自分の「ダイナミスト・レックス」が相手モンスターに攻撃を行い、その結果、戦闘によって破壊されました。
その場合、その戦闘で破壊された「ダイナミスト・レックス」の『①：このカードが攻撃を行ったダメージステップ終了時、このカード以外の自分フィールドの「ダイナミスト」モンスター１体をリリースし、以下の効果から１つを選択して発動できる』モンスター効果を発動する事はできますか？
A.「ダイナミスト・レックス」のモンスター効果は、ダメージステップ終了時にフィールドにて発動する誘発効果です。
質問の状況の場合、戦闘によって破壊された「ダイナミスト・レックス」はフィールドを離れ、エクストラデッキに表側表示で加わっていますので、ダメージステップ終了時に「ダイナミスト・レックス」のモンスター効果を発動する事はできません。