### PR TITLE
fix Nine Branches of the Yang Zing

### DIFF
--- a/c57831349.lua
+++ b/c57831349.lua
@@ -30,16 +30,14 @@ end
 function c57831349.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()
 	Duel.NegateActivation(ev)
-	if ec:IsRelateToEffect(re) then
-		ec:CancelToGrave()
-		if Duel.SendtoDeck(ec,nil,2,REASON_EFFECT)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
-			local g=Duel.GetMatchingGroup(c57831349.desfilter,tp,LOCATION_ONFIELD,0,e:GetHandler())
-			if g:GetCount()>0 then
-				Duel.BreakEffect()
-				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-				local sg=g:Select(tp,1,1,nil)
-				Duel.Destroy(sg,REASON_EFFECT)
-			end
+	ec:CancelToGrave()
+	if Duel.SendtoDeck(ec,nil,2,REASON_EFFECT)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
+		local g=Duel.GetMatchingGroup(c57831349.desfilter,tp,LOCATION_ONFIELD,0,e:GetHandler())
+		if g:GetCount()>0 then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+			local sg=g:Select(tp,1,1,nil)
+			Duel.Destroy(sg,REASON_EFFECT)
 		end
 	end
 end


### PR DESCRIPTION
even if the negated card is not relate to effect it should be shuffled to the deck

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19516&keyword=&tag=-1
 Question
自分のメインフェイズに相手が、手札から「エフェクト・ヴェーラー」の『①：相手メインフェイズにこのカードを手札から墓地へ送り、相手フィールドの効果モンスター１体を対象として発動できる。その相手モンスターの効果をターン終了時まで無効にする』モンスター効果を発動しました。

その発動にチェーンして「竜星の九支」を発動した場合、処理はどうなりますか？
Answer
自分フィールドに「竜星」と名のついたカードが表側表示で存在する状況で、モンスター効果が発動したのであれば、その発動にチェーンして「竜星の九支」を発動する事はできます。

質問の状況の場合、手札で発動し墓地へ送られた「エフェクト・ヴェーラー」のモンスター効果にチェーンして「竜星の九支」の効果を発動していますので、そのモンスター効果の発動を無効にした後、墓地へ送られている「エフェクト・ヴェーラー」を持ち主のデッキに戻す事になります。

なお、『その後、このカード以外の自分フィールドの「竜星」カード１枚を選んで破壊する』処理も通常通り適用されます。 