### PR TITLE
fix Super Hippo Carnival

### DIFF
--- a/c11050415.lua
+++ b/c11050415.lua
@@ -27,6 +27,7 @@ function c11050415.activate(e,tp,eg,ep,ev,re,r,rp)
 		if ft<=0 or (Duel.IsPlayerAffectedByEffect(tp,59822133) and ft>1) then return end
 		if Duel.IsPlayerCanSpecialSummonMonster(tp,18027139,0,0x4011,0,0,1,RACE_BEAST,ATTRIBUTE_EARTH)
 			and Duel.SelectYesNo(tp,aux.Stringid(11050415,0)) then
+			Duel.BreakEffect()
 			local c=e:GetHandler()
 			for i=1,ft do
 				local token=Duel.CreateToken(tp,11050415+i)


### PR DESCRIPTION
Fix this: The "Special Summon 1 "Performapal Hip Hippo" from your hand, Deck, or Graveyard" and the "you can Special Summon as many "Hippo Tokens" (Beast-Type/EARTH/Level 1/ATK 0/DEF 0) as possible" are the same.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12452
■『自分の手札・デッキ・墓地から「EMディスカバー・ヒッポ」１体を選んで特殊召喚する』処理と、『その後、自分フィールドに「カバートークン」（獣族・地・星１・攻／守０）を可能な限り特殊召喚できる』処理は同時に行われる扱いではありません。