### PR TITLE
fix Lightforce Sword

### DIFF
--- a/c49587034.lua
+++ b/c49587034.lua
@@ -19,7 +19,7 @@ function c49587034.activate(e,tp,eg,ep,ev,re,r,rp)
 	local rs=g:RandomSelect(1-tp,1)
 	local card=rs:GetFirst()
 	if card==nil then return end
-	if Duel.Remove(card,POS_FACEDOWN,REASON_EFFECT)>0 then
+	if Duel.Remove(card,POS_FACEDOWN,REASON_EFFECT)>0 and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		local ph=Duel.GetCurrentPhase()
 		local cp=Duel.GetTurnPlayer()
 		local e1=Effect.CreateEffect(e:GetHandler())


### PR DESCRIPTION
Fix this: If you activated Lightforce Sword by Junk Collector's effect, return banished card.

Mail:
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q. 
「光の封札剣」を除外して「ジャンク・コレクター」の効果を発動し、相手の手札を裏側表示で除外した場合、その除外したカードは相手ターンで数えて4ターン目の相手スタンバイフェイズに戻りますか？
A. 
ご質問の状況の場合、「光の封札剣」の”カードの発動”は行っていないため、『このカードの発動後、相手ターンで数えて４ターン目の相手スタンバイフェイズに、そのカードを相手の手札に戻す』効果は適用されず、裏側で除外され続けます。