### PR TITLE
new cards INOV

### DIFF
--- a/c15936370.lua
+++ b/c15936370.lua
@@ -1,0 +1,50 @@
+--パンドラの宝具箱
+function c15936370.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--pendulum set
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(15936370,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCondition(c15936370.pencon)
+	e1:SetTarget(c15936370.pentg)
+	e1:SetOperation(c15936370.penop)
+	c:RegisterEffect(e1)
+	--effect draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetCode(EFFECT_DRAW_COUNT)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(1,0)
+	e2:SetValue(2)
+	e2:SetCondition(c15936370.drcon)
+	c:RegisterEffect(e2)
+end
+function c15936370.pencon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,LOCATION_EXTRA,0)==0
+end
+function c15936370.desfilter(c)
+	return (c:GetSequence()==6 or c:GetSequence()==7) and c:IsDestructable()
+end
+function c15936370.pentg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsControler(1-tp) and c15936370.desfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c15936370.desfilter,tp,0,LOCATION_SZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c15936370.desfilter,tp,0,LOCATION_SZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c15936370.penop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		Duel.MoveToField(c,tp,1-tp,LOCATION_SZONE,POS_FACEUP,true)
+	end
+end
+function c15936370.drcon(e)
+	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),LOCATION_EXTRA,0)==0
+end

--- a/c1621413.lua
+++ b/c1621413.lua
@@ -1,0 +1,95 @@
+--ダーク・レクイエム・エクシーズ・ドラゴン
+function c1621413.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,nil,5,3)
+	c:EnableReviveLimit()
+	--atk
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(1621413,0))
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c1621413.atkcon)
+	e1:SetCost(c1621413.cost)
+	e1:SetTarget(c1621413.atktg)
+	e1:SetOperation(c1621413.atkop)
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(1621413,1))
+	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_DISABLE+CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c1621413.discon)
+	e2:SetCost(c1621413.cost)
+	e2:SetTarget(c1621413.distg)
+	e2:SetOperation(c1621413.disop)
+	c:RegisterEffect(e2)
+end
+function c1621413.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,16195942)
+end
+function c1621413.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c1621413.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and aux.nzatk(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,aux.nzatk,tp,0,LOCATION_MZONE,1,1,nil)
+end
+function c1621413.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) then
+		local atk=tc:GetBaseAttack()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetValue(0)
+		tc:RegisterEffect(e1)
+		if c:IsRelateToEffect(e) and c:IsFaceup() then
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_SINGLE)
+			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e2:SetCode(EFFECT_UPDATE_ATTACK)
+			e2:SetReset(RESET_EVENT+0x1fe0000)
+			e2:SetValue(atk)
+			c:RegisterEffect(e2)
+		end
+	end
+end
+function c1621413.discon(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and rp~=tp and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainDisablable(ev)
+		and e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,16195942)
+end
+function c1621413.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c1621413.spfilter(c,e,tp)
+	return c:IsType(TYPE_XYZ) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c1621413.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
+	if re:GetHandler():IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)>0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+		local g=Duel.GetMatchingGroup(c1621413.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp)
+		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(1621413,2)) then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sg=g:Select(tp,1,1,nil)
+			if sg:GetFirst():IsHasEffect(EFFECT_NECRO_VALLEY) then return end
+			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+end

--- a/c16759958.lua
+++ b/c16759958.lua
@@ -1,0 +1,70 @@
+--アロマセラフィ－アンゼリカ
+function c16759958.initial_effect(c)
+	--recover
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(16759958,0))
+	e1:SetCategory(CATEGORY_RECOVER)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCountLimit(1,16759958)
+	e1:SetCost(c16759958.reccost)
+	e1:SetTarget(c16759958.rectg)
+	e1:SetOperation(c16759958.recop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(16759958,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,16759959)
+	e2:SetCondition(c16759958.spcon)
+	e2:SetTarget(c16759958.sptg)
+	e2:SetOperation(c16759958.spop)
+	c:RegisterEffect(e2)
+end
+function c16759958.reccost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+end
+function c16759958.recfilter(c)
+	return c:IsSetCard(0xc9) and c:GetAttack()>0
+end
+function c16759958.rectg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c16759958.recfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c16759958.recfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	local g=Duel.SelectTarget(tp,c16759958.recfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,g:GetFirst():GetAttack())
+end
+function c16759958.recop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:GetAttack()>0 then
+		Duel.Recover(tp,tc:GetAttack(),REASON_EFFECT)
+	end
+end
+function c16759958.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xc9)
+end
+function c16759958.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetLP(tp)>Duel.GetLP(1-tp) and Duel.IsExistingMatchingCard(c16759958.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c16759958.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c16759958.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x47e0000)
+		e1:SetValue(LOCATION_REMOVED)
+		c:RegisterEffect(e1,true)
+	end
+end

--- a/c17871506.lua
+++ b/c17871506.lua
@@ -1,0 +1,20 @@
+--真紅眼の凶星竜－メテオ・ドラゴン
+function c17871506.initial_effect(c)
+	aux.EnableDualAttribute(c)
+	--indes
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_MZONE,0)
+	e1:SetTarget(c17871506.indtg)
+	e1:SetValue(1)
+	e1:SetCondition(aux.IsDualState)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	c:RegisterEffect(e2)
+end
+function c17871506.indtg(e,c)
+	return c:IsSetCard(0x3b) and c~=e:GetHandler()
+end

--- a/c18716735.lua
+++ b/c18716735.lua
@@ -1,0 +1,92 @@
+--レアメタルフォーゼ・ビスマギア
+function c18716735.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--destroy and set
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(18716735,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCountLimit(1)
+	e1:SetTarget(c18716735.target)
+	e1:SetOperation(c18716735.operation)
+	c:RegisterEffect(e1)
+	--to hand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(18716735,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_DESTROYED)
+	e2:SetCountLimit(1,18716735)
+	e2:SetCondition(c18716735.regcon)
+	e2:SetTarget(c18716735.regtg)
+	e2:SetOperation(c18716735.regop)
+	c:RegisterEffect(e2)
+end
+function c18716735.desfilter(c,tp)
+	if c:IsFacedown() or not c:IsDestructable() then return false end
+	local ft=Duel.GetLocationCount(tp,LOCATION_SZONE)
+	if ft==0 and c:IsLocation(LOCATION_SZONE) and c:GetSequence()<5 then
+		return Duel.IsExistingMatchingCard(c18716735.filter,tp,LOCATION_DECK,0,1,nil,true)
+	else
+		return Duel.IsExistingMatchingCard(c18716735.filter,tp,LOCATION_DECK,0,1,nil,false)
+	end
+end
+function c18716735.filter(c,ignore)
+	return c:IsSetCard(0xe1) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable(ignore)
+end
+function c18716735.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and chkc:IsControler(tp) and c18716735.desfilter(chkc,tp) and chkc~=e:GetHandler() end
+	if chk==0 then return Duel.IsExistingTarget(c18716735.desfilter,tp,LOCATION_ONFIELD,0,1,e:GetHandler(),tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c18716735.desfilter,tp,LOCATION_ONFIELD,0,1,1,e:GetHandler(),tp)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c18716735.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+		local g=Duel.SelectMatchingCard(tp,c18716735.filter,tp,LOCATION_DECK,0,1,1,nil,false)
+		if g:GetCount()>0 then
+			Duel.SSet(tp,g:GetFirst())
+			Duel.ConfirmCards(1-tp,g)
+		end
+	end
+end
+function c18716735.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+end
+function c18716735.thfilter(c)
+	return c:IsSetCard(0xe1) and c:IsType(TYPE_MONSTER)
+end
+function c18716735.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c18716735.thfilter,tp,LOCATION_DECK,0,1,nil) end
+end
+function c18716735.regop(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c18716735.thcon)
+	e1:SetOperation(c18716735.thop)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c18716735.thfilter2(c)
+	return c18716735.thfilter(c) and c:IsAbleToHand()
+end
+function c18716735.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c18716735.thfilter2,tp,LOCATION_DECK,0,1,nil)
+end
+function c18716735.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,18716735)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c18716735.thfilter2,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/c18993198.lua
+++ b/c18993198.lua
@@ -1,0 +1,47 @@
+--化合獣オキシン・オックス
+function c18993198.initial_effect(c)
+	aux.EnableDualAttribute(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(18993198,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1,18993198)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(aux.IsDualState)
+	e1:SetTarget(c18993198.sptg)
+	e1:SetOperation(c18993198.spop)
+	c:RegisterEffect(e1)
+end
+function c18993198.filter(c,e,tp)
+	return c:IsType(TYPE_DUAL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c18993198.lvfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_DUAL)
+end
+function c18993198.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c18993198.filter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+end
+function c18993198.spop(e,tp,eg,ep,ev,re,r,rp,chk)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c18993198.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()>0 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP) then
+		local lv=g:GetFirst():GetOriginalLevel()
+		local tg=Duel.GetMatchingGroup(c18993198.lvfilter,tp,LOCATION_MZONE,0,nil)
+		local tc=tg:GetFirst()
+		while tc do
+			if tc:GetLevel()~=lv then
+				local e1=Effect.CreateEffect(e:GetHandler())
+				e1:SetType(EFFECT_TYPE_SINGLE)
+				e1:SetCode(EFFECT_CHANGE_LEVEL_FINAL)
+				e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+				e1:SetValue(lv)
+				e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+				tc:RegisterEffect(e1)
+			end
+			tc=tg:GetNext()
+		end
+	end
+end

--- a/c20050865.lua
+++ b/c20050865.lua
@@ -1,0 +1,71 @@
+--水晶機巧－シトリィ
+function c20050865.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(20050865,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_MAIN_END+TIMING_BATTLE_START+TIMING_BATTLE_END)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,20050865)
+	e1:SetCondition(c20050865.sccon)
+	e1:SetTarget(c20050865.sctg)
+	e1:SetOperation(c20050865.scop)
+	c:RegisterEffect(e1)
+end
+function c20050865.sccon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return not e:GetHandler():IsStatus(STATUS_CHAINING) and Duel.GetTurnPlayer()~=tp
+		and (ph==PHASE_MAIN1 or (ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE) or ph==PHASE_MAIN2)
+end
+function c20050865.scfilter1(c,e,tp,mc)
+	local mg=Group.FromCards(c,mc)
+	return not c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(c20050865.scfilter2,tp,LOCATION_EXTRA,0,1,nil,mg)
+end
+function c20050865.scfilter2(c,mg)
+	return c:IsRace(RACE_MACHINE) and c:IsSynchroSummonable(nil,mg)
+end
+function c20050865.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c20050865.scfilter1(chkc,e,tp,e:GetHandler()) end
+	if chk==0 then return Duel.IsPlayerCanSpecialSummonCount(tp,2)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c20050865.scfilter1,tp,LOCATION_GRAVE,0,1,nil,e,tp,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c20050865.scfilter1,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c20050865.scop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not tc:IsRelateToEffect(e) or not Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	tc:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_DISABLE_EFFECT)
+	tc:RegisterEffect(e2)
+	Duel.SpecialSummonComplete()
+	if not c:IsRelateToEffect(e) then return end
+	local mg=Group.FromCards(c,tc)
+	local g=Duel.GetMatchingGroup(c20050865.scfilter2,tp,LOCATION_EXTRA,0,nil,mg)
+	if g:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=g:Select(tp,1,1,nil)
+		local e1=Effect.CreateEffect(c)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_IGNORE_IMMUNE)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)
+		e1:SetValue(LOCATION_REMOVED)
+		e1:SetReset(RESET_EVENT+0x47e0000)
+		c:RegisterEffect(e1,true)
+		local e2=e1:Clone()
+		tc:RegisterEffect(e2,true)
+		Duel.SynchroSummon(tp,sg:GetFirst(),nil,mg)
+	end
+end

--- a/c21772453.lua
+++ b/c21772453.lua
@@ -1,0 +1,62 @@
+--花札衛－紅葉に鹿－
+function c21772453.initial_effect(c)
+	c:EnableReviveLimit()
+	--spsummon from hand
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetCondition(c21772453.hspcon)
+	e1:SetOperation(c21772453.hspop)
+	c:RegisterEffect(e1)
+	--draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(21772453,0))
+	e2:SetCategory(CATEGORY_DRAW+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetTarget(c21772453.target)
+	e2:SetOperation(c21772453.operation)
+	c:RegisterEffect(e2)
+end
+function c21772453.hspfilter(c)
+	return c:IsSetCard(0xe6) and not c:IsCode(21772453)
+end
+function c21772453.hspcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>-1
+		and Duel.CheckReleaseGroup(c:GetControler(),c21772453.hspfilter,1,nil)
+end
+function c21772453.hspop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(c:GetControler(),c21772453.hspfilter,1,1,nil)
+	Duel.Release(g,REASON_COST)
+end
+function c21772453.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c21772453.desfilter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsDestructable()
+end
+function c21772453.operation(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	if Duel.Draw(p,d,REASON_EFFECT)~=0 then
+		local tc=Duel.GetOperatedGroup():GetFirst()
+		Duel.ConfirmCards(1-tp,tc)
+		if tc:IsType(TYPE_MONSTER) and tc:IsSetCard(0xe6) then
+			local g=Duel.GetMatchingGroup(c21772453.desfilter,tp,0,LOCATION_ONFIELD,nil)
+			if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(21772453,1)) then
+				Duel.BreakEffect()
+				local sg=g:Select(tp,1,1,nil)
+				Duel.Destroy(sg,REASON_EFFECT)
+			end
+		else
+			Duel.BreakEffect()
+			Duel.SendtoGrave(tc,REASON_EFFECT)
+		end
+		Duel.ShuffleHand(tp)
+	end
+end

--- a/c21999001.lua
+++ b/c21999001.lua
@@ -1,0 +1,77 @@
+--光波双顎機
+function c21999001.initial_effect(c)
+	--special summon from hand
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c21999001.sprcon)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(21999001,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1,21999001)
+	e2:SetCost(c21999001.spcost)
+	e2:SetTarget(c21999001.sptg)
+	e2:SetOperation(c21999001.spop)
+	c:RegisterEffect(e2)
+end
+function c21999001.sprcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
+		and Duel.IsExistingMatchingCard(aux.FilterEqualFunction(Card.GetSummonLocation,LOCATION_EXTRA),tp,0,LOCATION_MZONE,1,nil)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+end
+function c21999001.costfilter(c,e,tp)
+	return c:IsDiscardable() and Duel.IsExistingMatchingCard(c21999001.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,c,e,tp)
+end
+function c21999001.spfilter(c,e,tp)
+	return c:IsSetCard(0xe5) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c21999001.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	e:SetLabel(1)
+	return true
+end
+function c21999001.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return false end
+		if e:GetLabel()~=0 then
+			e:SetLabel(0)
+			return Duel.IsExistingMatchingCard(c21999001.costfilter,tp,LOCATION_HAND,0,1,nil,e,tp)
+		else
+			return Duel.IsExistingMatchingCard(c21999001.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp)
+		end
+	end
+	if e:GetLabel()~=0 then
+		e:SetLabel(0)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
+		local g=Duel.SelectMatchingCard(tp,c21999001.costfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+		Duel.SendtoGrave(g,REASON_COST+REASON_DISCARD)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK)
+end
+function c21999001.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c21999001.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c21999001.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c21999001.splimit(e,c)
+	return not c:IsSetCard(0xe5)
+end

--- a/c22011689.lua
+++ b/c22011689.lua
@@ -1,0 +1,80 @@
+--捕食植物モーレイ・ネペンテス
+function c22011689.initial_effect(c)
+	--atk
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(c22011689.atkval)
+	c:RegisterEffect(e1)
+	--equip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(22011689,0))
+	e2:SetCategory(CATEGORY_EQUIP)
+	e2:SetCode(EVENT_BATTLE_DESTROYING)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCondition(aux.bdocon)
+	e2:SetTarget(c22011689.eqtg)
+	e2:SetOperation(c22011689.eqop)
+	c:RegisterEffect(e2)
+	--destroy + lp gain
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(22011689,1))
+	e3:SetCategory(CATEGORY_DESTROY+CATEGORY_RECOVER)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCountLimit(1)
+	e3:SetTarget(c22011689.target)
+	e3:SetOperation(c22011689.operation)
+	c:RegisterEffect(e3)
+end
+function c22011689.atkval(e,c)
+	return Duel.GetCounter(0,1,1,0x1141)*200
+end
+function c22011689.eqtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 end
+	local bc=e:GetHandler():GetBattleTarget()
+	Duel.SetTargetCard(bc)
+	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,bc,1,0,0)
+end
+function c22011689.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsRelateToEffect(e) then
+		if not Duel.Equip(tp,tc,c,false) then return end
+		--Add Equip limit
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT+EFFECT_FLAG_OWNER_RELATE)
+		e1:SetCode(EFFECT_EQUIP_LIMIT)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetValue(c22011689.eqlimit)
+		tc:RegisterEffect(e1)
+		tc:RegisterFlagEffect(22011689,RESET_EVENT+0x1fe0000,0,1)
+	end
+end
+function c22011689.eqlimit(e,c)
+	return e:GetOwner()==c
+end
+function c22011689.desfilter(c,ec)
+	return c:IsDestructable() and c:GetFlagEffect(22011689)~=0 and c:GetEquipTarget()==ec
+end
+function c22011689.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsControler(tp) and c22011689.desfilter(chkc,c) end
+	if chk==0 then return Duel.IsExistingTarget(c22011689.desfilter,tp,LOCATION_SZONE,0,1,nil,c) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c22011689.desfilter,tp,LOCATION_SZONE,0,1,1,nil,c)
+	local atk=g:GetFirst():GetTextAttack()
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,atk)
+end
+function c22011689.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		local atk=tc:GetTextAttack()
+		Duel.Recover(tp,atk,REASON_EFFECT)
+	end
+end

