### PR TITLE
fix and update Destiny Board

### DIFF
--- a/c94212438.lua
+++ b/c94212438.lua
@@ -6,13 +6,14 @@ function c94212438.initial_effect(c)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetHintTiming(0,TIMING_END_PHASE)
 	c:RegisterEffect(e1)
-	--
+	--place card
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(94212438,0))
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCode(EVENT_PHASE+PHASE_END)
 	e2:SetCountLimit(1)
+	e2:SetLabel(94212438)
 	e2:SetCondition(c94212438.condition)
 	e2:SetOperation(c94212438.operation)
 	c:RegisterEffect(e2)
@@ -45,55 +46,34 @@ function c94212438.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
-	if c:GetFlagEffect(94212438)==0 then
-		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
-		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,31893528)
-		if g:GetCount()>0 then
-			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-		end
-	elseif c:GetFlagEffect(94212438)==1 then
-		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
-		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,67287533)
-		if g:GetCount()>0 then
-			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-		end
-	elseif c:GetFlagEffect(94212438)==2 then
-		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
-		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,94772232)
-		if g:GetCount()>0 then
-			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-		end
-	elseif c:GetFlagEffect(94212438)==3 then
-		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
-		local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,30170981)
-		if g:GetCount()>0 then
-			Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-		end
+	local ids={31893528,67287533,94772232,30170981}
+	local id=ids[c:GetFlagEffect(94212438)+1]
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(94212438,1))
+	local g=Duel.SelectMatchingCard(tp,Card.IsCode,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,id)
+	if g:GetCount()>0 and Duel.MoveToField(g:GetFirst(),tp,tp,LOCATION_SZONE,POS_FACEUP,true) then
+		c:RegisterFlagEffect(94212438,RESET_EVENT+0x1fe0000,0,0)
 	end
-	c:RegisterFlagEffect(94212438,RESET_EVENT+0x1fe0000,0,0)
 end
-function c94212438.cfilter2(c,tp)
-	return c:IsCode(94212438,31893528,67287533,94772232,30170981) and c:IsControler(tp)
+function c94212438.cfilter1(c,tp)
+	return c:IsControler(tp) and c:IsCode(94212438,31893528,67287533,94772232,30170981)
 end
-function c94212438.cfilter3(c)
+function c94212438.cfilter2(c)
 	return c:IsFaceup() and c:IsCode(94212438,31893528,67287533,94772232,30170981)
 end
 function c94212438.tgcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c94212438.cfilter2,1,nil,tp)
+	return eg:IsExists(c94212438.cfilter1,1,nil,tp)
 end
 function c94212438.tgop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c94212438.cfilter3,tp,LOCATION_ONFIELD,0,nil)
+	local g=Duel.GetMatchingGroup(c94212438.cfilter2,tp,LOCATION_ONFIELD,0,nil)
 	Duel.SendtoGrave(g,REASON_EFFECT)
 end
-function c94212438.cfilter1(c,code)
-	return c:IsFaceup() and c:IsCode(code)
+function c94212438.cfilter3(c)
+	return c:IsFaceup() and c:IsCode(31893528,67287533,94772232,30170981)
 end
 function c94212438.winop(e,tp,eg,ep,ev,re,r,rp)
 	local WIN_REASON_DESTINY_BOARD=0x15
-	local c=e:GetHandler()
-	local g=Duel.GetFieldGroup(tp,LOCATION_ONFIELD,0)
-	if g:IsExists(c94212438.cfilter1,1,nil,94212438) and g:IsExists(c94212438.cfilter1,1,nil,31893528) and g:IsExists(c94212438.cfilter1,1,nil,67287533)
-		 and g:IsExists(c94212438.cfilter1,1,nil,94772232) and g:IsExists(c94212438.cfilter1,1,nil,30170981) then
+	local g=Duel.GetMatchingGroup(c94212438.cfilter3,tp,LOCATION_ONFIELD,0,e:GetHandler())
+	if g:GetClassCount(Card.GetCode)==4 then
 		Duel.Win(tp,WIN_REASON_DESTINY_BOARD)
  	end
  end


### PR DESCRIPTION
1. The place effect must be in order, can't skip card, so shouldn't increase flag if it fail to place.
2. [The card text in DP17](https://twitter.com/YuGiOh_OCG_INFO/status/731779693658001408) say win effect require 4 types of "Spirit Message" cards, not only EATH (or INAL). So should we add a setcode for "Spirit Message"?
3. Add label for ダーク・サンクチュアリ.