### PR TITLE
fix U.A. Powered Jersey

### DIFF
--- a/c35884610.lua
+++ b/c35884610.lua
@@ -97,6 +97,7 @@ function c35884610.atcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c35884610.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
 	local tc=e:GetHandler():GetEquipTarget()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
Fix: if this card activate extra attack effect, and then destroyed by effect like U.A. Dreadnought Dunker, it will throw a error.
`attempt to index local 'tc' (a nil value)`