--- a/c22011689.lua
+++ b/c22011689.lua
@@ -31,7 +31,7 @@ function c22011689.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c22011689.atkval(e,c)
-	return Duel.GetCounter(0,1,1,0x1141)*200
+	return Duel.GetCounter(0,1,1,0x1041)*200
 end
 function c22011689.eqtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 end

--- a/c25669282.lua
+++ b/c25669282.lua
@@ -1,0 +1,84 @@
+--完全燃焼
+function c25669282.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,25669282+EFFECT_COUNT_CODE_OATH)
+	e1:SetCost(c25669282.cost)
+	e1:SetTarget(c25669282.target)
+	e1:SetOperation(c25669282.activate)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(25669282,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCondition(c25669282.spcon)
+	e2:SetCost(c25669282.spcost)
+	e2:SetTarget(c25669282.sptg)
+	e2:SetOperation(c25669282.spop)
+	c:RegisterEffect(e2)
+end
+function c25669282.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xeb) and c:IsAbleToRemoveAsCost()
+end
+function c25669282.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c25669282.cfilter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c25669282.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c25669282.spfilter1(c,e,tp)
+	return c:IsSetCard(0xeb) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(c25669282.spfilter2,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetCode())
+end
+function c25669282.spfilter2(c,e,tp,code)
+	return c:IsSetCard(0xeb) and not c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c25669282.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c25669282.spfilter1,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c25669282.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g1=Duel.SelectMatchingCard(tp,c25669282.spfilter1,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g1:GetCount()<=0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g2=Duel.SelectMatchingCard(tp,c25669282.spfilter2,tp,LOCATION_DECK,0,1,1,nil,e,tp,g1:GetFirst():GetCode())
+		g1:Merge(g2)
+		Duel.SpecialSummon(g1,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c25669282.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+		and aux.exccon(e,tp,eg,ep,ev,re,r,rp)
+end
+function c25669282.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c25669282.spfilter3(c,e,tp)
+	return c:IsFaceup() and c:IsType(TYPE_DUAL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c25669282.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_REMOVED) and chkc:IsControler(tp) and c25669282.spfilter3(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c25669282.spfilter3,tp,LOCATION_REMOVED,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c25669282.spfilter3,tp,LOCATION_REMOVED,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c25669282.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+		tc:EnableDualState()
+	end
+end

--- a/c26781870.lua
+++ b/c26781870.lua
@@ -1,0 +1,65 @@
+--イカサマ御法度
+function c26781870.initial_effect(c)
+	Duel.EnableGlobalFlag(GLOBALFLAG_SELF_TOGRAVE)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(26781870,0))
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--tohand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(26781870,1))
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_ACTIVATE)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetCondition(c26781870.condition)
+	e2:SetCost(c26781870.cost)
+	e2:SetTarget(c26781870.target)
+	e2:SetOperation(c26781870.activate)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetRange(LOCATION_SZONE)
+	c:RegisterEffect(e3)
+	--tograve
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetCode(EFFECT_SELF_TOGRAVE)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c26781870.sdcon)
+	c:RegisterEffect(e4)
+end
+function c26781870.cfilter(c,tp)
+	return c:GetSummonPlayer()==1-tp and c:IsPreviousLocation(LOCATION_HAND)
+end
+function c26781870.condition(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c26781870.cfilter,1,nil,tp)
+end
+function c26781870.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(26781870)==0 end
+	e:GetHandler():RegisterFlagEffect(26781870,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c26781870.filter(c)
+	return c:GetSummonLocation()==LOCATION_HAND and c:IsAbleToHand()
+		and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+end
+function c26781870.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c26781870.filter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c26781870.filter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
+end
+function c26781870.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local g=Duel.GetMatchingGroup(c26781870.filter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+	end
+end
+function c26781870.sdfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xe6) and c:IsType(TYPE_SYNCHRO)
+end
+function c26781870.sdcon(e)
+	return not Duel.IsExistingMatchingCard(c26781870.sdfilter,e:GetHandlerPlayer(),LOCATION_MZONE,LOCATION_MZONE,1,nil)
+end

--- a/c2743001.lua
+++ b/c2743001.lua
@@ -1,0 +1,66 @@
+--水晶機巧－フェニキシオン
+function c2743001.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsType,TYPE_SYNCHRO),aux.NonTuner(Card.IsType,TYPE_SYNCHRO),1)
+	c:EnableReviveLimit()
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(2743001,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c2743001.rmcon)
+	e1:SetTarget(c2743001.rmtg)
+	e1:SetOperation(c2743001.rmop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(2743001,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_DESTROYED)
+	e2:SetCondition(c2743001.spcon)
+	e2:SetTarget(c2743001.sptg)
+	e2:SetOperation(c2743001.spop)
+	c:RegisterEffect(e2)
+end
+function c2743001.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SYNCHRO
+end
+function c2743001.rmfilter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToRemove()
+end
+function c2743001.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c2743001.rmfilter,tp,0,LOCATION_GRAVE+LOCATION_ONFIELD,1,nil) end
+	local g=Duel.GetMatchingGroup(c2743001.rmfilter,tp,0,LOCATION_GRAVE+LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
+end
+function c2743001.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c2743001.rmfilter,tp,0,LOCATION_GRAVE+LOCATION_ONFIELD,nil)
+	if g:GetCount()>0 then
+		Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+	end
+end
+function c2743001.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:GetSummonType()==SUMMON_TYPE_SYNCHRO and bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0
+end
+function c2743001.spfilter(c,e,tp)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c2743001.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c2743001.spfilter(chkc,e,tp) and chkc~=e:GetHandler() end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c2743001.spfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler(),e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c2743001.spfilter,tp,LOCATION_GRAVE,0,1,1,e:GetHandler(),e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c2743001.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c27503418.lua
+++ b/c27503418.lua
@@ -1,0 +1,41 @@
+--王者の調和
+function c27503418.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c27503418.condition)
+	e1:SetOperation(c27503418.activate)
+	c:RegisterEffect(e1)
+end
+function c27503418.condition(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttackTarget()
+	return tc and tc:IsFaceup() and tc:IsControler(tp) and tc:IsType(TYPE_SYNCHRO)
+end
+function c27503418.filter1(c,e,tp,lv)
+	local rlv=c:GetLevel()-lv
+	return rlv>0 and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_SYNCHRO,tp,false,false)
+		and Duel.IsExistingMatchingCard(c27503418.filter2,tp,LOCATION_GRAVE,0,1,nil,tp,rlv)
+end
+function c27503418.filter2(c,tp,lv)
+	local rlv=lv-c:GetLevel()
+	return rlv==0 and c:IsType(TYPE_TUNER) and c:IsAbleToRemove()
+end
+function c27503418.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttackTarget()
+	if Duel.NegateAttack() and Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c27503418.filter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,tc:GetLevel())
+		and tc:IsAbleToRemove() and Duel.SelectYesNo(tp,aux.Stringid(27503418,0)) then
+		Duel.BreakEffect()
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g1=Duel.SelectMatchingCard(tp,c27503418.filter1,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc:GetLevel())
+		local lv=g1:GetFirst():GetLevel()-tc:GetLevel()
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local g2=Duel.SelectMatchingCard(tp,c27503418.filter2,tp,LOCATION_GRAVE,0,1,1,nil,tp,lv)
+		g2:AddCard(tc)
+		Duel.Remove(g2,POS_FACEUP,REASON_EFFECT)
+		Duel.SpecialSummon(g1,SUMMON_TYPE_SYNCHRO,tp,tp,false,false,POS_FACEUP)
+		g1:GetFirst():CompleteProcedure()
+	end
+end

--- a/c29838323.lua
+++ b/c29838323.lua
@@ -1,0 +1,88 @@
+--水晶機巧－シストバーン
+function c29838323.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(29838323,0))
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,29838323)
+	e1:SetTarget(c29838323.sptg)
+	e1:SetOperation(c29838323.spop)
+	c:RegisterEffect(e1)
+	--search
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(29838323,1))
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,29838323)
+	e2:SetCost(c29838323.thcost)
+	e2:SetTarget(c29838323.thtg)
+	e2:SetOperation(c29838323.thop)
+	c:RegisterEffect(e2)
+end
+function c29838323.desfilter(c)
+	return c:IsFaceup() and c:IsDestructable()
+end
+function c29838323.spfilter(c,e,tp)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c29838323.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(e:GetLabel()) and chkc:IsControler(tp) and c29838323.desfilter(chkc) end
+	if chk==0 then
+		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		if ft<-1 then return false end
+		local loc=LOCATION_ONFIELD
+		if ft==0 then loc=LOCATION_MZONE end
+		e:SetLabel(loc)
+		return Duel.IsExistingTarget(c29838323.desfilter,tp,loc,0,1,nil)
+			and Duel.IsExistingMatchingCard(c29838323.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c29838323.desfilter,tp,e:GetLabel(),0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c29838323.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c29838323.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c29838323.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c29838323.splimit(e,c)
+	return not (c:IsRace(RACE_MACHINE) and c:IsType(TYPE_SYNCHRO)) and c:IsLocation(LOCATION_EXTRA)
+end
+function c29838323.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c29838323.thfilter(c)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_MONSTER) and not c:IsCode(29838323) and c:IsAbleToHand()
+end
+function c29838323.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c29838323.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c29838323.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c29838323.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/c30086349.lua
+++ b/c30086349.lua
@@ -1,0 +1,73 @@
+--流星竜メテオ・ブラック・ドラゴン
+function c30086349.initial_effect(c)
+	--fusion material
+	aux.AddFusionProcFun2(c,c30086349.mfilter1,c30086349.mfilter2,true)
+	c:EnableReviveLimit()
+	--damage
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(30086349,0))
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c30086349.damcon)
+	e1:SetTarget(c30086349.damtg)
+	e1:SetOperation(c30086349.damop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(30086349,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetCondition(c30086349.spcon)
+	e2:SetTarget(c30086349.sptg)
+	e2:SetOperation(c30086349.spop)
+	c:RegisterEffect(e2)
+end
+c30086349.material_setcode=0x3b
+function c30086349.mfilter1(c)
+	return c:IsFusionSetCard(0x3b) and c:GetLevel()==7
+end
+function c30086349.mfilter2(c)
+	return c:IsRace(RACE_DRAGON) and c:GetLevel()==6
+end
+function c30086349.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
+end
+function c30086349.damfilter(c)
+	return c:IsFusionSetCard(0x3b) and c:GetBaseAttack()>0 and c:IsAbleToGrave()
+end
+function c30086349.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c30086349.damfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+end
+function c30086349.damop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c30086349.damfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil)
+	local tc=g:GetFirst()
+	if g:GetCount()>0 and Duel.SendtoGrave(g,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_GRAVE) then
+		Duel.Damage(1-tp,math.ceil(g:GetFirst():GetBaseAttack()/2),REASON_EFFECT)
+	end
+end
+function c30086349.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_MZONE)
+end
+function c30086349.spfilter(c,e,tp)
+	return c:IsType(TYPE_NORMAL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c30086349.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c30086349.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c30086349.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c30086349.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c30086349.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c30786387.lua
+++ b/c30786387.lua
@@ -1,0 +1,74 @@
+--花積み
+function c30786387.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(30786387,0))
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c30786387.target)
+	e1:SetOperation(c30786387.activate)
+	c:RegisterEffect(e1)
+	--tohand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(30786387,2))
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,30786387)
+	e2:SetCondition(aux.exccon)
+	e2:SetCost(c30786387.thcost)
+	e2:SetTarget(c30786387.thtg)
+	e2:SetOperation(c30786387.thop)
+	c:RegisterEffect(e2)
+end
+function c30786387.filter(c,e,tp)
+	return c:IsSetCard(0xe6) and c:IsType(TYPE_MONSTER)
+end
+function c30786387.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local g=Duel.GetMatchingGroup(c30786387.filter,tp,LOCATION_DECK,0,nil)
+		return g:GetClassCount(Card.GetCode)>=3
+	end
+end
+function c30786387.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c30786387.filter,tp,LOCATION_DECK,0,nil)
+	if g:GetClassCount(Card.GetCode)>=3 then
+		local rg=Group.CreateGroup()
+		for i=1,3 do
+			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(30786387,1))
+			local sg=g:Select(tp,1,1,nil)
+			local tc=sg:GetFirst()
+			rg:AddCard(tc)
+			g:Remove(Card.IsCode,nil,tc:GetCode())
+		end
+		Duel.ConfirmCards(1-tp,rg)
+		local tg=rg:GetFirst()
+		while tg do
+			Duel.MoveSequence(tg,0)
+			tg=rg:GetNext()
+		end
+		Duel.SortDecktop(tp,tp,3)
+	end
+end
+function c30786387.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c30786387.thfilter(c)
+	return c:IsSetCard(0xe6) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c30786387.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c30786387.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c30786387.thfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local sg=Duel.SelectTarget(tp,c30786387.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,sg,sg:GetCount(),0,0)
+end
+function c30786387.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,tc)
+	end
+end

--- a/c3298689.lua
+++ b/c3298689.lua
@@ -1,0 +1,94 @@
+--RUM－幻影騎士団ラウンチ 
+function c3298689.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c3298689.condition)
+	e1:SetTarget(c3298689.target)
+	e1:SetOperation(c3298689.activate)
+	c:RegisterEffect(e1)
+	--material
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(3298689,0))
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCost(c3298689.matcost)
+	e2:SetTarget(c3298689.mattg)
+	e2:SetOperation(c3298689.matop)
+	c:RegisterEffect(e2)
+end
+function c3298689.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2
+end
+function c3298689.filter1(c,e,tp)
+	local rk=c:GetRank()
+	return rk>0 and c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:GetOverlayCount()==0
+		and Duel.IsExistingMatchingCard(c3298689.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()+1)
+end
+function c3298689.filter2(c,e,tp,mc,rk)
+	 if c:GetOriginalCode()==6165656 and mc:GetCode()~=48995978 then return false end
+	return c:GetRank()==rk and c:IsAttribute(ATTRIBUTE_DARK) and mc:IsCanBeXyzMaterial(c)
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
+end
+function c3298689.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c3298689.filter1(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingTarget(c3298689.filter1,tp,LOCATION_MZONE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	local g=Duel.SelectTarget(tp,c3298689.filter1,tp,LOCATION_MZONE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c3298689.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<0 then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c3298689.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc,tc:GetRank()+1)
+	local sc=g:GetFirst()
+	if sc then
+		local mg=tc:GetOverlayGroup()
+		if mg:GetCount()~=0 then
+			Duel.Overlay(sc,mg)
+		end
+		sc:SetMaterial(Group.FromCards(tc))
+		Duel.Overlay(sc,Group.FromCards(tc))
+		Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
+		sc:CompleteProcedure()
+		if c:IsRelateToEffect(e) then
+			c:CancelToGrave()
+			Duel.Overlay(sc,Group.FromCards(c))
+		end
+	end
+end
+function c3298689.matcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c3298689.xyzfilter(c)
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_XYZ)
+end
+function c3298689.matfilter(c)
+	return c:IsSetCard(0x10db) and c:IsType(TYPE_MONSTER)
+end
+function c3298689.mattg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c3298689.xyzfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c3298689.xyzfilter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c3298689.matfilter,tp,LOCATION_HAND,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c3298689.xyzfilter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c3298689.matop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+		local g=Duel.SelectMatchingCard(tp,c3298689.matfilter,tp,LOCATION_HAND,0,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.Overlay(tc,g)
+		end
+	end
+end

--- a/c33833230.lua
+++ b/c33833230.lua
@@ -1,0 +1,70 @@
+--EMシール・イール
+function c33833230.initial_effect(c)
+	aux.EnablePendulumAttribute(c)
+	--Negate effect
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(33833230,0))
+	e1:SetCategory(CATEGORY_DISABLE)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCountLimit(1)
+	e1:SetTarget(c33833230.distg)
+	e1:SetOperation(c33833230.disop)
+	c:RegisterEffect(e1)
+	--Lock S&T
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(33833230,1))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetTarget(c33833230.lcktg)
+	e2:SetOperation(c33833230.lckop)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e3)
+end
+function c33833230.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and aux.disfilter1(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(aux.disfilter1,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,aux.disfilter1,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,1,0,0)
+end
+function c33833230.disop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.NegateRelatedChain(tc,RESET_TURN_SET)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
+	end
+end
+function c33833230.lcktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsControler(1-tp) and chkc:IsFacedown() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFacedown,tp,0,LOCATION_SZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEDOWN)
+	Duel.SelectTarget(tp,Card.IsFacedown,tp,0,LOCATION_SZONE,1,1,nil)
+	Duel.SetChainLimit(aux.FALSE)
+end
+function c33833230.lckop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CANNOT_TRIGGER)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(1)
+		tc:RegisterEffect(e1)
+	end
+end

--- a/c3576031.lua
+++ b/c3576031.lua
@@ -1,0 +1,73 @@
+--クリスタルP
+function c3576031.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--atk&def
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetRange(LOCATION_FZONE)
+	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetValue(300)
+	e2:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0xea))
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e3)
+	--draw
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(3576031,0))
+	e4:SetCategory(CATEGORY_DRAW)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetCode(EVENT_PHASE+PHASE_END)
+	e4:SetRange(LOCATION_FZONE)
+	e4:SetCountLimit(1)
+	e4:SetCondition(c3576031.drcon)
+	e4:SetTarget(c3576031.drtg)
+	e4:SetOperation(c3576031.drop)
+	c:RegisterEffect(e4)
+	if not c3576031.global_check then
+		c3576031.global_check=true
+		c3576031[0]=0
+		c3576031[1]=0
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_SPSUMMON_SUCCESS)
+		ge1:SetOperation(c3576031.checkop)
+		Duel.RegisterEffect(ge1,0)
+		local ge2=Effect.CreateEffect(c)
+		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge2:SetCode(EVENT_PHASE_START+PHASE_DRAW)
+		ge2:SetOperation(c3576031.clearop)
+		Duel.RegisterEffect(ge2,0)
+	end
+end
+function c3576031.checkop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	while tc do
+		if tc:IsSetCard(0xea) and bit.band(tc:GetSummonType(),SUMMON_TYPE_SYNCHRO)==SUMMON_TYPE_SYNCHRO then
+			local p=tc:GetSummonPlayer()
+			c3576031[p]=c3576031[p]+1
+		end
+		tc=eg:GetNext()
+	end
+end
+function c3576031.clearop(e,tp,eg,ep,ev,re,r,rp)
+	c3576031[0]=0
+	c3576031[1]=0
+end
+function c3576031.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return c3576031[tp]>0
+end
+function c3576031.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,c3576031[tp]) end
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,c3576031[tp])
+end
+function c3576031.drop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	Duel.Draw(tp,c3576031[tp],REASON_EFFECT)
+end

