### PR TITLE
fix Backs to the Wall

### DIFF
--- a/c32603633.lua
+++ b/c32603633.lua
@@ -16,12 +16,11 @@ function c32603633.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c32603633.filter(c,e,tp)
 	return c:IsSetCard(0x3d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and not Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_MZONE,0,1,nil,c:GetCode())
+		and not Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,c:GetCode())
 end
 function c32603633.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 
-		and Duel.IsExistingMatchingCard(c32603633.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
-	end
+		and Duel.IsExistingMatchingCard(c32603633.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE)
 end
 function c32603633.op(e,tp,eg,ep,ev,re,r,rp)
@@ -31,7 +30,7 @@ function c32603633.op(e,tp,eg,ep,ev,re,r,rp)
 	while g:GetCount()>0 and ft>0 do
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local sg=g:Select(tp,1,1,nil)
-		Duel.SpecialSummonStep(sg:GetFirst(), 0, tp, tp, false, false, POS_FACEUP)
+		Duel.SpecialSummonStep(sg:GetFirst(),0,tp,tp,false,false,POS_FACEUP)
 		ft=ft-1
 		g:Remove(Card.IsCode,nil,sg:GetFirst():GetCode())
 	end


### PR DESCRIPTION
Fix this: If your opponent controls "Six Samurai" monster, you can Special Summon a monster that has the same name as a monster your opponent already control.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9037&keyword=&tag=-1
Q.相手のモンスターゾーンに「六武衆－イロウ」が表側表示で存在しています。また、自分の墓地にも「六武衆－イロウ」が存在しています。
この状況で、自分は「究極・背水の陣」を発動する事はできますか？
A.「究極・背水の陣」の効果によって特殊召喚するモンスターは、自分の墓地の「六武衆」と名のついたモンスターで、かつ、フィールドに同名カードが存在しないモンスターでなければなりません。
質問の状況の場合、「六武衆－イロウ」は相手のモンスターゾーンに表側表示で存在していますので、「究極・背水の陣」の効果によって「六武衆－イロウ」を特殊召喚する事はできません。
（特殊召喚が可能な、他の「六武衆」と名のついたモンスターが自分の墓地に存在する場合には「究極・背水の陣」を発動する事はできますが、自分の墓地に存在するのが「六武衆－イロウ」のみ、というような場合には、「究極・背水の陣」を発動する事自体ができません。） 