### PR TITLE
fix Ma’at

### DIFF
--- a/c18631392.lua
+++ b/c18631392.lua
@@ -46,7 +46,12 @@ function c18631392.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.SendtoGrave(g1,REASON_COST)
 end
 function c18631392.anctg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,3) end
+	if chk==0 then 
+		if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)<3 then return false end
+		local g=Duel.GetDecktopGroup(tp,3)
+		local result=g:FilterCount(Card.IsAbleToHand,nil)>0
+		return result and Duel.IsPlayerCanDiscardDeck(tp,3)
+	end
 	Duel.Hint(HINT_SELECTMSG,tp,0)
 	local ac1=Duel.AnnounceCard(tp)
 	Duel.Hint(HINT_SELECTMSG,tp,0)


### PR DESCRIPTION
Fix this: If Thunder King Rai-Oh is on the field, Ma’at can activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7992&keyword=&tag=-1
Q.「マアト」の『１ターンに１度、カード名を３つ宣言して発動できる。自分のデッキの上からカードを３枚めくり、宣言したカードは手札に加える。それ以外のめくったカードは全て墓地へ送る。このカードの攻撃力・守備力は、この効果で手札に加えたカードの数×１０００ポイントになる』効果は、「ライオウ」の『このカードが自分フィールド上に表側表示で存在する限り、お互いにドロー以外の方法でデッキからカードを手札に加える事はできない』効果の適用中に発動する事はできますか？
A.「ライオウ」の効果の適用中に、「マアト」の効果を発動する事はできません。