--- a/c37626500.lua
+++ b/c37626500.lua
@@ -1,0 +1,7 @@
+--精霊の祝福
+function c37626500.initial_effect(c)
+	aux.AddRitualProcEqual2(c,c37626500.ritual_filter)
+end
+function c37626500.ritual_filter(c)
+	return c:IsType(TYPE_RITUAL) and c:IsAttribute(ATTRIBUTE_LIGHT) 
+end

--- a/c37803970.lua
+++ b/c37803970.lua
@@ -1,0 +1,38 @@
+--アメイジング・ペンデュラム
+function c37803970.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,37803970+EFFECT_COUNT_CODE_OATH)
+	e1:SetCondition(c37803970.condition)
+	e1:SetTarget(c37803970.target)
+	e1:SetOperation(c37803970.activate)
+	c:RegisterEffect(e1)
+end
+function c37803970.condition(e,tp,eg,ep,ev,re,r,rp)
+	return not Duel.GetFieldCard(tp,LOCATION_SZONE,6) and not Duel.GetFieldCard(tp,LOCATION_SZONE,7)
+end
+function c37803970.thfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x98) and c:IsType(TYPE_PENDULUM) and c:IsAbleToHand()
+end
+function c37803970.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local g=Duel.GetMatchingGroup(c37803970.thfilter,tp,LOCATION_EXTRA,0,nil)
+		return g:GetClassCount(Card.GetCode)>=2
+	end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,2,tp,LOCATION_EXTRA)
+end
+function c37803970.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c37803970.thfilter,tp,LOCATION_EXTRA,0,nil)
+	if g:GetClassCount(Card.GetCode)>=2 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+		local g1=g:Select(tp,1,1,nil)
+		g:Remove(Card.IsCode,nil,g1:GetFirst():GetCode())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+		local g2=g:Select(tp,1,1,nil)
+		g1:Merge(g2)
+		Duel.SendtoHand(g1,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g1)
+	end
+end

--- a/c38026562.lua
+++ b/c38026562.lua
@@ -1,0 +1,95 @@
+--超化合獣メタン・ハイド
+function c38026562.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsType,TYPE_DUAL),8,2)
+	c:EnableReviveLimit()
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(38026562,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c38026562.spcon)
+	e1:SetTarget(c38026562.sptg)
+	e1:SetOperation(c38026562.spop)
+	c:RegisterEffect(e1)
+	--cannot be battle target
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_SELECT_BATTLE_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(0,LOCATION_MZONE)
+	e2:SetCondition(c38026562.con)
+	e2:SetValue(c38026562.atlimit)
+	c:RegisterEffect(e2)
+	--cannot be effect target
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_MZONE,0)
+	e3:SetCondition(c38026562.con)
+	e3:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_DUAL))
+	e3:SetValue(aux.tgoval)
+	c:RegisterEffect(e3)
+	--to grave
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(38026562,1))
+	e4:SetCategory(CATEGORY_TOGRAVE)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCondition(c38026562.tgcon)
+	e4:SetCost(c38026562.tgcost)
+	e4:SetTarget(c38026562.tgtg)
+	e4:SetOperation(c38026562.tgop)
+	c:RegisterEffect(e4)
+end
+function c38026562.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetSummonType()==SUMMON_TYPE_XYZ
+end
+function c38026562.spfilter(c,e,tp)
+	return c:IsType(TYPE_DUAL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c38026562.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c38026562.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c38026562.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c38026562.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c38026562.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c38026562.con(e)
+	return e:GetHandler():GetOverlayCount()>0
+end
+function c38026562.atlimit(e,c)
+	return c:IsFaceup() and c:IsType(TYPE_DUAL)
+end
+function c38026562.tgcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(Card.IsType,1,nil,TYPE_DUAL)
+end
+function c38026562.tgcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c38026562.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_ONFIELD+LOCATION_HAND)>0 end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,0,LOCATION_ONFIELD+LOCATION_HAND)
+end
+function c38026562.tgop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(nil,1-tp,LOCATION_ONFIELD+LOCATION_HAND,0,nil)
+	if g:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_TOGRAVE)
+		local sg=g:Select(1-tp,1,1,nil)
+		Duel.HintSelection(sg)
+		Duel.SendtoGrave(sg,REASON_RULE)
+	end
+end

--- a/c38148100.lua
+++ b/c38148100.lua
@@ -1,0 +1,74 @@
+--アロマセラフィ－ローズマリー
+function c38148100.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
+	c:EnableReviveLimit()
+	--atk & def
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_MZONE,0)
+	e1:SetCondition(c38148100.adcon)
+	e1:SetTarget(aux.TargetBoolFunction(Card.IsRace,RACE_PLANT))
+	e1:SetValue(500)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e2)
+	--negate
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(38148100,0))
+	e3:SetCategory(CATEGORY_DISABLE)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetCode(EVENT_RECOVER)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c38148100.negcon)
+	e3:SetTarget(c38148100.negtg)
+	e3:SetOperation(c38148100.negop)
+	c:RegisterEffect(e3)
+end
+function c38148100.adcon(e)
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetLP(tp)>Duel.GetLP(1-tp)
+end
+function c38148100.negcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep==tp
+end
+function c38148100.negtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() and aux.disfilter1(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(aux.disfilter1,tp,0,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectTarget(tp,aux.disfilter1,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,1,0,0)
+end
+function c38148100.negop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if ((tc:IsFaceup() and not tc:IsDisabled()) or tc:IsType(TYPE_TRAPMONSTER)) and tc:IsRelateToEffect(e) then
+		Duel.NegateRelatedChain(tc,RESET_TURN_SET)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetValue(RESET_TURN_SET)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
+		if tc:IsType(TYPE_TRAPMONSTER) then
+			local e3=Effect.CreateEffect(c)
+			e3:SetType(EFFECT_TYPE_SINGLE)
+			e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e3:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+			e3:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+			tc:RegisterEffect(e3)
+		end
+	end
+end

--- a/c38848158.lua
+++ b/c38848158.lua
@@ -1,0 +1,47 @@
+--イグナイト・ユナイト
+function c38848158.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,38848158+EFFECT_COUNT_CODE_OATH)
+	e1:SetTarget(c38848158.target)
+	e1:SetOperation(c38848158.activate)
+	c:RegisterEffect(e1)
+end
+function c38848158.desfilter1(c)
+	return c:IsFaceup() and c:IsSetCard(0xc8) and c:IsDestructable()
+end
+function c38848158.spfilter(c,e,tp)
+	return c:IsSetCard(0xc8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c38848158.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(e:GetLabel()) and chkc:IsControler(tp) and chkc~=c and c38848158.desfilter1(chkc) end
+	if chk==0 then
+		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		if ft<-1 then return false end
+		local loc=LOCATION_ONFIELD
+		if ft==0 then loc=LOCATION_MZONE end
+		e:SetLabel(loc)
+		return Duel.IsExistingTarget(c38848158.desfilter1,tp,loc,0,1,c)
+			and Duel.IsExistingMatchingCard(c38848158.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c38848158.desfilter1,tp,e:GetLabel(),0,1,1,c)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c38848158.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c38848158.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+end

--- a/c39564736.lua
+++ b/c39564736.lua
@@ -1,0 +1,70 @@
+--重錬装融合
+function c39564736.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(39564736,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c39564736.target)
+	e1:SetOperation(c39564736.activate)
+	c:RegisterEffect(e1)
+end
+function c39564736.filter1(c,e)
+	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+end
+function c39564736.filter2(c,e,tp,m,f,chkf)
+	return c:IsType(TYPE_FUSION) and c:IsSetCard(0xe1) and (not f or f(c))
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function c39564736.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
+		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_HAND+LOCATION_MZONE,0,nil)
+		local res=Duel.IsExistingMatchingCard(c39564736.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		if not res then
+			local ce=Duel.GetChainMaterial(tp)
+			if ce~=nil then
+				local fgroup=ce:GetTarget()
+				local mg2=fgroup(ce,e,tp)
+				local mf=ce:GetValue()
+				res=Duel.IsExistingMatchingCard(c39564736.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+			end
+		end
+		return res
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c39564736.activate(e,tp,eg,ep,ev,re,r,rp)
+	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
+	local mg1=Duel.GetMatchingGroup(c39564736.filter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
+	local sg1=Duel.GetMatchingGroup(c39564736.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	local mg2=nil
+	local sg2=nil
+	local ce=Duel.GetChainMaterial(tp)
+	if ce~=nil then
+		local fgroup=ce:GetTarget()
+		mg2=fgroup(ce,e,tp)
+		local mf=ce:GetValue()
+		sg2=Duel.GetMatchingGroup(c39564736.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+	end
+	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
+		local sg=sg1:Clone()
+		if sg2 then sg:Merge(sg2) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tg=sg:Select(tp,1,1,nil)
+		local tc=tg:GetFirst()
+		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			tc:SetMaterial(mat1)
+			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+			Duel.BreakEffect()
+			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
+		else
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local fop=ce:GetOperation()
+			fop(ce,e,tp,tc,mat2)
+		end
+		tc:CompleteProcedure()
+	end
+end

--- a/c3966653.lua
+++ b/c3966653.lua
@@ -1,0 +1,66 @@
+--花札衛－猪鹿蝶－
+function c3966653.initial_effect(c)
+	c:EnableReviveLimit()
+	--synchro summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e1:SetRange(LOCATION_EXTRA)
+	e1:SetCondition(aux.SynCondition(nil,aux.NonTuner(nil),2,2))
+	e1:SetTarget(aux.SynTarget(nil,aux.NonTuner(nil),2,2))
+	e1:SetOperation(aux.SynOperation(nil,aux.NonTuner(nil),2,2))
+	e1:SetValue(SUMMON_TYPE_SYNCHRO)
+	c:RegisterEffect(e1)
+	--pierce
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_PIERCE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0xe6))
+	c:RegisterEffect(e2)
+	--activate limit
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(3966653,0))
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetCountLimit(1)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCost(c3966653.cost)
+	e3:SetOperation(c3966653.operation)
+	c:RegisterEffect(e3)
+end
+function c3966653.spfilter(c)
+	return c:IsSetCard(0xe6) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
+end
+function c3966653.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c3966653.spfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c3966653.spfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c3966653.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e1:SetTargetRange(0,1)
+	e1:SetValue(c3966653.aclimit)
+	e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
+	Duel.RegisterEffect(e1,tp)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e2:SetTargetRange(0,1)
+	e2:SetTarget(c3966653.sumlimit)
+	e2:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
+	Duel.RegisterEffect(e2,tp)
+end
+function c3966653.aclimit(e,re,tp)
+	return re:GetActivateLocation()==LOCATION_GRAVE
+end
+function c3966653.sumlimit(e,c,sump,sumtype,sumpos,targetp,se)
+	return c:IsLocation(LOCATION_GRAVE)
+end

--- a/c39964797.lua
+++ b/c39964797.lua
@@ -1,0 +1,69 @@
+--水晶機巧－クオンダム
+function c39964797.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
+	c:EnableReviveLimit()
+	--synchro summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(39964797,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_BATTLE_START+TIMING_BATTLE_END)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c39964797.sccon)
+	e1:SetTarget(c39964797.sctg)
+	e1:SetOperation(c39964797.scop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(39964797,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_DESTROYED)
+	e2:SetCondition(c39964797.spcon)
+	e2:SetTarget(c39964797.sptg)
+	e2:SetOperation(c39964797.spop)
+	c:RegisterEffect(e2)
+end
+function c39964797.sccon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return not e:GetHandler():IsStatus(STATUS_CHAINING) and Duel.GetTurnPlayer()~=tp
+		and (ph==PHASE_MAIN1 or (ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE) or ph==PHASE_MAIN2)
+end
+function c39964797.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,e:GetHandler()) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c39964797.scop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:GetControler()~=tp or not c:IsRelateToEffect(e) then return end
+	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,c)
+	if g:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=g:Select(tp,1,1,nil)
+		Duel.SynchroSummon(tp,sg:GetFirst(),c)
+	end
+end
+function c39964797.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:GetSummonType()==SUMMON_TYPE_SYNCHRO and bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0
+end
+function c39964797.spfilter(c,e,tp)
+	return c:IsSetCard(0xea) and not c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c39964797.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c39964797.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c39964797.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c39964797.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c39964797.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c41209827.lua
+++ b/c41209827.lua
@@ -1,0 +1,134 @@
+--スターヴ・ヴェノム・フュージョン・ドラゴン
+function c41209827.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcFunRep(c,c41209827.ffilter,2,false)
+	--atk up
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(41209827,0))
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c41209827.atkcon)
+	e1:SetTarget(c41209827.atktg)
+	e1:SetOperation(c41209827.atkop)
+	c:RegisterEffect(e1)
+	--copy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(41209827,1))
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCost(c41209827.copycost)
+	e2:SetTarget(c41209827.copytg)
+	e2:SetOperation(c41209827.copyop)
+	c:RegisterEffect(e2)
+	--destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(41209827,3))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_DESTROYED)
+	e3:SetCondition(c41209827.descon)
+	e3:SetTarget(c41209827.destg)
+	e3:SetOperation(c41209827.desop)
+	c:RegisterEffect(e3)
+end
+function c41209827.ffilter(c)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsLocation(LOCATION_MZONE) and not c:IsType(TYPE_TOKEN)
+end
+function c41209827.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
+end
+function c41209827.atkfilter(c)
+	return bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL and c:IsFaceup()
+end
+function c41209827.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c41209827.atkfilter,tp,0,LOCATION_MZONE,1,nil) end
+end
+function c41209827.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectMatchingCard(tp,c41209827.atkfilter,tp,0,LOCATION_MZONE,1,1,nil)
+	local tc=g:GetFirst()
+	if tc and c:IsRelateToEffect(e) and c:IsFaceup() then
+		local atk=tc:GetAttack()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(atk)
+		e1:SetReset(RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+	end
+end
+function c41209827.copycost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(41209827)==0 end
+	e:GetHandler():RegisterFlagEffect(41209827,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c41209827.copyfilter(c)
+	return c:IsFaceup() and c:IsLevelAbove(5)
+end
+function c41209827.copytg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and c41209827.copyfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c41209827.copyfilter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c41209827.copyfilter,tp,0,LOCATION_MZONE,1,1,nil)
+end
+function c41209827.copyop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsRelateToEffect(e) and not tc:IsType(TYPE_TOKEN) then
+		local code=tc:GetOriginalCode()
+		local cid=0
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetCode(EFFECT_CHANGE_CODE)
+		e1:SetValue(code)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+		if not tc:IsType(TYPE_TRAPMONSTER) then
+			cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+		end
+		local e2=Effect.CreateEffect(c)
+		e2:SetDescription(aux.Stringid(41209827,2))
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+		e2:SetCode(EVENT_PHASE+PHASE_END)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetCountLimit(1)
+		e2:SetLabelObject(e1)
+		e2:SetLabel(cid)
+		e2:SetOperation(c41209827.rstop)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e2)
+	end
+end
+function c41209827.rstop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local cid=e:GetLabel()
+	if cid~=0 then c:ResetEffect(cid,RESET_COPY) end
+	local e1=e:GetLabelObject()
+	e1:Reset()
+	Duel.HintSelection(Group.FromCards(c))
+	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+end
+function c41209827.descon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and bit.band(c:GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
+end
+function c41209827.desfilter(c)
+	return c:IsDestructable() and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+end
+function c41209827.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c41209827.desfilter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c41209827.desfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c41209827.desop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c41209827.desfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.Destroy(g,REASON_EFFECT)
+end

--- a/c42143067.lua
+++ b/c42143067.lua
@@ -1,0 +1,55 @@
+--怒気土器
+function c42143067.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(42143067,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,42143067)
+	e1:SetCost(c42143067.spcost)
+	e1:SetTarget(c42143067.sptg)
+	e1:SetOperation(c42143067.spop)
+	c:RegisterEffect(e1)
+end
+function c42143067.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	e:SetLabel(100)
+	return true
+end
+function c42143067.cfilter(c,e,tp)
+	return c:IsRace(RACE_ROCK) and c:IsDiscardable()
+		and Duel.IsExistingMatchingCard(c42143067.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetOriginalAttribute(),c:GetOriginalLevel())
+end
+function c42143067.spfilter(c,e,tp,att,lv)
+	return c:IsRace(RACE_ROCK) and c:GetOriginalAttribute()==att and c:GetOriginalLevel()==lv
+		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN))
+end
+function c42143067.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if e:GetLabel()~=100 then return false end
+		e:SetLabel(0)
+		return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+			and Duel.IsExistingMatchingCard(c42143067.cfilter,tp,LOCATION_HAND,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
+	local g=Duel.SelectMatchingCard(tp,c42143067.cfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	e:SetLabelObject(g:GetFirst())
+	Duel.SendtoGrave(g,REASON_COST+REASON_DISCARD)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+end
+function c42143067.spop(e,tp,eg,ep,ev,re,r,rp)
+	local gc=e:GetLabelObject()
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c42143067.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,gc:GetOriginalAttribute(),gc:GetOriginalLevel())
+	local tc=g:GetFirst()
+	if tc then
+		local spos=0
+		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false) then spos=spos+POS_FACEUP_ATTACK end
+		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN) then spos=spos+POS_FACEDOWN_DEFENSE end
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
+		if tc:IsFacedown() then
+			Duel.ConfirmCards(1-tp,tc)
+		end
+	end
+end

