### PR TITLE
fix Combination Attack

### DIFF
--- a/c8964854.lua
+++ b/c8964854.lua
@@ -18,21 +18,23 @@ function c8964854.filter(c,e,tp)
 	return c:GetAttackAnnouncedCount()>0 and Duel.IsExistingMatchingCard(c8964854.eqfilter,tp,LOCATION_SZONE,0,1,nil,e,tp,c)
 end
 function c8964854.eqfilter(c,e,tp,ec)
-	return c:IsStatus(STATUS_UNION) and c:GetEquipTarget()==ec and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	local op=c:GetOwner()
+	return c:IsStatus(STATUS_UNION) and c:GetEquipTarget()==ec
+		and Duel.GetLocationCount(op,LOCATION_MZONE)>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,op)
 end
 function c8964854.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c8964854.filter(chkc,e,tp) end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(c8964854.filter,tp,LOCATION_MZONE,0,1,nil,e,tp) end
+	if chk==0 then return Duel.IsExistingTarget(c8964854.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c8964854.filter,tp,LOCATION_MZONE,0,1,1,nil,e,tp)
+	Duel.SelectTarget(tp,c8964854.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_SZONE)
 end
 function c8964854.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+	local op=tc:GetOwner()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and Duel.GetLocationCount(op,LOCATION_MZONE)>0 then
 		local g=Duel.GetMatchingGroup(c8964854.eqfilter,tp,LOCATION_SZONE,0,nil,e,tp,tc)
-		if Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)>0 then
+		if Duel.SpecialSummon(g,0,tp,op,false,false,POS_FACEUP)>0 then
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_EXTRA_ATTACK)


### PR DESCRIPTION
Fix this: Combination Attack cannot target opponent monster.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6335&keyword=&tag=-1
Q.相手のモンスターゾーンに、「Y－ドラゴン・ヘッド」を装備した「X－ヘッド・キャノン」が表側攻撃表示で存在し、相手がその「X－ヘッド・キャノン」で攻撃を行っているバトルフェイズです。

その相手の「X－ヘッド・キャノン」を対象として、自分が「コンビネーション・アタック」を発動する事はできますか？
A.質問の状況の場合、相手の「X－ヘッド・キャノン」も、『ユニオンモンスターを装備して戦闘を行ったモンスター』にあたりますので、その「X－ヘッド・キャノン」を対象として、自分は「コンビネーション・アタック」を発動する事ができます。

その場合、『装備されたユニオンを解除する』処理によって「Y－ドラゴン・ヘッド」を相手のモンスターゾーンに特殊召喚し、対象の「X－ヘッド・キャノン」はもう1度攻撃する事ができるようになります。
なお、「Y－ドラゴン・ヘッド」を特殊召喚する際の表示形式は「コンビネーション・アタック」を発動したプレイヤーが表側攻撃表示か表側守備表示かを選ぶ事になります。 