### PR TITLE
fix Destiny HERO - Captain Tenacious

### DIFF
--- a/c77608643.lua
+++ b/c77608643.lua
@@ -15,6 +15,7 @@ function c77608643.initial_effect(c)
 	e2:SetDescription(aux.Stringid(77608643,0))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetCountLimit(1)
 	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
@@ -45,16 +46,18 @@ end
 function c77608643.spfilter(c,e,tp)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
-function c77608643.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c77608643.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return e:GetLabelObject():IsContains(chkc) and c77608643.spfilter(chkc,e,tp) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetLabelObject():IsExists(c77608643.spfilter,1,nil,e,tp) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE)
-end
-function c77608643.spop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=e:GetLabelObject():FilterSelect(tp,c77608643.spfilter,1,1,nil,e,tp)
-	if g:GetCount()~=0 then
-		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	Duel.SetTargetCard(g)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c77608643.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
Fix this: Captain Tenacious's effect is not target effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6659
■特殊召喚するモンスター1体を対象に取る効果です。