### PR TITLE
fix Fairy Tail - Snow White

### DIFF
--- a/c55623480.lua
+++ b/c55623480.lua
@@ -63,8 +63,7 @@ function c55623480.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c55623480.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and not e:GetHandler():IsStatus(STATUS_CHAINING) end
+	if chk==0 then return e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c55623480.spop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix this: _Fairy Tail - Snow White_'s effect cannot activate in the same Chain.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18665&keyword=&tag=-1
Q.自分の墓地の「妖精伝姫－シラユキ」の『②：このカードが墓地に存在する場合、自分の手札・フィールド・墓地からこのカード以外のカード７枚を除外して発動できる。このカードを墓地から特殊召喚する。この効果は相手ターンでも発動できる』モンスター効果を発動しました。

その発動にチェーンして、相手が「D.D.クロウ」のモンスター効果を発動し、効果を発動した「妖精伝姫－シラユキ」を対象とした場合、さらにチェーンしてその「妖精伝姫－シラユキ」の『②：このカードが墓地に存在する場合、自分の手札・フィールド・墓地からこのカード以外のカード７枚を除外して発動できる。このカードを墓地から特殊召喚する。この効果は相手ターンでも発動できる』モンスター効果を発動する事はできますか？
A.質問の状況のように、墓地の「妖精伝姫－シラユキ」のモンスター効果の発動にチェーンして、相手のカードの効果が発動した場合などに、さらにチェーンしてその「妖精伝姫－シラユキ」のモンスター効果をもう１度発動する事はできます。