### PR TITLE
fix "when oppponent's monster declares an attack" conditions

### DIFF
--- a/c10759529.lua
+++ b/c10759529.lua
@@ -11,7 +11,7 @@ function c10759529.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c10759529.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c10759529.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsCode,1,nil,32679370) end

--- a/c12216615.lua
+++ b/c12216615.lua
@@ -11,10 +11,10 @@ function c12216615.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c12216615.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_GRAVE,0,2,nil,36623431)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_GRAVE,0,2,nil,36623431)
 end
 function c12216615.filter(c)
-	return c:IsPosition(POS_FACEUP_ATTACK)
+	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsDestructable()
 end
 function c12216615.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c12216615.filter,tp,0,LOCATION_MZONE,1,nil) end

--- a/c1224927.lua
+++ b/c1224927.lua
@@ -11,10 +11,10 @@ function c1224927.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c1224927.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c1224927.filter(c)
-	return c:IsType(TYPE_SPELL+TYPE_TRAP)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsDestructable()
 end
 function c1224927.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c14315573.lua
+++ b/c14315573.lua
@@ -11,7 +11,7 @@ function c14315573.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c14315573.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c14315573.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c14430063.lua
+++ b/c14430063.lua
@@ -14,7 +14,7 @@ function c14430063.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c14430063.damcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsPosition(POS_FACEUP_ATTACK) and Duel.GetTurnPlayer()~=tp
+	return e:GetHandler():IsPosition(POS_FACEUP_ATTACK) and Duel.GetAttacker():IsControler(1-tp)
 end
 function c14430063.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsRelateToEffect(e) end

--- a/c20522190.lua
+++ b/c20522190.lua
@@ -11,10 +11,10 @@ function c20522190.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c20522190.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c20522190.filter(c)
-	return c:IsDefensePos() and c:IsAbleToRemove()
+	return c:IsDefencePos() and c:IsAbleToRemove()
 end
 function c20522190.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c20522190.filter,tp,0,LOCATION_MZONE,1,nil) end

--- a/c21481146.lua
+++ b/c21481146.lua
@@ -11,10 +11,10 @@ function c21481146.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c21481146.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.IsExistingMatchingCard(Card.IsPosition,tp,0,LOCATION_MZONE,3,nil,POS_FACEUP_ATTACK)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(Card.IsPosition,tp,0,LOCATION_MZONE,3,nil,POS_FACEUP_ATTACK)
 end
 function c21481146.filter(c)
-	return c:IsAttackPos()
+	return c:IsAttackPos() and c:IsDestructable()
 end
 function c21481146.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c21481146.filter,tp,0,LOCATION_MZONE,1,nil) end

--- a/c21558682.lua
+++ b/c21558682.lua
@@ -21,7 +21,7 @@ function c21558682.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c21558682.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.GetAttackTarget()~=nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()~=nil
 end
 function c21558682.filter(c,atg)
 	return c:IsFaceup() and c:IsCode(31709826) and atg:IsContains(c)
@@ -34,7 +34,7 @@ function c21558682.atktg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	end
 	if chk==0 then return true end
 	e:SetProperty(0)
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer() then
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp) then
 		local at=Duel.GetAttackTarget()
 		local atg=Duel.GetAttacker():GetAttackableTarget()
 		if at and Duel.IsExistingTarget(c21558682.filter,tp,LOCATION_MZONE,0,1,at,atg)

--- a/c21597117.lua
+++ b/c21597117.lua
@@ -11,7 +11,7 @@ function c21597117.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c21597117.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c21597117.spfilter(c,e,tp)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c21598948.lua
+++ b/c21598948.lua
@@ -31,12 +31,12 @@ function c21598948.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c21598948.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c21598948.atktg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	e:SetLabel(0)
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer() then
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp) then
 		e:SetLabel(1)
 		Duel.SetTargetCard(Duel.GetAttacker())
 		Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)

--- a/c22047978.lua
+++ b/c22047978.lua
@@ -11,7 +11,7 @@ function c22047978.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c22047978.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c22047978.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tg=Duel.GetAttacker()

--- a/c22991179.lua
+++ b/c22991179.lua
@@ -19,7 +19,7 @@ function c22991179.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c22991179.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c22991179.cfilter(c)
 	return c:IsRace(RACE_INSECT) and c:IsAbleToRemoveAsCost()

