### PR TITLE
fix Performapal Pinch Helper

### DIFF
--- a/c36415522.lua
+++ b/c36415522.lua
@@ -93,7 +93,7 @@ function c36415522.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c36415522.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()
-	if tc:IsRelateToBattle() and tc:IsFaceup() then
+	if tc:IsRelateToBattle() then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD)
 		e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)


### PR DESCRIPTION
nowhere in the text or rulings is specified that your monster needs to be face-up in order to prevent the battle damage
you are currently able to activate the effect, but you receive pircing damage if your face down monster is attacked