--- a/c42921475.lua
+++ b/c42921475.lua
@@ -1,0 +1,74 @@
+--妖精伝姫－ターリア
+function c42921475.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(42921475,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetTarget(c42921475.sptg)
+	e1:SetOperation(c42921475.spop)
+	c:RegisterEffect(e1)
+	--change effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(42921475,1))
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1,42921475)
+	e2:SetCondition(c42921475.chcon)
+	e2:SetCost(c42921475.chcost)
+	e2:SetTarget(c42921475.chtg)
+	e2:SetOperation(c42921475.chop)
+	c:RegisterEffect(e2)
+end
+function c42921475.spfilter(c,e,tp)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c42921475.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c42921475.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c42921475.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c42921475.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c42921475.chcon(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	return rp==1-tp and (rc:GetType()==TYPE_SPELL or rc:GetType()==TYPE_TRAP) and re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c42921475.costfilter(c)
+	return not c:IsStatus(STATUS_BATTLE_DESTROYED)
+end
+function c42921475.chcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,c42921475.cfilter,1,e:GetHandler()) end
+	local g=Duel.SelectReleaseGroup(tp,c42921475.cfilter,1,1,e:GetHandler())
+	Duel.Release(g,REASON_COST)
+end
+function c42921475.filter(c)
+	return c:IsFaceup() and c:IsCanTurnSet()
+end
+function c42921475.chtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c42921475.filter,rp,0,LOCATION_MZONE,1,nil) end
+end
+function c42921475.chop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Group.CreateGroup()
+	Duel.ChangeTargetCard(ev,g)
+	Duel.ChangeChainOperation(ev,c42921475.repop)
+end
+function c42921475.repop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:GetType()==TYPE_SPELL or c:GetType()==TYPE_TRAP then
+		c:CancelToGrave(false)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectMatchingCard(tp,c42921475.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.ChangePosition(g,POS_FACEDOWN_DEFENSE)
+	end
+end

--- a/c43266605.lua
+++ b/c43266605.lua
@@ -1,0 +1,69 @@
+--PSYフレーム・マルチスレッダー
+function c43266605.initial_effect(c)
+	--change name
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetCode(EFFECT_CHANGE_CODE)
+	e1:SetRange(LOCATION_HAND+LOCATION_GRAVE)
+	e1:SetValue(49036338)
+	c:RegisterEffect(e1)
+	--destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetTarget(c43266605.reptg)
+	e2:SetValue(c43266605.repval)
+	e2:SetOperation(c43266605.repop)
+	c:RegisterEffect(e2)
+	--special summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(43266605,1))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetRange(LOCATION_GRAVE)
+	e3:SetCountLimit(1,43266605)
+	e3:SetCondition(c43266605.spcon)
+	e3:SetTarget(c43266605.sptg)
+	e3:SetOperation(c43266605.spop)
+	c:RegisterEffect(e3)
+end
+function c43266605.repfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0xc1) and c:IsOnField() and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
+end
+function c43266605.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() and eg:IsExists(c43266605.repfilter,1,nil,tp) end
+	return Duel.SelectYesNo(tp,aux.Stringid(43266605,0))
+end
+function c43266605.repval(e,c)
+	return c43266605.repfilter(c,e:GetHandlerPlayer())
+end
+function c43266605.repop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT+REASON_DISCARD)
+end
+function c43266605.cfilter(c,tp)
+	return c:IsSetCard(0xc1) and c:IsType(TYPE_TUNER) and c:IsControler(tp)
+end
+function c43266605.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c43266605.cfilter,1,nil,tp)
+end
+function c43266605.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c43266605.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x47e0000)
+		e1:SetValue(LOCATION_REMOVED)
+		c:RegisterEffect(e1,true)
+	end
+end

--- a/c44088292.lua
+++ b/c44088292.lua
@@ -1,0 +1,48 @@
+--進化合獣ダイオーキシン
+function c44088292.initial_effect(c)
+	aux.EnableDualAttribute(c)
+	--cannot disable summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_DISABLE_SUMMON)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_SET_AVAILABLE)
+	e1:SetCondition(aux.IsDualState)
+	e1:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_DUAL))
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(44088292,0))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCountLimit(1)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(aux.IsDualState)
+	e2:SetCost(c44088292.cost)
+	e2:SetTarget(c44088292.target)
+	e2:SetOperation(c44088292.activate)
+	c:RegisterEffect(e2)
+end
+function c44088292.costfilter(c)
+	return c:IsType(TYPE_DUAL) and c:IsAbleToRemoveAsCost()
+end
+function c44088292.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c44088292.costfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c44088292.costfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c44088292.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and chkc:IsControler(tp) and chkc:IsDestructable() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsDestructable,tp,0,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,Card.IsDestructable,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c44088292.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/c4810828.lua
+++ b/c4810828.lua
@@ -1,0 +1,68 @@
+--古聖戴サウラヴィス
+function c4810828.initial_effect(c)
+	c:EnableReviveLimit()
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(4810828,0))
+	e1:SetCategory(CATEGORY_NEGATE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c4810828.negcon)
+	e1:SetCost(c4810828.negcost)
+	e1:SetTarget(c4810828.negtg)
+	e1:SetOperation(c4810828.negop)
+	c:RegisterEffect(e1)
+	--disable special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(74892653,0))
+	e2:SetCategory(CATEGORY_DISABLE_SUMMON+CATEGORY_REMOVE)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_SPSUMMON)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c4810828.discon)
+	e2:SetCost(c4810828.discost)
+	e2:SetTarget(c4810828.distg)
+	e2:SetOperation(c4810828.disop)
+	c:RegisterEffect(e2)
+end
+function c4810828.cfilter(c,tp)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsFaceup()
+end
+function c4810828.negcon(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return g and g:IsExists(c4810828.cfilter,1,nil,tp) and Duel.IsChainNegatable(ev)
+end
+function c4810828.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+end
+function c4810828.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+end
+function c4810828.negop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateActivation(ev) then
+		if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
+			Duel.SendtoGrave(eg,REASON_EFFECT)
+		end
+	end
+end
+function c4810828.discon(e,tp,eg,ep,ev,re,r,rp)
+	return tp~=ep and Duel.GetCurrentChain()==0
+end
+function c4810828.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToHandAsCost() end
+	Duel.SendtoHand(e:GetHandler(),nil,REASON_COST)
+end
+function c4810828.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE_SUMMON,eg,eg:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,eg,eg:GetCount(),0,0)
+end
+function c4810828.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateSummon(eg)
+	Duel.Remove(eg,POS_FACEUP,REASON_EFFECT)
+end

--- a/c4810828.lua
+++ b/c4810828.lua
@@ -16,7 +16,7 @@ function c4810828.initial_effect(c)
 	c:RegisterEffect(e1)
 	--disable special summon
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(74892653,0))
+	e2:SetDescription(aux.Stringid(4810828,1))
 	e2:SetCategory(CATEGORY_DISABLE_SUMMON+CATEGORY_REMOVE)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_SPSUMMON)

--- a/c51053997.lua
+++ b/c51053997.lua
@@ -1,0 +1,159 @@
+--PSYフレーム・アクセラレーター
+function c51053997.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(51053997,0))
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_END_PHASE)
+	e1:SetTarget(c51053997.target1)
+	e1:SetOperation(c51053997.operation)
+	c:RegisterEffect(e1)
+	--Activate(special summon)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(51053997,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_ACTIVATE)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCondition(c51053997.spcon)
+	e2:SetCost(c51053997.spcost)
+	e2:SetTarget(c51053997.sptg1)
+	e2:SetOperation(c51053997.spop)
+	c:RegisterEffect(e2)
+	--remove
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(51053997,2))
+	e3:SetCategory(CATEGORY_REMOVE)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetType(EFFECT_TYPE_QUICK_O)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(EVENT_FREE_CHAIN)
+	e3:SetHintTiming(0,TIMING_END_PHASE)
+	e3:SetCountLimit(1)
+	e3:SetCost(c51053997.cost)
+	e3:SetTarget(c51053997.target2)
+	e3:SetOperation(c51053997.operation)
+	c:RegisterEffect(e3)
+	--special summon
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(51053997,3))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetProperty(EFFECT_FLAG_DELAY)
+	e4:SetCode(EVENT_LEAVE_FIELD)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCountLimit(1)
+	e4:SetCondition(c51053997.spcon)
+	e4:SetCost(c51053997.spcost)
+	e4:SetTarget(c51053997.sptg2)
+	e4:SetOperation(c51053997.spop)
+	c:RegisterEffect(e4)
+end
+function c51053997.rmfilter(c)
+	return c:IsSetCard(0xc1) and c:IsAbleToRemove()
+end
+function c51053997.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c51053997.rmfilter(chkc) end
+	if chk==0 then return true end
+	if e:GetHandler():GetFlagEffect(51053997)==0 and Duel.CheckLPCost(tp,500)
+		and Duel.IsExistingTarget(c51053997.rmfilter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.SelectYesNo(tp,94) then
+		e:SetCategory(CATEGORY_REMOVE)
+		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		e:GetHandler():RegisterFlagEffect(51053997,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+		Duel.PayLPCost(tp,500)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local g=Duel.SelectTarget(tp,c51053997.rmfilter,tp,LOCATION_MZONE,0,1,1,nil)
+		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+	else
+		e:SetCategory(0)
+		e:SetProperty(0)
+	end
+end
+function c51053997.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLPCost(tp,500)
+		and e:GetHandler():GetFlagEffect(51053997)==0 end
+	Duel.PayLPCost(tp,500)
+	e:GetHandler():RegisterFlagEffect(51053997,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c51053997.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c51053997.rmfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c51053997.rmfilter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,c51053997.rmfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+end
+function c51053997.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:GetFlagEffect(51053997)==0 or not c:IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
+		local ct=1
+		if Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()==PHASE_STANDBY then ct=2 end
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(51053997,4))
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+		e1:SetCountLimit(1)
+		e1:SetLabelObject(tc)
+		e1:SetCondition(c51053997.retcon)
+		e1:SetOperation(c51053997.retop)
+		if Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()==PHASE_STANDBY then
+			e1:SetReset(RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN,2)
+			e1:SetValue(Duel.GetTurnCount())
+		else
+			e1:SetReset(RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN)
+			e1:SetValue(0)
+		end
+		Duel.RegisterEffect(e1,tp)
+		tc:RegisterFlagEffect(51053998,RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN,0,ct)
+	end
+end
+function c51053997.retcon(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetTurnPlayer()~=tp or Duel.GetTurnCount()==e:GetValue() then return false end
+	return e:GetLabelObject():GetFlagEffect(51053998)~=0
+end
+function c51053997.retop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:IsForbidden() then
+		Duel.SendtoGrave(tc,REASON_RULE)
+	else
+		Duel.ReturnToField(tc)
+	end
+end
+function c51053997.cfilter(c,tp)
+	return c:IsPreviousSetCard(0xc1) and c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp
+end
+function c51053997.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c51053997.cfilter,1,e:GetHandler(),tp)
+end
+function c51053997.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(51053999)==0 end
+	e:GetHandler():RegisterFlagEffect(51053999,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c51053997.spfilter(c,e,tp)
+	return c:IsSetCard(0xc1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c51053997.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c51053997.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+end
+function c51053997.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c51053997.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c51053997.spop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c51053997.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c52176579.lua
+++ b/c52176579.lua
@@ -1,0 +1,82 @@
+--クリストロン・エントリー
+function c52176579.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c52176579.target)
+	e1:SetOperation(c52176579.activate)
+	c:RegisterEffect(e1)
+	--level
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(52176579,0))
+	e2:SetCategory(CATEGORY_TOGRAVE)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,52176579)
+	e2:SetCondition(aux.exccon)
+	e2:SetCost(c52176579.lvcost)
+	e2:SetTarget(c52176579.lvtg)
+	e2:SetOperation(c52176579.lvop)
+	c:RegisterEffect(e2)
+end
+function c52176579.filter(c,e,tp)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c52176579.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
+		and Duel.IsExistingMatchingCard(c52176579.filter,tp,LOCATION_HAND,0,1,nil,e,tp)
+		and Duel.IsExistingMatchingCard(c52176579.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_HAND+LOCATION_GRAVE)
+end
+function c52176579.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g1=Duel.GetMatchingGroup(c52176579.filter,tp,LOCATION_HAND,0,nil,e,tp)
+	local g2=Duel.GetMatchingGroup(c52176579.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
+	if g1:GetCount()==0 or g2:GetCount()==0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local sg1=g1:Select(tp,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local sg2=g2:Select(tp,1,1,nil)
+	sg1:Merge(sg2)
+	if sg1:IsExists(Card.IsHasEffect,1,nil,EFFECT_NECRO_VALLEY) then return end
+	Duel.SpecialSummon(sg1,0,tp,tp,false,false,POS_FACEUP)
+end
+function c52176579.lvfilter(c)
+	local lv=c:GetLevel()
+	return lv>0 and c:IsFaceup() and c:IsSetCard(0xea) and Duel.IsExistingMatchingCard(c52176579.tgfilter,tp,LOCATION_DECK,0,1,nil,lv)
+end
+function c52176579.tgfilter(c,lv)
+	return c:IsSetCard(0xea) and c:GetLevel()~=lv and c:IsType(TYPE_MONSTER) and c:IsAbleToGrave()
+end
+function c52176579.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c52176579.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c52176579.lvfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c52176579.lvfilter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c52176579.lvfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
+end
+function c52176579.lvop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c52176579.tgfilter,tp,LOCATION_DECK,0,1,1,nil,tc)
+	if g:GetCount()>0 then
+		local gc=g:GetFirst()
+		if Duel.SendtoGrave(gc,REASON_EFFECT)~=0 and gc:IsLocation(LOCATION_GRAVE) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_CHANGE_LEVEL)
+			e1:SetValue(gc:GetLevel())
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			tc:RegisterEffect(e1)
+		end
+	end
+end

--- a/c55100740.lua
+++ b/c55100740.lua
@@ -1,0 +1,38 @@
+--化合獣ハイドロン・ホーク
+function c55100740.initial_effect(c)
+	aux.EnableDualAttribute(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(55100740,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1,55100740)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(aux.IsDualState)
+	e1:SetCost(c55100740.spcost)
+	e1:SetTarget(c55100740.sptg)
+	e1:SetOperation(c55100740.spop)
+	c:RegisterEffect(e1)
+end
+function c55100740.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
+end
+function c55100740.filter(c,e,tp)
+	return c:IsType(TYPE_DUAL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c55100740.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c55100740.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c55100740.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c55100740.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c55100740.spop(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+	end
+end

--- a/c55326322.lua
+++ b/c55326322.lua
@@ -1,0 +1,93 @@
+--水晶機巧－ローズニクス
+function c55326322.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1,55326322)
+	e1:SetTarget(c55326322.sptg)
+	e1:SetOperation(c55326322.spop)
+	c:RegisterEffect(e1)
+	--token
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,55326322)
+	e2:SetCost(c55326322.tkcost)
+	e2:SetTarget(c55326322.tktg)
+	e2:SetOperation(c55326322.tkop)
+	c:RegisterEffect(e2)
+end
+function c55326322.desfilter(c)
+	return c:IsFaceup() and c:IsDestructable()
+end
+function c55326322.spfilter(c,e,tp)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c55326322.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(e:GetLabel()) and chkc:IsControler(tp) and c55326322.desfilter(chkc) end
+	if chk==0 then
+		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		if ft<-1 then return false end
+		local loc=LOCATION_ONFIELD
+		if ft==0 then loc=LOCATION_MZONE end
+		e:SetLabel(loc)
+		return Duel.IsExistingTarget(c55326322.desfilter,tp,loc,0,1,nil)
+			and Duel.IsExistingMatchingCard(c55326322.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c55326322.desfilter,tp,e:GetLabel(),0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c55326322.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c55326322.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c55326322.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c55326322.splimit(e,c)
+	return not (c:IsRace(RACE_MACHINE) and c:IsType(TYPE_SYNCHRO)) and c:IsLocation(LOCATION_EXTRA)
+end
+function c55326322.tkcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c55326322.tktg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,55326323,0xea,0x4011,0,0,1,RACE_MACHINE,ATTRIBUTE_WATER) end
+	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+end
+function c55326322.tkop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		or not Duel.IsPlayerCanSpecialSummonMonster(tp,55326323,0xea,0x4011,0,0,1,RACE_MACHINE,ATTRIBUTE_WATER) then return end
+	local token=Duel.CreateToken(tp,55326323)
+	Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UNRELEASABLE_SUM)
+	e1:SetValue(1)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	token:RegisterEffect(e1,true)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_UNRELEASABLE_NONSUM)
+	token:RegisterEffect(e2,true)
+	Duel.SpecialSummonComplete()
+end

