### PR TITLE
fix Bahamut Shark

### DIFF
--- a/c440556.lua
+++ b/c440556.lua
@@ -28,22 +28,16 @@ function c440556.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c440556.spop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local c=e:GetHandler()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c440556.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp)
-	if g:GetCount()>0 then
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c440556.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp)
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetCode(EFFECT_CANNOT_ATTACK)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
-		c:RegisterEffect(e1)
-	else
-		local cg=Duel.GetFieldGroup(tp,LOCATION_EXTRA,0)
-		if cg and cg:GetCount()>0 then
-			Duel.ConfirmCards(1-tp,cg)
-		end
 	end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_ATTACK)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	c:RegisterEffect(e1)
 end


### PR DESCRIPTION
> 「バハムート・シャーク」の効果処理時に、特殊召喚が可能な水属性・ランク3以下のエクシーズモンスターがエクストラデッキに存在しない場合には、「バハムート・シャーク」の効果によってエクシーズモンスターを特殊召喚する事はできません。
その場合でも、このターン、「バハムート・シャーク」は攻撃する事ができません。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12499&keyword=&tag=-1

Fix: It shouldn't be able to attack if the effect is chained by _Vanity's Emptiness_ etc. And it shouldn't confirm extra if there aren't any monster to spsummon.