### PR TITLE
fix Dark Zebra

### DIFF
--- a/c59784896.lua
+++ b/c59784896.lua
@@ -15,7 +15,6 @@ function c59784896.initial_effect(c)
 end
 function c59784896.condition(e,tp,eg,ep,ev,re,r,rp)
 	return tp==Duel.GetTurnPlayer() and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==1
-		and e:GetHandler():IsAttackPos()
 end
 function c59784896.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
@@ -23,13 +22,12 @@ function c59784896.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c59784896.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) then
-		Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
+	if c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) and Duel.ChangePosition(c,POS_FACEUP_DEFENSE)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_COPY_INHERIT)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
 	end
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_COPY_INHERIT)
-	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
-	c:RegisterEffect(e1)
 end


### PR DESCRIPTION
Fix this: If Dark Zebra is Defense Position, Dark Zebra don't actevate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4920
■「ダークゼブラ」が表側守備表示で存在する場合でも、『自分がコントロールするモンスターがこのカードのみ』であれば、効果が発動し、チェーンブロックが作られます
（『このカードは守備表示になる』処理が適用されていませんので、『そのターン表示形式は変更できない』処理は適用されません。）