### PR TITLE
fix Jizukiru, the Star Destroying Kaiju

### DIFF
--- a/c63941210.lua
+++ b/c63941210.lua
@@ -67,9 +67,8 @@ function c63941210.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
 function c63941210.disop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.NegateEffect(ev)
 	local g=Duel.GetFieldGroup(tp,LOCATION_ONFIELD,LOCATION_ONFIELD)
-	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(63941210,1)) then
+	if Duel.NegateEffect(ev) and g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(63941210,1)) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 		local tg=g:Select(tp,1,1,nil)
 		Duel.HintSelection(tg)


### PR DESCRIPTION
Fix this: If Jizukiru cannot negate effect, Jizukiru can destroy 1 card on the field.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
相手が「電磁石の戦士マグネット・ベルセリオン」の①の効果を発動し、チェーンして自分が「壊星壊獣ジズキエル」の効果を発動し、 
更にチェーンして相手が「マグネット・フォース」を発動した場合『フィールドのカード１枚を選んで破壊できる』効果を適用できますか？ 
A. 
ご質問の状況の場合、「壊星壊獣ジズキエル」の効果で「電磁石の戦士マグネット・ベルセリオン」の効果を無効にすることができない為、 
その後のフィールドのカード１枚を選んで破壊できる処理を適用することはできません。