### PR TITLE
fix Snake Whistle

### DIFF
--- a/c81791932.lua
+++ b/c81791932.lua
@@ -11,8 +11,8 @@ function c81791932.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c81791932.cfilter(c,tp)
-	return c:IsRace(RACE_REPTILE) and c:GetPreviousControler()==tp
-		and c:IsPreviousLocation(LOCATION_ONFIELD)
+	return c:IsRace(RACE_REPTILE) and c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp
+		and c:IsPreviousLocation(LOCATION_MZONE)
 end
 function c81791932.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c81791932.cfilter,1,nil,tp)


### PR DESCRIPTION
Fix this: If face-down Reptile-Type monster was destroyed, or if Reptile-Type Pendulum Monster was destroyed in Pendulum Zone, Snake Whistle can activate.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7165
■自分のモンスターゾーンに表側表示で存在する爬虫類族モンスターが破壊された時に発動する事ができます。（裏側守備表示の爬虫類族モンスターが破壊された時に発動する事はできません。）