### PR TITLE
fix Union Monster, Armory Arm and Burner Visor

### DIFF
--- a/c11678191.lua
+++ b/c11678191.lua
@@ -88,8 +88,10 @@ function c11678191.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c11678191.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c11678191.postg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c12965761.lua
+++ b/c12965761.lua
@@ -88,8 +88,10 @@ function c12965761.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c12965761.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c12965761.tkcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c19086954.lua
+++ b/c19086954.lua
@@ -88,8 +88,10 @@ function c19086954.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c19086954.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c19086954.postg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c23265594.lua
+++ b/c23265594.lua
@@ -87,7 +87,9 @@ function c23265594.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c23265594.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end

--- a/c29071332.lua
+++ b/c29071332.lua
@@ -83,8 +83,10 @@ function c29071332.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c29071332.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c29071332.damcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c31768112.lua
+++ b/c31768112.lua
@@ -85,8 +85,10 @@ function c31768112.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c31768112.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c31768112.drcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c42940404.lua
+++ b/c42940404.lua
@@ -79,8 +79,10 @@ function c42940404.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c42940404.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c42940404.sfilter(c)

--- a/c47228077.lua
+++ b/c47228077.lua
@@ -85,8 +85,10 @@ function c47228077.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47228077.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c47228077.descon(e,tp,eg,ep,ev,re,r,rp)

--- a/c47415292.lua
+++ b/c47415292.lua
@@ -92,7 +92,9 @@ function c47415292.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47415292.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end

--- a/c47693640.lua
+++ b/c47693640.lua
@@ -102,8 +102,10 @@ function c47693640.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47693640.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c47693640.hdcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c48568432.lua
+++ b/c48568432.lua
@@ -82,8 +82,10 @@ function c48568432.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c48568432.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c48568432.spcon2(e,tp,eg,ep,ev,re,r,rp)

--- a/c57062206.lua
+++ b/c57062206.lua
@@ -83,7 +83,9 @@ function c57062206.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c57062206.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end

--- a/c59364406.lua
+++ b/c59364406.lua
@@ -89,8 +89,10 @@ function c59364406.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c59364406.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c59364406.descon(e,tp,eg,ep,ev,re,r,rp)

--- a/c63676256.lua
+++ b/c63676256.lua
@@ -91,8 +91,10 @@ function c63676256.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c63676256.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c63676256.descon(e,tp,eg,ep,ev,re,r,rp)

--- a/c64500000.lua
+++ b/c64500000.lua
@@ -90,7 +90,9 @@ function c64500000.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c64500000.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end

--- a/c65622692.lua
+++ b/c65622692.lua
@@ -90,7 +90,9 @@ function c65622692.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c65622692.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end

--- a/c65685470.lua
+++ b/c65685470.lua
@@ -99,8 +99,10 @@ function c65685470.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c65685470.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c65685470.drcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c67159705.lua
+++ b/c67159705.lua
@@ -88,8 +88,10 @@ function c67159705.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c67159705.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c67159705.desfilter(c)

--- a/c69456283.lua
+++ b/c69456283.lua
@@ -89,7 +89,9 @@ function c69456283.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c69456283.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end

--- a/c7369217.lua
+++ b/c7369217.lua
@@ -80,8 +80,10 @@ function c7369217.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c7369217.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c7369217.efilter(e,te)

--- a/c78349103.lua
+++ b/c78349103.lua
@@ -81,8 +81,10 @@ function c78349103.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c78349103.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c78349103.sfilter(c)

--- a/c84313685.lua
+++ b/c84313685.lua
@@ -85,8 +85,10 @@ function c84313685.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c84313685.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c84313685.gspcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c84814897.lua
+++ b/c84814897.lua
@@ -100,8 +100,10 @@ function c84814897.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c84814897.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c84814897.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c85359414.lua
+++ b/c85359414.lua
@@ -89,8 +89,10 @@ function c85359414.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c85359414.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c85359414.descon(e,tp,eg,ep,ev,re,r,rp)

--- a/c87564935.lua
+++ b/c87564935.lua
@@ -86,8 +86,10 @@ function c87564935.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c87564935.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c87564935.efilter1(e,re,rp)

--- a/c87798440.lua
+++ b/c87798440.lua
@@ -88,8 +88,10 @@ function c87798440.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c87798440.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c87798440.descon(e,tp,eg,ep,ev,re,r,rp)

--- a/c93108839.lua
+++ b/c93108839.lua
@@ -85,8 +85,10 @@ function c93108839.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c93108839.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c93108839.damcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c96300057.lua
+++ b/c96300057.lua
@@ -90,7 +90,9 @@ function c96300057.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c96300057.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end


### PR DESCRIPTION
Fix ths: If player have no space in monster zone, Union Monster, Armory Arm and Burner Visor don't send to graveyard.

Mail:
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「Y－ドラゴン・ヘッド」の『装備を解除して表側攻撃表示で特殊召喚する事ができる』効果の発動にチェーンして、相手が「おジャマトリオ」を発動した場合、処理はどうなりますか？
Q.
「アームズ・エイド」の『装備を解除して表側攻撃表示で特殊召喚できる』効果の発動にチェーンして、相手が「おジャマトリオ」を発動した場合、処理はどうなりますか？
A.
ご質問の場合、装備カード扱いとなっていた「Y-ドラゴン・ヘッド」や「アームズ・エイド」を特殊召喚できるモンスターゾーンの空きがなくなった為、墓地へ送られます。