### PR TITLE
fix Spirit of the Pot of Greed

### DIFF
--- a/c4896788.lua
+++ b/c4896788.lua
@@ -1,18 +1,36 @@
 --強欲な壺の精霊
 function c4896788.initial_effect(c)
-	--activate
+	--draw
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetCode(EVENT_CHAINING)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetCode(EVENT_CHAIN_SOLVING)
-	e1:SetCondition(c4896788.drcon)
-	e1:SetOperation(c4896788.drop)
+	e1:SetOperation(aux.chainreg)
 	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_DRAW)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c4896788.drcon)
+	e2:SetTarget(c4896788.drtg)
+	e2:SetOperation(c4896788.drop)
+	c:RegisterEffect(e2)
 end
 function c4896788.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsAttackPos()
+	return e:GetHandler():IsAttackPos() and e:GetHandler():GetFlagEffect(1)>0
 		and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsCode(55144522)
 end
+function c4896788.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(rp,1) end
+	Duel.SetTargetPlayer(rp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,rp,1)
+end
 function c4896788.drop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.ChangeTargetParam(ev,3)
+	if not e:GetHandler():IsAttackPos() or not e:GetHandler():IsRelateToEffect(e) then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
 end


### PR DESCRIPTION
Fix this: Spirit of the Pot of Greed's effect is not Continuous Effect.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5819
■「強欲な壺の精霊」のモンスター効果は誘発効果です。