### PR TITLE
fix Interrupted Kaiju Slumber

### DIFF
--- a/c99330325.lua
+++ b/c99330325.lua
@@ -22,6 +22,15 @@ function c99330325.initial_effect(c)
 	e2:SetOperation(c99330325.thop)
 	c:RegisterEffect(e2)
 end
+function c99330325.chkfilter1(c,e,tp)
+	return c:IsSetCard(0xd3) and c:IsType(TYPE_MONSTER) and 
+		not c:IsHasEffect(EFFECT_REVIVE_LIMIT) and Duel.IsPlayerCanSpecialSummon(tp,0,POS_FACEUP,tp,c)
+		and Duel.IsExistingMatchingCard(c99330325.chkfilter2,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetCode())
+end
+function c99330325.chkfilter2(c,e,tp,cd)
+	return c:IsSetCard(0xd3) and c:IsType(TYPE_MONSTER) and not c:IsCode(cd)
+		and not c:IsHasEffect(EFFECT_REVIVE_LIMIT) and Duel.IsPlayerCanSpecialSummon(tp,0,POS_FACEUP,1-tp,c)
+end
 function c99330325.filter1(c,e,tp)
 	return c:IsSetCard(0xd3) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsExistingMatchingCard(c99330325.filter2,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetCode())
@@ -33,7 +42,7 @@ end
 function c99330325.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
 		and Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
-		and Duel.IsExistingMatchingCard(c99330325.filter1,tp,LOCATION_DECK,0,1,nil,e,tp) end
+		and Duel.IsExistingMatchingCard(c99330325.chkfilter1,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)


### PR DESCRIPTION
a recent Video for the announcement of EP16 (https://www.youtube.com/watch?v=iOUmqid5deo) suggests in the example duel, that Kaiju Slumber can be activated even if there is a Kaiju already on the field ... this is currently not possible

this fix uses a similar workaround as The Kaiju Files to get around that problem

(not sure if that Video can be seen as a valid ruling source for that one, but at least the translator used on the Video title suggests that it's official^^)