### PR TITLE
fix Ritual Buster and Ascending Soul

### DIFF
--- a/c54094821.lua
+++ b/c54094821.lua
@@ -8,8 +8,11 @@ function c54094821.initial_effect(c)
 	e1:SetOperation(c54094821.activate)
 	c:RegisterEffect(e1)
 end
+function c54094821.cfilter(c)
+	return bit.band(c:GetSummonType(),SUMMON_TYPE_RITUAL)==SUMMON_TYPE_RITUAL
+end
 function c54094821.condition(e,tp,eg,ep,ev,re,r,rp)
-	return eg:GetCount()==1 and eg:GetFirst():GetSummonType()==SUMMON_TYPE_RITUAL
+	return eg:IsExists(c54094821.cfilter,1,nil)
 end
 function c54094821.activate(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c88301833.lua
+++ b/c88301833.lua
@@ -19,11 +19,14 @@ function c88301833.initial_effect(c)
 	e2:SetOperation(c88301833.thop)
 	c:RegisterEffect(e2)
 end
+function c88301833.cfilter(c)
+	return bit.band(c:GetSummonType(),SUMMON_TYPE_RITUAL)==SUMMON_TYPE_RITUAL
+end
 function c88301833.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:GetCount()==1 and eg:GetFirst():GetSummonType()==SUMMON_TYPE_RITUAL
+	return eg:IsExists(c88301833.cfilter,1,nil)
 end
 function c88301833.thfilter(c,e,tp)
-	return c:IsLocation(LOCATION_GRAVE) and c:IsControler(tp) and c:IsAbleToHand() and c:IsCanBeEffectTarget(e)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_RELEASE) and c:IsControler(tp) and c:IsAbleToHand() and c:IsCanBeEffectTarget(e)
 end
 function c88301833.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tc=eg:GetFirst()


### PR DESCRIPTION
Fix:
1. If you use Nekroz Kaleidoscope to ritual summon 2+ monster at same time, those card can't active.
2. If you use Nekroz Kaleidoscope and **send** a monster in extra to graveyard, Ascending Soul can return it to hand.