### PR TITLE
update Raidraptor - Nest

### DIFF
--- a/c8559793.lua
+++ b/c8559793.lua
@@ -36,6 +36,5 @@ function c8559793.operation(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 and not g:GetFirst():IsHasEffect(EFFECT_NECRO_VALLEY) then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
-		Duel.ShuffleDeck(tp)
 	end
 end


### PR DESCRIPTION
the deck is automaticly shuffled after adding a card from the deck to the hand anyway
also, removing the shuffle command here prevents the deck from being shuffled when adding the card from the grave to the hand, a shuffle shouldn't happen there