### PR TITLE
fix Storm Neos + Chaos Neos

### DIFF
--- a/c17032740.lua
+++ b/c17032740.lua
@@ -58,19 +58,19 @@ function c17032740.spfilter1(c,mg,ft)
 	local mg2=mg:Clone()
 	mg2:RemoveCard(c)
 	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
-	return ft>=-1 and c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+	return ft>=-1 and c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 		and mg2:IsExists(c17032740.spfilter2,1,nil,mg2,ft)
 end
 function c17032740.spfilter2(c,mg,ft)
 	local mg2=mg:Clone()
 	mg2:RemoveCard(c)
 	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
-	return ft>=0 and c:IsFusionCode(43237273) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+	return ft>=0 and c:IsFusionCode(43237273) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 		and mg2:IsExists(c17032740.spfilter3,1,nil,ft)
 end
 function c17032740.spfilter3(c,ft)
 	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
-	return ft>=1 and c:IsFusionCode(17732278) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+	return ft>=1 and c:IsFusionCode(17732278) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 end
 function c17032740.spcon(e,c)
 	if c==nil then return true end

--- a/c17032740.lua
+++ b/c17032740.lua
@@ -79,12 +79,11 @@ function c17032740.spcon(e,c)
 	if ft<-2 then return false end
 	local mg=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,43237273,17732278)
 	if ft>0 then return mg:IsExists(c17032740.spfilter1,1,nil,mg) end
-	local f1=Duel.GetMatchingGroupCount(c17032740.spfilter,tp,LOCATION_MZONE,0,nil,89943723,0,0)>0 and 1 or 0
-	local f2=Duel.GetMatchingGroupCount(c17032740.spfilter,tp,LOCATION_MZONE,0,nil,43237273,0,0)>0 and 1 or 0
-	local f3=Duel.GetMatchingGroupCount(c17032740.spfilter,tp,LOCATION_MZONE,0,nil,17732278,0,0)>0 and 1 or 0
-	if ft==-2 then return f1+f2+f3==3 and mg:IsExists(c17032740.spfilter1,1,nil,mg)
-	elseif ft==-1 then return f1+f2+f3>=2 and mg:IsExists(c17032740.spfilter1,1,nil,mg)
-	else return f1+f2+f3>=1 and mg:IsExists(c17032740.spfilter1,1,nil,mg) end
+	local mg2=mg:Filter(Card.IsLocation,nil,LOCATION_MZONE)
+	local ct=mg2:GetClassCount(Card.GetFusionCode)
+	if ft==-2 then return ct==3 and mg:IsExists(c17032740.spfilter1,1,nil,mg)
+	elseif ft==-1 then return ct>=2 and mg:IsExists(c17032740.spfilter1,1,nil,mg)
+	else return ct>=1 and mg:IsExists(c17032740.spfilter1,1,nil,mg) end
 end
 function c17032740.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c17032740.lua
+++ b/c17032740.lua
@@ -51,49 +51,80 @@ end
 function c17032740.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
-function c17032740.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
+function c17032740.spfilter(c,code1,code2,code3)
+	return c:IsAbleToDeckOrExtraAsCost() and (c:IsFusionCode(code1) or c:IsFusionCode(code2) or c:IsFusionCode(code3))
+end
+function c17032740.spfilter1(c,mg)
+	local mg2=mg:Clone()
+	mg2:RemoveCard(c)
+	return c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+		and mg2:IsExists(c17032740.spfilter2,1,nil,mg2)
+end
+function c17032740.spfilter2(c,mg)
+	local mg2=mg:Clone()
+	mg2:RemoveCard(c)
+	return c:IsFusionCode(43237273) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+		and mg2:IsExists(c17032740.spfilter3,1,nil)
+end
+function c17032740.spfilter3(c)
+	return c:IsFusionCode(17732278) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+end
+function c17032740.rmfilter(c,code)
+	return c:IsFusionCode(code) and c:IsCode(code)
 end
 function c17032740.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<-2 then return false end
