### PR TITLE
fix Cursed Bill

### DIFF
--- a/c46967601.lua
+++ b/c46967601.lua
@@ -54,9 +54,13 @@ function c46967601.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if dam<0 then dam=0 end
 	Duel.SetTargetPlayer(e:GetLabel())
 	Duel.SetTargetParam(dam)
+	Duel.SetTargetCard(e:GetLabelObject())
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,e:GetLabel(),dam)
 end
 function c46967601.damop(e,tp,eg,ep,ev,re,r,rp)
-	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
-	Duel.Damage(p,d,REASON_EFFECT)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()>0 then
+		local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+		Duel.Damage(p,g:GetFirst():GetTextDefence(),REASON_EFFECT)
+	end
 end


### PR DESCRIPTION
Fix this: If the equipped monster doesn't exist in the graveyard, inflict damage to the player.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11319
Q.相手のモンスターゾーンに自分の発動した「呪いのお札」が装備されている「甲虫装甲騎士」が表側表示で存在しています。

この状況で「ハンマーシュート」が発動し、その「甲虫装甲騎士」が破壊された事で、「呪いのお札」の『装備モンスターが破壊される事によってこのカードが墓地へ送られた時、墓地へ送られた装備モンスターの元々の守備力分のダメージを装備モンスターのコントローラーのライフに与える』効果が発動しました。

その発動にチェーンして相手が「リビングデッドの呼び声」を発動し、その「甲虫装甲騎士」を特殊召喚した場合、効果処理はどうなりますか？
A.質問の状況のように、「呪いのお札」を装備している状態で破壊され墓地へ送られたモンスターが、「呪いのお札」の効果処理時に墓地に存在しなくなっている場合には、『墓地へ送られた装備モンスターの元々の守備力分のダメージを装備モンスターのコントローラーのライフに与える』処理は適用されません。 