### PR TITLE
fix Magician's Navigate

### DIFF
--- a/c7922915.lua
+++ b/c7922915.lua
@@ -40,15 +40,14 @@ function c7922915.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c7922915.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
-	if g:GetCount()>0 then
-		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
-	end
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g2=Duel.SelectMatchingCard(tp,c7922915.filter2,tp,LOCATION_DECK,0,1,1,nil,e,tp)
-	if g2:GetCount()>0 then
-		Duel.BreakEffect() 
-		Duel.SpecialSummon(g2,0,tp,tp,false,false,POS_FACEUP)
+	if g:GetCount()>0 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)~=0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g2=Duel.SelectMatchingCard(tp,c7922915.filter2,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g2:GetCount()>0 then
+			Duel.BreakEffect() 
+			Duel.SpecialSummon(g2,0,tp,tp,false,false,POS_FACEUP)
+		end
 	end
 end
 function c7922915.cfilter(c)


### PR DESCRIPTION
Fix this: If player have no Dark Magician from player's hand, Special Summon 1 Level 7 or lower DARK Spellcaster-Type monster from player's Deck.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18742&keyword=&tag=-1
Q.「マジシャンズ・ナビゲート」の『①：手札から「ブラック・マジシャン」１体を特殊召喚する。その後、デッキからレベル７以下の魔法使い族・闇属性モンスター１体を特殊召喚する』効果の発動にチェーンして、相手が「マインドクラッシュ」を発動し、「ブラック・マジシャン」を宣言しました。
その相手の「マインドクラッシュ」の効果によって、手札の「ブラック・マジシャン」が墓地へ捨てられた場合、「マジシャンズ・ナビゲート」の効果処理はどうなりますか？
A.質問の状況の場合、「マジシャンズ・ナビゲート」の効果処理時に、手札に「ブラック・マジシャン」が存在せず、『手札から「ブラック・マジシャン」１体を特殊召喚する』処理を適用する事ができませんので、『その後、デッキからレベル７以下の魔法使い族・闇属性モンスター１体を特殊召喚する』処理を適用する事もできません。 