### PR TITLE
fix Vampire Sorcerer

### DIFF
--- a/c88728507.lua
+++ b/c88728507.lua
@@ -21,7 +21,8 @@ function c88728507.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c88728507.condition(e,tp,eg,ep,ev,re,r,rp)
-	return rp~=tp and e:GetHandler():GetPreviousControler()==tp
+	local c=e:GetHandler()
+	return rp~=tp and c:GetPreviousControler()==tp and c:IsReason(REASON_BATTLE+REASON_EFFECT)
 end
 function c88728507.filter(c)
 	return c:IsSetCard(0x8e) and (c:IsType(TYPE_SPELL+TYPE_TRAP) or c:IsAttribute(ATTRIBUTE_DARK)) and c:IsAbleToHand()


### PR DESCRIPTION
fix this: Vampire Sorcerer is currently able to activate its effect if tributed for a tribute summon with an opponents The Monarchs Stormforth
a tribute due to Stormforth is not considered a removal due to a card effect