### PR TITLE
fix The Phantom Knights of Shade Brigandine, Tomb Shield

### DIFF
--- a/c51606429.lua
+++ b/c51606429.lua
@@ -23,7 +23,8 @@ function c51606429.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c51606429.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,51606429,0x10db,0x11,3,0,0,RACE_WARRIOR,ATTRIBUTE_DARK) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end

--- a/c98827725.lua
+++ b/c98827725.lua
@@ -18,7 +18,8 @@ function c98827725.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c98827725.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,98827725,0x10db,0x11,4,0,300,RACE_WARRIOR,ATTRIBUTE_DARK) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end


### PR DESCRIPTION
Fix this: You can banish Shade Brigandine or Tomb Shield to activate Junk Collector's effect.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「幻影騎士団トゥーム・シールド」を除外して「ジャンク・コレクター」の効果を発動できますか？ 
A. 
墓地の「幻影騎士団トゥーム・シールド」を除外して、「ジャンク・コレクター」の効果を発動する事はできません。