--- a/c56049970.lua
+++ b/c56049970.lua
@@ -1,0 +1,89 @@
+--水晶機巧－プラシレータ
+function c56049970.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(56049970,0))
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,56049970)
+	e1:SetTarget(c56049970.sptg1)
+	e1:SetOperation(c56049970.spop1)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(56049970,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,56049970)
+	e2:SetCost(c56049970.spcost)
+	e2:SetTarget(c56049970.sptg2)
+	e2:SetOperation(c56049970.spop2)
+	c:RegisterEffect(e2)
+end
+function c56049970.desfilter(c)
+	return c:IsFaceup() and c:IsDestructable()
+end
+function c56049970.spfilter1(c,e,tp)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c56049970.sptg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(e:GetLabel()) and chkc:IsControler(tp) and c56049970.desfilter(chkc) end
+	if chk==0 then
+		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		if ft<-1 then return false end
+		local loc=LOCATION_ONFIELD
+		if ft==0 then loc=LOCATION_MZONE end
+		e:SetLabel(loc)
+		return Duel.IsExistingTarget(c56049970.desfilter,tp,loc,0,1,nil)
+			and Duel.IsExistingMatchingCard(c56049970.spfilter1,tp,LOCATION_DECK,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c56049970.desfilter,tp,e:GetLabel(),0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c56049970.spop1(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c56049970.spfilter1,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c56049970.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c56049970.splimit(e,c)
+	return not (c:IsRace(RACE_MACHINE) and c:IsType(TYPE_SYNCHRO)) and c:IsLocation(LOCATION_EXTRA)
+end
+function c56049970.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c56049970.spfilter2(c,e,tp)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c56049970.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c56049970.spfilter2,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c56049970.spop2(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c56049970.spfilter2,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c56119752.lua
+++ b/c56119752.lua
@@ -1,0 +1,25 @@
+--プレゼントカード
+function c56119752.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_HANDES+CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,56119752+EFFECT_COUNT_CODE_OATH)
+	e1:SetTarget(c56119752.target)
+	e1:SetOperation(c56119752.activate)
+	c:RegisterEffect(e1)
+end
+function c56119752.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)
+	if chk==0 then return ct>0 and Duel.IsPlayerCanDraw(1-tp,5) end
+	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,1-tp,ct)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,1-tp,5)
+end
+function c56119752.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_HAND)
+	if Duel.SendtoGrave(g,REASON_EFFECT+REASON_DISCARD)~=0 then
+		Duel.BreakEffect()
+		Duel.Draw(1-tp,5,REASON_EFFECT)
+	end
+end

--- a/c57261568.lua
+++ b/c57261568.lua
@@ -96,7 +96,7 @@ function c57261568.synop(e,tp,eg,ep,ev,re,r,rp,syncard,f,minc,maxc)
 	local res=g:CheckWithSumEqual(Card.GetSynchroLevel,lv,minc,maxc,syncard)
 	local res2=g:CheckWithSumEqual(c57261568.cardiansynlevel,lv2,minc,maxc)
 	local sg=nil
-	if (res2 and res and Duel.SelectYesNo(tp,aux.Stringid(57261568,2)))
+	if (res2 and res and Duel.SelectYesNo(tp,aux.Stringid(57261568,3)))
 		or (res2 and not res) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
 		sg=g:SelectWithSumEqual(tp,c57261568.cardiansynlevel,lv2,minc,maxc)

--- a/c57261568.lua
+++ b/c57261568.lua
@@ -1,0 +1,108 @@
+--花札衛－牡丹に蝶－
+function c57261568.initial_effect(c)
+	c:EnableReviveLimit()
+	--spsummon from hand
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetCondition(c57261568.hspcon)
+	e1:SetOperation(c57261568.hspop)
+	c:RegisterEffect(e1)
+	--draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(57261568,0))
+	e2:SetCategory(CATEGORY_DRAW)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetTarget(c57261568.target)
+	e2:SetOperation(c57261568.operation)
+	c:RegisterEffect(e2)
+	--synchro level
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_SYNCHRO_MATERIAL_CUSTOM)
+	e3:SetTarget(c57261568.syntg)
+	e3:SetValue(1)
+	e3:SetOperation(c57261568.synop)
+	c:RegisterEffect(e3)
+end
+function c57261568.hspfilter(c)
+	return c:IsSetCard(0xe6) and not c:IsCode(57261568)
+end
+function c57261568.hspcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>-1
+		and Duel.CheckReleaseGroup(c:GetControler(),c57261568.hspfilter,1,nil)
+end
+function c57261568.hspop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(c:GetControler(),c57261568.hspfilter,1,1,nil)
+	Duel.Release(g,REASON_COST)
+end
+function c57261568.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c57261568.operation(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	if Duel.Draw(p,d,REASON_EFFECT)~=0 then
+		local tc=Duel.GetOperatedGroup():GetFirst()
+		Duel.ConfirmCards(1-tp,tc)
+		if tc:IsType(TYPE_MONSTER) and tc:IsSetCard(0xe6) then
+			local ct=Duel.GetFieldGroupCount(1-tp,LOCATION_DECK,0)
+			if ct<3 then return end
+			Duel.BreakEffect()
+			local g=Duel.GetDecktopGroup(1-tp,3)
+			Duel.ConfirmCards(tp,g)
+			local opt=Duel.SelectOption(tp,aux.Stringid(57261568,1),aux.Stringid(57261568,2))
+			Duel.SortDecktop(tp,1-tp,3)
+			if opt==1 then
+				for i=1,3 do
+					local mg=Duel.GetDecktopGroup(tp,1)
+					Duel.MoveSequence(mg:GetFirst(),1)
+				end
+			end
+		else
+			Duel.BreakEffect()
+			Duel.SendtoGrave(tc,REASON_EFFECT)
+		end
+		Duel.ShuffleHand(tp)
+	end
+end
+function c57261568.cardiansynlevel(c)
+	return 2
+end
+function c57261568.synfilter(c,syncard,tuner,f)
+	return c:IsFaceup() and c:IsNotTuner() and c:IsCanBeSynchroMaterial(syncard,tuner) and (f==nil or f(c))
+end
+function c57261568.syntg(e,syncard,f,minc,maxc)
+	local c=e:GetHandler()
+	local lv=syncard:GetLevel()-c:GetLevel()
+	local lv2=syncard:GetLevel()-c57261568.cardiansynlevel(c)
+	if lv<=0 and lv2<=0 then return false end
+	local g=Duel.GetMatchingGroup(c57261568.synfilter,syncard:GetControler(),LOCATION_MZONE,LOCATION_MZONE,c,syncard,c,f)
+	local res=g:CheckWithSumEqual(Card.GetSynchroLevel,lv,minc,maxc,syncard)
+	local res2=g:CheckWithSumEqual(c57261568.cardiansynlevel,lv2,minc,maxc)
+	return res or res2
+end
+function c57261568.synop(e,tp,eg,ep,ev,re,r,rp,syncard,f,minc,maxc)
+	local c=e:GetHandler()
+	local lv=syncard:GetLevel()-c:GetLevel()
+	local lv2=syncard:GetLevel()-c57261568.cardiansynlevel(c)
+	local g=Duel.GetMatchingGroup(c57261568.synfilter,syncard:GetControler(),LOCATION_MZONE,LOCATION_MZONE,c,syncard,c,f)
+	local res=g:CheckWithSumEqual(Card.GetSynchroLevel,lv,minc,maxc,syncard)
+	local res2=g:CheckWithSumEqual(c57261568.cardiansynlevel,lv2,minc,maxc)
+	local sg=nil
+	if (res2 and res and Duel.SelectYesNo(tp,aux.Stringid(57261568,2)))
+		or (res2 and not res) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
+		sg=g:SelectWithSumEqual(tp,c57261568.cardiansynlevel,lv2,minc,maxc)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
+		sg=g:SelectWithSumEqual(tp,Card.GetSynchroLevel,lv,minc,maxc,syncard)
+	end
+	Duel.SetSynchroMaterial(sg)
+end

--- a/c57831349.lua
+++ b/c57831349.lua
@@ -1,0 +1,45 @@
+--竜星の九支
+function c57831349.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_TODECK+CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetCondition(c57831349.condition)
+	e1:SetTarget(c57831349.target)
+	e1:SetOperation(c57831349.activate)
+	c:RegisterEffect(e1)
+end
+function c57831349.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x9e)
+end
+function c57831349.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c57831349.cfilter,tp,LOCATION_ONFIELD,0,1,nil)
+		and (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
+end
+function c57831349.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_TODECK,eg,1,0,0)
+	end
+end
+function c57831349.desfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x9e) and c:IsDestructable()
+end
+function c57831349.activate(e,tp,eg,ep,ev,re,r,rp)
+	local ec=re:GetHandler()
+	Duel.NegateActivation(ev)
+	if ec:IsRelateToEffect(re) then
+		ec:CancelToGrave()
+		if Duel.SendtoDeck(ec,nil,2,REASON_EFFECT)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
+			local g=Duel.GetMatchingGroup(c57831349.desfilter,tp,LOCATION_ONFIELD,0,e:GetHandler())
+			if g:GetCount()>0 then
+				Duel.BreakEffect()
+				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+				local sg=g:Select(tp,1,1,nil)
+				Duel.Destroy(sg,REASON_EFFECT)
+			end
+		end
+	end
+end

--- a/c58383100.lua
+++ b/c58383100.lua
@@ -1,0 +1,90 @@
+--光波鏡騎士
+function c58383100.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(58383100,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCost(c58383100.spcost)
+	e1:SetTarget(c58383100.sptg)
+	e1:SetOperation(c58383100.spop)
+	c:RegisterEffect(e1)
+	--search
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetOperation(c58383100.regop)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(58383100,1))
+	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_PHASE+PHASE_END)
+	e3:SetRange(LOCATION_GRAVE)
+	e3:SetCountLimit(1,58383100)
+	e3:SetCondition(c58383100.thcon)
+	e3:SetTarget(c58383100.thtg)
+	e3:SetOperation(c58383100.thop)
+	c:RegisterEffect(e3)
+end
+function c58383100.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+end
+function c58383100.cfilter(c,e,tp)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE)
+		and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousSetCard(0xe5)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP)
+end
+function c58383100.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and eg:IsExists(c58383100.cfilter,1,nil,e,tp)
+		and eg:GetCount()==1
+		and Duel.IsExistingMatchingCard(Card.IsAbleToGrave,tp,LOCATION_HAND+LOCATION_MZONE,0,1,e:GetHandler()) end
+	local g=eg:Filter(c58383100.cfilter,nil,e,tp)
+	Duel.SetTargetCard(g)
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_HAND+LOCATION_MZONE)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c58383100.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tg=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then
+		tg=Duel.SelectMatchingCard(tp,Card.IsAbleToGrave,tp,LOCATION_MZONE,0,1,1,nil)
+	else
+		tg=Duel.SelectMatchingCard(tp,Card.IsAbleToGrave,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)
+	end
+	local tc=tg:GetFirst()
+	if tc and Duel.SendtoGrave(tc,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_GRAVE) then
+		local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+end
+function c58383100.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	c:RegisterFlagEffect(58383100,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c58383100.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(58383100)>0
+end
+function c58383100.thfilter(c)
+	return c:IsSetCard(0xe5) and c:IsAbleToHand()
+end
+function c58383100.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c58383100.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c58383100.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c58383100.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/c63992027.lua
+++ b/c63992027.lua
@@ -1,0 +1,47 @@
+--二重光波
+function c63992027.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c63992027.condition)
+	e1:SetTarget(c63992027.target)
+	e1:SetOperation(c63992027.operation)
+	c:RegisterEffect(e1)
+end
+function c63992027.condition(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	if g:GetCount()==0 then return false end
+	local tg=g:GetMaxGroup(Card.GetAttack)
+	return tg:IsExists(Card.IsControler,1,nil,1-tp)
+end
+function c63992027.filter(c,e,tp)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and (c:IsSetCard(0x107b) or c:IsSetCard(0xe5)) and c:GetOverlayCount()>0
+		and (not e or Duel.IsExistingMatchingCard(c63992027.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c))
+end
+function c63992027.spfilter(c,e,tp,ec)
+	return c:IsCode(ec:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c63992027.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c63992027.filter(chkc,nil,nil) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c63992027.filter,tp,LOCATION_MZONE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,c63992027.filter,tp,LOCATION_MZONE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c63992027.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) then return end
+	local og=tc:GetOverlayGroup()
+	if og:GetCount()==0 then return end
+	if Duel.SendtoGrave(og,REASON_EFFECT)~=0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c63992027.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+end

--- a/c64014615.lua
+++ b/c64014615.lua
@@ -1,0 +1,41 @@
+--大欲な壺
+function c64014615.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TODECK+CATEGORY_DRAW)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,64014615+EFFECT_COUNT_CODE_OATH)
+	e1:SetTarget(c64014615.target)
+	e1:SetOperation(c64014615.activate)
+	c:RegisterEffect(e1)
+end
+function c64014615.filter(c)
+	return c:IsFaceup() and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
+end
+function c64014615.sfilter(c,tp)
+	return c:IsLocation(LOCATION_DECK) and c:IsControler(tp)
+end
+function c64014615.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_REMOVED) and c64014615.filter(chkc) end
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1)
+		and Duel.IsExistingTarget(c64014615.filter,tp,LOCATION_REMOVED,LOCATION_REMOVED,3,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectTarget(tp,c64014615.filter,tp,LOCATION_REMOVED,LOCATION_REMOVED,3,3,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c64014615.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	if not tg or tg:FilterCount(Card.IsRelateToEffect,nil,e)~=3 then return end
+	Duel.SendtoDeck(tg,nil,0,REASON_EFFECT)
+	local g=Duel.GetOperatedGroup()
+	if g:IsExists(c64014615.sfilter,1,nil,tp) then Duel.ShuffleDeck(tp) end
+	if g:IsExists(c64014615.sfilter,1,nil,1-tp) then Duel.ShuffleDeck(1-tp) end
+	local ct=g:FilterCount(Card.IsLocation,nil,LOCATION_DECK+LOCATION_EXTRA)
+	if ct==3 then
+		Duel.BreakEffect()
+		Duel.Draw(tp,1,REASON_EFFECT)
+	end
+end

--- a/c64414267.lua
+++ b/c64414267.lua
@@ -1,0 +1,92 @@
+--煉獄の騎士 ヴァトライムス
+function c64414267.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x9c),4,2)
+	c:EnableReviveLimit()
+	--attribute
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CHANGE_ATTRIBUTE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e1:SetValue(ATTRIBUTE_DARK)
+	c:RegisterEffect(e1)
+	--pos
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(64414267,0))
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e2:SetCondition(c64414267.spcon1)
+	e2:SetCost(c64414267.spcost)
+	e2:SetTarget(c64414267.sptg)
+	e2:SetOperation(c64414267.spop)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetType(EFFECT_TYPE_QUICK_O)
+	e3:SetCode(EVENT_FREE_CHAIN)
+	e3:SetCondition(c64414267.spcon2)
+	c:RegisterEffect(e3)
+end
+function c64414267.cfilter(c)
+	return c:IsSetCard(0x9c) and c:IsType(TYPE_MONSTER)
+end
+function c64414267.spcon1(e,tp,eg,ep,ev,re,r,rp)
+	local ct=Duel.GetMatchingGroup(c64414267.cfilter,tp,LOCATION_GRAVE,0,nil)
+	return ct:GetClassCount(Card.GetCode)<7
+end
+function c64414267.spcon2(e,tp,eg,ep,ev,re,r,rp)
+	local ct=Duel.GetMatchingGroup(c64414267.cfilter,tp,LOCATION_GRAVE,0,nil)
+	return ct:GetClassCount(Card.GetCode)>=7
+end
+function c64414267.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,1,REASON_COST)
+		and Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil)
+		and c:GetFlagEffect(64414267)==0 end
+	c:RemoveOverlayCard(tp,1,1,REASON_COST)
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
+	c:RegisterFlagEffect(64414267,RESET_CHAIN,0,1)
+end
+function c64414267.spfilter(c,e,tp,mc)
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsSetCard(0x9c) and mc:IsCanBeXyzMaterial(c)
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
+end
+function c64414267.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c64414267.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,e:GetHandler()) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c64414267.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)>=0 then
+		if c:IsFaceup() and c:IsRelateToEffect(e) and c:IsControler(tp) and not c:IsImmuneToEffect(e) then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local g=Duel.SelectMatchingCard(tp,c64414267.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,c)
+			local sc=g:GetFirst()
+			if sc then
+				local mg=c:GetOverlayGroup()
+				if mg:GetCount()~=0 then
+					Duel.Overlay(sc,mg)
+				end
+				sc:SetMaterial(Group.FromCards(c))
+				Duel.Overlay(sc,Group.FromCards(c))
+				Duel.SpecialSummon(sc,SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)
+				sc:CompleteProcedure()
+			end
+		end
+	end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c64414267.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c64414267.splimit(e,c,sump,sumtype,sumpos,targetp,se)
+	return bit.band(sumtype,SUMMON_TYPE_XYZ)==SUMMON_TYPE_XYZ
+end

--- a/c64450427.lua
+++ b/c64450427.lua
@@ -1,0 +1,45 @@
+--EMウィム・ウィッチ
+function c64450427.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(64450427,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCountLimit(1,64450427)
+	e1:SetCondition(c64450427.spcon)
+	e1:SetTarget(c64450427.sptg)
+	e1:SetOperation(c64450427.spop)
+	c:RegisterEffect(e1)
+	--double tribute
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DOUBLE_TRIBUTE)
+	e2:SetValue(c64450427.dtcon)
+	c:RegisterEffect(e2)
+end
+function c64450427.cfilter(c)
+	return c:GetSummonLocation()==LOCATION_EXTRA
+end
+function c64450427.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return not Duel.IsExistingMatchingCard(c64450427.cfilter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c64450427.cfilter,tp,0,LOCATION_MZONE,1,nil)
+end
+function c64450427.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c64450427.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
+	end
+end
+function c64450427.dtcon(e,c)
+	return c:IsType(TYPE_PENDULUM)
+end