-	local g1=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723)
-	local g2=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,43237273)
-	local g3=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,17732278)
-	if g1:GetCount()==0 or g2:GetCount()==0 or g3:GetCount()==0 then return false end
-	if ft>0 then return true end
-	local f1=g1:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)>0 and 1 or 0
-	local f2=g2:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)>0 and 1 or 0
-	local f3=g3:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)>0 and 1 or 0
-	if ft==-2 then return f1+f2+f3==3
-	elseif ft==-1 then return f1+f2+f3>=2
-	else return f1+f2+f3>=1 end
+	local mg=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,43237273,17732278)
+	if ft>0 then return mg:IsExists(c17032740.spfilter1,1,nil,mg) end
+	local f1=Duel.GetMatchingGroupCount(c17032740.spfilter,tp,LOCATION_MZONE,0,nil,89943723,0,0)>0 and 1 or 0
+	local f2=Duel.GetMatchingGroupCount(c17032740.spfilter,tp,LOCATION_MZONE,0,nil,43237273,0,0)>0 and 1 or 0
+	local f3=Duel.GetMatchingGroupCount(c17032740.spfilter,tp,LOCATION_MZONE,0,nil,17732278,0,0)>0 and 1 or 0
+	if ft==-2 then return f1+f2+f3==3 and mg:IsExists(c17032740.spfilter1,1,nil,mg)
+	elseif ft==-1 then return f1+f2+f3>=2 and mg:IsExists(c17032740.spfilter1,1,nil,mg)
+	else return f1+f2+f3>=1 and mg:IsExists(c17032740.spfilter1,1,nil,mg) end
 end
 function c17032740.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local g1=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723)
-	local g2=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,43237273)
-	local g3=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,17732278)
-	g1:Merge(g2)
-	g1:Merge(g3)
+	local mg1=Duel.GetMatchingGroup(c17032740.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,43237273,17732278)
+	local mg2=mg1:Filter(Card.IsLocation,nil,LOCATION_MZONE)
 	local g=Group.CreateGroup()
 	local tc=nil
 	for i=1,3 do
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-		if ft<=0 then
-			tc=g1:FilterSelect(tp,Card.IsLocation,1,1,nil,LOCATION_MZONE):GetFirst()
-		else
-			tc=g1:Select(tp,1,1,nil):GetFirst()
+		if i==1 then
+			if ft<=0 then
+				tc=mg2:FilterSelect(tp,c17032740.spfilter1,1,1,nil,mg2):GetFirst()
+			else
+				tc=mg1:FilterSelect(tp,c17032740.spfilter1,1,1,nil,mg1):GetFirst()
+			end
+		end
+		if i==2 then
+			if ft<=0 then
+				tc=mg2:FilterSelect(tp,c17032740.spfilter2,1,1,nil,mg2):GetFirst()
+			else
+				tc=mg1:FilterSelect(tp,c17032740.spfilter2,1,1,nil,mg1):GetFirst()
+			end
+		end
+		if i==3 then
+			if ft<=0 then
+				tc=mg2:FilterSelect(tp,c17032740.spfilter3,1,1,nil,mg2):GetFirst()
+			else
+				tc=mg1:FilterSelect(tp,c17032740.spfilter3,1,1,nil,mg1):GetFirst()
+			end
 		end
 		g:AddCard(tc)
 		if tc:IsFusionCode(89943723) then
-			g1:Remove(Card.IsFusionCode,nil,89943723)
+			mg1:Remove(c17032740.rmfilter,nil,89943723)
+			mg2:Remove(c17032740.rmfilter,nil,89943723)
 		elseif tc:IsFusionCode(43237273) then
-			g1:Remove(Card.IsFusionCode,nil,43237273)
+			mg1:Remove(c17032740.rmfilter,nil,43237273)
+			mg2:Remove(c17032740.rmfilter,nil,43237273)
 		elseif tc:IsFusionCode(17732278) then
-			g1:Remove(Card.IsFusionCode,nil,17732278)
+			mg1:Remove(c17032740.rmfilter,nil,17732278)
+			mg2:Remove(c17032740.rmfilter,nil,17732278)
 		end
 		ft=ft+1
 	end

--- a/c49352945.lua
+++ b/c49352945.lua
@@ -66,19 +66,19 @@ function c49352945.spfilter1(c,mg,ft)
 	local mg2=mg:Clone()
 	mg2:RemoveCard(c)
 	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
-	return ft>=-1 and c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+	return ft>=-1 and c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 		and mg2:IsExists(c49352945.spfilter2,1,nil,mg2,ft)
 end
 function c49352945.spfilter2(c,mg,ft)
 	local mg2=mg:Clone()
 	mg2:RemoveCard(c)
 	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
