### PR TITLE
fix Cubic Unification

### DIFF
--- a/c34325937.lua
+++ b/c34325937.lua
@@ -91,7 +91,7 @@ function c34325937.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c34325937.cfilter(c)
-	return c:IsSetCard(0xe3) and c:IsPreviousLocation(LOCATION_MZONE)
+	return c:IsPreviousSetCard(0xe3) and c:IsPreviousLocation(LOCATION_MZONE)
 		and c:IsPreviousPosition(POS_FACEUP)
 end
 function c34325937.spcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix this: If Elemental HERO Prisma that treated Cubic monster leaves the field, Cubic Unification cannot activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13286
Q.自身の『①：１ターンに１度、エクストラデッキの融合モンスター１体を相手に見せ、そのモンスターにカード名が記されている融合素材モンスター１体をデッキから墓地へ送って発動できる。エンドフェイズまで、このカードはこの効果を発動するために墓地へ送ったモンスターと同名カードとして扱う』モンスター効果によって、「E・HERO プリズマー」のカード名が「暗黒方界神クリムゾン・ノヴァ」として扱われています。
その「E・HERO プリズマー」が戦闘で破壊された場合、墓地の「方界合神」の『②：表側表示の「方界」モンスターが、戦闘で破壊された場合、またはフィールドから離れた場合、墓地のこのカードを除外して発動できる。手札・デッキからレベル４以下の「方界」モンスター１体を召喚条件を無視して特殊召喚する。この効果で特殊召喚されたモンスターは、このターン戦闘・効果では破壊されない』効果を発動する事はできますか？
A.質問の状況の場合でも、モンスターゾーンに表側表示で存在する「方界」と名のついたモンスターが戦闘で破壊された扱いとなりますので、墓地の「方界合神」の効果を発動し、『手札・デッキからレベル４以下の「方界」モンスター１体を召喚条件を無視して特殊召喚する』処理を適用する事ができます。 