### PR TITLE
fix Dark Magic Circle

### DIFF
--- a/c47222536.lua
+++ b/c47222536.lua
@@ -49,7 +49,7 @@ function c47222536.activate(e,tp,eg,ep,ev,re,r,rp)
 	else Duel.SortDecktop(tp,tp,3) end
 end
 function c47222536.cfilter(c,tp)
-	return c:IsCode(46986414) and c:IsControler(tp)
+	return c:IsFaceup() and c:IsCode(46986414) and c:IsControler(tp)
 end
 function c47222536.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c47222536.cfilter,1,nil,tp)


### PR DESCRIPTION
Fix this: If Dark Magician is Normal or Special Summoned in face-down, Dark Magic Circle can activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18744&keyword=&tag=-1
Q.自分の魔法＆罠ゾーンに「黒の魔導陣」が表側表示で存在しています。
この状況で、自分の墓地の「ブラック・マジシャン」を対象に「バースト・リバース」を発動し、裏側守備表示で特殊召喚した場合、「黒の魔導陣」の『②：自分フィールドに「ブラック・マジシャン」が召喚・特殊召喚された場合、相手フィールドのカード１枚を対象として発動できる。そのカードを除外する』効果を発動する事はできますか？
A.「黒の魔導陣」の相手フィールドのカードを除外する効果は、自分のモンスターゾーンに「ブラック・マジシャン」が表側表示で召喚（または表側表示で特殊召喚）された場合にのみ発動する事ができる効果となります。
したがって、「バースト・リバース」の対象として「ブラック・マジシャン」を選択している場合でも、「黒の魔導陣」の効果を発動する事はできません。 