### PR TITLE
fix Performage Hat Tricker

### DIFF
--- a/c31292357.lua
+++ b/c31292357.lua
@@ -39,7 +39,7 @@ function c31292357.cttg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c31292357.ctop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and c:AddCounter(0x3036,1)~=0 then
+	if c:IsRelateToEffect(e) and c:GetCounter(0x3036)~=3 and c:AddCounter(0x3036,1)~=0 then
 		local cid=Duel.GetChainInfo(ev,CHAININFO_CHAIN_ID)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_FIELD)


### PR DESCRIPTION
fix this: if you activate the effect several times in the same chain and fail to add a counter due to the max amount being reached somewhen in the middle of the resolution the damage is still negated (example: you have 4 effects that would inflict damage, you activate the effect 4 times -> the 4th effect would still deal 0 damage, despite no counter being placed)