### PR TITLE
fix Ancient Telescope

### DIFF
--- a/c17092736.lua
+++ b/c17092736.lua
@@ -10,12 +10,18 @@ function c17092736.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c17092736.cftg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_DECK)>=5 end
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_DECK)>0 end
 	Duel.SetTargetPlayer(tp)
 end
 function c17092736.cfop(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
-	local g=Duel.GetDecktopGroup(1-p,5)
+	local ct=math.min(5,Duel.GetFieldGroupCount(p,0,LOCATION_DECK))
+	local t={}
+	for i=1,ct do
+		t[i]=i
+	end
+	local ac=Duel.AnnounceNumber(p,table.unpack(t))
+	local g=Duel.GetDecktopGroup(1-p,ac)
 	if g:GetCount()>0 then
 		Duel.ConfirmCards(p,g)
 	end


### PR DESCRIPTION
Fix 1: Player cannot confirm 4 or less cards from the top of opponent Deck.
Fix 2: Player cannot activate Ancient Telescope if opponent have 4 or less cards in opponent's Deck.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4852
■確認するカードの枚数は効果処理時に1～5枚を選びます。
■相手のデッキの枚数が5枚未満の場合でも、相手のデッキが0枚の状態でなければ、「古代の遠眼鏡」を発動する事はできます。