### PR TITLE
fix 次元障壁

### DIFF
--- a/c83326048.lua
+++ b/c83326048.lua
@@ -51,23 +51,10 @@ function c83326048.operation(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetLabel(ct)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e2,tp)
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e3:SetCode(EVENT_CHAIN_SOLVING)
-	e3:SetOperation(c83326048.disop)
-	e3:SetLabel(ct)
-	e3:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e3,tp)
 end
 function c83326048.sumlimit(e,c,sump,sumtype,sumpos,targetp)
 	return c:IsType(e:GetLabel())
 end
 function c83326048.distg(e,c)
 	return c:IsType(e:GetLabel())
-end
-function c83326048.disop(e,tp,eg,ep,ev,re,r,rp)
-	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
-	if tl==LOCATION_MZONE and re:IsActiveType(e:GetLabel()) then
-		Duel.NegateEffect(ev)
-	end
 end


### PR DESCRIPTION
> 「次元障壁」を発動する際に宣言された種類のモンスターは、モンスターゾーンに表側表示で存在する間、その効果が無効化されます。
質問の状況のように、自身をリリースして発動する「ABC－ドラゴン・バスター」のモンスター効果は、融合モンスターを宣言して発動した「次元障壁」の効果が適用されている場合でも、その効果が無効化される事はありません。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19595&keyword=&tag=-1