### PR TITLE
Update c4130270.lua

### DIFF
--- a/c4130270.lua
+++ b/c4130270.lua
@@ -14,5 +14,5 @@ function c4130270.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c4130270.etarget(e,c)
-	return c:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)
+	return bit.band(c:GetOriginalType(),TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)~=0
 end


### PR DESCRIPTION
It should be Card.GetOriginalType. otherwise if a fusion monster is treated as an equip card, it would be able to be sent to hand (and then to extra), but it shouldn't happen. 