### PR TITLE
fix De-Fusion

### DIFF
--- a/c95286165.lua
+++ b/c95286165.lua
@@ -20,10 +20,11 @@ function c95286165.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c95286165.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,1,0,0)
 end
-function c95286165.mgfilter(c,e,tp,fusc)
+function c95286165.mgfilter(c,e,tp,fusc,mg)
 	return not c:IsControler(tp) or not c:IsLocation(LOCATION_GRAVE)
 		or bit.band(c:GetReason(),0x40008)~=0x40008 or c:GetReasonCard()~=fusc
 		or not c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsHasEffect(EFFECT_NECRO_VALLEY)
+		or not fusc:CheckFusionMaterial(mg,c)
 end
 function c95286165.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
@@ -33,7 +34,8 @@ function c95286165.activate(e,tp,eg,ep,ev,re,r,rp)
 	local sumtype=tc:GetSummonType()
 	if Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)==0 or bit.band(sumtype,SUMMON_TYPE_FUSION)~=SUMMON_TYPE_FUSION or mg:GetCount()==0
 		or mg:GetCount()>Duel.GetLocationCount(tp,LOCATION_MZONE)
-		or mg:IsExists(c95286165.mgfilter,1,nil,e,tp,tc) then
+		or mg:IsExists(c95286165.mgfilter,1,nil,e,tp,tc,mg)
+		or Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		sumable=false
 	end
 	if sumable and Duel.SelectYesNo(tp,aux.Stringid(95286165,0)) then


### PR DESCRIPTION
Fix 1: If Cyber End Dragon return to the Extra Deck, player can Special Summon Proto-Cyber Dragon that were used for its Fusion Summon by De-Fusion.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12165&keyword=&tag=-1
Q.「プロト・サイバー・ドラゴン」を融合素材とした「サイバー・ツイン・ドラゴン」や「サイバー・エンド・ドラゴン」に対して「融合解除」を発動した場合、「サイバー・ツイン・ドラゴン」や「サイバー・エンド・ドラゴン」をエクストラデッキに戻した後、墓地に存在する「プロト・サイバー・ドラゴン」を特殊召喚する事はできますか？
また、「サイバー・ドラゴン」として扱われている「ファントム・オブ・カオス」や「N・ブラック・パンサー」を融合素材として使用した「サイバー・ツイン・ドラゴン」等に対して「融合解除」を発動した場合、墓地に存在する「ファントム・オブ・カオス」や「N・ブラック・パンサー」を特殊召喚する事はできますか？
A.融合素材として使用して墓地に送られた「プロト・サイバー・ドラゴン」は、カード名が「サイバー・ドラゴン」として扱われません。
したがって、「サイバー・ツイン・ドラゴン」や「サイバー・エンド・ドラゴン」に対して「融合解除」を発動しても、墓地に存在する「プロト・サイバー・ドラゴン」を特殊召喚する事はできません。
また、「サイバー・ドラゴン」として扱われている「ファントム・オブ・カオス」や「N・ブラック・パンサー」を融合素材として使用した「サイバー・ツイン・ドラゴン」等に対して「融合解除」を発動した場合においても、墓地に存在する「ファントム・オブ・カオス」等を特殊召喚する事はできません。

Fix 2: If Blue-Eyes Spirit Dragon has on the field, player can Special Summon monster that were used for its Fusion Summon by De-Fusion.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
相手フィールドに「青眼の精霊龍」が存在する場合に自分フィールドの「サイバー・ツイン・ドラゴン」を対象に「融合解除」を発動した場合、墓地に存在する、融合素材とした「サイバー・ドラゴン」を特殊召喚できますか？ 
A. 
ご質問の状況の場合、自分は「融合解除」の効果で「サイバー・ドラゴン」一組を特殊召喚できません。