--- a/c24673894.lua
+++ b/c24673894.lua
@@ -11,7 +11,7 @@ function c24673894.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c24673894.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c24673894.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c25642998.lua
+++ b/c25642998.lua
@@ -12,7 +12,7 @@ function c25642998.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c25642998.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c25642998.dfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_FISH+RACE_SEASERPENT+RACE_AQUA)

--- a/c26533075.lua
+++ b/c26533075.lua
@@ -23,7 +23,7 @@ function c26533075.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c26533075.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c26533075.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c36378044.lua
+++ b/c36378044.lua
@@ -28,12 +28,12 @@ function c36378044.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c36378044.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c36378044.atktg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	e:SetLabel(0)
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer()
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
 		and Duel.SelectYesNo(tp,aux.Stringid(36378044,1)) then
 		e:SetLabel(1)
 		Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,3)

--- a/c36708764.lua
+++ b/c36708764.lua
@@ -11,7 +11,7 @@ function c36708764.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c36708764.condition(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c36708764.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c37390589.lua
+++ b/c37390589.lua
@@ -23,7 +23,7 @@ function c37390589.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 			return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup()
 		else return false end
 	end
-	local b1=Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetTurnPlayer()~=tp
+	local b1=Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
 		and Duel.GetAttacker():IsLocation(LOCATION_MZONE) and Duel.GetAttacker():IsCanBeEffectTarget(e)
 	local b2=Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil)
 	if chk==0 then return b1 or b2 end

--- a/c37507488.lua
+++ b/c37507488.lua
@@ -12,7 +12,7 @@ function c37507488.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37507488.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()==1-tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c37507488.filter(c)
 	return c:IsAbleToHand()

--- a/c39537362.lua
+++ b/c39537362.lua
@@ -22,7 +22,7 @@ function c39537362.initial_effect(c)
 end
 function c39537362.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer()
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
 		and Duel.SelectYesNo(tp,aux.Stringid(39537362,1)) then 
 		e:SetLabel(1)
 		Duel.SetTargetCard(Duel.GetAttacker())
@@ -30,7 +30,7 @@ function c39537362.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	else e:SetLabel(0) end
 end
 function c39537362.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c39537362.target2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING) end

--- a/c40838625.lua
+++ b/c40838625.lua
@@ -11,7 +11,7 @@ function c40838625.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c40838625.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c40838625.filter(c)
 	return c:IsAttackPos() and c:IsCanTurnSet()

--- a/c43250041.lua
+++ b/c43250041.lua
@@ -12,7 +12,7 @@ function c43250041.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c43250041.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c43250041.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c43452193.lua
+++ b/c43452193.lua
@@ -12,7 +12,7 @@ function c43452193.initial_effect(c)
 end
 function c43452193.condition(e,tp,eg,ep,ev,re,r,rp)
 	local at=Duel.GetAttackTarget()
-	return Duel.GetTurnPlayer()~=tp and at and at:IsFaceup() and at:IsSetCard(0x3008)
+	return at and Duel.GetAttacker():IsControler(1-tp) and at:IsFaceup() and at:IsSetCard(0x3008)
 end
 function c43452193.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local a=Duel.GetAttacker()

