### PR TITLE
fix ABC-Dragon Buster, AtoZ Dragon Buster Cannon and so on

### DIFF
--- a/c12678870.lua
+++ b/c12678870.lua
@@ -97,6 +97,6 @@ function c12678870.spop(e,tp,eg,ep,ev,re,r,rp)
 		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 		g:Sub(sg)
-		Duel.SendtoGrave(g,REASON_EFFECT)
+		Duel.SendtoGrave(g,REASON_RULE)
 	end
 end

--- a/c1561110.lua
+++ b/c1561110.lua
@@ -155,6 +155,6 @@ function c1561110.spop2(e,tp,eg,ep,ev,re,r,rp)
 		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 		g:Sub(sg)
-		Duel.SendtoGrave(g,REASON_RULE)
+		Duel.SendtoGrave(g,REASON_EFFECT)
 	end
 end

--- a/c1561110.lua
+++ b/c1561110.lua
@@ -145,10 +145,16 @@ function c1561110.sptg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,sg,3,0,0)
 end
 function c1561110.spop2(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
-	local ct=sg:GetCount()
-	if ct>0 and (ct==1 or not Duel.IsPlayerAffectedByEffect(tp,59822133)) then
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if ft<=0 or g:GetCount()==0 or (g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if g:GetCount()<=ft then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		g:Sub(sg)
+		Duel.SendtoGrave(g,REASON_EFFECT)
 	end
 end

--- a/c1561110.lua
+++ b/c1561110.lua
@@ -155,6 +155,6 @@ function c1561110.spop2(e,tp,eg,ep,ev,re,r,rp)
 		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 		g:Sub(sg)
-		Duel.SendtoGrave(g,REASON_EFFECT)
+		Duel.SendtoGrave(g,REASON_RULE)
 	end
 end

--- a/c39778366.lua
+++ b/c39778366.lua
@@ -41,14 +41,20 @@ end
 function c39778366.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<=0 then return end
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
-	if sg:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
-	if sg:GetCount()>ft then
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local sg=nil
+	if g:GetCount()>ft then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		sg=sg:Select(tp,ft,ft,nil)
+		sg=g:Select(tp,ft,ft,nil)
+		g:Sub(sg)
+	else
+		sg=g
 	end
 	Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+	if g:GetCount()>0 then
+		Duel.SendtoGrave(g,REASON_RULE)
+	end
 end
 function c39778366.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end

--- a/c42901635.lua
+++ b/c42901635.lua
@@ -138,6 +138,6 @@ function c42901635.spop2(e,tp,eg,ep,ev,re,r,rp)
 		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 		g:Sub(sg)
-		Duel.SendtoGrave(g,REASON_EFFECT)
+		Duel.SendtoGrave(g,REASON_RULE)
 	end
 end

--- a/c48063985.lua
+++ b/c48063985.lua
@@ -130,6 +130,6 @@ function c48063985.spop(e,tp,eg,ep,ev,re,r,rp)
 		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 		g:Sub(sg)
-		Duel.SendtoGrave(g,REASON_EFFECT)
+		Duel.SendtoGrave(g,REASON_RULE)
 	end
 end

--- a/c57815601.lua
+++ b/c57815601.lua
@@ -42,7 +42,7 @@ function c57815601.activate(e,tp,eg,ep,ev,re,r,rp)
 			local sg=g:Select(tp,ft,ft,nil)
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 			g:Sub(sg)
-			Duel.SendtoGrave(g,REASON_EFFECT)
+			Duel.SendtoGrave(g,REASON_RULE)
 		end
 	end
 	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then

--- a/c65172015.lua
+++ b/c65172015.lua
@@ -140,10 +140,16 @@ function c65172015.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g1,2,tp,LOCATION_REMOVED)
 end
 function c65172015.spop2(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
-	local ct=sg:GetCount()
-	if ct>0 and (ct==1 or not Duel.IsPlayerAffectedByEffect(tp,59822133)) then
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if ft<=0 or g:GetCount()==0 or (g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if g:GetCount()<=ft then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		g:Sub(sg)
+		Duel.SendtoGrave(g,REASON_RULE)
 	end
 end

--- a/c86274272.lua
+++ b/c86274272.lua
@@ -109,6 +109,6 @@ function c86274272.spop(e,tp,eg,ep,ev,re,r,rp)
 		local sg=g:Select(tp,ft,ft,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 		g:Sub(sg)
-		Duel.SendtoGrave(g,REASON_EFFECT)
+		Duel.SendtoGrave(g,REASON_RULE)
 	end
 end


### PR DESCRIPTION
ABC-Dragon Buster, AtoZ Dragon Buster Cannon and Scramble: If player have only 1 space in monster zone, target monster don't send to graveyard.
Ritual Beast Ulti, Verserion the Electromagna Warrior: Use ``REASON_RULE``.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12475&keyword=&tag=-1
Q.除外されている「A－アサルト・コア」、「B－バスター・ドレイク」、「C－クラッシュ・ワイバーン」を対象として、「ABC－ドラゴン・バスター」の『②：相手ターンにこのカードをリリースし、除外されている自分の機械族・光属性のユニオンモンスター３種類を対象として発動できる。そのモンスターを特殊召喚する』モンスター効果を発動しました。

その発動にチェーンして、相手が「おジャマトリオ」を発動し、自分のモンスターゾーンの空きが2つになった場合、処理はどうなりますか？
A.質問の状況の場合、「ABC－ドラゴン・バスター」のモンスター効果の処理時に、自分のモンスターゾーンの空きが2つになっていますので、対象として選択した3体のモンスターのうち、特殊召喚する2体を任意に選びます。
残りの1体はモンスターゾーンに空きがなく特殊召喚する事ができませんので、フィールドに特殊召喚されず、墓地へ送られる事になります。

（例えば、効果処理時に、フィールドに特殊召喚するモンスターとして、「B－バスター・ドレイク」と「C－クラッシュ・ワイバーン」を選んだ場合、モンスターゾーンの空きがなく特殊召喚できなかった「A－アサルト・コア」は墓地へ送られる事になります。） 