### PR TITLE
fix extra attack effects activation limit

### DIFF
--- a/c48770333.lua
+++ b/c48770333.lua
@@ -27,7 +27,6 @@ function c48770333.initial_effect(c)
 	e3:SetCountLimit(1)
 	e3:SetCondition(c48770333.atkcon)
 	e3:SetCost(c48770333.atkcost)
-	e3:SetTarget(c48770333.atktg)
 	e3:SetOperation(c48770333.atkop)
 	c:RegisterEffect(e3)
 end
@@ -57,9 +56,6 @@ end
 function c48770333.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsCanRemoveCounter(tp,1,1,0x37,3,REASON_COST) end
 	Duel.RemoveCounter(tp,1,1,0x37,3,REASON_COST)
-end
-function c48770333.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK)==0 end
 end
 function c48770333.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c58820923.lua
+++ b/c58820923.lua
@@ -79,7 +79,8 @@ function c58820923.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c58820923.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK)==0 end
+	if chk==0 then return e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK)==0
+		and e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK_MONSTER)==0 end
 end
 function c58820923.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c68396121.lua
+++ b/c68396121.lua
@@ -70,8 +70,7 @@ function c68396121.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c68396121.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK)==0
-		and e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK_MONSTER)==0 end
+	if chk==0 then return e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK_MONSTER)==0 end
 end
 function c68396121.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c68396121.lua
+++ b/c68396121.lua
@@ -70,7 +70,8 @@ function c68396121.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c68396121.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK)==0 end
+	if chk==0 then return e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK)==0
+		and e:GetHandler():GetEffectCount(EFFECT_EXTRA_ATTACK_MONSTER)==0 end
 end
 function c68396121.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Temp fix for https://github.com/Fluorohydride/ygopro/issues/1761

Fix: Thunder King, the Lightningstrike Kaiju shouldn't limit the activation of its effect.