### PR TITLE
fix Night Beam, Nordic Relic Laevateinn

### DIFF
--- a/c89792713.lua
+++ b/c89792713.lua
@@ -36,7 +36,9 @@ function c89792713.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c89792713.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	Duel.SetChainLimit(aux.FALSE)
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		Duel.SetChainLimit(aux.FALSE)
+	end
 end
 function c89792713.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c89882100.lua
+++ b/c89882100.lua
@@ -19,7 +19,9 @@ function c89882100.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c89882100.filter,tp,0,LOCATION_SZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	Duel.SetChainLimit(c89882100.limit(g:GetFirst()))
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		Duel.SetChainLimit(c89882100.limit(g:GetFirst()))
+	end
 end
 function c89882100.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()


### PR DESCRIPTION
Fix this: If Night Beam sent to graveyard by Diamond Dude or Nordic Relic Laevateinn banished by Junk Collector, the card cannot be chained to the effect of Night Beam and Nordic Relic Laevateinn.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
相手が「D－HERO ダイヤモンドガイ」の効果で「ナイト・ショット」を墓地へ送り、セットされた自分の「光の召集」を対象にその「ナイト・ショット」を発動した場合、チェーンして自分は対象となった「光の召集」を発動できますか？ 
A. 
ご質問の状況の場合、「ナイト・ショット」の『カードの発動』ではありませんので、相手は対象に選択されたチェーンして「光の召集」を発動できます。 

Q. 
「極星宝レーヴァテイン」を除外して「ジャンク・コレクター」の効果を発動した場合、チェーンして自分は「神の桎梏グレイプニル」を発動できますか？ 
A. 
ご質問の状況の場合、「極星宝レーヴァテイン」の『カードの発動』ではありませんので、相手はチェーンして「神の桎梏グレイプニル」を発動できます。