### PR TITLE
fix Silent Sword

### DIFF
--- a/c18563744.lua
+++ b/c18563744.lua
@@ -38,7 +38,7 @@ end
 function c18563744.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)


### PR DESCRIPTION
Fix this: If monster has changed control, Silent Sword's effect apply.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10710&keyword=&tag=-1
Q.「沈黙の剣士－サイレント・ソードマン」を対象として、自分は「沈黙の剣」を発動しました。

その発動にチェーンして、相手が「TG1－EM1」を発動し、『相手フィールド上に存在するモンスター１体と、自分フィールド上に表側表示で存在する「TG」と名のついたモンスター１体を選択して発動する。選択したモンスターのコントロールを入れ替える』効果によって、対象の「沈黙の剣士－サイレント・ソードマン」のコントロールが相手に移っている場合、処理はどうなりますか？
A.質問の状況のように、「沈黙の剣」の対象として選択されたモンスターのコントロールが、効果処理時に相手に移っている場合には、「沈黙の剣」の効果は適用されません。

（『その自分のモンスターの攻撃力・守備力は１５００アップし』の処理も、『ターン終了時まで相手の効果を受けない』処理も適用されません。） 