--- a/c44046281.lua
+++ b/c44046281.lua
@@ -46,7 +46,7 @@ function c44046281.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c44046281.tgcon(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp and Duel.GetAttackTarget()==nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 end
 function c44046281.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c44095762.lua
+++ b/c44095762.lua
@@ -11,7 +11,7 @@ function c44095762.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c44095762.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c44095762.filter(c)
 	return c:IsAttackPos()

--- a/c44509898.lua
+++ b/c44509898.lua
@@ -12,7 +12,7 @@ function c44509898.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c44509898.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c44509898.filter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c4483989.lua
+++ b/c4483989.lua
@@ -22,13 +22,13 @@ function c4483989.initial_effect(c)
 end
 function c4483989.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local at=Duel.GetAttackTarget()
-	return tp~=Duel.GetTurnPlayer() and at and at:IsPosition(POS_FACEUP_DEFENSE)
+	return at and Duel.GetAttacker():IsControler(1-tp) and at:IsPosition(POS_FACEUP_DEFENSE)
 end
 function c4483989.atktg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	e:SetLabel(0)
 	local at=Duel.GetAttackTarget()
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer()
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
 		and at and at:IsPosition(POS_FACEUP_DEFENSE) then
 		e:SetLabel(1)
 		Duel.GetAttacker():CreateEffectRelation(e)

--- a/c44883600.lua
+++ b/c44883600.lua
@@ -19,7 +19,7 @@ function c44883600.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c44883600.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.IsExistingMatchingCard(Card.IsPosition,tp,LOCATION_MZONE,0,2,nil,POS_FACEUP_DEFENSE)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(Card.IsPosition,tp,LOCATION_MZONE,0,2,nil,POS_FACEUP_DEFENSE)
 end
 function c44883600.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c45118716.lua
+++ b/c45118716.lua
@@ -15,7 +15,7 @@ function c45118716.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c45118716.condition(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c45118716.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end

--- a/c4923662.lua
+++ b/c4923662.lua
@@ -13,7 +13,7 @@ function c4923662.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c4923662.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c4923662.cost(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,nil,1,nil) end

--- a/c50491121.lua
+++ b/c50491121.lua
@@ -15,7 +15,7 @@ function c50491121.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c50491121.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c50491121.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0x6f)

--- a/c52575195.lua
+++ b/c52575195.lua
@@ -32,7 +32,7 @@ function c52575195.tgcon1(e,tp,eg,ep,ev,re,r,rp)
 		and tc:IsAttribute(ATTRIBUTE_LIGHT) and tc:IsRace(RACE_BEASTWARRIOR)
 end
 function c52575195.tgcon2(e,tp,eg,ep,ev,re,r,rp)
-	if tp==Duel.GetTurnPlayer() then return false end
+	if Duel.GetAttacker():IsControler(tp) then return false end
 	local tc=Duel.GetAttackTarget()
 	e:SetLabelObject(tc)
 	return tc and tc:IsFaceup() and tc:IsAttribute(ATTRIBUTE_LIGHT) and tc:IsRace(RACE_BEASTWARRIOR)

--- a/c56051648.lua
+++ b/c56051648.lua
@@ -11,7 +11,7 @@ function c56051648.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c56051648.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.GetAttackTarget()==nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 		and Duel.IsExistingMatchingCard(Card.IsRace,tp,LOCATION_GRAVE,0,3,nil,RACE_INSECT)
 end
 function c56051648.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c56339050.lua
+++ b/c56339050.lua
@@ -23,10 +23,9 @@ end
 function c56339050.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc==Duel.GetAttacker() end
 	if chk==0 then return true end
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetTurnPlayer()~=tp then
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) then
 		local tc=Duel.GetAttacker()
-		if Duel.IsExistingMatchingCard(c56339050.cfilter,tp,LOCATION_MZONE,0,1,nil,tc:GetAttack())
-			and tc:IsOnField() and tc:IsCanBeEffectTarget(e) then
+		if tc:IsControler(1-tp) and Duel.IsExistingMatchingCard(c56339050.cfilter,tp,LOCATION_MZONE,0,1,nil,tc:GetAttack()) and tc:IsOnField() and tc:IsCanBeEffectTarget(e) then
 			e:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
 			e:SetProperty(EFFECT_FLAG_CARD_TARGET)
 			Duel.SetTargetCard(tc)
@@ -55,7 +54,7 @@ function c56339050.cfilter(c,atk)
 end
 function c56339050.condition2(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetAttacker()
-	return Duel.GetTurnPlayer()~=tp and Duel.IsExistingMatchingCard(c56339050.cfilter,tp,LOCATION_MZONE,0,1,nil,tc:GetAttack())
+	return tc:IsControler(1-tp) and Duel.IsExistingMatchingCard(c56339050.cfilter,tp,LOCATION_MZONE,0,1,nil,tc:GetAttack())
 end
 function c56339050.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tc=Duel.GetAttacker()

--- a/c5650082.lua
+++ b/c5650082.lua
@@ -11,10 +11,10 @@ function c5650082.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c5650082.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c5650082.filter(c)
-	return c:IsAttackPos() and c:IsAbleToHand()
+	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsAbleToHand()
 end
 function c5650082.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c5650082.filter,tp,0,LOCATION_MZONE,1,nil) end

