### PR TITLE
fix Deep-Eyes White Dragon

### DIFF
--- a/c22804410.lua
+++ b/c22804410.lua
@@ -36,7 +36,7 @@ function c22804410.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c22804410.spfilter(c,tp)
-	return c:IsSetCard(0xdd) and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
+	return c:IsPreviousSetCard(0xdd) and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
 		and (c:IsReason(REASON_BATTLE) or c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()~=tp)
 end
 function c22804410.spcon(e,tp,eg,ep,ev,re,r,rp)
@@ -44,7 +44,8 @@ function c22804410.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c22804410.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(Card.IsRace,tp,LOCATION_GRAVE,0,1,nil,RACE_DRAGON) end
 	local g=Duel.GetMatchingGroup(Card.IsRace,tp,LOCATION_GRAVE,0,nil,RACE_DRAGON)
 	local dam=g:GetClassCount(Card.GetCode)*600
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)


### PR DESCRIPTION
Fix 1: If player don't have Dragon-Type monster in the Graveyard, Deep-Eyes White Dragon can activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19179&keyword=&tag=-1
なお、自分の墓地に他のドラゴン族モンスターが1体も存在していない場合は、手札の「ディープアイズ・ホワイト・ドラゴン」のモンスター効果を発動する事はできません。


Fix 2: If Elemental HERO Prisma that treated Blue-Eyes monster leaves the field, Deep-Eyes White Dragon cannot activate effect.

Mail:
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q. 
カード名が「青眼の白龍」として扱われている「E・HERO プリズマー」が戦闘で破壊された場合、手札の「ディープアイズ・ホワイト・ドラゴン」の①の効果を発動できますか？
A.
フィールド上でカード名が「青眼の白龍」として扱われている「E・HERO プリズマー」が戦闘で破壊された場合においても、「ディープアイズ・ホワイト・ドラゴン」の効果を発動する事ができます。