### PR TITLE
fix Criosphinx

### DIFF
--- a/c18654201.lua
+++ b/c18654201.lua
@@ -17,7 +17,7 @@ function c18654201.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c18654201.filter(c,tp)
-	return c:IsControler(tp) and c:IsPreviousLocation(LOCATION_MZONE)
+	return c:IsControler(tp) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsType(TYPE_MONSTER)
 end
 function c18654201.regop(e,tp,eg,ep,ev,re,r,rp)
 	local p1=false local p2=false
@@ -37,7 +37,7 @@ function c18654201.hdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,ep,LOCATION_HAND)
 end
 function c18654201.hdop(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) then return end
+	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end
 	if ep==PLAYER_ALL then
 		Duel.DiscardHand(0,nil,1,1,REASON_EFFECT)
 		Duel.DiscardHand(1,nil,1,1,REASON_EFFECT)


### PR DESCRIPTION
Fix this:
- If trap monster returned to the hand, Criosphinx activate.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6789&keyword=&tag=-1
Q.自身の『①：自分・相手のメインフェイズに発動できる。このカードは発動後、通常モンスター（爬虫類族・地・星４・攻１６００／守１８００）となり、モンスターゾーンに特殊召喚する。このカードは罠カードとしても扱う』効果によって、モンスターカードとして扱われている「アポピスの化神」が、「強制脱出装置」の効果によって手札に戻りました。
この場合、「クリオスフィンクス」の『このカードが自分フィールド上に表側表示で存在する限り、フィールド上のモンスターが持ち主の手札に戻った時、そのモンスターの持ち主は手札からカードを１枚選択して墓地に送る』効果は発動しますか？
A.質問の状況の場合、「アポピスの化神」は罠カードとなりますので、モンスターが持ち主の手札に戻った扱いにはなりません。
したがって、「クリオスフィンクス」の効果は発動しません。

- If Criosphinx is face-down after chain solved, player should send the card in their hand to the Graveyard.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9144&keyword=&tag=-1
Q.「強制脱出装置」の効果によって、モンスターゾーンに存在しているモンスターが自分の手札に戻りました。
この状況で、「クリオスフィンクス」の『このカードが自分フィールド上に表側表示で存在する限り、フィールド上のモンスターが持ち主の手札に戻った時、そのモンスターの持ち主は手札からカードを１枚選択して墓地に送る』効果が発動した際に、チェーンして「月の書」が発動し、「クリオスフィンクス」自身が裏側守備表示になった場合、効果処理はどうなりますか？
A.「クリオスフィンクス」の効果の処理時に、効果を発動した「クリオスフィンクス」自身が裏側守備表示になっている場合には、『そのモンスターの持ち主は手札からカードを１枚選択して墓地に送る』処理は適用されません。