### PR TITLE
fix Swords at Dawn

### DIFF
--- a/c25067275.lua
+++ b/c25067275.lua
@@ -31,8 +31,12 @@ function c25067275.ecfilter(c)
 end
 function c25067275.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c25067275.ecfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then
+		if not Duel.IsExistingTarget(c25067275.ecfilter,tp,LOCATION_GRAVE,0,1,nil) then return false end
+		if e:GetHandler():IsLocation(LOCATION_HAND) then
+			return Duel.GetLocationCount(tp,LOCATION_SZONE)>1
+		else return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 end
+	end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(25067275,0))
 	local g=Duel.SelectTarget(tp,c25067275.ecfilter,tp,LOCATION_GRAVE,0,1,1,nil)
 	local ec=g:GetFirst()


### PR DESCRIPTION
Fix this: If player have only 1 space in spell&trap zone, Swords at Dawn can activate from the hand.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分の魔法＆罠ゾーンに空きが１つしか存在しない場合、自分は手札から「旗鼓堂々」を発動できますか？ 
A. 
「旗鼓堂々」は、自分の魔法＆罠ゾーンに「旗鼓堂々」と装備魔法カードを置ける2か所の空きがなければ発動そのものができません。 
よって、ご質問の状況の場合も、「旗鼓堂々」は発動できません。