### PR TITLE
fix Tuner's High

### DIFF
--- a/c85821180.lua
+++ b/c85821180.lua
@@ -5,6 +5,7 @@ function c85821180.initial_effect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetLabel(0)
 	e1:SetCost(c85821180.cost)
 	e1:SetTarget(c85821180.target)
 	e1:SetOperation(c85821180.activate)
@@ -12,27 +13,36 @@ function c85821180.initial_effect(c)
 end
 function c85821180.cfilter(c,e,tp)
 	return c:IsType(TYPE_MONSTER) and c:IsDiscardable()
-		and Duel.IsExistingMatchingCard(c85821180.filter,tp,LOCATION_DECK,0,1,nil,e,tp,c)
+		and Duel.IsExistingMatchingCard(c85821180.filter,tp,LOCATION_DECK,0,1,nil,c:GetRace(),c:GetAttribute(),c:GetLevel(),e,tp)
 end
-function c85821180.filter(c,e,tp,dc)
-	return c:IsType(TYPE_TUNER) and c:IsRace(dc:GetRace()) and c:IsAttribute(dc:GetAttribute())
-		and c:GetLevel()==dc:GetLevel()+1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+function c85821180.filter(c,race,att,lv,e,tp)
+	return c:IsType(TYPE_TUNER) and c:IsRace(race) and c:IsAttribute(att) and c:GetLevel()==lv+1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c85821180.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c85821180.cfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
-	local g=Duel.SelectMatchingCard(tp,c85821180.cfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
-	Duel.SendtoGrave(g,REASON_COST+REASON_DISCARD)
-	e:SetLabelObject(g:GetFirst())
+	e:SetLabel(100)
+	return true
 end
 function c85821180.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 end
+	if chk==0 then
+		if e:GetLabel()~=100 or Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return false end
+		return Duel.IsExistingMatchingCard(c85821180.cfilter,tp,LOCATION_HAND,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
+	local g=Duel.SelectMatchingCard(tp,c85821180.cfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	e:SetLabel(tc:GetRace())
+	e:SetValue(tc:GetAttribute())
+	Duel.SetTargetParam(tc:GetLevel())
+	Duel.SendtoGrave(g,REASON_COST+REASON_DISCARD)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c85821180.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local race=e:GetLabel()
+	local att=e:GetValue()
+	local lv=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c85821180.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp,e:GetLabelObject())
+	local g=Duel.SelectMatchingCard(tp,c85821180.filter,tp,LOCATION_DECK,0,1,1,nil,race,att,lv,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end


### PR DESCRIPTION
Fix 1: You can activate Tuner's High by Diamond Dude's effect.
Fix 2: If Zombie World has on the field, player cannot Special Summoned monster except Zombie-Type.
Fix 3: Cost Down activated turn, player cannot Special Summon monster with the 1 Level lower than the discarded monster.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18069&keyword=&tag=-1
Q.「アンデットワールド」の『このカードがフィールド上に存在する限り、フィールド上及び墓地に存在する全てのモンスターをアンデット族として扱う』効果の適用中に、手札の「トップ・ランナー」を捨てて、「チューナーズ・ハイ」を発動する事はできますか？
A.「アンデットワールド」の効果が適用されている場合でも、「チューナーズ・ハイ」を発動する事はできます。

質問の状況の場合、手札から捨てた「トップ・ランナー」は機械族・風属性・レベル4のモンスターとなりますので、『そのモンスターと同じ種族・属性でレベルが１つ高いチューナー１体をデッキから特殊召喚する』処理によって、デッキから機械族・風属性・レベル5の「クイック・シンクロン」を特殊召喚する事になります。 

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18071&keyword=&tag=-1
Q.「コストダウン」の『手札を１枚捨てる。自分の手札にある全てのモンスターカードのレベルを、発動ターンのエンドフェイズまで２つ下げる』効果が適用されているターンです。

このターンに、手札の「ジャンク・シンクロン」を捨てて、「チューナーズ・ハイ」を発動した場合、処理はどうなりますか？
A.質問の状況の場合、手札から捨てた「ジャンク・シンクロン」は「コストダウン」の効果によってレベルが2つ下がっていますので、手札から戦士族・闇属性・レベル1のモンスターを捨てた事になります。

したがって、『そのモンスターと同じ種族・属性でレベルが１つ高いチューナー１体をデッキから特殊召喚する』処理によって、デッキから戦士族・闇属性・レベル2の「トラパート」を特殊召喚する事になります。 