-	return ft>=0 and c:IsFusionCode(17955766) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+	return ft>=0 and c:IsFusionCode(17955766) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 		and mg2:IsExists(c49352945.spfilter3,1,nil,ft)
 end
 function c49352945.spfilter3(c,ft)
 	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
-	return ft>=1 and c:IsFusionCode(54959865) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+	return ft>=1 and c:IsFusionCode(54959865) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial(nil,true)
 end
 function c49352945.spcon(e,c)
 	if c==nil then return true end

--- a/c49352945.lua
+++ b/c49352945.lua
@@ -62,23 +62,23 @@ end
 function c49352945.spfilter(c,code1,code2,code3)
 	return c:IsAbleToDeckOrExtraAsCost() and (c:IsFusionCode(code1) or c:IsFusionCode(code2) or c:IsFusionCode(code3))
 end
-function c49352945.spfilter1(c,mg)
+function c49352945.spfilter1(c,mg,ft)
 	local mg2=mg:Clone()
 	mg2:RemoveCard(c)
-	return c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
-		and mg2:IsExists(c49352945.spfilter2,1,nil,mg2)
+	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
+	return ft>=-1 and c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+		and mg2:IsExists(c49352945.spfilter2,1,nil,mg2,ft)
 end
-function c49352945.spfilter2(c,mg)
+function c49352945.spfilter2(c,mg,ft)
 	local mg2=mg:Clone()
 	mg2:RemoveCard(c)
-	return c:IsFusionCode(17955766) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
-		and mg2:IsExists(c49352945.spfilter3,1,nil)
+	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
+	return ft>=0 and c:IsFusionCode(17955766) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+		and mg2:IsExists(c49352945.spfilter3,1,nil,ft)
 end
-function c49352945.spfilter3(c)
-	return c:IsFusionCode(54959865) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
-end
-function c49352945.rmfilter(c,code)
-	return c:IsFusionCode(code) and c:IsCode(code)
+function c49352945.spfilter3(c,ft)
+	if c:IsLocation(LOCATION_MZONE) then ft=ft+1 end
+	return ft>=1 and c:IsFusionCode(54959865) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
 end
 function c49352945.spcon(e,c)
 	if c==nil then return true end
@@ -86,54 +86,27 @@ function c49352945.spcon(e,c)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<-2 then return false end
 	local mg=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,17955766,54959865)
-	if ft>0 then return mg:IsExists(c49352945.spfilter1,1,nil,mg) end
-	local mg2=mg:Filter(Card.IsLocation,nil,LOCATION_MZONE)
-	local ct=mg2:GetClassCount(Card.GetFusionCode)
-	if ft==-2 then return ct==3 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
-	elseif ft==-1 then return ct>=2 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
-	else return ct>=1 and mg:IsExists(c49352945.spfilter1,1,nil,mg) end
+	return mg:IsExists(c49352945.spfilter1,1,nil,mg,ft)
 end
 function c49352945.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local mg1=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,17955766,54959865)
-	local mg2=mg1:Filter(Card.IsLocation,nil,LOCATION_MZONE)
+	local mg=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,17955766,54959865)
 	local g=Group.CreateGroup()
 	local tc=nil
 	for i=1,3 do
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 		if i==1 then
-			if ft<=0 then
-				tc=mg2:FilterSelect(tp,c49352945.spfilter1,1,1,nil,mg2):GetFirst()
-			else
-				tc=mg1:FilterSelect(tp,c49352945.spfilter1,1,1,nil,mg1):GetFirst()
-			end
+			tc=mg:FilterSelect(tp,c49352945.spfilter1,1,1,nil,mg,ft):GetFirst()
 		end
 		if i==2 then
-			if ft<=0 then
-				tc=mg2:FilterSelect(tp,c49352945.spfilter2,1,1,nil,mg2):GetFirst()
-			else
-				tc=mg1:FilterSelect(tp,c49352945.spfilter2,1,1,nil,mg1):GetFirst()
-			end
+			tc=mg:FilterSelect(tp,c49352945.spfilter2,1,1,nil,mg,ft):GetFirst()
 		end
 		if i==3 then
