### PR TITLE
fix Union Hangar

### DIFF
--- a/c66399653.lua
+++ b/c66399653.lua
@@ -61,7 +61,7 @@ end
 function c66399653.eqop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 		local sg=Duel.SelectMatchingCard(tp,c66399653.cfilter,tp,LOCATION_DECK,0,1,1,nil,tc)
 		local ec=sg:GetFirst()


### PR DESCRIPTION
> 質問の状況のように、「ユニオン格納庫」の対象として選択した機械族・光属性のユニオンモンスターのコントロールが効果処理時に相手に移っている場合、ユニオンモンスターを装備カード扱いとして装備させる事はできませんので、『カード名が異なる機械族・光属性のユニオンモンスター１体をデッキから選び、そのモンスターに装備する』処理は適用されません。
（デッキからユニオンモンスターを選ぶ処理自体行いません。）
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19496&keyword=&tag=-1

Fix: It shouldn't do equip if the controller of the target is changed.