### PR TITLE
fix Black Garden

### DIFF
--- a/c71645242.lua
+++ b/c71645242.lua
@@ -83,7 +83,7 @@ function c71645242.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 	if bit.band(bit.rshift(ev,1-tp),1)~=0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,71645243,0,0x4011,800,800,2,RACE_PLANT,ATTRIBUTE_DARK) then
-		local token=Duel.CreateToken(1-tp,71645243)
+		local token=Duel.CreateToken(tp,71645243)
 		Duel.SpecialSummonStep(token,0x20,tp,tp,false,false,POS_FACEUP_ATTACK)
 	end
 	Duel.SpecialSummonComplete()


### PR DESCRIPTION
fix: if Remove Brainwashing is on the field, tokens summoned to the field of the controller of black garden currently switch control to the opponent. However, the owner of the tokens should be tp in any case since he summons those, not the opponent.