### PR TITLE
fix Ghostrick Specter

### DIFF
--- a/c81907872.lua
+++ b/c81907872.lua
@@ -48,8 +48,7 @@ function c81907872.posop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c81907872.cfilter(c,tp)
 	return c:IsControler(tp) and c:GetPreviousControler()==tp and c:IsReason(REASON_DESTROY) and c:GetReasonPlayer()~=tp
-		and c:IsSetCard(0x8d) and c:IsType(TYPE_MONSTER) and c:IsPreviousLocation(LOCATION_MZONE)
-		and (c:IsReason(REASON_EFFECT) or (c:IsReason(REASON_BATTLE) and c==Duel.GetAttackTarget()))
+		and c:IsSetCard(0x8d) and c:IsType(TYPE_MONSTER) and (c:IsReason(REASON_EFFECT) or (c:IsReason(REASON_BATTLE) and c==Duel.GetAttackTarget()))
 end
 function c81907872.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c81907872.cfilter,1,nil,tp)


### PR DESCRIPTION
Fix this: When a Ghostrick is destroyed in Deck or hand, and sent to your Graveyard, Ghostrick Specter cannot activate.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
相手の「E・HERO マリン・ネオス」の効果で手札の「ゴーストリック・マリー」が破壊された場合、手札の「ゴーストリック・スペクター」の効果を発動できますか？ 
A. 
相手が発動した「E・HERO マリン・ネオス」の効果によって、手札の「ゴーストリック・マリー」が破壊されて墓地へ送られたのであれば、手札に存在する「ゴーストリック・スペクター」の効果を発動する事ができます。 

Q. 
また、相手の「死のデッキ破壊ウイルス」の『その後、相手はデッキから攻撃力１５００以上のモンスターを３体まで選んで破壊できる』効果でデッキの「ゴーストリック・イエティ」を破壊した場合、手札の「ゴーストリック・スペクター」の効果を発動できますか？ 
A. 
相手が発動した「死のデッキ破壊ウイルス」の効果によって、デッキの中の「ゴーストリック・イエティ」を破壊して墓地へ送った場合においても、手札の「ゴーストリック・スペクター」の効果を発動する事ができます。