### PR TITLE
fix Blue-Eyes Spirit Dragon related cards

### DIFF
--- a/c12670770.lua
+++ b/c12670770.lua
@@ -113,7 +113,8 @@ end
 function c12670770.spop(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c12670770.spfilter,tp,LOCATION_REMOVED,0,nil,e,tp)
-	if ft<=0 or tg:GetCount()==0 or (ft>1 and tg:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<=0 or tg:GetCount()==0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=tg:Select(tp,ft,ft,nil)
 	local tc=g:GetFirst()

--- a/c13803864.lua
+++ b/c13803864.lua
@@ -35,7 +35,8 @@ end
 function c13803864.spop(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c13803864.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp)
-	if ft<=0 or tg:GetCount()==0 or (ft>1 and tg:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<=0 or tg:GetCount()==0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=tg:Select(tp,ft,ft,nil)
 	if g:GetCount()>0 then

--- a/c23282832.lua
+++ b/c23282832.lua
@@ -25,10 +25,11 @@ function c23282832.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,PLAYER_ALL,LOCATION_GRAVE)
 end
 function c23282832.op(e,tp,eg,ep,ev,re,r,rp)
-	local ft1=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if ft1<=0 then return end
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c23282832.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,ft1,ft1,nil,e,tp,Duel.GetTurnCount())
+	local g=Duel.SelectMatchingCard(tp,c23282832.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,ft,ft,nil,e,tp,Duel.GetTurnCount())
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c24221808.lua
+++ b/c24221808.lua
@@ -68,7 +68,8 @@ function c24221808.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=e:GetLabelObject()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=g:Filter(c24221808.spfilter,nil,e:GetHandler(),e,tp)
-	if ft<=0 or tg:GetCount()==0 or (ft>1 and tg:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<=0 or tg:GetCount()==0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sg=tg:Select(tp,ft,ft,nil)
 	Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)

--- a/c27174286.lua
+++ b/c27174286.lua
@@ -23,10 +23,11 @@ function c27174286.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_REMOVED)
 end
 function c27174286.op(e,tp,eg,ep,ev,re,r,rp)
-	local ft1=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if ft1<=0 then return end
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c27174286.filter,tp,LOCATION_REMOVED,0,ft1,ft1,nil,e,tp)
+	local g=Duel.SelectMatchingCard(tp,c27174286.filter,tp,LOCATION_REMOVED,0,ft,ft,nil,e,tp)
 	if g:GetCount()>0 then
 		local fid=e:GetHandler():GetFieldID()
 		local tc=g:GetFirst()

--- a/c32603633.lua
+++ b/c32603633.lua
@@ -26,6 +26,7 @@ end
 function c32603633.op(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local g=Duel.GetMatchingGroup(c32603633.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
 	while g:GetCount()>0 and ft>0 do
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/c3758046.lua
+++ b/c3758046.lua
@@ -50,7 +50,8 @@ end
 function c3758046.spop(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c3758046.filter,tp,LOCATION_GRAVE,0,nil,e,tp,Duel.GetTurnCount())
-	if ft<=0 or (Duel.IsPlayerAffectedByEffect(tp,59822133) and tg:GetCount()>1 and ft>1) then return end
+	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local g=nil
 	if tg:GetCount()>ft then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/c55008284.lua
+++ b/c55008284.lua
@@ -28,6 +28,7 @@ end
 function c55008284.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
 	local g=Duel.GetMatchingGroup(c55008284.spfilter,tp,LOCATION_DECK,0,nil,e,tp,tc:GetCode())

--- a/c6713443.lua
+++ b/c6713443.lua
@@ -33,7 +33,8 @@ end
 function c6713443.spop(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c6713443.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
-	if ft<=0 or tg:GetCount()==0 or (ft>1 and tg:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<=0 or tg:GetCount()==0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=tg:Select(tp,ft,ft,nil)
 	local ct=Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)

--- a/c72881007.lua
+++ b/c72881007.lua
@@ -45,6 +45,7 @@ function c72881007.activate(e,tp,eg,ep,ev,re,r,rp)
 	g=Duel.GetOperatedGroup()
 	local ct=g:FilterCount(c72881007.ctfilter,nil,1-tp)
 	if ft>ct then ft=ct end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	g=Duel.SelectMatchingCard(tp,c72881007.filter,tp,LOCATION_GRAVE,0,ft,ft,nil,e,tp)
 	if g:GetCount()>0 then

--- a/c74845897.lua
+++ b/c74845897.lua
@@ -20,7 +20,8 @@ end
 function c74845897.op(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c74845897.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
-	if ft<=0 or (Duel.IsPlayerAffectedByEffect(tp,59822133) and tg:GetCount()>1 and ft>1) then return end
+	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local g=nil
 	if tg:GetCount()>ft then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/c77778835.lua
+++ b/c77778835.lua
@@ -34,7 +34,8 @@ function c77778835.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) then return end
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c77778835.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
-	if ft<=0 or tg:GetCount()==0 or (ft>1 and tg:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<=0 or tg:GetCount()==0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=tg:Select(tp,ft,ft,nil)
 	local tc=g:GetFirst()

--- a/c82052602.lua
+++ b/c82052602.lua
@@ -54,10 +54,11 @@ function c82052602.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterFlagEffect(tp,82052602,RESET_PHASE+PHASE_END,0,1)
 end
 function c82052602.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ft1=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if ft1==0 then return end
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c82052602.filter,tp,LOCATION_GRAVE,0,ft1,ft1,nil,Duel.GetTurnCount(),e,tp)
+	local g=Duel.SelectMatchingCard(tp,c82052602.filter,tp,LOCATION_GRAVE,0,ft,ft,nil,Duel.GetTurnCount(),e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 		Duel.BreakEffect()

--- a/c88307361.lua
+++ b/c88307361.lua
@@ -39,7 +39,8 @@ end
 function c88307361.sumop(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c88307361.filter,tp,LOCATION_DECK,0,nil,e,tp)
-	if ft<=0 or tg:GetCount()==0 or (ft>1 and tg:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<=0 or tg:GetCount()==0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=tg:Select(tp,ft,ft,nil)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix: Some cards shouldn't ignore Blue-Eyes Spirit Dragon, and some cards should be able to spsummon 1 monster instead of 0 when Blue-Eyes Spirit Dragon is in effect.