### PR TITLE
fix Stegocyber

### DIFF
--- a/c99733359.lua
+++ b/c99733359.lua
@@ -15,7 +15,7 @@ function c99733359.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c99733359.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetBattleDamage(tp)>0
+	return Duel.GetTurnPlayer()~=tp
 end
 function c99733359.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,1000) end


### PR DESCRIPTION
Fix this: If player had activated Waboku, Stegocyber cannot activate.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17075&keyword=&tag=-1
Q.自分の発動した「和睦の使者」が適用されている場合や、相手が攻撃力の低いモンスターで自分のモンスターに攻撃した場合など、その戦闘によって自分が戦闘ダメージを受けない状況でも、「盾航戦車ステゴサイバー」の『①：このカードが墓地に存在し、相手モンスターが攻撃した場合、そのダメージ計算時に１０００LPを払って発動できる。このカードを墓地から特殊召喚し、その戦闘で発生する自分への戦闘ダメージは０になる。この効果で特殊召喚したこのカードはフィールドから離れた場合に除外される』効果を発動する事はできますか？
A.相手のターンのバトルフェイズのダメージ計算時を迎えたのであれば、その戦闘で自分が戦闘ダメージを受けない状況であっても、自分の墓地の「盾航戦車ステゴサイバー」の効果を発動する事はできます。