### PR TITLE
fix Kumongous, the Sticky String Kaiju

### DIFF
--- a/c29726552.lua
+++ b/c29726552.lua
@@ -1,4 +1,4 @@
---Kumongous, the Sticky String Kaiju
+--粘糸壊獣クモグス
 function c29726552.initial_effect(c)
 	c:SetUniqueOnField(1,0,20000000,LOCATION_MZONE)
 	--special summon rule
@@ -54,7 +54,7 @@ function c29726552.spcon2(e,c)
 		and Duel.IsExistingMatchingCard(c29726552.cfilter,tp,0,LOCATION_MZONE,1,nil)
 end
 function c29726552.filter(c,tp)
-	return c:GetSummonPlayer()==tp
+	return c:GetSummonPlayer()==tp and c:IsFaceup()
 end
 function c29726552.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsCanRemoveCounter(tp,1,1,0x37,2,REASON_COST) end


### PR DESCRIPTION
Fix this: If monster Special Summoned in face-down, Kumongous can activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19936&keyword=&tag=-1
Q.自分のモンスターゾーンに「粘糸壊獣クモグス」が表側表示で存在しています。

この状況で、相手は「バースト・リバース」の『２０００ライフポイント払って発動できる。自分の墓地のモンスター１体を選択して裏側守備表示で特殊召喚する』効果を発動し、モンスターを裏側守備表示で特殊召喚しました。

この時、自分は「粘糸壊獣クモグス」の『④：相手がモンスターを召喚・特殊召喚した時、自分・相手フィールドの壊獣カウンターを２つ取り除いて発動できる。次のターンの終了時まで、そのモンスターは攻撃できず、効果は無効化される』モンスター効果を発動する事はできますか？
A.相手がモンスターを裏側守備表示で特殊召喚した場合、自分は壊獣カウンターを取り除いて発動する「粘糸壊獣クモグス」のモンスター効果を発動する事はできません。 