### PR TITLE
fix The Creator

### DIFF
--- a/c61505339.lua
+++ b/c61505339.lua
@@ -36,8 +36,7 @@ function c61505339.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local sg=Duel.SelectMatchingCard(tp,Card.IsAbleToGrave,tp,LOCATION_HAND,0,1,1,nil)
 	if sg:GetCount()==0 then return end
-	Duel.SendtoGrave(sg,REASON_EFFECT)
-	Duel.BreakEffect()
+	if Duel.SendtoGrave(sg,REASON_EFFECT)==0 or not sg:GetFirst():IsLocation(LOCATION_GRAVE) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
Fix 1: The "send 1 card from your hand to the Graveyard" and the "Special Summon that target" are not the same.
Fix 2: If the sending card from your hand was banished by Macro Cosmos's effect, target monster Special Summon.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6176
■『手札を１枚墓地に送り』の処理と、『選択したモンスター１体を特殊召喚する』処理は同時に行われる扱いとなります。