### PR TITLE
fix Harpie Dancer

### DIFF
--- a/c68815132.lua
+++ b/c68815132.lua
@@ -35,7 +35,7 @@ function c68815132.sumfilter(c)
 end
 function c68815132.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND+LOCATION_EXTRA) then
+	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND) then
 		if Duel.IsExistingMatchingCard(c68815132.sumfilter,tp,LOCATION_HAND,0,1,nil)
 			and Duel.SelectYesNo(tp,aux.Stringid(68815132,1)) then
 			Duel.BreakEffect()


### PR DESCRIPTION
Fix this: If Fusion, Synchro or Xyz Monster returned to deck, you can Normal Summon 1 WIND monster.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12704&keyword=&tag=-1
その場合、選択したモンスターは手札には戻らず、持ち主のエクストラデッキに戻りますので、『その後、風属性モンスター1体を召喚できる』効果を適用する事はできません。