### PR TITLE
fix

### DIFF
--- a/c19748583.lua
+++ b/c19748583.lua
@@ -87,8 +87,10 @@ function c19748583.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c19748583.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local tc=c:GetEquipTarget():GetBattleTarget()
-	if tc:IsRelateToBattle() and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+	local ec=c:GetEquipTarget()
+	if not ec then return end
+	local tc=ec:GetBattleTarget()
+	if tc and tc:IsRelateToBattle() and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		Duel.BreakEffect()
 		Duel.Destroy(c,REASON_EFFECT)
 	end

--- a/c27873305.lua
+++ b/c27873305.lua
@@ -45,6 +45,7 @@ function c27873305.operation(e,tp,eg,ep,ev,re,r,rp)
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 			local g=Duel.SelectMatchingCard(tp,c27873305.eqfilter,tp,0,LOCATION_MZONE,1,1,bc)
 			local ec=g:GetFirst()
+			if not ec then return end
 			local atk=ec:GetTextAttack()
 			if atk<0 then atk=0 end
 			if not Duel.Equip(tp,ec,c,false) then return end

--- a/c41925941.lua
+++ b/c41925941.lua
@@ -20,10 +20,12 @@ function c41925941.condition(e,tp,eg,ep,ev,re,r,rp)
 	local d=Duel.GetAttackTarget()
 	if a:IsControler(tp) then 
 		e:SetLabelObject(d)
-		return a:IsFaceup() and a:IsRace(RACE_FIEND) and a:IsRelateToBattle() and d and d:IsFaceup() and d:IsRelateToBattle()
-	else
+		return a:IsFaceup() and a:IsRace(RACE_FIEND) and a:IsRelateToBattle()
+			and d and d:IsFaceup() and d:IsRelateToBattle()
+	elseif d and d:IsControler(tp) then
 		e:SetLabelObject(a)
-		return d:IsFaceup() and d:IsRace(RACE_FIEND) and d:IsRelateToBattle() and a and a:IsFaceup() and a:IsRelateToBattle()
+		return d:IsFaceup() and d:IsRace(RACE_FIEND) and d:IsRelateToBattle()
+			and a and a:IsFaceup() and a:IsRelateToBattle()
 	end
 end
 function c41925941.cost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c43730887.lua
+++ b/c43730887.lua
@@ -49,7 +49,7 @@ end
 function c43730887.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)
 	end
 end

--- a/c5183693.lua
+++ b/c5183693.lua
@@ -56,7 +56,7 @@ function c5183693.atkcon(e)
 	if Duel.GetCurrentPhase()~=PHASE_DAMAGE_CAL then return false end
 	local eqc=e:GetHandler():GetEquipTarget()
 	local bc=eqc:GetBattleTarget()
-	return eqc:GetLevel()>0 and bc:GetLevel()>eqc:GetLevel()
+	return eqc:GetLevel()>0 and bc and bc:GetLevel()>eqc:GetLevel()
 end
 function c5183693.atkval(e,c)
 	local bc=c:GetBattleTarget()

--- a/c57314798.lua
+++ b/c57314798.lua
@@ -145,11 +145,15 @@ function c57314798.desop(e,tp,eg,ep,ev,re,r,rp)
 		local g2=Duel.SelectMatchingCard(1-tp,c57314798.setfilter,1-tp,LOCATION_GRAVE,0,1,1,nil)
 		local tc1=g1:GetFirst()
 		local tc2=g2:GetFirst()
-		if tc1:IsHasEffect(EFFECT_NECRO_VALLEY) or tc2:IsHasEffect(EFFECT_NECRO_VALLEY) then return end
-		Duel.SSet(tp,tc1)
-		Duel.ConfirmCards(1-tp,tc1)
-		Duel.SSet(1-tp,tc2)
-		Duel.ConfirmCards(tp,tc2)
+		if (tc1 and tc1:IsHasEffect(EFFECT_NECRO_VALLEY)) or (tc2 and tc2:IsHasEffect(EFFECT_NECRO_VALLEY)) then return end
+		if tc1 then
+			Duel.SSet(tp,tc1)
+			Duel.ConfirmCards(1-tp,tc1)
+		end
+		if tc2 then
+			Duel.SSet(1-tp,tc2)
+			Duel.ConfirmCards(tp,tc2)
+		end
 	end
 end
 function c57314798.spfilter(c)

--- a/c68077936.lua
+++ b/c68077936.lua
@@ -43,7 +43,7 @@ function c68077936.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c68077936.descon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c68077936.cfilter,1,nil,tp) and re:IsActiveType(TYPE_SPELL) and aux.exccon(e)
+	return eg:IsExists(c68077936.cfilter,1,nil,tp) and re and re:IsActiveType(TYPE_SPELL) and aux.exccon(e)
 end
 function c68077936.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end

--- a/c88032456.lua
+++ b/c88032456.lua
@@ -26,7 +26,9 @@ function c88032456.filter(c,e,tp)
 	if c:IsType(TYPE_MONSTER) then
 		return c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 	else
-		return c:IsSSetable(true) and (c:IsType(TYPE_FIELD) or Duel.GetLocationCount(tp,LOCATION_SZONE)>0)
+		local ct=Duel.GetLocationCount(tp,LOCATION_SZONE)
+		if e:IsHasType(EFFECT_TYPE_ACTIVATE) and not e:GetHandler():IsLocation(LOCATION_SZONE) then ct=ct-1 end
+		return c:IsSSetable() and (c:IsType(TYPE_FIELD) or ct>0)
 	end
 end
 function c88032456.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c90673413.lua
+++ b/c90673413.lua
@@ -64,7 +64,8 @@ function c90673413.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c90673413.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsReason(REASON_LOST_TARGET) and c:GetPreviousEquipTarget():IsLocation(LOCATION_OVERLAY)
+	local tc=c:GetPreviousEquipTarget()
+	return c:IsReason(REASON_LOST_TARGET) and tc and tc:IsLocation(LOCATION_OVERLAY)
 end
 function c90673413.atkfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ)

--- a/c98777036.lua
+++ b/c98777036.lua
@@ -84,7 +84,7 @@ function c98777036.ctcos(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(sg,REASON_COST)
 end
 function c98777036.cttar(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c98777036.ctffilter(e,e:GetLabel()) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c98777036.ctffilter(chkc,e:GetLabel()) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
 	local g=Duel.SelectTarget(tp,c98777036.ctffilter,tp,0,LOCATION_MZONE,1,1,nil,e:GetLabel())


### PR DESCRIPTION
怀抱圣剑的王后：效果处理时不在场，报错
凯撒末日神：效果处理时没有怪兽可装备，报错
冥王的咆哮：直接攻击时报错
拘束臂：召唤时必发效果空发，报错
下克上的首饰：直接攻击时报错
源数龙：一方墓地没有魔法·陷阱卡时不能成功盖放
融爆：自己的卡不是被卡的效果破坏也会触发检查，报错
复制猫：场上已有4张魔法·陷阱卡，对方墓地只有魔法·陷阱，仍能从手卡发动但不能选对象
我我我复仇：不明原因失去对象，报错
特拉戈迪亚：控制权效果被转移对象时判断条件错误