### PR TITLE
fix Gandora the Dragon of Destruction

### DIFF
--- a/c64681432.lua
+++ b/c64681432.lua
@@ -46,13 +46,13 @@ function c64681432.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c64681432.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c) end
-	local sg=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c) end
+	local sg=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 end
 function c64681432.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local sg=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
+	local sg=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
 	local ct=Duel.Destroy(sg,REASON_EFFECT,LOCATION_REMOVED)
 	if ct>0 and c:IsFaceup() and c:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)


### PR DESCRIPTION
Fix this: If _Imperial Iron Wall_ has on the field, _Gandora the Dragon of Destruction_ can activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7458&keyword=&tag=-1
「王宮の鉄壁」の効果が適用されている時に、「抹殺の使徒」や「奈落の落とし穴」、「破壊竜ガンドラ」等の効果を発動する事はできません。