### PR TITLE
fix Silent Paladin

### DIFF
--- a/c19502505.lua
+++ b/c19502505.lua
@@ -52,7 +52,7 @@ end
 function c19502505.negcon(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
 	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	return g and g:GetCount()==1
+	return g and g:GetCount()==1 and g:IsExists(Card.IsType,1,nil,TYPE_MONSTER)
 		and re:IsActiveType(TYPE_SPELL) and re:IsHasType(EFFECT_TYPE_ACTIVATE)
 		and not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)
 end


### PR DESCRIPTION
Fix this: When a Spell Card is activated that targets exactly 1 Spell/Trap Card, player can Silent Paladin's effect.