### PR TITLE
fix Judgment of the Desert

### DIFF
--- a/c4869446.lua
+++ b/c4869446.lua
@@ -7,9 +7,30 @@ function c4869446.initial_effect(c)
 	c:RegisterEffect(e1)
 	--
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHANGE_POS)
 	e2:SetRange(LOCATION_SZONE)
-	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e2:SetOperation(c4869446.posop)
 	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e3:SetTarget(c4869446.postg)
+	c:RegisterEffect(e3)
+end
+function c4869446.cfilter(c)
+	return c:IsFaceup() and c:IsPreviousPosition(POS_FACEDOWN)
+end
+function c4869446.posop(e,tp,eg,ep,ev,re,r,rp)
+	local g=eg:Filter(c4869446.cfilter,nil)
+	local tc=g:GetFirst()
+	while tc do
+		e:GetHandler():SetCardTarget(tc)
+		tc=g:GetNext()
+	end
+end
+function c4869446.postg(e,c)
+	return e:GetHandler():IsHasCardTarget(c)
 end


### PR DESCRIPTION
Fix this: The Battle Positions of face-up monsters that are flipped face-up before activation of _Judgment of the Desert_ cannot be changed.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6065
■「砂漠の裁き」が魔法＆罠ゾーンに表側表示で存在する間にリバースする等によって表側表示になったモンスターの表示形式が変更できなくなります。（「砂漠の裁き」の効果が適用される前に表側表示になっているモンスターには適用されません。）