-			if ft<=0 then
-				tc=mg2:FilterSelect(tp,c49352945.spfilter3,1,1,nil,mg2):GetFirst()
-			else
-				tc=mg1:FilterSelect(tp,c49352945.spfilter3,1,1,nil,mg1):GetFirst()
-			end
+			tc=mg:FilterSelect(tp,c49352945.spfilter3,1,1,nil,ft):GetFirst()
 		end
 		g:AddCard(tc)
-		if tc:IsFusionCode(89943723) then
-			mg1:Remove(c49352945.rmfilter,nil,89943723)
-			mg2:Remove(c49352945.rmfilter,nil,89943723)
-		elseif tc:IsFusionCode(17955766) then
-			mg1:Remove(c49352945.rmfilter,nil,17955766)
-			mg2:Remove(c49352945.rmfilter,nil,17955766)
-		elseif tc:IsFusionCode(54959865) then
-			mg1:Remove(c49352945.rmfilter,nil,54959865)
-			mg2:Remove(c49352945.rmfilter,nil,54959865)
-		end
-		ft=ft+1
+		mg:RemoveCard(tc)
+		if tc:IsLocation(LOCATION_MZONE) then ft=ft+1 end
 	end
 	local cg=g:Filter(Card.IsFacedown,nil)
 	if cg:GetCount()>0 then

--- a/c49352945.lua
+++ b/c49352945.lua
@@ -87,12 +87,11 @@ function c49352945.spcon(e,c)
 	if ft<-2 then return false end
 	local mg=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,17955766,54959865)
 	if ft>0 then return mg:IsExists(c49352945.spfilter1,1,nil,mg) end
-	local f1=Duel.GetMatchingGroupCount(c49352945.spfilter,tp,LOCATION_MZONE,0,nil,89943723,0,0)>0 and 1 or 0
-	local f2=Duel.GetMatchingGroupCount(c49352945.spfilter,tp,LOCATION_MZONE,0,nil,17955766,0,0)>0 and 1 or 0
-	local f3=Duel.GetMatchingGroupCount(c49352945.spfilter,tp,LOCATION_MZONE,0,nil,54959865,0,0)>0 and 1 or 0
-	if ft==-2 then return f1+f2+f3==3 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
-	elseif ft==-1 then return f1+f2+f3>=2 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
-	else return f1+f2+f3>=1 and mg:IsExists(c49352945.spfilter1,1,nil,mg) end
+	local mg2=mg:Filter(Card.IsLocation,nil,LOCATION_MZONE)
+	local ct=mg2:GetClassCount(Card.GetFusionCode)
+	if ft==-2 then return ct==3 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
+	elseif ft==-1 then return ct>=2 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
+	else return ct>=1 and mg:IsExists(c49352945.spfilter1,1,nil,mg) end
 end
 function c49352945.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c49352945.lua
+++ b/c49352945.lua
@@ -59,49 +59,80 @@ end
 function c49352945.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
-function c49352945.spfilter(c,code)
-	return c:IsAbleToDeckOrExtraAsCost() and c:IsFusionCode(code)
+function c49352945.spfilter(c,code1,code2,code3)
+	return c:IsAbleToDeckOrExtraAsCost() and (c:IsFusionCode(code1) or c:IsFusionCode(code2) or c:IsFusionCode(code3))
+end
+function c49352945.spfilter1(c,mg)
+	local mg2=mg:Clone()
+	mg2:RemoveCard(c)
+	return c:IsFusionCode(89943723) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+		and mg2:IsExists(c49352945.spfilter2,1,nil,mg2)
+end
+function c49352945.spfilter2(c,mg)
+	local mg2=mg:Clone()
+	mg2:RemoveCard(c)
+	return c:IsFusionCode(17955766) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+		and mg2:IsExists(c49352945.spfilter3,1,nil)
+end
+function c49352945.spfilter3(c)
+	return c:IsFusionCode(54959865) and c:IsAbleToDeckOrExtraAsCost() and c:IsCanBeFusionMaterial()
+end
+function c49352945.rmfilter(c,code)
+	return c:IsFusionCode(code) and c:IsCode(code)
 end
 function c49352945.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<-2 then return false end