--- a/c57115864.lua
+++ b/c57115864.lua
@@ -11,7 +11,7 @@ function c57115864.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c57115864.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c57115864.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c59560625.lua
+++ b/c59560625.lua
@@ -21,7 +21,7 @@ function c59560625.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c59560625.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c59560625.filter1(c,e)
 	return c:IsCanBeEffectTarget(e)

--- a/c60080151.lua
+++ b/c60080151.lua
@@ -11,7 +11,7 @@ function c60080151.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c60080151.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c60080151.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tg=Duel.GetAttacker()

--- a/c60312997.lua
+++ b/c60312997.lua
@@ -10,7 +10,7 @@ function c60312997.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c60312997.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetAttackTarget()==nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 		and eg:GetFirst():IsLocation(LOCATION_MZONE)
 end
 function c60312997.filter(c,lv)

--- a/c60417395.lua
+++ b/c60417395.lua
@@ -38,7 +38,7 @@ function c60417395.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c60417395.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp
+	return eg:GetFirst():IsControler(1-tp)
 end
 function c60417395.cfilter1(c)
 	return c:IsFaceup() and c:IsRace(RACE_FIEND) and c:IsAbleToGraveAsCost()

--- a/c60534585.lua
+++ b/c60534585.lua
@@ -10,7 +10,7 @@ function c60534585.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c60534585.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetAttackTarget()==nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 		and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
 end
 function c60534585.spfilter(c,e,tp)

--- a/c62271284.lua
+++ b/c62271284.lua
@@ -12,7 +12,7 @@ function c62271284.initial_effect(c)
 end
 function c62271284.condition(e,tp,eg,ep,ev,re,r,rp)
 	local at=Duel.GetAttackTarget()
-	return tp~=Duel.GetTurnPlayer() and at and at:IsFaceup() and at:IsType(TYPE_NORMAL)
+	return at and Duel.GetAttacker():IsControler(1-tp) and at:IsFaceup() and at:IsType(TYPE_NORMAL)
 end
 function c62271284.filter(c)
 	return not (c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:IsAttackPos())

--- a/c65150219.lua
+++ b/c65150219.lua
@@ -21,7 +21,7 @@ function c65150219.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x2b)
 end
 function c65150219.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.IsExistingMatchingCard(c65150219.cfilter,tp,LOCATION_MZONE,0,1,nil)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(c65150219.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c65150219.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end

--- a/c65743242.lua
+++ b/c65743242.lua
@@ -10,7 +10,7 @@ function c65743242.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c65743242.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c65743242.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c67095270.lua
+++ b/c67095270.lua
@@ -9,7 +9,7 @@ function c67095270.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c67095270.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c67095270.activate(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c67630339.lua
+++ b/c67630339.lua
@@ -49,7 +49,7 @@ function c67630339.clear(e,tp,eg,ep,ev,re,r,rp)
 	c67630339[1]=0
 end
 function c67630339.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetAttackTarget()==nil and c67630339[tp]==2
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil and c67630339[tp]==2
 		and c67630339[2]:GetFlagEffect(67630339)~=0 and Duel.GetAttacker()~=c67630339[2]
 end
 function c67630339.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c67987611.lua
+++ b/c67987611.lua
@@ -14,7 +14,7 @@ function c67987611.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x4)
 end
 function c67987611.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.IsExistingMatchingCard(c67987611.cfilter,tp,LOCATION_MZONE,0,1,nil)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.IsExistingMatchingCard(c67987611.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c67987611.filter(c)
 	return not c:IsPosition(POS_FACEUP_ATTACK)

--- a/c70342110.lua
+++ b/c70342110.lua
@@ -12,7 +12,7 @@ function c70342110.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c70342110.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c70342110.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c72885174.lua
+++ b/c72885174.lua
@@ -12,7 +12,7 @@ function c72885174.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c72885174.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.GetAttackTarget()
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()
 end
 function c72885174.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/c75987257.lua
+++ b/c75987257.lua
@@ -23,7 +23,7 @@ function c75987257.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c75987257.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c75987257.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c7617253.lua
+++ b/c7617253.lua
@@ -13,7 +13,7 @@ function c7617253.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c7617253.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c7617253.costfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x1034) and c:IsAbleToGraveAsCost()

--- a/c7864030.lua
+++ b/c7864030.lua
@@ -28,7 +28,7 @@ function c7864030.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c7864030.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and not Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_GRAVE,0,1,nil,TYPE_SPELL+TYPE_TRAP)
+	return Duel.GetAttacker():IsControler(1-tp) and not Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_GRAVE,0,1,nil,TYPE_SPELL+TYPE_TRAP)
 end
 function c7864030.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
