### PR TITLE
fix Dried Winds

### DIFF
--- a/c28265983.lua
+++ b/c28265983.lua
@@ -1,24 +1,28 @@
 --渇きの風
 function c28265983.initial_effect(c)
+	Duel.EnableGlobalFlag(GLOBALFLAG_DELAYED_QUICKEFFECT)
 	--activate
+	local e0=Effect.CreateEffect(c)
+	e0:SetDescription(aux.Stringid(28265983,0))
+	e0:SetType(EFFECT_TYPE_ACTIVATE)
+	e0:SetCode(EVENT_FREE_CHAIN)
+	e0:SetTarget(c28265983.target)
+	c:RegisterEffect(e0)
+	--activate(destroy)
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(28265983,1))
+	e1:SetCategory(CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetHintTiming(TIMING_RECOVER,0)
-	e1:SetTarget(c28265983.target)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_RECOVER)
+	e1:SetCountLimit(1,28265983)
+	e1:SetCondition(c28265983.descon1)
+	e1:SetTarget(c28265983.destg1)
+	e1:SetOperation(c28265983.desop1)
 	c:RegisterEffect(e1)
-	--destroy
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(28265983,1))
-	e2:SetCategory(CATEGORY_DESTROY)
+	local e2=e1:Clone()
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e2:SetCode(EVENT_RECOVER)
 	e2:SetRange(LOCATION_SZONE)
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e2:SetCountLimit(1,28265983)
-	e2:SetCondition(c28265983.descon1)
-	e2:SetTarget(c28265983.destg1)
-	e2:SetOperation(c28265983.desop1)
 	c:RegisterEffect(e2)
 	--destroy
 	local e3=Effect.CreateEffect(c)
@@ -34,36 +38,16 @@ function c28265983.initial_effect(c)
 	e3:SetOperation(c28265983.desop2)
 	c:RegisterEffect(e3)
 end
-function c28265983.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return c28265983.destg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc) end
+function c28265983.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local res,teg,tep,tev,tre,tr,trp=Duel.CheckEvent(EVENT_RECOVER,true)
-	local b1=res and c28265983.descon1(e,tp,teg,tep,tev,tre,tr,trp) and c28265983.destg1(e,tp,teg,tep,tev,tre,tr,trp,0)
-	local b2=c28265983.descon2(e,tp,eg,ep,ev,re,r,rp) and c28265983.descost2(e,tp,eg,ep,ev,re,r,rp,0) and c28265983.destg2(e,tp,eg,ep,ev,re,r,rp,0)
-	if (b1 or b2) and Duel.SelectYesNo(tp,94) then
-		local opt=0
-		if b1 and b2 then
-			opt=Duel.SelectOption(tp,aux.Stringid(28265983,1),aux.Stringid(28265983,2))
-		elseif b1 then
-			opt=Duel.SelectOption(tp,aux.Stringid(28265983,1))
-		else
-			opt=Duel.SelectOption(tp,aux.Stringid(28265983,2))+1
-		end
-		if opt==0 then
-			e:SetCategory(CATEGORY_DESTROY)
-			e:SetProperty(EFFECT_FLAG_CARD_TARGET)
-			e:SetOperation(c28265983.desop1)
-			c28265983.destg1(e,tp,teg,tep,tev,tre,tr,trp,1)
-		else
-			e:SetCategory(CATEGORY_DESTROY)
-			e:SetProperty(0)
-			e:SetOperation(c28265983.desop2)
-			c28265983.descost2(e,tp,eg,ep,ev,re,r,rp,1)
-			c28265983.destg2(e,tp,eg,ep,ev,re,r,rp,1)
-		end
+	local b=c28265983.descon2(e,tp,eg,ep,ev,re,r,rp) and c28265983.descost2(e,tp,eg,ep,ev,re,r,rp,0) and c28265983.destg2(e,tp,eg,ep,ev,re,r,rp,0)
+	if b and Duel.SelectYesNo(tp,94) then
+		e:SetCategory(CATEGORY_DESTROY)
+		e:SetOperation(c28265983.desop2)
+		c28265983.descost2(e,tp,eg,ep,ev,re,r,rp,1)
+		c28265983.destg2(e,tp,eg,ep,ev,re,r,rp,1)
 	else
 		e:SetCategory(0)
-		e:SetProperty(0)
 		e:SetOperation(nil)
 	end
 end
@@ -75,11 +59,10 @@ function c28265983.desfilter1(c)
 end
 function c28265983.destg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c28265983.desfilter1(chkc) end
-	if chk==0 then return Duel.GetFlagEffect(tp,28265983)==0 end
+	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c28265983.desfilter1,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
-	Duel.RegisterFlagEffect(tp,28265983,RESET_PHASE+PHASE_END,0,1)
 end
 function c28265983.desop1(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end


### PR DESCRIPTION
Duel.CheckEvent cannot check delayed event.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=15763&keyword=&tag=-1
Q.相手の「サイクロン」の発動にチェーンして、自分がその対象となった「炎虎梁山爆」の『このカードの発動時に、自分は自分フィールド上の永続魔法・永続罠カードの数×５００ライフポイント回復する』効果を発動しました。
その一連のチェーン処理後、自分の魔法＆罠ゾーンにセットされている「渇きの風」のカードの発動と、『①：自分のLPが回復した場合、相手フィールドの表側表示モンスター１体を対象としてこの効果を発動する。そのモンスターを破壊する』効果を同一のチェーンブロックで発動する事はできますか？
A.質問の状況の場合でも、自分のライフポイントが回復していますので、一連のチェーン処理後に「渇きの風」のカードの発動と、その同一のチェーンブロックでの効果の発動を行う事ができます。
なお、質問の状況の場合、相手の「サイクロン」で破壊され墓地へ送られた「炎虎梁山爆」の『フィールド上に表側表示で存在するこのカードが相手の効果によって墓地へ送られた場合、自分の墓地の永続魔法・永続罠カードの数×５００ポイントダメージを相手ライフに与える』効果がチェーン1にて発動する事になりますので、「渇きの風」のカードの発動はチェーン2以降にて行う事になります。