### PR TITLE
fix Dark Designator

### DIFF
--- a/c78053598.lua
+++ b/c78053598.lua
@@ -10,14 +10,16 @@ function c78053598.initial_effect(c)
 end
 function c78053598.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,0,LOCATION_DECK,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	local code=Duel.AnnounceCard(tp,TYPE_MONSTER)
+	Duel.SetTargetParam(code)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,TYPE_MONSTER)
 end
 function c78053598.filter(c,code)
 	return c:IsType(TYPE_MONSTER) and c:IsCode(code) and c:IsAbleToHand()
 end
 function c78053598.activate(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local code=Duel.AnnounceCard(tp,TYPE_MONSTER)
+	local code=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(1-tp,c78053598.filter,1-tp,LOCATION_DECK,0,1,1,nil,code)
 	local tc=g:GetFirst()

--- a/c8323633.lua
+++ b/c8323633.lua
@@ -4,14 +4,21 @@ function c8323633.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c8323633.target)
 	e1:SetOperation(c8323633.operation)
 	c:RegisterEffect(e1)
+end
+function c8323633.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	local ac=Duel.AnnounceCard(tp,TYPE_MONSTER)
+	Duel.SetTargetParam(ac)
+	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,TYPE_MONSTER)
 end
 function c8323633.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local ac=Duel.AnnounceCard(tp,TYPE_MONSTER)
+	local ac=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	c:SetHint(CHINT_CARD,ac)
 	--remove
 	local e1=Effect.CreateEffect(c)

--- a/c8323633.lua
+++ b/c8323633.lua
@@ -4,21 +4,14 @@ function c8323633.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetTarget(c8323633.target)
 	e1:SetOperation(c8323633.operation)
 	c:RegisterEffect(e1)
-end
-function c8323633.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local ac=Duel.AnnounceCard(tp,TYPE_MONSTER)
-	Duel.SetTargetParam(ac)
-	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,TYPE_MONSTER)
 end
 function c8323633.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local ac=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	local ac=Duel.AnnounceCard(tp,TYPE_MONSTER)
 	c:SetHint(CHINT_CARD,ac)
 	--remove
 	local e1=Effect.CreateEffect(c)


### PR DESCRIPTION
Fix this: Player announced card name when effect solved.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「闇の指名者」や「夜霧のスナイパー」を発動する際、どのタイミングでカード名を宣言しますか？ 
A. 
「闇の指名者」や「夜霧のスナイパー」はカードの発動を宣言する時点でカード名を宣言します。