### PR TITLE
fix Fusion Fright Waltz

### DIFF
--- a/c34449261.lua
+++ b/c34449261.lua
@@ -43,8 +43,9 @@ function c34449261.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	local dam=tg:Filter(Card.IsFaceup,nil):GetSum(Card.GetAttack)
 	local g=Duel.GetMatchingGroup(c34449261.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tg)
-	if g:GetCount()>0 and Duel.Destroy(g,REASON_EFFECT)~=0 then
+	if g:GetCount()>0 and Duel.Destroy(g,REASON_EFFECT)~=0 and dam>0 then
 		local dg=Duel.GetOperatedGroup()
+		Duel.BreakEffect()
 		if dg:IsExists(aux.FilterEqualFunction(Card.GetPreviousControler,tp),1,nil) then Duel.Damage(tp,dam,REASON_EFFECT,true) end
 		if dg:IsExists(aux.FilterEqualFunction(Card.GetPreviousControler,1-tp),1,nil) then Duel.Damage(1-tp,dam,REASON_EFFECT,true) end
 		Duel.RDComplete()


### PR DESCRIPTION
Fix this: The "destroy as many other Special Summoned monsters on the field as possible" and the "each player that had a monster(s) destroyed by this effect takes damage equal to the combined current ATK of the targeted monster(s) on the field" are the same.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12468
■『対象のモンスター以外の、フィールドの特殊召喚されたモンスターを全て破壊する』処理と、『その後、この効果でモンスターを破壊されたプレイヤーは、対象のモンスターの攻撃力の合計分のダメージを受ける』処理は同時に行われる扱いではありません。