### PR TITLE
fix Stardust Sifr Spark Dragon

### DIFF
--- a/c26268488.lua
+++ b/c26268488.lua
@@ -13,6 +13,7 @@ function c26268488.initial_effect(c)
 	--indes
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
 	e2:SetCode(EFFECT_INDESTRUCTABLE_COUNT)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetTargetRange(LOCATION_ONFIELD,0)


### PR DESCRIPTION
Fix this: The face-down card is destroyed by card effect while Stardust Sifr Spark Dragon is on the field.