--- a/c65236257.lua
+++ b/c65236257.lua
@@ -1,0 +1,33 @@
+--創星の因子
+function c65236257.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_END_PHASE+TIMING_EQUIP)
+	e1:SetTarget(c65236257.target)
+	e1:SetOperation(c65236257.activate)
+	c:RegisterEffect(e1)
+end
+function c65236257.filter(c)
+	return c:IsDestructable() and c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c65236257.cfilter(c)
+	return c:IsSetCard(0x9c) and c:IsFaceup()
+end
+function c65236257.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local ct=Duel.GetMatchingGroupCount(c65236257.cfilter,tp,LOCATION_ONFIELD,0,c)
+	if chk==0 then return ct>0
+		and Duel.IsExistingMatchingCard(c65236257.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,ct,c) end
+	local g=Duel.GetMatchingGroup(c65236257.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,ct,0,0)
+end
+function c65236257.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local ct=Duel.GetMatchingGroupCount(c65236257.cfilter,tp,LOCATION_ONFIELD,0,c)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectMatchingCard(tp,c65236257.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,ct,ct,c)
+	Duel.Destroy(g,REASON_EFFECT)
+end

--- a/c65536818.lua
+++ b/c65536818.lua
@@ -1,0 +1,97 @@
+--源竜星－ボウテンコウ
+function c65536818.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
+	c:EnableReviveLimit()
+	c:SetSPSummonOnce(65536818)
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(65536818,0))
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetTarget(c65536818.thtg)
+	e1:SetOperation(c65536818.thop)
+	c:RegisterEffect(e1)
+	--level
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(65536818,1))
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetCountLimit(1)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCost(c65536818.lvcost)
+	e2:SetOperation(c65536818.lvop)
+	c:RegisterEffect(e2)
+	--spsummon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(65536818,2))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e3:SetCode(EVENT_LEAVE_FIELD)
+	e3:SetCondition(c65536818.spcon)
+	e3:SetTarget(c65536818.sptg)
+	e3:SetOperation(c65536818.spop)
+	c:RegisterEffect(e3)
+end
+function c65536818.thfilter(c)
+	return c:IsSetCard(0x9e) and c:IsAbleToHand()
+end
+function c65536818.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c65536818.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c65536818.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c65536818.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c65536818.costfilter(c,lv)
+	local clv=c:GetLevel()
+	return clv>0 and clv~=lv and c:IsRace(RACE_WYRM) and c:IsAbleToGraveAsCost()
+end
+function c65536818.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local lv=e:GetHandler():GetLevel()
+	if chk==0 then return Duel.IsExistingMatchingCard(c65536818.costfilter,tp,LOCATION_DECK,0,1,nil,lv) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c65536818.costfilter,tp,LOCATION_DECK,0,1,1,nil,lv)
+	Duel.SendtoGrave(g,REASON_COST)
+	e:SetLabel(g:GetFirst():GetLevel())
+end
+function c65536818.lvop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local lv=e:GetLabel()
+	if c:IsRelateToEffect(e) and c:IsFaceup() then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CHANGE_LEVEL)
+		e1:SetValue(lv)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+	end
+end
+function c65536818.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetLocation()~=LOCATION_DECK
+end
+function c65536818.spfilter(c,e,tp)
+	return c:IsSetCard(0x9e) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c65536818.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c65536818.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c65536818.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c65536818.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c65959844.lua
+++ b/c65959844.lua
@@ -1,0 +1,91 @@
+--化合電界
+function c65959844.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--decrease tribute
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(65959844,0))
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SUMMON_PROC)
+	e2:SetRange(LOCATION_FZONE)
+	e2:SetTargetRange(LOCATION_HAND,0)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c65959844.ntcon)
+	e2:SetTarget(c65959844.nttg)
+	c:RegisterEffect(e2)
+	--extra summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_EXTRA_SUMMON_COUNT)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetTargetRange(LOCATION_HAND+LOCATION_MZONE,0)
+	e3:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_DUAL))
+	c:RegisterEffect(e3)
+	--destroy
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(65959844,1))
+	e4:SetCategory(CATEGORY_REMOVE+CATEGORY_DESTROY)
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e4:SetRange(LOCATION_FZONE)
+	e4:SetCountLimit(1)
+	e4:SetTarget(c65959844.destg)
+	e4:SetOperation(c65959844.desop)
+	c:RegisterEffect(e4)
+end
+function c65959844.ntcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+end
+function c65959844.nttg(e,c)
+	return c:IsLevelAbove(5) and c:IsType(TYPE_DUAL)
+end
+function c65959844.rmfilter(c)
+	return c:IsDualState() and c:IsAbleToRemove()
+end
+function c65959844.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and chkc:IsDestructable() end
+	if chk==0 then return Duel.IsExistingMatchingCard(c65959844.rmfilter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingTarget(Card.IsDestructable,tp,0,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,Card.IsDestructable,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,tp,LOCATION_MZONE)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c65959844.desop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c65959844.rmfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	local rc=g:GetFirst()
+	if rc and Duel.Remove(rc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 and rc:IsLocation(LOCATION_REMOVED) then
+		local tc=Duel.GetFirstTarget()
+		if tc:IsRelateToEffect(e) then
+			Duel.Destroy(tc,REASON_EFFECT)
+		end
+		rc:RegisterFlagEffect(65959844,RESET_PHASE+PHASE_END+RESET_OPPO_TURN,0,1)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_PHASE+PHASE_END)
+		e1:SetCountLimit(1)
+		e1:SetLabelObject(rc)
+		e1:SetCondition(c65959844.retcon)
+		e1:SetOperation(c65959844.retop)
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function c65959844.retcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==1-tp and e:GetLabelObject():GetFlagEffect(65959844)~=0
+end
+function c65959844.retop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:IsForbidden() then
+		Duel.SendtoGrave(tc,REASON_RULE)
+	else
+		Duel.ReturnToField(tc)
+	end
+end

--- a/c66171432.lua
+++ b/c66171432.lua
@@ -1,0 +1,101 @@
+--超こいこい 
+function c66171432.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(66171432,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,66171432+EFFECT_COUNT_CODE_OATH)
+	e1:SetTarget(c66171432.target)
+	e1:SetOperation(c66171432.activate)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(66171432,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCost(c66171432.spcost)
+	e2:SetTarget(c66171432.sptg)
+	e2:SetOperation(c66171432.spop)
+	c:RegisterEffect(e2)
+end
+function c66171432.filter(c,e,tp)
+	return c:IsSetCard(0xe6) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+end
+function c66171432.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,30459350)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c66171432.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+end
+function c66171432.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.IsPlayerAffectedByEffect(tp,30459350) then return end
+	Duel.ConfirmDecktop(tp,3)
+	local g=Duel.GetDecktopGroup(tp,3)
+	local sg=g:Filter(c66171432.filter,nil,e,tp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if ft>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
+	if g:GetCount()>0 then
+		Duel.DisableShuffleCheck()
+		if sg:GetCount()>0 and ft>0 then
+			if sg:GetCount()>ft then
+				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+				sg=sg:Select(tp,ft,ft,nil)
+			end
+			g:Sub(sg)
+			local tc=sg:GetFirst()
+			while tc do
+				if Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP) then
+					if tc:GetLevel()>0 then
+						local e1=Effect.CreateEffect(c)
+						e1:SetType(EFFECT_TYPE_SINGLE)
+						e1:SetCode(EFFECT_CHANGE_LEVEL)
+						e1:SetValue(2)
+						e1:SetReset(RESET_EVENT+0x1fe0000)
+						tc:RegisterEffect(e1)
+					end
+					local e2=Effect.CreateEffect(c)
+					e2:SetType(EFFECT_TYPE_SINGLE)
+					e2:SetCode(EFFECT_DISABLE)
+					e2:SetReset(RESET_EVENT+0x1fe0000)
+					tc:RegisterEffect(e2)
+					local e3=Effect.CreateEffect(c)
+					e3:SetType(EFFECT_TYPE_SINGLE)
+					e3:SetCode(EFFECT_DISABLE_EFFECT)
+					e3:SetReset(RESET_EVENT+0x1fe0000)
+					tc:RegisterEffect(e3)
+				end
+				tc=sg:GetNext()
+			end
+			Duel.SpecialSummonComplete()
+		end
+		Duel.Remove(g,POS_FACEDOWN,REASON_EFFECT)
+		local og=Duel.GetOperatedGroup()
+		local ct=og:FilterCount(Card.IsLocation,nil,LOCATION_REMOVED)
+		if ct>0 then
+			Duel.SetLP(tp,Duel.GetLP(tp)-ct*1000)
+		end
+	end
+end
+function c66171432.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost()
+		and Duel.CheckReleaseGroup(tp,nil,1,nil) end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+	local g=Duel.SelectReleaseGroup(tp,nil,1,1,nil)
+	Duel.Release(g,REASON_COST)
+end
+function c66171432.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c66171432.filter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c66171432.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c66171432.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,true,false,POS_FACEUP)
+	end
+end

--- a/c69105797.lua
+++ b/c69105797.lua
@@ -1,0 +1,78 @@
+--捕食植物スキッド・ドロセーラ
+function c69105797.initial_effect(c)
+	--attack all
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(69105797,0))
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCondition(c69105797.condition)
+	e1:SetCost(c69105797.cost)
+	e1:SetTarget(c69105797.target)
+	e1:SetOperation(c69105797.operation)
+	c:RegisterEffect(e1)
+	--counter
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_COUNTER)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCondition(c69105797.ccon)
+	e2:SetOperation(c69105797.cop)
+	c:RegisterEffect(e2)
+end
+function c69105797.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsAbleToEnterBP()
+end
+function c69105797.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c69105797.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c69105797.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_ATTACK_ALL)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(c69105797.atkfilter)
+		tc:RegisterEffect(e1)
+	end
+end
+function c69105797.atkfilter(e,c)
+	return c:GetCounter(0x1141)>0
+end
+function c69105797.ccon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and not c:IsLocation(LOCATION_DECK)
+end
+function c69105797.cfilter(c)
+	return c:IsFaceup() and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+end
+function c69105797.cop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local g=Duel.GetMatchingGroup(c69105797.cfilter,tp,0,LOCATION_MZONE,nil)
+	local tc=g:GetFirst()
+	while tc do
+		tc:AddCounter(0x1141,1)
+		if tc:GetLevel()>1 then
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_CHANGE_LEVEL)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			e1:SetCondition(c69105797.lvcon)
+			e1:SetValue(1)
+			tc:RegisterEffect(e1)
+		end
+		tc=g:GetNext()
+	end
+end
+function c69105797.lvcon(e)
+	return e:GetHandler():GetCounter(0x1141)>0
+end

--- a/c69105797.lua
+++ b/c69105797.lua
@@ -46,7 +46,7 @@ function c69105797.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c69105797.atkfilter(e,c)
-	return c:GetCounter(0x1141)>0
+	return c:GetCounter(0x1041)>0
 end
 function c69105797.ccon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -60,7 +60,7 @@ function c69105797.cop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c69105797.cfilter,tp,0,LOCATION_MZONE,nil)
 	local tc=g:GetFirst()
 	while tc do
-		tc:AddCounter(0x1141,1)
+		tc:AddCounter(0x1041,1)
 		if tc:GetLevel()>1 then
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
@@ -74,5 +74,5 @@ function c69105797.cop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c69105797.lvcon(e)
-	return e:GetHandler():GetCounter(0x1141)>0
+	return e:GetHandler():GetCounter(0x1041)>0
 end

--- a/c69228245.lua
+++ b/c69228245.lua
@@ -1,0 +1,88 @@
+--EMチェーンジラフ
+function c69228245.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(69228245,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCode(EVENT_BATTLE_DESTROYED)
+	e1:SetCondition(c69228245.spcon)
+	e1:SetTarget(c69228245.sptg)
+	e1:SetOperation(c69228245.spop)
+	c:RegisterEffect(e1)
+	--summon success
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(69228245,1))
+	e2:SetCategory(CATEGORY_DISABLE)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetTarget(c69228245.target)
+	e2:SetOperation(c69228245.operation)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e3)
+	--disable
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_DISABLE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e4:SetTarget(c69228245.distg)
+	c:RegisterEffect(e4)
+	--cannot attack
+	local e5=e4:Clone()
+	e5:SetCode(EFFECT_CANNOT_ATTACK)
+	c:RegisterEffect(e5)
+end
+function c69228245.cfilter(c,tp)
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousControler()==tp
+end
+function c69228245.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:GetCount()==1 and eg:IsExists(c69228245.cfilter,1,nil,tp)
+end
+function c69228245.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=eg:GetFirst()
+	if chk==0 then return e:GetHandler():IsDestructable()
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and tc and tc:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,e:GetHandler(),1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tc,1,tp,tc:GetLocation())
+end
+function c69228245.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=eg:GetFirst()
+	if c:IsRelateToEffect(e)
+		and Duel.Destroy(c,REASON_EFFECT)~=0
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and tc and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK)~=0	then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(1)
+		tc:RegisterEffect(e1)
+	end
+end
+function c69228245.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,1,0,0)
+end
+function c69228245.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		c:SetCardTarget(tc)
+	end
+end
+function c69228245.distg(e,c)
+	return e:GetHandler():IsHasCardTarget(c)
+end

--- a/c76359406.lua
+++ b/c76359406.lua
@@ -1,0 +1,66 @@
+--水晶機巧－アメトリクス
+function c76359406.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
+	c:EnableReviveLimit()
+	--position
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(76359406,0))
+	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c76359406.poscon)
+	e1:SetTarget(c76359406.postg)
+	e1:SetOperation(c76359406.posop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(76359406,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_DESTROYED)
+	e2:SetCondition(c76359406.spcon)
+	e2:SetTarget(c76359406.sptg)
+	e2:SetOperation(c76359406.spop)
+	c:RegisterEffect(e2)
+end
+function c76359406.poscon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SYNCHRO
+end
+function c76359406.posfilter(c)
+	return c:IsFaceup() and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+end
+function c76359406.postg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c76359406.posfilter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c76359406.posfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
+end
+function c76359406.posop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c76359406.posfilter,tp,0,LOCATION_MZONE,nil)
+	if g:GetCount()>0 then
+		Duel.ChangePosition(g,POS_FACEUP_DEFENSE)
+	end
+end
+function c76359406.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:GetSummonType()==SUMMON_TYPE_SYNCHRO and bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0
+end
+function c76359406.spfilter(c,e,tp)
+	return c:IsSetCard(0xea) and not c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c76359406.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c76359406.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c76359406.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c76359406.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c76359406.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c76471944.lua
+++ b/c76471944.lua
@@ -1,0 +1,45 @@
+--超重忍者サルト－B
+function c76471944.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_MACHINE),aux.NonTuner(Card.IsSetCard,0x9a),1)
+	c:EnableReviveLimit()
+	--defense attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DEFENSE_ATTACK)
+	e1:SetValue(1)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(76471944,0))
+	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c76471944.descon)
+	e2:SetTarget(c76471944.destg)
+	e2:SetOperation(c76471944.desop)
+	c:RegisterEffect(e2)
+end
+function c76471944.descon(e,tp,eg,ep,ev,re,r,rp)
+	return not Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_GRAVE,0,1,nil,TYPE_SPELL+TYPE_TRAP)
+end
+function c76471944.desfilter(c,tp)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsDestructable()
+end
+function c76471944.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c76471944.desfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c76471944.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c76471944.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
+end
+function c76471944.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		Duel.Damage(1-tp,500,REASON_EFFECT)
+	end
+end

