### PR TITLE
fix Dragocytos Corrupted Nethersoul Dragon

### DIFF
--- a/c21435914.lua
+++ b/c21435914.lua
@@ -49,10 +49,10 @@ function c21435914.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c21435914.damtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and aux.nzatk(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,aux.nzatk,tp,0,LOCATION_MZONE,1,1,nil)
 	local atk=g:GetFirst():GetAttack()
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,atk/2)
 end


### PR DESCRIPTION
Fix this: Dragocytos can target monster with 0 ATK.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14704&keyword=&tag=-1
Q.「冥界濁龍 ドラゴキュートス」の『③：自分スタンバイフェイズに相手フィールドの表側表示モンスター１体を対象として発動できる。そのモンスターの攻撃力を半分にし、その数値分だけ相手にダメージを与える』効果の対象として、攻撃力0のモンスターを選択する事はできますか？
A.「冥界濁龍 ドラゴキュートス」の効果によって、攻撃力が０のモンスターを対象とする事はできません。 