### PR TITLE
fix Number S39: Utopia Prime

### DIFF
--- a/c86532744.lua
+++ b/c86532744.lua
@@ -39,10 +39,13 @@ function c86532744.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,sg:GetCount()*300)
 end
+function c86532744.ctfilter(c)
+	return c:IsLocation(LOCATION_REMOVED) and not c:IsReason(REASON_REDIRECT)
+end
 function c86532744.operation(e,tp,eg,ep,ev,re,r,rp)
 	local sg=Duel.GetMatchingGroup(c86532744.filter,tp,0,LOCATION_MZONE,nil)
 	Duel.Destroy(sg,REASON_EFFECT,LOCATION_REMOVED)
-	local ct=Duel.GetOperatedGroup():FilterCount(Card.IsLocation,nil,LOCATION_REMOVED)
+	local ct=Duel.GetOperatedGroup():FilterCount(c86532744.ctfilter,nil)
 	if ct>0 then
 		Duel.BreakEffect()
 		Duel.Damage(1-tp,ct*300,REASON_EFFECT)


### PR DESCRIPTION
Fix this: If Dark Magician of Chaos was banished by Utopia Prime's effect, opponent take damage.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13107
Q.相手のモンスターゾーンに「黒魔族復活の棺」の効果で特殊召喚されている「混沌の黒魔術師」1体のみが表側表示で存在しています。
自分が「SNo.39 希望皇ホープONE」の『自分のライフポイントが相手より３０００ポイント以上少ない場合、このカードのエクシーズ素材を３つ取り除き、ライフポイントを１０ポイントになるように払って発動できる。相手フィールド上の特殊召喚されたモンスターを全て破壊し、ゲームから除外する。その後、この効果で除外したモンスターの数×３００ポイントダメージを相手ライフに与える』モンスター効果を発動した場合、処理はどうなりますか？
A.質問の状況の場合、相手のモンスターゾーンに存在する「混沌の黒魔術師」は「SNo.39 希望皇ホープONE」のモンスター効果によって破壊される事になりますが、フィールド上から離れる際に、「混沌の黒魔術師」自身の『③：表側表示のこのカードはフィールドから離れた場合に除外される』モンスター効果によって除外されますので、『その後、この効果で除外したモンスターの数×３００ポイントダメージを相手ライフに与える』処理は適用されません。
（この場合、『相手フィールド上の特殊召喚されたモンスターを全て破壊し、ゲームから除外する』処理にて処理が完了した扱いとなります。）