@@ -53,7 +53,7 @@ function c7864030.operation1(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c7864030.condition2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetAttackTarget()~=e:GetHandler()
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()~=e:GetHandler()
 end
 function c7864030.operation2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c82340056.lua
+++ b/c82340056.lua
@@ -11,7 +11,7 @@ function c82340056.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c82340056.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetLP(tp)<=3000 and Duel.GetTurnPlayer()~=tp and Duel.GetAttackTarget()==nil
+	return Duel.GetLP(tp)<=3000 and Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 end
 function c82340056.filter(c)
 	return c:IsSetCard(0x21) and c:IsAbleToHand()

--- a/c8279188.lua
+++ b/c8279188.lua
@@ -20,7 +20,7 @@ function c8279188.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c8279188.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c8279188.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c88482761.lua
+++ b/c88482761.lua
@@ -24,7 +24,7 @@ function c88482761.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c88482761.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c88482761.rmfilter1(c,e,tp)
 	return c:IsSetCard(0x2016) and c:IsAbleToRemove()

--- a/c89040386.lua
+++ b/c89040386.lua
@@ -14,16 +14,16 @@ function c89040386.cfilter(c)
 	return c:IsSetCard(0x33) and c:IsType(TYPE_MONSTER)
 end
 function c89040386.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.GetAttackTarget()==nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 		and Duel.IsExistingMatchingCard(c89040386.cfilter,tp,LOCATION_GRAVE,0,5,nil)
 end
 function c89040386.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_MZONE,1,nil) end
-	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_MZONE,nil)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0 end
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c89040386.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_MZONE,nil)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
 	if g:GetCount()>0 then
 		Duel.Destroy(g,REASON_EFFECT)
 	end

--- a/c89041555.lua
+++ b/c89041555.lua
@@ -11,7 +11,8 @@ function c89041555.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c89041555.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and bit.band(eg:GetFirst():GetSummonType(),SUMMON_TYPE_ADVANCE)==SUMMON_TYPE_ADVANCE
+	local tc=eg:GetFirst()
+	return tc:IsControler(1-tp) and bit.band(tc:GetSummonType(),SUMMON_TYPE_ADVANCE)==SUMMON_TYPE_ADVANCE
 end
 function c89041555.filter(c)
 	return c:IsAttackPos()

--- a/c9201964.lua
+++ b/c9201964.lua
@@ -10,7 +10,7 @@ function c9201964.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c9201964.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.GetAttackTarget()==nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 end
 function c9201964.cfilter(c)
 	return c:IsSetCard(0xc008) and c:IsAbleToRemoveAsCost()

--- a/c92773018.lua
+++ b/c92773018.lua
@@ -22,7 +22,7 @@ function c92773018.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c92773018.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c92773018.cfilter(c)
 	return c:IsFaceup() and (c:IsCode(70095154) or aux.IsMaterialListCode(c,70095154)) and c:IsAbleToGraveAsCost()
@@ -37,7 +37,7 @@ function c92773018.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc==Duel.GetAttacker() end
 	if chk==0 then return true end
 	local tg=Duel.GetAttacker()
-	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and tp~=Duel.GetTurnPlayer()
+	if Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetAttacker():IsControler(1-tp)
 		and Duel.IsExistingMatchingCard(c92773018.cfilter,tp,LOCATION_MZONE,0,1,nil)
 		and tg:IsOnField() and tg:IsCanBeEffectTarget(e)
 		and Duel.SelectYesNo(tp,aux.Stringid(92773018,1)) then

--- a/c92854392.lua
+++ b/c92854392.lua
@@ -11,7 +11,7 @@ function c92854392.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c92854392.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c92854392.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local at=Duel.GetAttackTarget()

--- a/c92870717.lua
+++ b/c92870717.lua
@@ -25,7 +25,7 @@ function c92870717.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c92870717.descon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c92870717.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c96008713.lua
+++ b/c96008713.lua
@@ -12,7 +12,7 @@ function c96008713.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c96008713.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer() and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)>0
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)>0
 end
 function c96008713.filter(c)
 	return c:IsFaceup() and c:IsControlerCanBeChanged()

