### PR TITLE
fix Naturia Cherries

### DIFF
--- a/c60668166.lua
+++ b/c60668166.lua
@@ -27,6 +27,7 @@ end
 function c60668166.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ct=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ct<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
 	local g=Duel.GetMatchingGroup(c60668166.filter,tp,LOCATION_DECK,0,nil,e,tp)
 	if g:GetCount()>0 then
 		local t1=g:GetFirst()


### PR DESCRIPTION
Fix this: If _Blue-eyes Spirit Dragon_ has on the field, _Naturia Cherries_ can Special Summon 2 _Naturia Cherries_.