### PR TITLE
fix Counterforce

### DIFF
--- a/c30488793.lua
+++ b/c30488793.lua
@@ -20,13 +20,14 @@ function c30488793.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local a1=Duel.GetAttacker():GetAttack()
 	local a2=Duel.GetAttackTarget():GetAttack()
-	local dam=a1-a2
-	if dam<0 then dam=-dam end
+	local dam=math.abs(a1-a2)
 	Duel.SetTargetPlayer(1-tp)
 	Duel.SetTargetParam(dam)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,0,0,1-tp,dam)
 end
 function c30488793.activate(e,tp,eg,ep,ev,re,r,rp)
-	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
-	Duel.Damage(p,d,REASON_EFFECT)
+	if Duel.GetAttacker():GetAttack():IsFaceup() and Duel.GetAttackTarget():GetAttack():IsFaceup() then
+		local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+		Duel.Damage(p,d,REASON_EFFECT)
+	end
 end


### PR DESCRIPTION
Fix this: If yourself monster or your opponent monster is face-down, your opponent take damage.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8564&keyword=&tag=-1
Q.自分の「No.39 希望皇ホープ」が相手の「アマゾネスの剣士」を攻撃した際に、「No.39 希望皇ホープ」の『①：自分または相手のモンスターの攻撃宣言時、このカードのX素材を１つ取り除いて発動できる。そのモンスターの攻撃を無効にする』効果を発動し、自身の攻撃を無効にしました。
この状況で、自分が「反発力」を発動した際に、相手がチェーンして「月の書」を発動し、攻撃を行った「No.39 希望皇ホープ」、攻撃対象となった「アマゾネスの剣士」のどちらかを裏側守備表示にした場合、「反発力」の効果処理はどうなりますか？
A.質問の状況のように、「反発力」の効果処理時に、攻撃を行った攻撃モンスターまたは攻撃対象モンスターのどちらかが裏側守備表示になっているような場合には、『その２体のモンスターの攻撃力の差分のダメージを相手ライフに与える』処理は適用されません。 