-	local g1=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723)
-	local g2=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,17955766)
-	local g3=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,54959865)
-	if g1:GetCount()==0 or g2:GetCount()==0 or g3:GetCount()==0 then return false end
-	if ft>0 then return true end
-	local f1=g1:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)>0 and 1 or 0
-	local f2=g2:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)>0 and 1 or 0
-	local f3=g3:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)>0 and 1 or 0
-	if ft==-2 then return f1+f2+f3==3
-	elseif ft==-1 then return f1+f2+f3>=2
-	else return f1+f2+f3>=1 end
+	local mg=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,17955766,54959865)
+	if ft>0 then return mg:IsExists(c49352945.spfilter1,1,nil,mg) end
+	local f1=Duel.GetMatchingGroupCount(c49352945.spfilter,tp,LOCATION_MZONE,0,nil,89943723,0,0)>0 and 1 or 0
+	local f2=Duel.GetMatchingGroupCount(c49352945.spfilter,tp,LOCATION_MZONE,0,nil,17955766,0,0)>0 and 1 or 0
+	local f3=Duel.GetMatchingGroupCount(c49352945.spfilter,tp,LOCATION_MZONE,0,nil,54959865,0,0)>0 and 1 or 0
+	if ft==-2 then return f1+f2+f3==3 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
+	elseif ft==-1 then return f1+f2+f3>=2 and mg:IsExists(c49352945.spfilter1,1,nil,mg)
+	else return f1+f2+f3>=1 and mg:IsExists(c49352945.spfilter1,1,nil,mg) end
 end
 function c49352945.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local g1=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723)
-	local g2=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,17955766)
-	local g3=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,54959865)
-	g1:Merge(g2)
-	g1:Merge(g3)
+	local mg1=Duel.GetMatchingGroup(c49352945.spfilter,tp,LOCATION_ONFIELD,0,nil,89943723,17955766,54959865)
+	local mg2=mg1:Filter(Card.IsLocation,nil,LOCATION_MZONE)
 	local g=Group.CreateGroup()
 	local tc=nil
 	for i=1,3 do
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-		if ft<=0 then
-			tc=g1:FilterSelect(tp,Card.IsLocation,1,1,nil,LOCATION_MZONE):GetFirst()
-		else
-			tc=g1:Select(tp,1,1,nil):GetFirst()
+		if i==1 then
+			if ft<=0 then
+				tc=mg2:FilterSelect(tp,c49352945.spfilter1,1,1,nil,mg2):GetFirst()
+			else
+				tc=mg1:FilterSelect(tp,c49352945.spfilter1,1,1,nil,mg1):GetFirst()
+			end
+		end
+		if i==2 then
+			if ft<=0 then
+				tc=mg2:FilterSelect(tp,c49352945.spfilter2,1,1,nil,mg2):GetFirst()
+			else
+				tc=mg1:FilterSelect(tp,c49352945.spfilter2,1,1,nil,mg1):GetFirst()
+			end
+		end
+		if i==3 then
+			if ft<=0 then
+				tc=mg2:FilterSelect(tp,c49352945.spfilter3,1,1,nil,mg2):GetFirst()
+			else
+				tc=mg1:FilterSelect(tp,c49352945.spfilter3,1,1,nil,mg1):GetFirst()
+			end
 		end
 		g:AddCard(tc)
 		if tc:IsFusionCode(89943723) then
-			g1:Remove(Card.IsFusionCode,nil,89943723)
+			mg1:Remove(c49352945.rmfilter,nil,89943723)
+			mg2:Remove(c49352945.rmfilter,nil,89943723)
 		elseif tc:IsFusionCode(17955766) then
-			g1:Remove(Card.IsFusionCode,nil,17955766)
+			mg1:Remove(c49352945.rmfilter,nil,17955766)
+			mg2:Remove(c49352945.rmfilter,nil,17955766)
 		elseif tc:IsFusionCode(54959865) then
-			g1:Remove(Card.IsFusionCode,nil,54959865)
+			mg1:Remove(c49352945.rmfilter,nil,54959865)
+			mg2:Remove(c49352945.rmfilter,nil,54959865)
 		end
 		ft=ft+1
 	end


### PR DESCRIPTION
similar to the fix https://github.com/Fluorohydride/ygopro-scripts/commit/dca7df498bbd8d6ce7e62a759cd307981ca25722
at the moment you can summon Storm Neos if you have neos + Air Hummingbird on the field only and use Fusion Tag on Air Hummingbird and reveal Marine Dolphin (also no cards are returned to the deck then, you can simply summon 3 Storm Neos)
same situation with Chaos Neos and Fusion Tag on Dark Panther by revealing Twinkle Moss