### PR TITLE
fix Performapal Rain Goat

### DIFF
--- a/c16617334.lua
+++ b/c16617334.lua
@@ -7,7 +7,7 @@ function c16617334.initial_effect(c)
 	e1:SetCode(EVENT_CHAINING)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
-	e1:SetCondition(c16617334.condition)
+	e1:SetCondition(aux.damcon1)
 	e1:SetCost(c16617334.effcost)
 	e1:SetOperation(c16617334.operation)
 	c:RegisterEffect(e1)
@@ -27,12 +27,6 @@ end
 function c16617334.effcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
-end
-function c16617334.condition(e,tp,eg,ep,ev,re,r,rp)
-	local ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_DAMAGE)
-	if ex then return true end
-	ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_RECOVER)
-	return ex
 end
 function c16617334.operation(e,tp,eg,ep,ev,re,r,rp)
 	local cid=Duel.GetChainInfo(ev,CHAININFO_CHAIN_ID)


### PR DESCRIPTION
Fix this :When a card or effect is activated that would recover LP, Performapal Rain Goat can activate effect.