### PR TITLE
fix changing level

### DIFF
--- a/c23168060.lua
+++ b/c23168060.lua
@@ -21,7 +21,7 @@ function c23168060.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
 		e1:SetValue(3)
-		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_END)
 		c:RegisterEffect(e1)
 	end
 end

--- a/c26082117.lua
+++ b/c26082117.lua
@@ -38,7 +38,7 @@ function c26082117.op(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
 		e1:SetValue(e:GetLabel())
-		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_END)
 		c:RegisterEffect(e1)
 	end
 end

--- a/c50457953.lua
+++ b/c50457953.lua
@@ -30,7 +30,7 @@ function c50457953.lvop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
 		e1:SetValue(tc:GetLevel())
-		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
 		c:RegisterEffect(e1)
 	end
 end

--- a/c56427559.lua
+++ b/c56427559.lua
@@ -37,7 +37,7 @@ function c56427559.lvop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
 		e1:SetValue(tc:GetLevel())
-		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
 		c:RegisterEffect(e1)
 	end
 end

--- a/c65536818.lua
+++ b/c65536818.lua
@@ -70,7 +70,7 @@ function c65536818.lvop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
 		e1:SetValue(lv)
-		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
 		c:RegisterEffect(e1)
 	end
 end

--- a/c94203886.lua
+++ b/c94203886.lua
@@ -60,7 +60,7 @@ function c94203886.lvop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
 		e1:SetValue(tc:GetLevel())
-		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
 		c:RegisterEffect(e1)
 	end
 end

--- a/c97750534.lua
+++ b/c97750534.lua
@@ -41,7 +41,7 @@ function c97750534.tgop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
 		e1:SetValue(lv)
-		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
 		c:RegisterEffect(e1)
 	end
 end


### PR DESCRIPTION
> Q. 
自身の効果で既にレベル7となっている《ガガガマジシャン》と《源竜星－ボウテンコウ》が存在する時《スキルドレイン》を発動した場合、《ガガガマジシャン》と《源竜星－ボウテンコウ》のレベルはどうなりますか？その後、《サイクロン》で《スキルドレイン》を破壊、《ガガガマジシャン》と《源竜星－ボウテンコウ》のレベルはどうなりますか？ 
A. 
ご質問の状況の場合、「スキルドレイン」の効果が適用された「ガガガマジシャン」のレベルは4、「源竜星－ボウテンコウ」のレベルは5となります。 
また、「スキルドレイン」がフィールドを離れても戻ったレベルのままとなります。

Changing level should be like changing attack, which will reset when disabled.