### PR TITLE
fix & update Moon Mirror Shield

### DIFF
--- a/c19508728.lua
+++ b/c19508728.lua
@@ -52,23 +52,18 @@ end
 function c19508728.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()
 	local tc=ec:GetBattleTarget()
-	return ec and tc and tc:IsFaceup()
+	return ec and tc and tc:IsFaceup() and tc:IsControler(1-tp)
 end
 function c19508728.atkop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local ec=e:GetHandler():GetEquipTarget()
 	local tc=ec:GetBattleTarget()
 	if ec and tc and ec:IsFaceup() and tc:IsFaceup() then
-		local atk=tc:GetAttack()
-		local def=tc:GetDefense()
+		local val=math.max(tc:GetAttack(),tc:GetDefense())
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
-		if atk>=def then
-			e1:SetValue(atk+100)
-		else
-			e1:SetValue(def+100)
-		end
+		e1:SetValue(val+100)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE_CAL)
 		ec:RegisterEffect(e1)
 		local e2=e1:Clone()


### PR DESCRIPTION
Update: Use math.max()
Fix: If the Moon Mirror Shield you control equipped monster battles an opponent's monster, Moon Mirror Shield activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17217&keyword=&tag=-1
Q.「月鏡の盾」を相手モンスターに装備させる事はできますか？

また、できる場合、『①：このカードの装備モンスターが相手モンスターと戦闘を行うダメージ計算時に発動する。装備モンスターの攻撃力・守備力はダメージ計算時のみ、戦闘を行う相手モンスターの攻撃力と守備力の内、高い方の数値＋１００になる』効果は発動しますか？
A.「月鏡の盾」を相手モンスターに装備させる事はできます。

しかしながら、「月鏡の盾」の効果は、「月鏡の盾」の装備モンスターが、「月鏡の盾」をコントロールしているプレイヤーから見て相手となるプレイヤーのモンスターと戦闘を行うダメージ計算時にのみ発動する事になります。

したがって、自分の「月鏡の盾」を装備した相手モンスターが、自分のモンスターに攻撃を行ったとしても、「月鏡の盾」の効果は発動しません。 