### PR TITLE
fix 方界波動

### DIFF
--- a/c35058588.lua
+++ b/c35058588.lua
@@ -39,7 +39,7 @@ function c35058588.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local tc=g:GetFirst()
 	if tc==hc then tc=g:GetNext() end
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_ATTACK_FINAL)


### PR DESCRIPTION
> 質問の状況の場合、「方界波動」にチェーンした「禁じられた聖槍」の効果によって、「方界波動」の対象となっている自分の「方界超帝インディオラ・デス・ボルト」が魔法カードの効果を受けなくなっている場合には、『その自分のモンスターの攻撃力を倍にし』の処理も、『その相手のモンスターの攻撃力を半分にする』処理も適用されません。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8029&keyword=&tag=-1