--- a/c78316184.lua
+++ b/c78316184.lua
@@ -1,0 +1,83 @@
+--サイバー・エンジェル－美朱濡－
+function c78316184.initial_effect(c)
+	c:EnableReviveLimit()
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(78316184,0))
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c78316184.descon)
+	e1:SetTarget(c78316184.destg)
+	e1:SetOperation(c78316184.desop)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(78316184,1))
+	e2:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c78316184.negcon)
+	e2:SetCost(c78316184.negcost)
+	e2:SetTarget(c78316184.negtg)
+	e2:SetOperation(c78316184.negop)
+	c:RegisterEffect(e2)
+end
+function c78316184.descon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_RITUAL)==SUMMON_TYPE_RITUAL
+end
+function c78316184.desfilter(c)
+	return c:GetSummonLocation()==LOCATION_EXTRA and c:IsDestructable()
+end
+function c78316184.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c78316184.desfilter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c78316184.desfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,g:GetCount()*1000)
+end
+function c78316184.desop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c78316184.desfilter,tp,0,LOCATION_MZONE,nil)
+	local ct=Duel.Destroy(g,REASON_EFFECT)
+	if Duel.Damage(1-tp,ct*1000,REASON_EFFECT)~=0 then
+		local c=e:GetHandler()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EXTRA_ATTACK)
+		e1:SetValue(1)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+	end
+end
+function c78316184.negcon(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) or not Duel.IsChainNegatable(ev) then return false end
+	if re:IsHasCategory(CATEGORY_NEGATE)
+		and Duel.GetChainInfo(ev-1,CHAININFO_TRIGGERING_EFFECT):IsHasType(EFFECT_TYPE_ACTIVATE) then return false end
+	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)
+	return ex and tg~=nil and tc+tg:FilterCount(Card.IsOnField,nil)-tg:GetCount()>0
+end
+function c78316184.costfilter(c)
+	return bit.band(c:GetType(),0x81)==0x81 and c:IsAbleToDeckAsCost()
+end
+function c78316184.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c78316184.costfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectMatchingCard(tp,c78316184.costfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SendtoDeck(g,nil,2,REASON_COST)
+end
+function c78316184.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c78316184.negop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateActivation(ev)
+	if re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end

--- a/c79538761.lua
+++ b/c79538761.lua
@@ -1,0 +1,98 @@
+--トルクチューン・ギア
+function c79538761.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(79538761,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c79538761.eqtg)
+	e1:SetOperation(c79538761.eqop)
+	c:RegisterEffect(e1)
+	--unequip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(79538761,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(c79538761.uncon)
+	e2:SetTarget(c79538761.sptg)
+	e2:SetOperation(c79538761.spop)
+	c:RegisterEffect(e2)
+	--destroy sub
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e3:SetCondition(c79538761.uncon)
+	e3:SetValue(c79538761.repval)
+	c:RegisterEffect(e3)
+	--add type
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_EQUIP)
+	e4:SetCode(EFFECT_ADD_TYPE)
+	e4:SetValue(TYPE_TUNER)
+	c:RegisterEffect(e4)
+	--atkup
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_EQUIP)
+	e5:SetCode(EFFECT_UPDATE_ATTACK)
+	e5:SetValue(500)
+	c:RegisterEffect(e5)
+	--defup
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_EQUIP)
+	e6:SetCode(EFFECT_UPDATE_DEFENSE)
+	e6:SetValue(500)
+	c:RegisterEffect(e6)
+	--eqlimit
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE)
+	e7:SetCode(EFFECT_EQUIP_LIMIT)
+	e7:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e7:SetValue(1)
+	c:RegisterEffect(e7)
+end
+function c79538761.uncon(e)
+	return e:GetHandler():IsStatus(STATUS_UNION)
+end
+function c79538761.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return e:GetHandler():GetFlagEffect(79538761)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,c) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,c)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	c:RegisterFlagEffect(79538761,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c79538761.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	if not Duel.Equip(tp,c,tc,false) then return end
+	c:SetStatus(STATUS_UNION,true)
+end
+function c79538761.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:GetFlagEffect(79538761)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+	c:RegisterFlagEffect(79538761,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c79538761.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
+		Duel.SendtoGrave(c,REASON_RULE)
+	end
+end
+function c79538761.repval(e,re,r,rp)
+	return bit.band(r,REASON_BATTLE+REASON_EFFECT)~=0
+end

--- a/c80250319.lua
+++ b/c80250319.lua
@@ -1,0 +1,77 @@
+--グレイドル・スライムJr.
+function c80250319.initial_effect(c)
+	--special summon from grave
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(80250319,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(c80250319.sptg1)
+	e1:SetOperation(c80250319.spop1)
+	c:RegisterEffect(e1)
+	--special summon from deck
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(80250319,2))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_BATTLE_DESTROYED)
+	e2:SetCondition(c80250319.spcon2)
+	e2:SetTarget(c80250319.sptg2)
+	e2:SetOperation(c80250319.spop2)
+	c:RegisterEffect(e2)
+end
+function c80250319.spfilter1(c,e,tp)
+	return c:IsSetCard(0xd1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c80250319.sptg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c80250319.spfilter1(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c80250319.spfilter1,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c80250319.spfilter1,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c80250319.spfilter2(c,e,tp,lv)
+	return c:IsRace(RACE_AQUA) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c80250319.spop1(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+		local g=Duel.GetMatchingGroup(c80250319.spfilter2,tp,LOCATION_HAND,0,nil,e,tp,tc:GetLevel())
+		if g:GetCount()>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+			and Duel.SelectYesNo(tp,aux.Stringid(80250319,1)) then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sg=g:Select(tp,1,1,nil)
+			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c80250319.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c80250319.splimit(e,c)
+	return not c:IsAttribute(ATTRIBUTE_WATER)
+end
+function c80250319.spcon2(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
+end
+function c80250319.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c80250319.spfilter1,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c80250319.spop2(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c80250319.spfilter1,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c80476891.lua
+++ b/c80476891.lua
@@ -1,0 +1,82 @@
+--進化合獣ヒュードラゴン
+function c80476891.initial_effect(c)
+	aux.EnableDualAttribute(c)
+	--atkup
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(80476891,0))
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_FIELD)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetCondition(aux.IsDualState)
+	e1:SetTarget(c80476891.target)
+	e1:SetOperation(c80476891.operation)
+	c:RegisterEffect(e1)
+	--destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(aux.IsDualState)
+	e2:SetTarget(c80476891.reptg)
+	e2:SetValue(c80476891.repval)
+	e2:SetOperation(c80476891.repop)
+	c:RegisterEffect(e2)
+end
+function c80476891.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=eg:GetFirst()
+	if chk==0 then return tc:IsType(TYPE_DUAL) and tc~=e:GetHandler() end
+	Duel.SetTargetCard(tc)
+end
+function c80476891.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(500)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_UPDATE_DEFENSE)
+		tc:RegisterEffect(e2)
+	end
+end
+function c80476891.repfilter(c,tp,e)
+	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
+		and c:IsType(TYPE_DUAL) and c:IsReason(REASON_EFFECT) and c:GetFlagEffect(80476891)==0
+end
+function c80476891.desfilter(c,tp)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_ONFIELD)
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+end
+function c80476891.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c80476891.desfilter,tp,LOCATION_ONFIELD,0,1,nil,tp)
+		and eg:IsExists(c80476891.repfilter,1,nil,tp,e) end
+	if Duel.SelectYesNo(tp,aux.Stringid(80476891,1)) then
+		local g=eg:Filter(c80476891.repfilter,nil,tp,e)
+		if g:GetCount()==1 then
+			e:SetLabelObject(g:GetFirst())
+		else
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+			local cg=g:Select(tp,1,1,nil)
+			e:SetLabelObject(cg:GetFirst())
+		end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+		local tg=Duel.SelectMatchingCard(tp,c80476891.desfilter,tp,LOCATION_ONFIELD,0,1,1,nil,tp)
+		Duel.HintSelection(tg)
+		Duel.SetTargetCard(tg)
+		tg:GetFirst():RegisterFlagEffect(80476891,RESET_EVENT+0x1fc0000+RESET_CHAIN,0,1)
+		tg:GetFirst():SetStatus(STATUS_DESTROY_CONFIRMED,true)
+		return true
+	else return false end
+end
+function c80476891.repval(e,c)
+	return c==e:GetLabelObject()
+end
+function c80476891.repop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
+	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)
+end

--- a/c81599449.lua
+++ b/c81599449.lua
@@ -1,0 +1,45 @@
+--化合獣カーボン・クラブ
+function c81599449.initial_effect(c)
+	aux.EnableDualAttribute(c)
+	--to grave/search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(81599449,0))
+	e1:SetCategory(CATEGORY_TOGRAVE+CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1,81599449)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(aux.IsDualState)
+	e1:SetTarget(c81599449.tgtg)
+	e1:SetOperation(c81599449.tgop)
+	c:RegisterEffect(e1)
+end
+function c81599449.filter(c,tp)
+	return c:IsType(TYPE_DUAL) and c:IsAbleToGrave()
+		and Duel.IsExistingMatchingCard(c81599449.thfilter,tp,LOCATION_DECK,0,1,c)
+end
+function c81599449.tgfilter(c)
+	return c:IsType(TYPE_DUAL) and c:IsAbleToGrave()
+end
+function c81599449.thfilter(c)
+	return c:IsType(TYPE_DUAL) and c:IsAbleToHand()
+end
+function c81599449.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c81599449.filter,tp,LOCATION_DECK,0,1,nil,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c81599449.tgop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c81599449.tgfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 and Duel.SendtoGrave(g,REASON_EFFECT)~=0
+		and g:GetFirst():IsLocation(LOCATION_GRAVE) then
+		local sg=Duel.GetMatchingGroup(c81599449.thfilter,tp,LOCATION_DECK,0,nil)
+		if sg:GetCount()>0 then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+			local tg=sg:Select(tp,1,1,nil)
+			Duel.SendtoHand(tg,nil,REASON_EFFECT)
+			Duel.ConfirmCards(1-tp,tg)
+		end
+	end
+end

--- a/c82321037.lua
+++ b/c82321037.lua
@@ -1,0 +1,96 @@
+--真竜皇バハルストスF
+function c82321037.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCountLimit(1,82321037)
+	e1:SetTarget(c82321037.sptg)
+	e1:SetOperation(c82321037.spop)
+	c:RegisterEffect(e1)
+	--tohand
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_DESTROYED)
+	e2:SetCountLimit(1,82321037+1)
+	e2:SetCondition(c82321037.thcon)
+	e2:SetTarget(c82321037.thtg)
+	e2:SetOperation(c82321037.thop)
+	c:RegisterEffect(e2)
+end
+function c82321037.desfilter(c,tc)
+	return c~=tc and c:IsType(TYPE_MONSTER) and ((c:IsLocation(LOCATION_MZONE) and c:IsFaceup()) or c:IsLocation(LOCATION_HAND)) and c:IsDestructable()
+end
+function c82321037.desfilter2(c,tc)
+	return c82321037.desfilter(c,tc) and c:IsAttribute(ATTRIBUTE_WATER)
+end
+function c82321037.rmfilter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToRemove()
+end
+function c82321037.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local g1=Duel.GetMatchingGroup(c82321037.desfilter,tp,LOCATION_MZONE+LOCATION_HAND,0,nil,c)
+	local g2=Duel.GetMatchingGroup(c82321037.desfilter2,tp,LOCATION_MZONE+LOCATION_HAND,0,nil,c)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if chk==0 then return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and g1:GetCount()>=2 and g2:GetCount()>=1
+		and (ft>0 or Duel.IsExistingMatchingCard(c82321037.desfilter,tp,LOCATION_MZONE,0,1,nil,c)) end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g1,2,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+end
+function c82321037.spop(e,tp,eg,ep,ev,re,r,rp)
+	if not c82321037.sptg(e,tp,eg,ep,ev,re,r,rp,0) then return end
+	local c=e:GetHandler()
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g1=Duel.SelectMatchingCard(tp,c82321037.desfilter2,tp,LOCATION_MZONE+LOCATION_HAND,0,1,1,nil,c)
+	if g1:GetCount()<=0 then return end
+	local tc1=g1:GetFirst()
+	local g2
+	if tc1:IsLocation(LOCATION_HAND) and ft<1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		g2=Duel.SelectMatchingCard(tp,c82321037.desfilter,tp,LOCATION_MZONE,0,1,1,tc1,c)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		g2=Duel.SelectMatchingCard(tp,c82321037.desfilter,tp,LOCATION_MZONE+LOCATION_HAND,0,1,1,tc1,c)
+	end
+	if g2:GetCount()<=0 then return end
+	g1:Merge(g2)
+	if Duel.Destroy(g1,REASON_EFFECT)==2 then
+		if not c:IsRelateToEffect(e) then return end
+		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+			and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+			Duel.SendtoGrave(c,REASON_RULE)
+			return
+		end
+		local g=Duel.GetMatchingGroup(c82321037.rmfilter,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
+		if g1:FilterCount(Card.IsAttribute,nil,ATTRIBUTE_WATER)==2 and g:GetCount()>0
+			and Duel.SelectYesNo(tp,aux.Stringid(82321037,1)) then
+			local g=Duel.SelectMatchingCard(tp,c82321037.rmfilter,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,1,2,nil)
+			Duel.HintSelection(g)
+			Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+		end
+	end
+end
+function c82321037.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsReason(REASON_EFFECT)
+end
+function c82321037.thfilter(c,e,tp)
+	return not c:IsAttribute(ATTRIBUTE_WATER) and c:IsRace(RACE_WYRM) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+end
+function c82321037.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local g=Duel.GetMatchingGroup(c82321037.thfilter,tp,LOCATION_DECK,0,nil,e,tp)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and g:GetCount()>0 end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+end
+function c82321037.thop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c82321037.thfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+	end
+end

--- a/c83326048.lua
+++ b/c83326048.lua
@@ -1,0 +1,73 @@
+--次元障壁
+function c83326048.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DISABLE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,0x1c0)
+	e1:SetCountLimit(1,83326048+EFFECT_COUNT_CODE_OATH)
+	e1:SetTarget(c83326048.target)
+	e1:SetOperation(c83326048.operation)
+	c:RegisterEffect(e1)
+end
+function c83326048.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CARDTYPE)
+	Duel.SetTargetParam(Duel.SelectOption(tp,1057,1056,1063,1073,1074))
+end
+function c83326048.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local opt=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	local ct=nil
+	if opt==0 then ct=TYPE_RITUAL end
+	if opt==1 then
+		ct=TYPE_FUSION
+		local e0=Effect.CreateEffect(c)
+		e0:SetType(EFFECT_TYPE_FIELD)
+		e0:SetCode(27581098)
+		e0:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e0:SetTargetRange(1,1)
+		e0:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e0,tp)
+	end
+	if opt==2 then ct=TYPE_SYNCHRO end
+	if opt==3 then ct=TYPE_XYZ end
+	if opt==4 then ct=TYPE_PENDULUM end	
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetLabel(ct)
+	e1:SetTargetRange(1,1)
+	e1:SetTarget(c83326048.sumlimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_DISABLE)
+	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e2:SetTarget(c83326048.distg)
+	e2:SetLabel(ct)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e2,tp)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetOperation(c83326048.disop)
+	e3:SetLabel(ct)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function c83326048.sumlimit(e,c,sump,sumtype,sumpos,targetp)
+	return c:IsType(e:GetLabel())
+end
+function c83326048.distg(e,c)
+	return c:IsType(e:GetLabel())
+end
+function c83326048.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_MZONE and re:IsActiveType(e:GetLabel()) then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/c83443619.lua
+++ b/c83443619.lua
@@ -1,0 +1,88 @@
+--水晶機巧－スモーガ－
+function c83443619.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(83443619,0))
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,83443619)
+	e1:SetTarget(c83443619.sptg)
+	e1:SetOperation(c83443619.spop)
+	c:RegisterEffect(e1)
+	--search
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(83443619,1))
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,83443619)
+	e2:SetCost(c83443619.thcost)
+	e2:SetTarget(c83443619.thtg)
+	e2:SetOperation(c83443619.thop)
+	c:RegisterEffect(e2)
+end
+function c83443619.desfilter(c)
+	return c:IsFaceup() and c:IsDestructable()
+end
+function c83443619.spfilter(c,e,tp)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c83443619.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(e:GetLabel()) and chkc:IsControler(tp) and c83443619.desfilter(chkc) end
+	if chk==0 then
+		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		if ft<-1 then return false end
+		local loc=LOCATION_ONFIELD
+		if ft==0 then loc=LOCATION_MZONE end
+		e:SetLabel(loc)
+		return Duel.IsExistingTarget(c83443619.desfilter,tp,loc,0,1,nil)
+			and Duel.IsExistingMatchingCard(c83443619.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c83443619.desfilter,tp,e:GetLabel(),0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c83443619.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c83443619.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g:GetCount()>0 then
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(c83443619.splimit)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c83443619.splimit(e,c)
+	return not (c:IsRace(RACE_MACHINE) and c:IsType(TYPE_SYNCHRO)) and c:IsLocation(LOCATION_EXTRA)
+end
+function c83443619.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c83443619.thfilter(c)
+	return c:IsSetCard(0xea) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToHand()
+end
+function c83443619.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c83443619.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c83443619.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c83443619.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/c84442536.lua
+++ b/c84442536.lua
@@ -1,0 +1,67 @@
+--グレイドル・コンバット
+function c84442536.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetCondition(c84442536.condition)
+	e1:SetTarget(c84442536.target)
+	e1:SetOperation(c84442536.activate)
+	c:RegisterEffect(e1)
+end
+function c84442536.cfilter(c,tp)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsSetCard(0xd1)
+end
+function c84442536.condition(e,tp,eg,ep,ev,re,r,rp)
+	if not (re:IsHasProperty(EFFECT_FLAG_CARD_TARGET)
+		and (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE))) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()~=1 then return false end
+	local tc=g:GetFirst()
+	e:SetLabelObject(tc)
+	return c84442536.cfilter(tc,tp) 
+end
+function c84442536.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=e:GetLabelObject()
+	if chk==0 then return tc and (Duel.IsChainNegatable(ev) or tc:IsDestructable()) end
+	local sel=0
+	if Duel.IsChainNegatable(ev) and tc:IsDestructable() then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+		sel=Duel.SelectOption(tp,aux.Stringid(84442536,0),aux.Stringid(84442536,1))
+	elseif tc:IsDestructable() then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+		sel=Duel.SelectOption(tp,aux.Stringid(84442536,0))
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+		sel=Duel.SelectOption(tp,aux.Stringid(84442536,1))+1
+	end
+	e:SetLabel(sel)
+	if sel==1 then
+		Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+		if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+			Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+		end
+	end
+end
+function c84442536.activate(e,tp,eg,ep,ev,re,r,rp)
+	local sel=e:GetLabel()
+	if sel==0 then
+		Duel.ChangeChainOperation(ev,c84442536.repop)
+	else
+		Duel.NegateActivation(ev)
+		if re:GetHandler():IsRelateToEffect(re) then
+			Duel.Destroy(eg,REASON_EFFECT)
+		end
+	end
+end
+function c84442536.repop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:GetType()==TYPE_SPELL or c:GetType()==TYPE_TRAP then
+		c:CancelToGrave(false)
+	end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/c90519313.lua
+++ b/c90519313.lua
@@ -1,0 +1,31 @@
+--検疫
+function c90519313.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--confirm
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(90519313,0))
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_PHASE+PHASE_END)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetTarget(c90519313.cftg)
+	e2:SetOperation(c90519313.cfop)
+	c:RegisterEffect(e2)
+end
+function c90519313.cftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_SZONE) and chkc:IsFacedown() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFacedown,tp,0,LOCATION_SZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEDOWN)
+	Duel.SelectTarget(tp,Card.IsFacedown,tp,0,LOCATION_SZONE,1,1,nil)
+end
+function c90519313.cfop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFacedown() then
+		Duel.ConfirmCards(tp,tc)
+	end
+end

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -1,0 +1,118 @@
+--餅カエル
+function c90809975.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_AQUA),2,2)
+	c:EnableReviveLimit()
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(90809975,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_FIELD)
+	e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCost(c90809975.spcost)
+	e1:SetTarget(c90809975.sptg)
+	e1:SetOperation(c90809975.spop)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(90809975,1))
+	e2:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c90809975.negcon)
+	e2:SetCost(c90809975.negcost)
+	e2:SetTarget(c90809975.negtg)
+	e2:SetOperation(c90809975.negop)
+	c:RegisterEffect(e2)
+	--to hand
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(90809975,2))
+	e3:SetCategory(CATEGORY_TOHAND)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_TO_GRAVE)
+	e3:SetTarget(c90809975.thtg)
+	e3:SetOperation(c90809975.thop)
+	c:RegisterEffect(e3)
+end
+function c90809975.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c90809975.spfilter(c,e,tp)
+	return c:IsSetCard(0x12) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c90809975.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c90809975.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c90809975.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c90809975.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c90809975.negcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if ep==tp or c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	return (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
+end
+function c90809975.cfilter(c)
+	return c:IsRace(RACE_AQUA) and (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsAbleToGraveAsCost()
+end
+function c90809975.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c90809975.cfilter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c90809975.cfilter,tp,LOCATION_MZONE+LOCATION_HAND,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c90809975.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	if not Duel.NegateActivation(ev) then return end
+	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK) then
+		if rc:IsType(TYPE_MONSTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+			and rc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+			and Duel.SelectYesNo(tp,aux.Stringid(90809975,3)) then
+			Duel.BreakEffect()
+			Duel.SpecialSummon(rc,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+			Duel.ConfirmCards(1-tp,rc)
+		elseif (rc:IsType(TYPE_FIELD) or Duel.GetLocationCount(tp,LOCATION_SZONE)>0)
+			and rc:IsSSetable() and Duel.SelectYesNo(tp,aux.Stringid(90809975,4)) then
+			Duel.BreakEffect()
+			Duel.SSet(tp,rc)
+			Duel.ConfirmCards(1-tp,rc)
+		end
+	end
+end
+function c90809975.thfilter(c)
+	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToHand()
+end
+function c90809975.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c90809975.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c90809975.thfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c90809975.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c90809975.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,tc)
+	end
+end

--- a/c91231901.lua
+++ b/c91231901.lua
@@ -1,0 +1,67 @@
+--「A」細胞組み換え装置
+function c91231901.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOGRAVE+CATEGORY_COUNTER)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c91231901.target)
+	e1:SetOperation(c91231901.activate)
+	c:RegisterEffect(e1)
+	--to hand
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(91231901,0))
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCondition(aux.exccon)
+	e2:SetCost(c91231901.thcost)
+	e2:SetTarget(c91231901.thtg)
+	e2:SetOperation(c91231901.thop)
+	c:RegisterEffect(e2)
+end
+function c91231901.filter(c)
+	return c:GetLevel()>0 and c:IsSetCard(0xc) and c:IsAbleToGrave()
+end
+function c91231901.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end 
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
+		and Duel.IsExistingMatchingCard(c91231901.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
+	Duel.SetOperationInfo(0,CATEGORY_COUNTER,g,1,0x100e,1)
+end
+function c91231901.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c91231901.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		local sg=g:GetFirst()
+		if Duel.SendtoGrave(g,REASON_EFFECT)~=0 and sg:IsLocation(LOCATION_GRAVE) then
+			local tc=Duel.GetFirstTarget()
+			if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+				tc:AddCounter(0x100e,sg:GetLevel())
+			end
+		end
+	end
+end
+function c91231901.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c91231901.thfilter(c)
+	return c:IsSetCard(0xc) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c91231901.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c91231901.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c91231901.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c91231901.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/c91449532.lua
+++ b/c91449532.lua
@@ -1,0 +1,59 @@
+--EMオールカバー・ヒッポ
+function c91449532.initial_effect(c)
+	--Special Summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(91449532,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(c91449532.sptg)
+	e1:SetOperation(c91449532.spop)
+	c:RegisterEffect(e1)
+	--Change position
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(91449532,1))
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetTarget(c91449532.postg)
+	e2:SetOperation(c91449532.posop)
+	c:RegisterEffect(e2)
+end
+function c91449532.spfilter(c,e,tp)
+	return c:IsSetCard(0x9f) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c91449532.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c91449532.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+end
+function c91449532.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c91449532.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
+		local c=e:GetHandler()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
+		Duel.SpecialSummonComplete()
+	end
+end
+function c91449532.postg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAttackPos,tp,LOCATION_MZONE,0,1,nil) end
+end
+function c91449532.posop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(Card.IsAttackPos,tp,LOCATION_MZONE,0,nil)
+	if g:GetCount()>0 then
+		Duel.ChangePosition(g,POS_FACEUP_DEFENSE)
+	end
+end

