### PR TITLE
fix Appointer of the Red Lotus

### DIFF
--- a/c43262273.lua
+++ b/c43262273.lua
@@ -38,12 +38,12 @@ function c43262273.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_END)
 		e1:SetCountLimit(1)
-		if Duel.GetTurnPlayer()==1-tp and Duel.GetCurrentPhase()==PHASE_END then
+		if Duel.GetTurnPlayer()==1-tp then
 			e1:SetLabel(Duel.GetTurnCount())
-			e1:SetReset(RESET_PHASE+PHASE_END,3)
+			e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN,2)
 		else
 			e1:SetLabel(0)
-			e1:SetReset(RESET_PHASE+PHASE_END,2)
+			e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
 		end
 		e1:SetLabelObject(tc)
 		e1:SetCondition(c43262273.retcon)


### PR DESCRIPTION
fix: If you activate the card during your opponents turn outside of the end phase the card currently returns on the same turn. It should only return during the end phase of the opponents next turn.