### PR TITLE
fix Infinite Dismissal

### DIFF
--- a/c54109233.lua
+++ b/c54109233.lua
@@ -4,6 +4,9 @@ function c54109233.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_END_PHASE)
+	e1:SetTarget(c54109233.target1)
+	e1:SetOperation(c54109233.activate)
 	c:RegisterEffect(e1)
 	--destroy
 	local e2=Effect.CreateEffect(c)
@@ -15,6 +18,7 @@ function c54109233.initial_effect(c)
 	e2:SetCode(EVENT_PHASE+PHASE_END)
 	e2:SetTarget(c54109233.target)
 	e2:SetOperation(c54109233.activate)
+	e2:SetLabel(1)
 	c:RegisterEffect(e2)
 	if not c54109233.global_check then
 		c54109233.global_check=true
@@ -36,13 +40,28 @@ end
 function c54109233.filter(c)
 	return c:IsLevelBelow(3) and c:GetFlagEffect(54109233)~=0 and c:IsDestructable()
 end
-function c54109233.target(e,tp,eg,ep,ev,re,r,rp,chk)
+function c54109233.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
+	if Duel.GetCurrentPhase()==PHASE_END and Duel.SelectYesNo(tp,94) then
+		e:SetCategory(CATEGORY_DESTROY)
+		e:SetLabel(1)
+		local g=Duel.GetMatchingGroup(c54109233.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+		e:GetHandler():RegisterFlagEffect(54109234,RESET_PHASE+PHASE_END,0,1)
+		e:GetHandler():RegisterFlagEffect(0,RESET_CHAIN,EFFECT_FLAG_CLIENT_HINT,1,0,65)
+	else
+		e:SetCategory(0)
+		e:SetLabel(0)
+	end
+end
+function c54109233.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(54109234)==0 end
 	local g=Duel.GetMatchingGroup(c54109233.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+	e:GetHandler():RegisterFlagEffect(54109234,RESET_PHASE+PHASE_END,0,1)
 end
 function c54109233.activate(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) then return end
+	if e:GetLabel()==0 or not e:GetHandler():IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c54109233.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.Destroy(g,REASON_EFFECT)
 end


### PR DESCRIPTION
Fix this: You cannot activate and use effect in the same Chain.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5112
■エンドフェイズに「メサイアの蟻地獄」のカードの発動を行う場合、カードの発動と同一のチェーンブロックにて、『フィールド上に表側表示で存在する全てのレベル３以下のモンスターは、召喚・反転召喚したターンのエンドフェイズ時に破壊される』効果の発動を行う事もできます。