### PR TITLE
fix Artifacts Unleashed

### DIFF
--- a/c56611470.lua
+++ b/c56611470.lua
@@ -13,7 +13,7 @@ function c56611470.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(56611470,0))
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_DELAY)
 	e2:SetCode(EVENT_DESTROYED)
 	e2:SetCondition(c56611470.drcon)
 	e2:SetCost(c56611470.drcost)
@@ -48,16 +48,10 @@ function c56611470.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetTargetCard(sg1)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
+function c56611470.tfilter(c,e)
+	return c:IsRelateToEffect(e) and c:IsFaceup()
+end
 function c56611470.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<-1 then return end
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
-	if g:GetCount()<2 then return end
-	local xyzg=Duel.GetMatchingGroup(c56611470.xyzfilter,tp,LOCATION_EXTRA,0,nil,g)
-	if xyzg:GetCount()>0 then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local xyz=xyzg:Select(tp,1,1,nil):GetFirst()
-		Duel.XyzSummon(tp,xyz,g)
-	end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_ATTACK)
@@ -65,6 +59,15 @@ function c56611470.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetTarget(c56611470.attg)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<-1 then return end
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c56611470.tfilter,nil,e)
+	if g:GetCount()<2 then return end
+	local xyzg=Duel.GetMatchingGroup(c56611470.xyzfilter,tp,LOCATION_EXTRA,0,nil,g)
+	if xyzg:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local xyz=xyzg:Select(tp,1,1,nil):GetFirst()
+		Duel.XyzSummon(tp,xyz,g)
+	end
 end
 function c56611470.attg(e,c)
 	return not c:IsSetCard(0x97)


### PR DESCRIPTION
Fix this: If target monster was face-down, Artifacts Xyz Monster can Xyz Summon.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9790&keyword=&tag=-1
Q.「アーティファクト－ヴァジュラ」と「アーティファクト－デスサイズ」の2体を対象として「アーティファクトの解放」を発動しました。
その発動にチェーンして、「月の書」が発動し、「アーティファクト－ヴァジュラ」が裏側守備表示になった場合、「アーティファクトの解放」の『選択したモンスター２体のみを素材としてエクシーズモンスター１体をエクシーズ召喚する。このカードを発動したターン、「アーティファクト」と名のついたモンスター以外の自分フィールド上のモンスターは攻撃できない』処理はどうなりますか？
A.「アーティファクトの解放」の対象として選択した2体のモンスターのうち、1体が裏側守備表示になっている場合、『選択したモンスター２体のみを素材としてエクシーズモンスター１体をエクシーズ召喚する』事はできません。選択したモンスター2体はそのままモンスターゾーンに残ります。
なお、その場合でも、『このカードを発動したターン、「アーティファクト」と名のついたモンスター以外の自分フィールド上のモンスターは攻撃できない』は適用されます。