### PR TITLE
fix Malefic Truth Dragon

### DIFF
--- a/c37115575.lua
+++ b/c37115575.lua
@@ -98,10 +98,10 @@ end
 function c37115575.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)~=0 then
+	if Duel.SpecialSummon(c,0,tp,tp,true,true,POS_FACEUP)~=0 then
 		c:CompleteProcedure()
 	elseif Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) and c:IsLocation(LOCATION_HAND) then
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,true) and c:IsLocation(LOCATION_HAND) then
 		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end


### PR DESCRIPTION
the last change accidently changed one of the true parameters to false, sometimes causing truth dragon to not be summoned after paying the lp