### PR TITLE
fix 弱体化の仮面

### DIFF
--- a/c57882509.lua
+++ b/c57882509.lua
@@ -4,18 +4,21 @@ function c57882509.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetCode(EVENT_BE_BATTLE_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
 	e1:SetTarget(c57882509.target)
 	e1:SetOperation(c57882509.activate)
 	c:RegisterEffect(e1)
 end
 function c57882509.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=Duel.GetAttacker()
-	if chk==0 then return tc:IsOnField() end
-	tc:CreateEffectRelation(e)
+	if chk==0 then return tc and tc:IsCanBeEffectTarget(e)
+		and not (Duel.GetCurrentPhase()==PHASE_DAMAGE and Duel.IsDamageCalculated()) end
+	Duel.SetTargetCard(tc)
 end
 function c57882509.activate(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetAttacker()
+	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
> ■「弱体化の仮面」はバトルステップでのモンスターの攻撃宣言時から、ダメージステップ開始時からダメージ計算前までに発動するカードです。
■攻撃宣言を行っているモンスター１体を対象に取る効果です。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5102