### PR TITLE
fix logic

### DIFF
--- a/c16708652.lua
+++ b/c16708652.lua
@@ -14,7 +14,7 @@ function c16708652.initial_effect(c)
 end
 function c16708652.condition(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
-	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or Duel.IsDamageCalculated())
+	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
 end
 function c16708652.filter(c)
 	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsSetCard(0x11)

--- a/c50903514.lua
+++ b/c50903514.lua
@@ -29,7 +29,7 @@ function c50903514.initial_effect(c)
 end
 function c50903514.condition(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
-	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or Duel.IsDamageCalculated())
+	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
 end
 function c50903514.filter(c)
 	return c:IsFaceup() and c:IsRace(RACE_WARRIOR)

--- a/c55461064.lua
+++ b/c55461064.lua
@@ -17,7 +17,7 @@ function c55461064.initial_effect(c)
 end
 function c55461064.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
-	return Duel.GetTurnPlayer()~=tp and ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or Duel.IsDamageCalculated())
+	return Duel.GetTurnPlayer()~=tp and ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
 end
 function c55461064.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end

--- a/c56535497.lua
+++ b/c56535497.lua
@@ -45,7 +45,7 @@ end
 function c56535497.condition2(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	if Duel.GetTurnPlayer()==tp then return ph==PHASE_MAIN1 or ph==PHASE_MAIN2
-	else return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or Duel.IsDamageCalculated()) end
+	else return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and (ph~=PHASE_DAMAGE or not Duel.IsDamageCalculated()) end
 end
 function c56535497.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end


### PR DESCRIPTION
Fix the logic error introduced in
https://github.com/Fluorohydride/ygopro-scripts/commit/b44a5b70045d299ea68d2c80405573dfe04eea16
https://github.com/Fluorohydride/ygopro-scripts/commit/eb65614cac6c8bd9f3eb4b7bc6d2771e31e8355e

They should be able to active outside of `PHASE_DAMAGE` or in `PHASE_DAMAGE` but not `IsDamageCalculated`.
