### PR TITLE
fix Fiend's Sanctuary

### DIFF
--- a/c24874630.lua
+++ b/c24874630.lua
@@ -48,7 +48,7 @@ function c24874630.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c24874630.desop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLP(tp)>1000 and Duel.SelectYesNo(tp,aux.Stringid(24874630,0)) then
+	if Duel.GetLP(tp)>=1000 and Duel.SelectYesNo(tp,aux.Stringid(24874630,0)) then
 		Duel.PayLPCost(tp,1000)
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)


### PR DESCRIPTION
Fix this: If player's LP is 1000, Metal Fiend Token's controller cannot pay LP.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分フィールドに「メタルデビル・トークン」が存在し、自分スタンバイフェイズに自分のライフポイントが1000の場合どうなりますか？ 
A. 
ご質問の状況の場合、自分は「メタルデビル・トークン」をフィールドに維持するためのコストとして1000ライフポイントを払っても構いませんし、1000ライフポイントを払わずに「メタルデビル・トークン」を破壊する事もできます。 

なお、上記の状況で1000ライフポイントを払った場合、自分のライフポイントは0となり、デュエルに敗北します。