### PR TITLE
fix Celtic Guard of Noble Arms, Superheavy Samurai and so on

### DIFF
--- a/c21521304.lua
+++ b/c21521304.lua
@@ -25,13 +25,6 @@ function c21521304.initial_effect(c)
 	e2:SetTarget(c21521304.sptg)
 	e2:SetOperation(c21521304.spop)
 	c:RegisterEffect(e2)
-	--add setcode
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e3:SetCode(EFFECT_ADD_SETCODE)
-	e3:SetValue(0x107f)
-	c:RegisterEffect(e3)
 end
 c21521304.xyz_number=39
 function c21521304.atkcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c23204029.lua
+++ b/c23204029.lua
@@ -31,13 +31,6 @@ function c23204029.initial_effect(c)
 	e3:SetTarget(c23204029.target)
 	e3:SetOperation(c23204029.operation)
 	c:RegisterEffect(e3)
-	--add setcode
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_SINGLE)
-	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e4:SetCode(EFFECT_ADD_SETCODE)
-	e4:SetValue(0x3008)
-	c:RegisterEffect(e4)
 end
 function c23204029.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and aux.disfilter1(chkc) end

--- a/c34566435.lua
+++ b/c34566435.lua
@@ -11,13 +11,6 @@ function c34566435.initial_effect(c)
 	e1:SetTarget(c34566435.target)
 	e1:SetOperation(c34566435.operation)
 	c:RegisterEffect(e1)
-	--add setcode
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e2:SetCode(EFFECT_ADD_SETCODE)
-	e2:SetValue(0xad)
-	c:RegisterEffect(e2)
 end
 function c34566435.filter(c)
 	return (c:IsLocation(LOCATION_GRAVE) or c:IsFaceup()) and c:IsType(TYPE_FUSION) and c:IsSetCard(0xad)

--- a/c36953371.lua
+++ b/c36953371.lua
@@ -18,13 +18,6 @@ function c36953371.initial_effect(c)
 	e2:SetTarget(c36953371.destg)
 	e2:SetOperation(c36953371.desop)
 	c:RegisterEffect(e2)
-	--add setcode
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e3:SetCode(EFFECT_ADD_SETCODE)
-	e3:SetValue(0x9a)
-	c:RegisterEffect(e3)
 end
 function c36953371.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SYNCHRO

--- a/c40945356.lua
+++ b/c40945356.lua
@@ -26,13 +26,6 @@ function c40945356.initial_effect(c)
 	e2:SetTarget(c40945356.target2)
 	e2:SetOperation(c40945356.operation2)
 	c:RegisterEffect(e2)
-	--add setcode
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e3:SetCode(EFFECT_ADD_SETCODE)
-	e3:SetValue(0x2b)
-	c:RegisterEffect(e3)
 end
 function c40945356.cfilter(c)
 	return c:IsSetCard(0x2b) and c:IsType(TYPE_MONSTER) and c:IsDiscardable()

--- a/c42880485.lua
+++ b/c42880485.lua
@@ -52,13 +52,6 @@ function c42880485.initial_effect(c)
 	e8:SetCode(EFFECT_DEFENCE_ATTACK)
 	e8:SetValue(1)
 	c:RegisterEffect(e8)
-	--add setcode
-	local e9=Effect.CreateEffect(c)
-	e9:SetType(EFFECT_TYPE_SINGLE)
-	e9:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e9:SetCode(EFFECT_ADD_SETCODE)
-	e9:SetValue(0x9a)
-	c:RegisterEffect(e9)
 end
 function c42880485.splimcon(e)
 	return not e:GetHandler():IsForbidden()

--- a/c45467446.lua
+++ b/c45467446.lua
@@ -36,13 +36,6 @@ function c45467446.initial_effect(c)
 	e5:SetTarget(c45467446.sptg)
 	e5:SetOperation(c45467446.spop)
 	c:RegisterEffect(e5)
-	--add setcode
-	local e6=Effect.CreateEffect(c)
-	e6:SetType(EFFECT_TYPE_SINGLE)
-	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e6:SetCode(EFFECT_ADD_SETCODE)
-	e6:SetValue(0xdd)
-	c:RegisterEffect(e6)
 end
 function c45467446.rmfilter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToRemove()

--- a/c45531624.lua
+++ b/c45531624.lua
@@ -27,13 +27,6 @@ function c45531624.initial_effect(c)
 	e3:SetTarget(c45531624.drtg)
 	e3:SetOperation(c45531624.drop)
 	c:RegisterEffect(e3)
-	--add setcode
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_SINGLE)
-	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e4:SetCode(EFFECT_ADD_SETCODE)
-	e4:SetValue(0xe4)
-	c:RegisterEffect(e4)
 end
 function c45531624.atcon(e)
 	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),LOCATION_HAND,0)>=1

--- a/c494922.lua
+++ b/c494922.lua
@@ -21,13 +21,6 @@ function c494922.initial_effect(c)
 	e2:SetTarget(c494922.settg)
 	e2:SetOperation(c494922.setop)
 	c:RegisterEffect(e2)
-	--add setcode
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e3:SetCode(EFFECT_ADD_SETCODE)
-	e3:SetValue(0x9a)
-	c:RegisterEffect(e3)
 end
 function c494922.filter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP)

--- a/c75988594.lua
+++ b/c75988594.lua
@@ -3,13 +3,6 @@ function c75988594.initial_effect(c)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()
-	--add setcode
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_ADD_SETCODE)
-	e1:SetValue(0x9a)
-	c:RegisterEffect(e1)
 	--salvage
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(75988594,0))

--- a/c78274190.lua
+++ b/c78274190.lua
@@ -36,13 +36,6 @@ function c78274190.initial_effect(c)
 	e5:SetTarget(c78274190.target)
 	e5:SetOperation(c78274190.operation)
 	c:RegisterEffect(e5)
-	--add setcode
-	local e6=Effect.CreateEffect(c)
-	e6:SetType(EFFECT_TYPE_SINGLE)
-	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e6:SetCode(EFFECT_ADD_SETCODE)
-	e6:SetValue(0x9a)
-	c:RegisterEffect(e6)
 end
 function c78274190.sccon(e)
 	local tp=e:GetHandlerPlayer()

--- a/c85528209.lua
+++ b/c85528209.lua
@@ -3,13 +3,6 @@ function c85528209.initial_effect(c)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(Card.IsSetCard,0x9a),1)
 	c:EnableReviveLimit()
-	--add setcode
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_ADD_SETCODE)
-	e1:SetValue(0x9a)
-	c:RegisterEffect(e1)
 	--defence attack
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
Fix this: If Celtic Guard of Noble Arms changed name, Celtic Guard of Noble Arms treated as a "Celtic Guard" card.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19063&keyword=&tag=-1
Q.「エルフの聖剣士」を対象として「ヒーロー・マスク」が発動し、『①：自分フィールドの表側表示モンスター１体を対象として発動できる。デッキから「E・HERO」モンスター１体を墓地へ送り、対象の自分の表側表示モンスターはエンドフェイズまで、この効果で墓地へ送ったモンスターと同名カードとして扱う』効果によって、エンドフェイズまで「E・HERO ネオス」として扱われる状態となりました。
その場合、「エルフの聖剣士」はどのように扱われますか？
A.質問の状況の場合、「ヒーロー・マスク」の効果が適用され、「エルフの聖剣士」のカード名は「E・HERO ネオス」として扱われています。
この場合、カード名は「エルフの聖剣士」として扱われず、「エルフの剣士」と名のついたカードとしても扱われない状態になります。
（「ヒーロー・マスク」の効果の適用がなくなった際には、元の状態に戻ります。）