--- a/c92353449.lua
+++ b/c92353449.lua
@@ -1,0 +1,37 @@
+--レッドアイズ・インサイト
+function c92353449.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,92353449+EFFECT_COUNT_CODE_OATH)
+	e1:SetCost(c92353449.cost)
+	e1:SetTarget(c92353449.target)
+	e1:SetOperation(c92353449.activate)
+	c:RegisterEffect(e1)
+end
+function c92353449.cfilter(c)
+	return c:IsSetCard(0x3b) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
+end
+function c92353449.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c92353449.cfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c92353449.cfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c92353449.thfilter(c)
+	return c:IsSetCard(0x3b) and c:IsType(TYPE_SPELL+TYPE_TRAP) and not c:IsCode(92353449) and c:IsAbleToHand()
+end
+function c92353449.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c92353449.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c92353449.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c92353449.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/c93665266.lua
+++ b/c93665266.lua
@@ -1,0 +1,59 @@
+--水晶機巧－クオン
+function c93665266.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(93665266,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_MAIN_END+TIMING_BATTLE_START+TIMING_BATTLE_END)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,93665266)
+	e1:SetCondition(c93665266.sccon)
+	e1:SetTarget(c93665266.sctg)
+	e1:SetOperation(c93665266.scop)
+	c:RegisterEffect(e1)
+end
+function c93665266.sccon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return not e:GetHandler():IsStatus(STATUS_CHAINING) and Duel.GetTurnPlayer()~=tp
+		and (ph==PHASE_MAIN1 or (ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE) or ph==PHASE_MAIN2)
+end
+function c93665266.scfilter1(c,e,tp,mc)
+	local mg=Group.FromCards(c,mc)
+	return not c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(c93665266.scfilter2,tp,LOCATION_EXTRA,0,1,nil,mg)
+end
+function c93665266.scfilter2(c,mg)
+	return c:IsRace(RACE_MACHINE) and c:IsSynchroSummonable(nil,mg)
+end
+function c93665266.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanSpecialSummonCount(tp,2)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c93665266.scfilter1,tp,LOCATION_HAND,0,1,nil,e,tp,e:GetHandler()) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c93665266.scop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local c=e:GetHandler()
+	local g=Duel.SelectMatchingCard(tp,c93665266.scfilter1,tp,LOCATION_HAND,0,1,1,nil,e,tp,c)
+	local tc=g:GetFirst()
+	if not tc or not Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	tc:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_DISABLE_EFFECT)
+	tc:RegisterEffect(e2)
+	Duel.SpecialSummonComplete()
+	if not c:IsRelateToEffect(e) then return end
+	local mg=Group.FromCards(c,tc)
+	local g=Duel.GetMatchingGroup(c93665266.scfilter2,tp,LOCATION_EXTRA,0,nil,mg)
+	if g:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=g:Select(tp,1,1,nil)
+		Duel.SynchroSummon(tp,sg:GetFirst(),nil,mg)
+	end
+end

--- a/c94388754.lua
+++ b/c94388754.lua
@@ -1,0 +1,59 @@
+--花札衛－萩に猪－
+function c94388754.initial_effect(c)
+	c:EnableReviveLimit()
+	--spsummon from hand
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetCondition(c94388754.hspcon)
+	e1:SetOperation(c94388754.hspop)
+	c:RegisterEffect(e1)
+	--draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(94388754,0))
+	e2:SetCategory(CATEGORY_DRAW+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetTarget(c94388754.target)
+	e2:SetOperation(c94388754.operation)
+	c:RegisterEffect(e2)
+end
+function c94388754.hspfilter(c)
+	return c:IsSetCard(0xe6) and not c:IsCode(94388754)
+end
+function c94388754.hspcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>-1
+		and Duel.CheckReleaseGroup(c:GetControler(),c94388754.hspfilter,1,nil)
+end
+function c94388754.hspop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(c:GetControler(),c94388754.hspfilter,1,1,nil)
+	Duel.Release(g,REASON_COST)
+end
+function c94388754.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c94388754.operation(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	if Duel.Draw(p,d,REASON_EFFECT)~=0 then
+		local tc=Duel.GetOperatedGroup():GetFirst()
+		Duel.ConfirmCards(1-tp,tc)
+		if tc:IsType(TYPE_MONSTER) and tc:IsSetCard(0xe6) then
+			local g=Duel.GetMatchingGroup(Card.IsDestructable,tp,0,LOCATION_MZONE,nil)
+			if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(94388754,1)) then
+				Duel.BreakEffect()
+				local sg=g:Select(tp,1,1,nil)
+				Duel.Destroy(sg,REASON_EFFECT)
+			end
+		else
+			Duel.BreakEffect()
+			Duel.SendtoGrave(tc,REASON_EFFECT)
+		end
+		Duel.ShuffleHand(tp)
+	end
+end

--- a/c95500396.lua
+++ b/c95500396.lua
@@ -1,0 +1,90 @@
+--超重武者装留チュウサイ
+function c95500396.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_HAND+LOCATION_MZONE)
+	e1:SetTarget(c95500396.eqtg)
+	e1:SetOperation(c95500396.eqop)
+	c:RegisterEffect(e1)
+end
+function c95500396.eqfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x9a)
+end
+function c95500396.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c95500396.eqfilter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c95500396.eqfilter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c95500396.eqfilter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+end
+function c95500396.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if c:IsLocation(LOCATION_MZONE) and c:IsFacedown() then return end
+	local tc=Duel.GetFirstTarget()
+	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 or tc:GetControler()~=tp or tc:IsFacedown() or not tc:IsRelateToEffect(e) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	Duel.Equip(tp,c,tc,true)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_EQUIP_LIMIT)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	e1:SetValue(c95500396.eqlimit)
+	e1:SetLabelObject(tc)
+	c:RegisterEffect(e1)
+	--atk limit
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_SELECT_BATTLE_TARGET)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetTargetRange(0,LOCATION_MZONE)
+	e2:SetValue(c95500396.atlimit)
+	e2:SetLabelObject(tc)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	c:RegisterEffect(e2)
+	--spsummon
+	local e3=Effect.CreateEffect(c)
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCountLimit(1,95500396)
+	e3:SetCost(c95500396.spcost)
+	e3:SetTarget(c95500396.sptg)
+	e3:SetOperation(c95500396.spop)
+	e3:SetReset(RESET_EVENT+0x1fe0000)
+	c:RegisterEffect(e3)
+end
+function c95500396.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end
+function c95500396.atlimit(e,c)
+	return c~=e:GetLabelObject()
+end
+function c95500396.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local tc=c:GetEquipTarget()
+	if chk==0 then return c:GetControler()==tc:GetControler() and tc:IsReleasable() end
+	Duel.Release(tc,REASON_COST)
+end
+function c95500396.spfilter(c,e,tp)
+	return c:IsSetCard(0x9a) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c95500396.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c95500396.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c95500396.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c95500396.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c96622984.lua
+++ b/c96622984.lua
@@ -1,0 +1,69 @@
+--捕食植物フライ・ヘル
+function c96622984.initial_effect(c)
+	--add counter
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(96622984,0))
+	e1:SetCategory(CATEGORY_COUNTER)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c96622984.target)
+	e1:SetOperation(c96622984.operation)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(96622984,1))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_BATTLE_START)
+	e2:SetTarget(c96622984.destg)
+	e2:SetOperation(c96622984.desop)
+	c:RegisterEffect(e2)
+end
+function c96622984.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsCanAddCounter(0x1141,1) end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,nil,0x1141,1) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectTarget(tp,Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,1,nil,0x1141,1)
+	Duel.SetOperationInfo(0,CATEGORY_COUNTER,nil,1,0,0)
+end
+function c96622984.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsCanAddCounter(0x1141,1) then
+		tc:AddCounter(0x1141,1)
+		if tc:GetLevel()>1 then
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_CHANGE_LEVEL)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			e1:SetCondition(c96622984.lvcon)
+			e1:SetValue(1)
+			tc:RegisterEffect(e1)
+		end
+	end
+end
+function c96622984.lvcon(e)
+	return e:GetHandler():GetCounter(0x1141)>0
+end
+function c96622984.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local tc=c:GetBattleTarget()
+	if chk==0 then return tc and tc:IsFaceup() and tc:IsLevelBelow(c:GetLevel()) and tc:IsDestructable() end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tc,1,0,0)
+end
+function c96622984.desop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=c:GetBattleTarget()
+	if tc:IsRelateToBattle() and Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.BreakEffect()
+		tc=Duel.GetOperatedGroup():GetFirst()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
+		e1:SetCode(EFFECT_UPDATE_LEVEL)
+		e1:SetValue(tc:GetOriginalLevel())
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e1)
+	end
+end

--- a/c96622984.lua
+++ b/c96622984.lua
@@ -22,16 +22,16 @@ function c96622984.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c96622984.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsCanAddCounter(0x1141,1) end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,nil,0x1141,1) end
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsCanAddCounter(0x1041,1) end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,nil,0x1041,1) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectTarget(tp,Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,1,nil,0x1141,1)
+	local g=Duel.SelectTarget(tp,Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,1,nil,0x1041,1)
 	Duel.SetOperationInfo(0,CATEGORY_COUNTER,nil,1,0,0)
 end
 function c96622984.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsCanAddCounter(0x1141,1) then
-		tc:AddCounter(0x1141,1)
+	if tc:IsRelateToEffect(e) and tc:IsCanAddCounter(0x1041,1) then
+		tc:AddCounter(0x1041,1)
 		if tc:GetLevel()>1 then
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
@@ -44,7 +44,7 @@ function c96622984.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c96622984.lvcon(e)
-	return e:GetHandler():GetCounter(0x1141)>0
+	return e:GetHandler():GetCounter(0x1041)>0
 end
 function c96622984.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c99274184.lua
+++ b/c99274184.lua
@@ -1,0 +1,73 @@
+--クリストロン・インパクト
+function c99274184.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c99274184.target)
+	e1:SetOperation(c99274184.activate)
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(99274184,0))
+	e2:SetCategory(CATEGORY_DISABLE+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCondition(c99274184.discon)
+	e2:SetCost(c99274184.discost)
+	e2:SetTarget(c99274184.distg)
+	e2:SetOperation(c99274184.disop)
+	c:RegisterEffect(e2)
+end
+function c99274184.filter(c,e,tp)
+	return c:IsFaceup() and c:IsSetCard(0xea) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c99274184.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_REMOVED) and c99274184.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c99274184.filter,tp,LOCATION_REMOVED,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c99274184.filter,tp,LOCATION_REMOVED,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c99274184.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+		local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+		if g:GetCount()>0 then
+			local sc=g:GetFirst()
+			while sc do
+				local e1=Effect.CreateEffect(e:GetHandler())
+				e1:SetType(EFFECT_TYPE_SINGLE)
+				e1:SetCode(EFFECT_SET_DEFENSE_FINAL)
+				e1:SetValue(0)
+				e1:SetReset(RESET_EVENT+0x1fe0000)
+				sc:RegisterEffect(e1)
+				sc=g:GetNext()
+			end
+		end
+	end
+end
+function c99274184.tgfilter(c,tp)
+	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsSetCard(0xea)
+end
+function c99274184.discon(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return tg and tg:IsExists(c99274184.tgfilter,1,nil,tp) and Duel.IsChainDisablable(ev)
+		and aux.exccon(e,tp,eg,ep,ev,re,r,rp)
+end
+function c99274184.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c99274184.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c99274184.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
+end

--- a/c99397762.lua
+++ b/c99397762.lua
@@ -1,0 +1,41 @@
+--光波防輪
+function c99397762.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c99397762.target)
+	e1:SetOperation(c99397762.activate)
+	c:RegisterEffect(e1)
+end
+function c99397762.filter(c)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and (c:IsSetCard(0x107b) or c:IsSetCard(0xe5))
+end
+function c99397762.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c99397762.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and Duel.IsExistingTarget(c99397762.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,c99397762.filter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c99397762.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) and c:IsRelateToEffect(e) then
+		c:CancelToGrave()
+		Duel.Overlay(tc,Group.FromCards(c))
+		--
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_INDESTRUCTABLE_COUNT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetCountLimit(1)
+		e1:SetValue(c99397762.indval)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+	end
+end
+function c99397762.indval(e,re,r,rp)
+	return bit.band(r,REASON_BATTLE+REASON_EFFECT)~=0
+end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=1&sess=1&pid=1119001&rp=99999

Scripts are from https://github.com/Fluorohydride/ygopro-pre-script

Some cards were not included:

1. _フルメタルフォーゼ・アルカエスト/Fullmetalfoes Alkahest_ and the other Metalfoes fusion monsters
I don't know how should we make _Super Polymerization_ can use opponent's equip cards.
Temp code for reference:
https://github.com/Fluorohydride/ygopro-pre-script/blob/master/scripts/INOV-JP/c77693536.lua
https://github.com/Fluorohydride/ygopro-pre-script/blob/master/scripts/INOV-JP/c4688231.lua
https://github.com/Fluorohydride/ygopro-pre-script/tree/master/scripts/changes%20to%20offical%20cards

2. _機殻の凍結/Qliphort Down_
I think the triple tribute effect need changes to ocgcore.
Temp code for reference:
https://github.com/Fluorohydride/ygopro-pre-script/blob/master/scripts/INOV-JP/c20447641.lua

3. _サモン・ゲート/Summon Gate_
I don't know how to limit the monster count of pendulum summon and the activation of cards like _Rank-Up-Magic - The Seventh One_.
Temp code for reference:
https://github.com/Fluorohydride/ygopro-pre-script/blob/master/scripts/INOV-JP/c29724053.lua