### PR TITLE
fix Faustian Bargain

### DIFF
--- a/c68396778.lua
+++ b/c68396778.lua
@@ -31,7 +31,6 @@ function c68396778.activate(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) then
 		Duel.SendtoGrave(tc,REASON_EFFECT)
 		if tc:IsLocation(LOCATION_GRAVE) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
-			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local g=Duel.SelectMatchingCard(tp,c68396778.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 			if g:GetCount()>0 then


### PR DESCRIPTION
Fix this: The "send 1 Special Summoned monster on either side of the field to the Graveyard" and the "Special Summon 1 Level 4 or lower Normal Monster from your hand" are not the same.

Mail:
遊戯王OCG事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。

Q.
「悪魔の貢物」の『フィールド上の特殊召喚されたモンスター１体を選択して墓地へ送り』の処理と、『手札からレベル４以下の通常モンスター１体を特殊召喚する』処理は同時に行われる扱いですか？
A.
「悪魔への貢物」の処理は、それぞれ同時に処理する扱いとなります。