### PR TITLE
fix PSY-Framelord Zeta

### DIFF
--- a/c37192109.lua
+++ b/c37192109.lua
@@ -54,7 +54,7 @@ function c37192109.rmop(e,tp,eg,ep,ev,re,r,rp)
 			if oc:IsControler(tp) then
 				oc:RegisterFlagEffect(37192109,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN,0,rct,fid)
 			else
-				oc:RegisterFlagEffect(37192109,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY+RESET_OPPO_TURN,0,1,fid)
+				oc:RegisterFlagEffect(37192109,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY+RESET_OPPO_TURN,0,rct,fid)
 			end
 			oc=og:GetNext()
 		end


### PR DESCRIPTION
fix this: If you use the effect in your own Standby Phase the opponents monster currently doesn't return in your next Standby Phase