### PR TITLE
fix Enchanting Fitting Room

### DIFF
--- a/c30531525.lua
+++ b/c30531525.lua
@@ -19,6 +19,7 @@ function c30531525.filter(c,e,tp)
 end
 function c30531525.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>3
 		and Duel.IsExistingMatchingCard(c30531525.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
 end
 function c30531525.activate(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix this: Player can activate Enchanting Fitting Room if player have 3 or less cards in player's Deck.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6055
■自分のデッキが3枚以下の場合、「魔の試着部屋」を発動する事はできません。