### PR TITLE
fix Dawn of the Herald

### DIFF
--- a/c27383110.lua
+++ b/c27383110.lua
@@ -71,6 +71,9 @@ function c27383110.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,false,true,POS_FACEUP)
 		tc:CompleteProcedure()
 		e:SetLabelObject(tc)
+		if e:GetHandler():IsLocation(LOCATION_ONFIELD) then
+			Duel.SendtoGrave(e:GetHandler(),REASON_RULE)
+		end
 		Duel.RaiseSingleEvent(e:GetHandler(),EVENT_CUSTOM+27383110,e,0,tp,tp,0)
 	end
 end


### PR DESCRIPTION
attempt to fix https://github.com/Fluorohydride/ygopro/issues/1763
the card activates in the grave now as it should and not on the field like in the current state
I'm not sure if this can cause any problems or if I'm missing something, if so please inform me^^