### PR TITLE
fix 巨竜の守護騎士

### DIFF
--- a/c33460840.lua
+++ b/c33460840.lua
@@ -37,7 +37,7 @@ function c33460840.eqop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectMatchingCard(tp,c33460840.filter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,c)
 	local tc=g:GetFirst()
-	if not Duel.Equip(tp,tc,c,true) then return end
+	if not (tc and Duel.Equip(tp,tc,c,true)) then return end
 	local atk=tc:GetTextAttack()/2
 	local def=tc:GetTextDefense()/2
 	if atk<0 then atk=0 end


### PR DESCRIPTION
Fix: It will throw a error when there don't exist any card to equip.