### PR TITLE
fix Rescueroid

### DIFF
--- a/c24311595.lua
+++ b/c24311595.lua
@@ -26,7 +26,7 @@ function c24311595.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c24311595.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix this: If Rescueroid leave on the field by Liberty at Last, Rescueroid's effect apply.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=236&keyword=&tag=-1
Q.「レスキューロイド」の『このカードが自分フィールド上に表側表示で存在する限り、自分フィールド上に存在する「ロイド」と名のついたモンスターが戦闘によって破壊され墓地に送られた時、そのモンスターを手札に戻す事ができる』効果の発動にチェーンして「自由解放」が発動し、効果を発動した「レスキューロイド」自身がフィールドに存在しなくなった場合、効果処理はどうなりますか？
A.「レスキューロイド」の効果処理時に、その「レスキューロイド」自身がフィールドを離れている場合には効果処理は適用されません。
（戦闘によって破壊され墓地へ送られたモンスターを手札に戻す事はできません。） 
