### PR TITLE
fix hint

### DIFF
--- a/c19254117.lua
+++ b/c19254117.lua
@@ -2,6 +2,7 @@
 function c19254117.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(19254117,0))
 	e1:SetCategory(CATEGORY_ATKCHANGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetHintTiming(TIMING_DAMAGE_STEP)
@@ -14,6 +15,7 @@ function c19254117.initial_effect(c)
 	c:RegisterEffect(e1)
 	--attack target
 	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(19254117,1))
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_FREE_CHAIN)
 	e2:SetRange(LOCATION_GRAVE)
@@ -46,6 +48,7 @@ function c19254117.activate(e,tp,eg,ep,ev,re,r,rp)
 		--def to 0
 		tc:RegisterFlagEffect(19254117,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		local e2=Effect.CreateEffect(c)
+		e2:SetDescription(aux.Stringid(19254117,2))
 		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e2:SetCode(EVENT_PHASE+PHASE_END)
 		e2:SetCountLimit(1)


### PR DESCRIPTION
修复同一回合同一张仁王立发动1效果然后发动墓地效果除外然后被回到墓地的场合，回合结束时用户无法判断是触发守备力变0还是触发墓地效果