### PR TITLE
errata W-Wing Catapult & fix Y-Dragon Head,Z-Metal Tank,Heavy Mech Support Platform

### DIFF
--- a/c23265594.lua
+++ b/c23265594.lua
@@ -25,7 +25,6 @@ function c23265594.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
 	e3:SetCode(EFFECT_UPDATE_ATTACK)
 	e3:SetValue(500)
-	e3:SetCondition(c23265594.uncon)
 	c:RegisterEffect(e3)
 	--Def up
 	local e4=Effect.CreateEffect(c)

--- a/c64500000.lua
+++ b/c64500000.lua
@@ -25,7 +25,6 @@ function c64500000.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
 	e3:SetCode(EFFECT_UPDATE_ATTACK)
 	e3:SetValue(600)
-	e3:SetCondition(c64500000.uncon)
 	c:RegisterEffect(e3)
 	--Def up
 	local e4=Effect.CreateEffect(c)

--- a/c65622692.lua
+++ b/c65622692.lua
@@ -31,7 +31,6 @@ function c65622692.initial_effect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
 	e4:SetCode(EFFECT_UPDATE_DEFENSE)
 	e4:SetValue(400)
-	e4:SetCondition(c65622692.uncon)
 	c:RegisterEffect(e4)
 	--destroy sub
 	local e5=Effect.CreateEffect(c)

--- a/c96300057.lua
+++ b/c96300057.lua
@@ -25,14 +25,12 @@ function c96300057.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
 	e3:SetCode(EFFECT_UPDATE_ATTACK)
 	e3:SetValue(400)
-	e3:SetCondition(c96300057.uncon)
 	c:RegisterEffect(e3)
 	--Def up
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
 	e4:SetCode(EFFECT_UPDATE_DEFENSE)
 	e4:SetValue(400)
-	e4:SetCondition(c96300057.uncon)
 	c:RegisterEffect(e4)
 	--destroy sub
 	local e5=Effect.CreateEffect(c)
@@ -54,13 +52,13 @@ function c96300057.uncon(e)
 	return e:GetHandler():IsStatus(STATUS_UNION)
 end
 function c96300057.repval(e,re,r,rp)
-	return bit.band(r,REASON_BATTLE)~=0
+	return bit.band(r,REASON_BATTLE+REASON_EFFECT)~=0
 end
 function c96300057.eqlimit(e,c)
-	return c:IsCode(51638941)
+	return c:IsCode(51638941) or e:GetHandler():GetEquipTarget()==c
 end
 function c96300057.filter(c)
-	return c:IsFaceup() and c:IsCode(51638941) and c:GetUnionCount()==0
+	return c:IsFaceup() and c:IsCode(51638941)
 end
 function c96300057.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c96300057.filter(chkc) end
@@ -91,7 +89,7 @@ end
 function c96300057.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
 		Duel.SendtoGrave(c,REASON_RULE)
 	end


### PR DESCRIPTION
errata: W-Wing Catapult
http://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=6475

If Y-Dragon Head,Z-Metal Tank,Heavy Mech Support Platform equipped by Relinquished, Relinquished don't gain ATK/DEF.