### PR TITLE
fix Twilight Ninja Shingetsu

### DIFF
--- a/c14541657.lua
+++ b/c14541657.lua
@@ -35,7 +35,7 @@ end
 function c14541657.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsReason(REASON_BATTLE)
-		or (rp~=tp and c:IsReason(REASON_DESTROY) and c:GetPreviousControler()==tp)
+		or (rp==1-tp and c:IsReason(REASON_DESTROY) and c:GetPreviousControler()==tp)
 end
 function c14541657.thfilter(c)
 	return c:IsSetCard(0x2b) and c:IsType(TYPE_MONSTER) and not c:IsCode(14541657) and c:IsAbleToHand()


### PR DESCRIPTION
fix: if Twilight Ninja is destroyed while equipped to a Monster (e.g. Zubaba General) it can activate the effect if the monster is removed from the field, that shouldn't happen