### PR TITLE
fix Number S0: Utopic ZEXAL

### DIFF
--- a/c52653092.lua
+++ b/c52653092.lua
@@ -172,7 +172,10 @@ function c52653092.actop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
 	e1:SetTargetRange(0,1)
-	e1:SetValue(aux.TRUE)
+	e1:SetValue(c52653092.actlimit)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+end
+function c52653092.actlimit(e,re,tp)
+	return not re:GetHandler():IsImmuneToEffect(e)
 end


### PR DESCRIPTION
Fix this: Utopic ZEXAL's effect activate turn, Ultimate Falcon cannot activate.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「RR－アルティメット・ファルコン」が存在する状態で「SNo.0 ホープ・ゼアル」の④の効果が適用された場合、既にフィールドに存在する「RR－アルティメット・ファルコン」の②の効果を発動できますか？ 
Q. 
「SNo.0 ホープ・ゼアル」の④の効果が適用された場合、後から特殊召喚された「RR－アルティメット・ファルコン」の②の効果を発動できますか？ 
A. 
ご質問のどちらの場合も、「SNo.0 ホープ・ゼアル」の『④』の効果を受けない「RR－アルティメット・ファルコン」は、『②』の効果を発動する事ができます。