### PR TITLE
fix Cross Porter

### DIFF
--- a/c73146473.lua
+++ b/c73146473.lua
@@ -41,7 +41,6 @@ function c73146473.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c73146473.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 	if g:GetCount()>0 then
-		Duel.BreakEffect()
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
Fix this: If Cross Porter was sent to Graveyard by itself effect, Cross Porter cannot activate "this card is sent to the Graveyard" effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7575
■『選択した自分のモンスターを墓地へ送り』の処理と、『手札から「N」と名のついたモンスター１体を特殊召喚する』処理は同時に行われる扱いとなります。