--- a/c96355986.lua
+++ b/c96355986.lua
@@ -12,7 +12,7 @@ function c96355986.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c96355986.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c96355986.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()

--- a/c96427353.lua
+++ b/c96427353.lua
@@ -17,7 +17,7 @@ function c96427353.cfilter(c)
 	return c:IsSetCard(0x2b) and c:IsType(TYPE_MONSTER)
 end
 function c96427353.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetAttackTarget()==nil
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 		and Duel.IsExistingMatchingCard(c96427353.cfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler())
 end
 function c96427353.cost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c96700602.lua
+++ b/c96700602.lua
@@ -11,7 +11,7 @@ function c96700602.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c96700602.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c96700602.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsType,1,nil,TYPE_SYNCHRO) end

--- a/c97705809.lua
+++ b/c97705809.lua
@@ -15,7 +15,7 @@ function c97705809.cfilter(c)
 	return c:IsFacedown() or not c:IsSetCard(0x16) or not c:IsRace(RACE_MACHINE)
 end
 function c97705809.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)~=0
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)~=0
 		and not Duel.IsExistingMatchingCard(c97705809.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c97705809.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c97970833.lua
+++ b/c97970833.lua
@@ -10,7 +10,7 @@ function c97970833.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c97970833.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c97970833.filter(c,tp)
 	return c:IsCode(34487429) and c:GetActivateEffect():IsActivatable(tp)

--- a/c98427577.lua
+++ b/c98427577.lua
@@ -11,7 +11,7 @@ function c98427577.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c98427577.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c98427577.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()


### PR DESCRIPTION
Fixed cards:
- 1224927 Malevolent Catastrophe
- 4483989 Prepare to Strike Back
- 4923662 Chaos Burst
- 5650082 Storming Mirror Force
- 7617253 Rainbow Path
- 7864030 Superheavy Samurai Blowtorch
- 8279188 Depth Amulet
- 9201964 D - Fortune
- 10759529 Kid Guard
- 12216615 Koa'ki Meiru Shield
- 14315573 Negate Attack
- 14430063 Archfiend Interceptor
- 20522190 Dark Mirror Force
- 21481146 Radiant Mirror Force
- 21558682 Jam Defender
- 21597117 A Hero Emerges
- 21598948 Fairy Box
- 22047978 Battle Break
- 22991179 Insect Neglect
- 24673894 Changing Destiny
- 25642998 Poseidon Wave
- 26533075 Security Orb
- 36378044 Lucky Punch
- 36708764 Roulette Spider
- 37390589 Kunai with Chain
- 37507488 Relieve Monster
- 39537362 Ordeal of a Traveler
- 40838625 Sandstorm Mirror Force
- 43250041 Draining Shield
- 43452193 Mirror Gate
- 44046281 Dimension Gate
- 44095762 Mirror Force
- 44509898 Pinpoint Guard
- 44883600 Double Defender
- 45118716 Spell Recycler
- 50491121 Heroic Challenger
- 52575195 Vivid Knight
- 56051648 Spider Egg
- 56339050 Roar of the Earthbound
- 57115864 Lumenize
- 59560625 Shift
- 60080151 Memory of an Adversary
- 60312997 Reanimation Wave
- 60417395 Darkness Neosphere
- 60534585 Battle Instinct
- 62271284 Justi-Break
- 65150219 Armor Ninjitsu Art of Freezing
- 65743242 Call of the Earthbound
- 67095270 Dimension Wall
- 67630339 Confusion Chaff
- 67987611 Amazoness Archers
- 70342110 Dimensional Prison
- 72885174 Slip of Fortune
- 75987257 Butterflyoke
- 82340056 Offering to the Immortals
- 88482761 Dice-Roll Battle
- 89040386 Blackwing - Backlash
- 89041555 Blast Held by a Tribute
- 92773018 Cybernetic Hidden Technology
- 92854392 Staunch Defender
- 92870717 Dragonox, the Empowered Warrior
- 96008713 Magical Arm Shield
- 96355986 Enchanted Javelin
- 96427353 Aqua Armor Ninja
- 96700602 Barrier Wave
- 97705809 Supercharge
- 97970833 Last Resort
- 98427577 Scrap-Iron Scarecrow