### PR TITLE
fix ダイナミスト・ラッシュ

### DIFF
--- a/c41554273.lua
+++ b/c41554273.lua
@@ -23,7 +23,7 @@ function c41554273.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c41554273.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
-	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+	if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_END)
@@ -43,6 +43,7 @@ function c41554273.activate(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e2)
 	end
+	Duel.SpecialSummonComplete()
 end
 function c41554273.descon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()


### PR DESCRIPTION
Fix: If Skill Drain is in effect, the monster will be disabled for an instant.