### PR TITLE
Change option selection of Koa'ki cards and Magic Drain etc.

### DIFF
--- a/c10060427.lua
+++ b/c10060427.lua
@@ -45,6 +45,8 @@ function c10060427.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_WARRIOR) and not c:IsPublic()
 end
 function c10060427.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c10060427.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c10060427.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -54,8 +56,10 @@ function c10060427.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(10060427,0),aux.Stringid(10060427,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(10060427,1),aux.Stringid(10060427,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(10060427,1),aux.Stringid(10060427,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(10060427,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -67,7 +71,7 @@ function c10060427.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c10060427.otfilter(c,tp)

--- a/c12435193.lua
+++ b/c12435193.lua
@@ -30,6 +30,8 @@ function c12435193.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_DRAGON) and not c:IsPublic()
 end
 function c12435193.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c12435193.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c12435193.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -39,8 +41,10 @@ function c12435193.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(12435193,0),aux.Stringid(12435193,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(12435193,1),aux.Stringid(12435193,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(12435193,1),aux.Stringid(12435193,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(12435193,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -52,7 +56,7 @@ function c12435193.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c12435193.disspsum(e,c)

--- a/c14309486.lua
+++ b/c14309486.lua
@@ -39,6 +39,8 @@ function c14309486.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_ROCK) and not c:IsPublic()
 end
 function c14309486.mtop(e,tp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c14309486.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c14309486.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -48,8 +50,10 @@ function c14309486.mtop(e,tp)
 		select=Duel.SelectOption(tp,aux.Stringid(14309486,0),aux.Stringid(14309486,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(14309486,1),aux.Stringid(14309486,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(14309486,1),aux.Stringid(14309486,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(14309486,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -61,7 +65,7 @@ function c14309486.mtop(e,tp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c14309486.condition(e,tp,eg,ep,ev,re,r,rp)

--- a/c19642889.lua
+++ b/c19642889.lua
@@ -32,6 +32,8 @@ function c19642889.cfilter2(c)
 	return c:GetType()==TYPE_TRAP and not c:IsPublic()
 end
 function c19642889.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c19642889.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c19642889.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -41,8 +43,10 @@ function c19642889.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(19642889,0),aux.Stringid(19642889,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(19642889,1),aux.Stringid(19642889,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(19642889,1),aux.Stringid(19642889,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(19642889,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -54,7 +58,7 @@ function c19642889.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c19642889.negop1(e,tp,eg,ep,ev,re,r,rp)

--- a/c22047978.lua
+++ b/c22047978.lua
@@ -22,24 +22,30 @@ function c22047978.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c22047978.cfilter(c)
-	return c:IsType(TYPE_MONSTER) and not c:IsPublic()
+	return not c:IsPublic() and c:IsType(TYPE_MONSTER)
 end
 function c22047978.activate(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+	if Duel.IsChainDisablable(0) then
+		local sel=1
 		local g=Duel.GetMatchingGroup(c22047978.cfilter,1-tp,LOCATION_HAND,0,nil)
-		if g:GetCount()>0 and Duel.SelectYesNo(1-tp,aux.Stringid(22047978,0)) then
+		Duel.Hint(HINT_SELECTMSG,1-tp,aux.Stringid(22047978,0))
+		if g:GetCount()>0 then
+			sel=Duel.SelectOption(1-tp,1213,1214)
+		else
+			sel=Duel.SelectOption(1-tp,1214)+1
+		end
+		if sel==0 then
 			Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_CONFIRM)
 			local cg=g:Select(1-tp,1,1,nil)
 			Duel.ConfirmCards(tp,cg)
 			Duel.ShuffleHand(1-tp)
-			if Duel.IsChainDisablable(0) then
-				Duel.NegateEffect(0)
-				return
-			end
+			Duel.NegateEffect(0)
+			return
 		end
-		if Duel.Destroy(tc,REASON_EFFECT)>0 then
-			Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
-		end
+	end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED)
+		and Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
 	end
 end

--- a/c30936186.lua
+++ b/c30936186.lua
@@ -32,6 +32,8 @@ function c30936186.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_BEASTWARRIOR) and not c:IsPublic()
 end
 function c30936186.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c30936186.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c30936186.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -41,8 +43,10 @@ function c30936186.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(30936186,0),aux.Stringid(30936186,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(30936186,1),aux.Stringid(30936186,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(30936186,1),aux.Stringid(30936186,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(30936186,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -54,7 +58,7 @@ function c30936186.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c30936186.cfilter(c)

--- a/c32314730.lua
+++ b/c32314730.lua
@@ -32,6 +32,8 @@ function c32314730.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_BEASTWARRIOR) and not c:IsPublic()
 end
 function c32314730.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c32314730.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c32314730.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -41,8 +43,10 @@ function c32314730.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(32314730,0),aux.Stringid(32314730,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(32314730,1),aux.Stringid(32314730,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(32314730,1),aux.Stringid(32314730,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(32314730,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -54,7 +58,7 @@ function c32314730.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c32314730.thcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c38167722.lua
+++ b/c38167722.lua
@@ -27,13 +27,20 @@ function c38167722.cfilter(c)
 end
 function c38167722.activate(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
-	local g=Duel.GetMatchingGroup(c38167722.cfilter,p,0,LOCATION_HAND,nil)
-	if g:GetCount()>0 and Duel.SelectYesNo(1-p,aux.Stringid(38167722,0)) then
-		Duel.Hint(HINT_SELECTMSG,1-p,HINTMSG_CONFIRM)
-		local sg=g:Select(1-p,1,1,nil)
-		Duel.ConfirmCards(p,sg)
-		Duel.ShuffleHand(1-p)
-		if Duel.IsChainDisablable(0) then
+	if Duel.IsChainDisablable(0) then
+		local sel=1
+		local g=Duel.GetMatchingGroup(c38167722.cfilter,p,0,LOCATION_HAND,nil)
+		Duel.Hint(HINT_SELECTMSG,1-p,aux.Stringid(38167722,0))
+		if g:GetCount()>0 then
+			sel=Duel.SelectOption(1-p,1213,1214)
+		else
+			sel=Duel.SelectOption(1-p,1214)+1
+		end
+		if sel==0 then
+			Duel.Hint(HINT_SELECTMSG,1-p,HINTMSG_CONFIRM)
+			local sg=g:Select(1-p,1,1,nil)
+			Duel.ConfirmCards(p,sg)
+			Duel.ShuffleHand(1-p)
 			Duel.NegateEffect(0)
 			return
 		end

--- a/c39037517.lua
+++ b/c39037517.lua
@@ -31,6 +31,8 @@ function c39037517.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_INSECT) and not c:IsPublic()
 end
 function c39037517.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c39037517.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c39037517.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -40,8 +42,10 @@ function c39037517.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(39037517,0),aux.Stringid(39037517,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(39037517,1),aux.Stringid(39037517,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(39037517,1),aux.Stringid(39037517,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(39037517,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -53,7 +57,7 @@ function c39037517.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c39037517.filter(c,e)

--- a/c41201555.lua
+++ b/c41201555.lua
@@ -33,6 +33,8 @@ function c41201555.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_PLANT) and not c:IsPublic()
 end
 function c41201555.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c41201555.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c41201555.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -42,8 +44,10 @@ function c41201555.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(41201555,0),aux.Stringid(41201555,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(41201555,1),aux.Stringid(41201555,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(41201555,1),aux.Stringid(41201555,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(41201555,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -55,7 +59,7 @@ function c41201555.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c41201555.condition(e,tp,eg,ep,ev,re,r,rp)

--- a/c41224658.lua
+++ b/c41224658.lua
@@ -26,14 +26,21 @@ function c41224658.cfilter(c)
 	return not c:IsPublic() and c:IsType(TYPE_MONSTER)
 end
 function c41224658.desop(e,tp,eg,ep,ev,re,r,rp)
-	local dis=false
 	if Duel.IsChainDisablable(0) then
+		local sel=1
 		local cg=Duel.GetMatchingGroup(c41224658.cfilter,tp,0,LOCATION_HAND,nil)
-		if cg:GetCount()>0 and Duel.SelectYesNo(1-tp,aux.Stringid(41224658,1)) then
+		Duel.Hint(HINT_SELECTMSG,1-tp,aux.Stringid(41224658,1))
+		if cg:GetCount()>0 then
+			sel=Duel.SelectOption(1-tp,1213,1214)
+		else
+			sel=Duel.SelectOption(1-tp,1214)+1
+		end
+		if sel==0 then
 			Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_CONFIRM)
 			local sg=cg:Select(1-tp,1,1,nil)
 			Duel.ConfirmCards(tp,sg)
 			Duel.ShuffleHand(1-tp)
+			Duel.NegateEffect(0)
 			return
 		end
 	end

--- a/c45041488.lua
+++ b/c45041488.lua
@@ -34,6 +34,8 @@ function c45041488.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_ROCK) and not c:IsPublic()
 end
 function c45041488.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c45041488.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c45041488.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -44,8 +46,10 @@ function c45041488.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(45041488,0),aux.Stringid(45041488,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(45041488,1),aux.Stringid(45041488,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(45041488,1),aux.Stringid(45041488,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(45041488,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -57,7 +61,7 @@ function c45041488.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c45041488.condition(e,tp,eg,ep,ev,re,r,rp)

--- a/c49680980.lua
+++ b/c49680980.lua
@@ -34,6 +34,8 @@ function c49680980.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_ROCK) and not c:IsPublic()
 end
 function c49680980.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c49680980.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c49680980.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -44,8 +46,10 @@ function c49680980.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(49680980,0),aux.Stringid(49680980,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(49680980,1),aux.Stringid(49680980,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(49680980,1),aux.Stringid(49680980,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(49680980,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -57,7 +61,7 @@ function c49680980.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c49680980.condition(e,tp,eg,ep,ev,re,r,rp)

--- a/c5037726.lua
+++ b/c5037726.lua
@@ -41,18 +41,25 @@ function c5037726.cfilter(c)
 	return not c:IsPublic() and c:IsType(TYPE_TRAP)
 end
 function c5037726.operation(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	local g=Duel.GetMatchingGroup(c5037726.cfilter,tp,0,LOCATION_HAND,nil)
-	if g:GetCount()>0 and Duel.SelectYesNo(1-tp,aux.Stringid(5037726,0)) then
-		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_CONFIRM)
-		local sg=g:Select(1-tp,1,1,nil)
-		Duel.ConfirmCards(tp,sg)
-		Duel.ShuffleHand(1-tp)
-		if Duel.IsChainDisablable(0) then
+	if Duel.IsChainDisablable(0) then
+		local sel=1
+		local g=Duel.GetMatchingGroup(c5037726.cfilter,tp,0,LOCATION_HAND,nil)
+		Duel.Hint(HINT_SELECTMSG,1-tp,aux.Stringid(5037726,0))
+		if g:GetCount()>0 then
+			sel=Duel.SelectOption(1-tp,1213,1214)
+		else
+			sel=Duel.SelectOption(1-tp,1214)+1
+		end
+		if sel==0 then
+			Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_CONFIRM)
+			local sg=g:Select(1-tp,1,1,nil)
+			Duel.ConfirmCards(tp,sg)
+			Duel.ShuffleHand(1-tp)
 			Duel.NegateEffect(0)
 			return
 		end
 	end
+	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c53039326.lua
+++ b/c53039326.lua
@@ -40,6 +40,8 @@ function c53039326.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c53039326.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g=Duel.GetMatchingGroup(c53039326.cfilter,tp,LOCATION_HAND,0,nil)
 	local sel=1
 	if g:GetCount()~=0 then
@@ -53,7 +55,7 @@ function c53039326.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,cg)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c53039326.check(e,tp,eg,ep,ev,re,r,rp)

--- a/c54520292.lua
+++ b/c54520292.lua
@@ -32,6 +32,8 @@ function c54520292.cfilter2(c)
 	return c:GetType()==TYPE_SPELL+TYPE_CONTINUOUS and not c:IsPublic()
 end
 function c54520292.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c54520292.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c54520292.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -41,8 +43,10 @@ function c54520292.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(54520292,0),aux.Stringid(54520292,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(54520292,1),aux.Stringid(54520292,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(54520292,1),aux.Stringid(54520292,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(54520292,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -54,7 +58,7 @@ function c54520292.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c54520292.descost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c5817857.lua
+++ b/c5817857.lua
@@ -30,6 +30,8 @@ function c5817857.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_ZOMBIE) and not c:IsPublic()
 end
 function c5817857.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c5817857.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c5817857.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -39,8 +41,10 @@ function c5817857.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(5817857,0),aux.Stringid(5817857,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(5817857,1),aux.Stringid(5817857,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(5817857,1),aux.Stringid(5817857,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(5817857,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -52,7 +56,7 @@ function c5817857.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c5817857.rfilter(c)

--- a/c59344077.lua
+++ b/c59344077.lua
@@ -13,12 +13,19 @@ function c59344077.condition(e,tp,eg,ep,ev,re,r,rp)
 	return rp~=tp and re:IsActiveType(TYPE_SPELL) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
 end
 function c59344077.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsType,tp,0,LOCATION_HAND,nil,TYPE_SPELL)
-	if g:GetCount()>0 and Duel.SelectYesNo(1-tp,aux.Stringid(59344077,0)) then
-		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_DISCARD)
-		local sg=g:Select(1-tp,1,1,nil)
-		Duel.SendtoGrave(sg,REASON_EFFECT+REASON_DISCARD)
-		if Duel.IsChainDisablable(0) then
+	if Duel.IsChainDisablable(0) then
+		local sel=1
+		local g=Duel.GetMatchingGroup(Card.IsType,tp,0,LOCATION_HAND,nil,TYPE_SPELL)
+		Duel.Hint(HINT_SELECTMSG,1-tp,aux.Stringid(59344077,0))
+		if g:GetCount()>0 then
+			sel=Duel.SelectOption(1-tp,1213,1214)
+		else
+			sel=Duel.SelectOption(1-tp,1214)+1
+		end
+		if sel==0 then
+			Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_DISCARD)
+			local sg=g:Select(1-tp,1,1,nil)
+			Duel.SendtoGrave(sg,REASON_EFFECT+REASON_DISCARD)
 			Duel.NegateEffect(0)
 			return
 		end

--- a/c65026212.lua
+++ b/c65026212.lua
@@ -42,6 +42,8 @@ function c65026212.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x1d) and c:IsAbleToGraveAsCost()
 end
 function c65026212.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c65026212.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c65026212.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -51,8 +53,10 @@ function c65026212.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(65026212,0),aux.Stringid(65026212,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(65026212,1),aux.Stringid(65026212,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(65026212,1),aux.Stringid(65026212,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(65026212,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -63,7 +67,7 @@ function c65026212.mtop(e,tp,eg,ep,ev,re,r,rp)
 		local g=g2:Select(tp,1,1,nil)
 		Duel.SendtoGrave(g,REASON_COST)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c65026212.spfilter(c)

--- a/c66816282.lua
+++ b/c66816282.lua
@@ -34,6 +34,8 @@ function c66816282.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_ROCK) and not c:IsPublic()
 end
 function c66816282.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c66816282.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c66816282.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -44,8 +46,10 @@ function c66816282.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(66816282,0),aux.Stringid(66816282,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(66816282,1),aux.Stringid(66816282,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(66816282,1),aux.Stringid(66816282,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(66816282,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -57,7 +61,7 @@ function c66816282.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c66816282.condition(e,tp,eg,ep,ev,re,r,rp)

--- a/c68809475.lua
+++ b/c68809475.lua
@@ -33,6 +33,8 @@ function c68809475.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_MACHINE) and not c:IsPublic()
 end
 function c68809475.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c68809475.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c68809475.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -42,8 +44,10 @@ function c68809475.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(68809475,0),aux.Stringid(68809475,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(68809475,1),aux.Stringid(68809475,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(68809475,1),aux.Stringid(68809475,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(68809475,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -55,7 +59,7 @@ function c68809475.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c68809475.filter(c)

--- a/c72258771.lua
+++ b/c72258771.lua
@@ -41,6 +41,8 @@ function c72258771.cfilter1(c)
 	return c:IsCode(36623431) and c:IsAbleToGraveAsCost()
 end
 function c72258771.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c72258771.cfilter1,tp,LOCATION_HAND,0,nil)
 	local select=1
 	if g1:GetCount()>0 then
@@ -53,7 +55,7 @@ function c72258771.mtop(e,tp,eg,ep,ev,re,r,rp)
 		local g=g1:Select(tp,1,1,nil)
 		Duel.SendtoGrave(g,REASON_COST)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c72258771.otfilter(c,tp)

--- a/c74576482.lua
+++ b/c74576482.lua
@@ -33,6 +33,8 @@ function c74576482.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAttribute(ATTRIBUTE_WATER) and not c:IsPublic()
 end
 function c74576482.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c74576482.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c74576482.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -42,8 +44,10 @@ function c74576482.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(74576482,0),aux.Stringid(74576482,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(74576482,1),aux.Stringid(74576482,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(74576482,1),aux.Stringid(74576482,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(74576482,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -55,7 +59,7 @@ function c74576482.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c74576482.tdcost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c80367387.lua
+++ b/c80367387.lua
@@ -29,6 +29,8 @@ function c80367387.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_WARRIOR) and not c:IsPublic()
 end
 function c80367387.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c80367387.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c80367387.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -39,8 +41,10 @@ function c80367387.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(80367387,0),aux.Stringid(80367387,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(80367387,1),aux.Stringid(80367387,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(80367387,1),aux.Stringid(80367387,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(80367387,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -52,7 +56,7 @@ function c80367387.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c80367387.atcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c80925836.lua
+++ b/c80925836.lua
@@ -28,6 +28,8 @@ function c80925836.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_FIEND) and not c:IsPublic()
 end
 function c80925836.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c80925836.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c80925836.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -38,8 +40,10 @@ function c80925836.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(80925836,0),aux.Stringid(80925836,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(80925836,1),aux.Stringid(80925836,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(80925836,1),aux.Stringid(80925836,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(80925836,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -51,7 +55,7 @@ function c80925836.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c80925836.disop(e,tp,eg,ep,ev,re,r,rp)

--- a/c95090813.lua
+++ b/c95090813.lua
@@ -32,6 +32,8 @@ function c95090813.cfilter2(c)
 	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_WARRIOR) and not c:IsPublic()
 end
 function c95090813.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
 	local g1=Duel.GetMatchingGroup(c95090813.cfilter1,tp,LOCATION_HAND,0,nil)
 	local g2=Duel.GetMatchingGroup(c95090813.cfilter2,tp,LOCATION_HAND,0,nil)
 	local select=2
@@ -41,8 +43,10 @@ function c95090813.mtop(e,tp,eg,ep,ev,re,r,rp)
 		select=Duel.SelectOption(tp,aux.Stringid(95090813,0),aux.Stringid(95090813,2))
 		if select==1 then select=2 end
 	elseif g2:GetCount()>0 then
-		select=Duel.SelectOption(tp,aux.Stringid(95090813,1),aux.Stringid(95090813,2))
-		select=select+1
+		select=Duel.SelectOption(tp,aux.Stringid(95090813,1),aux.Stringid(95090813,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(95090813,2))
+		select=2
 	end
 	if select==0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -54,7 +58,7 @@ function c95090813.mtop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 		Duel.ShuffleHand(tp)
 	else
-		Duel.Destroy(e:GetHandler(),REASON_COST)
+		Duel.Destroy(c,REASON_COST)
 	end
 end
 function c95090813.filter(c)


### PR DESCRIPTION
If there isn't any suitable card in hand, show Duel.SelectOption as usual, to avoid expose hand information.
Add hint for Koa'ki cards, like Amorphage cards.

Fix: If Splendid Venus is in effect, Magic Drain etc shouldn't be able to let opponent discard card.
Fix: If Spiritual Light Art - Hijiri lose its target, the opponent should be able to show card.
