### PR TITLE
fix Disarm and Parry

### DIFF
--- a/c26834022.lua
+++ b/c26834022.lua
@@ -27,6 +27,7 @@ function c26834022.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 	local g=Duel.SelectMatchingCard(tp,c26834022.filter,tp,LOCATION_HAND,0,1,1,nil)
 	if g:GetCount()==0 then return end
+	Duel.ConfirmCards(1-tp,g)
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 	Duel.NegateActivation(ev)
 	if re:GetHandler():IsRelateToEffect(re) then

--- a/c52228131.lua
+++ b/c52228131.lua
@@ -27,6 +27,7 @@ function c52228131.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 	local g=Duel.SelectMatchingCard(tp,c52228131.filter,tp,LOCATION_HAND,0,1,1,nil)
 	if g:GetCount()==0 then return end
+	Duel.ConfirmCards(1-tp,g)
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 	Duel.NegateActivation(ev)
 	if re:GetHandler():IsRelateToEffect(re) then


### PR DESCRIPTION
> ■『手札から「剣闘獣」と名のついたカード１枚をデッキに戻す』は効果処理です。効果処理の際に手札から選んだ「剣闘獣」と名のついたカード1枚を**相手に確認させた後**、デッキに戻す事になります。（自分の手札に「剣闘獣」と名のついたカードがない場合、「ディザーム」を発動する事自体ができません。）
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7320