### PR TITLE
fix Cú Chulainn the Awakened

### DIFF
--- a/c10789972.lua
+++ b/c10789972.lua
@@ -4,32 +4,34 @@ function c10789972.initial_effect(c)
 	--atkup
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(10789972,0))
-	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetCategory(CATEGORY_REMOVE+CATEGORY_ATKCHANGE)
 	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)
-	e1:SetCost(c10789972.cost)
+	e1:SetTarget(c10789972.target)
 	e1:SetOperation(c10789972.operation)
 	c:RegisterEffect(e1)
 end
-function c10789972.cfilter(c)
-	return c:IsType(TYPE_NORMAL) and c:IsAbleToRemoveAsCost()
+function c10789972.filter(c)
+	return c:IsType(TYPE_NORMAL) and c:IsAbleToRemove()
 end
-function c10789972.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c10789972.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
+function c10789972.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c10789972.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c10789972.filter,tp,LOCATION_GRAVE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c10789972.cfilter,tp,LOCATION_GRAVE,0,1,1,nil)
-	e:SetLabel(g:GetFirst():GetAttack())
-	Duel.Remove(g,POS_FACEUP,REASON_COST)
+	local g=Duel.SelectTarget(tp,c10789972.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
 end
 function c10789972.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if e:GetLabel()~=0 and c:IsFaceup() and c:IsRelateToEffect(e) then
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)~=0 and c:IsFaceup() and c:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
-		e1:SetValue(e:GetLabel())
+		e1:SetValue(tc:GetBaseAttack())
 		e1:SetReset(RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_STANDBY,2)
 		c:RegisterEffect(e1)
 	end


### PR DESCRIPTION
Fix this: Cú Chulainn's effect is not target effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6992
■自分の墓地に存在する通常モンスター1体を対象に取る効果です。