### PR TITLE
fix Convert Contact and Solar Recharge

### DIFF
--- a/c691925.lua
+++ b/c691925.lua
@@ -18,7 +18,8 @@ function c691925.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.DiscardHand(tp,c691925.costfilter,1,1,REASON_COST+REASON_DISCARD,nil)
 end
 function c691925.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,4) and Duel.IsPlayerCanDiscardDeck(tp,2) end
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) and Duel.IsPlayerCanDiscardDeck(tp,2)
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=4 end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(2)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)

--- a/c82639107.lua
+++ b/c82639107.lua
@@ -18,6 +18,7 @@ function c82639107.filter(c)
 end
 function c82639107.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDraw(tp,2)
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=3
 		and Duel.IsExistingMatchingCard(c82639107.filter,tp,LOCATION_HAND,0,1,nil)
 		and Duel.IsExistingMatchingCard(c82639107.filter,tp,LOCATION_DECK,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)


### PR DESCRIPTION
Fix: Convert Contact can active when the player has only 2 cards in deck.