### PR TITLE
fix D.D. Trap Hole

### DIFF
--- a/c5606466.lua
+++ b/c5606466.lua
@@ -18,13 +18,13 @@ function c5606466.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c5606466.filter(c,e,tp)
-	return c:IsFacedown() and c:GetReasonPlayer()==tp and c:IsCanBeEffectTarget(e) and c:IsDestructable() and c:IsAbleToRemove()
+	return c:IsPosition(POS_FACEDOWN_DEFENCE) and c:GetReasonPlayer()==tp and c:IsCanBeEffectTarget(e) and c:IsDestructable() and c:IsAbleToRemove()
 end
 function c5606466.filter2(c,e)
 	return c:IsDestructable() and c:IsAbleToRemove() and c:IsCanBeEffectTarget(e)
 end
 function c5606466.filter3(c,e,tp)
-	return c:IsFacedown() and c:GetSummonPlayer()==tp and c:IsCanBeEffectTarget(e) and c:IsDestructable() and c:IsAbleToRemove()
+	return c:IsPosition(POS_FACEDOWN_DEFENCE) and c:GetSummonPlayer()==tp and c:IsCanBeEffectTarget(e) and c:IsDestructable() and c:IsAbleToRemove()
 end
 function c5606466.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end


### PR DESCRIPTION
Fix this: If monsters changed to face-down Attack Position, player can activate D.D. Trap Hole.