### PR TITLE
fix Winged Kuriboh LV9

### DIFF
--- a/c33776734.lua
+++ b/c33776734.lua
@@ -45,13 +45,15 @@ function c33776734.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterFlagEffect(tp,33776734,RESET_CHAIN,0,0)
 end
 function c33776734.spop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetHandler():IsRelateToEffect(e) then
-		Duel.SpecialSummon(e:GetHandler(),0,tp,tp,false,false,POS_FACEUP)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c33776734.rmtarget(e,c)
-	local ty=c:GetOriginalType()
-	return bit.band(ty,TYPE_SPELL)~=0 and c:IsFaceup() and not c:IsStatus(STATUS_ACTIVATE_DISABLED)
+	return c:IsFaceup() and not c:IsType(TYPE_TRAP) and c:IsStatus(STATUS_ACTIVATED)
 end
 function c33776734.val(e,c)
 	return Duel.GetMatchingGroupCount(Card.IsType,c:GetControler(),0,LOCATION_GRAVE,nil,TYPE_SPELL)*500

--- a/c33776734.lua
+++ b/c33776734.lua
@@ -32,9 +32,40 @@ function c33776734.initial_effect(c)
 	local e4=e3:Clone()
 	e4:SetCode(EFFECT_SET_DEFENSE)
 	c:RegisterEffect(e4)
+	if not c33776734.global_check then
+		c33776734.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		ge1:SetCode(EVENT_CHAINING)
+		ge1:SetOperation(c33776734.checkop1)
+		Duel.RegisterEffect(ge1,0)
+		local ge2=ge1:Clone()
+		e2:SetCode(EVENT_CHAIN_NEGATED)
+		e2:SetOperation(c33776734.checkop2)
+		Duel.RegisterEffect(ge2,0)
+	end
 end
 c33776734.lvupcount=1
 c33776734.lvup={33776734}
+function c33776734.checkop1(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	while tc do
+		if re and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) and tc==re:GetHandler() then
+			tc:RegisterFlagEffect(33776734,RESET_EVENT+0x1fe0000,0,1) 
+		end
+		tc=eg:GetNext()
+	end
+end
+function c33776734.checkop2(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	while tc do
+		if re and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) and tc==re:GetHandler() then
+			tc:ResetFlagEffect(33776734)
+		end
+		tc=eg:GetNext()
+	end
+end
 function c33776734.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentChain()>=2
 end
@@ -53,7 +84,7 @@ function c33776734.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c33776734.rmtarget(e,c)
-	return c:IsFaceup() and not c:IsType(TYPE_TRAP) and c:IsStatus(STATUS_ACTIVATED)
+	return c:IsFaceup() and c:GetFlagEffect(33776734)>0
 end
 function c33776734.val(e,c)
 	return Duel.GetMatchingGroupCount(Card.IsType,c:GetControler(),0,LOCATION_GRAVE,nil,TYPE_SPELL)*500


### PR DESCRIPTION
Fix 1: If player have no space in monster zone, Winged Kuriboh LV9 don't send to graveyard.

Fix 2: If Pendulum Monster would be destroyed in Pendulum Zone, that Pendulum Monster doesn't banish.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6904&keyword=&tag=-1
Q.相手のモンスターゾーンに「ハネクリボー LV９」が存在しています。
この状況で、自分が「銅鑼ドラゴン」をペンデュラムゾーンに魔法カードとして発動しました。
その後、そのペンデュラムゾーンの「銅鑼ドラゴン」が相手の発動した「砂塵の大竜巻」の効果で破壊された場合、どうなりますか？
A.質問の状況の場合、「ハネクリボー LV９」の『このカードが自分フィールド上に表側表示で存在する限り、お互いに発動した魔法カードは墓地へ送られずゲームから除外する』効果が適用されていますので、ペンデュラムゾーンにて破壊された「銅鑼ドラゴン」は除外される事になります。 