### PR TITLE
fix Weights & Zenmaisures

### DIFF
--- a/c42548470.lua
+++ b/c42548470.lua
@@ -33,10 +33,10 @@ function c42548470.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc2=g:GetNext()
 	local lv1=tc1:GetLevel()
 	local lv2=tc2:GetLevel()
-	if lv1==lv2 then return end
 	if tc1:IsFaceup() and tc1:IsRelateToEffect(e) and tc2:IsFaceup() and tc2:IsRelateToEffect(e) then
 		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_TARGET)
 		local sg=g:Select(1-tp,1,1,nil)
+		if lv1==lv2 then return end
 		if sg:GetFirst()==tc1 then
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
Fix this: If Wind-Up Soldier's level and Wind-Up Rat's level are the same, your opponent cannot choose 1 of them.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6060&keyword=&tag=-1
Q.レベル4の「ゼンマイソルジャー」と、レベル3の「ゼンマイネズミ」を対象として、自分は「揺れる発条秤」を発動しました。
その発動にチェーンして相手が「スター・チェンジャー」を発動し、「揺れる発条秤」の対象となっている2体のモンスターのレベルが効果処理時に同じになっている場合、処理はどうなりますか？
A.質問の状況の場合、「揺れる発条秤」の効果の対象となった「ゼンマイソルジャー」と「ゼンマイネズミ」のレベルが効果処理時に同じになっていますので、**『その内１体を相手が選び』の処理は行いますが**、2体のモンスターのレベルは同じになっていますので『もう１体のモンスターのレベルはエンドフェイズ時まで、相手が選んだモンスターと同じになる』処理は適用されません。