### PR TITLE
fix Card of Demise

### DIFF
--- a/c59750328.lua
+++ b/c59750328.lua
@@ -22,8 +22,9 @@ function c59750328.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c59750328.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ct=3-Duel.GetMatchingGroupCount(aux.TRUE,tp,LOCATION_HAND,0,e:GetHandler())
-	if chk==0 then return ct>0 and Duel.IsPlayerCanDraw(tp,ct) end
+	local ct=3-Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)
+	local dr=3-Duel.GetMatchingGroupCount(aux.TRUE,tp,LOCATION_HAND,0,e:GetHandler())
+	if chk==0 then return ct>0 and Duel.IsPlayerCanDraw(tp,dr) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,ct)
 end

--- a/c59750328.lua
+++ b/c59750328.lua
@@ -22,7 +22,7 @@ function c59750328.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c59750328.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ct=3-Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)
+	local ct=3-Duel.GetMatchingGroupCount(aux.TRUE,tp,LOCATION_HAND,0,e:GetHandler())
 	if chk==0 then return ct>0 and Duel.IsPlayerCanDraw(tp,ct) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,ct)


### PR DESCRIPTION
it shouldn't count itself among the cards in the hand, this causes a few problems:
- you can't activate it if you have 3 cards including itself in the hand
- you can activate it if you have only 1 card in your deck and 2 cards including itself in the hand)