### PR TITLE
fix Honest

### DIFF
--- a/c37742478.lua
+++ b/c37742478.lua
@@ -38,8 +38,8 @@ function c37742478.condition2(e,tp,eg,ep,ev,re,r,rp)
 	if phase~=PHASE_DAMAGE or Duel.IsDamageCalculated() then return false end
 	local a=Duel.GetAttacker()
 	local d=Duel.GetAttackTarget()
-	return (d~=nil and a:GetControler()==tp and a:IsAttribute(ATTRIBUTE_LIGHT) and a:IsRelateToBattle())
-		or (d~=nil and d:GetControler()==tp and d:IsFaceup() and d:IsAttribute(ATTRIBUTE_LIGHT) and d:IsRelateToBattle())
+	return d~=nil and d:IsFaceup() and ((a:GetControler()==tp and a:IsAttribute(ATTRIBUTE_LIGHT) and a:IsRelateToBattle())
+		or (d:GetControler()==tp and d:IsAttribute(ATTRIBUTE_LIGHT) and d:IsRelateToBattle()))
 end
 function c37742478.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end


### PR DESCRIPTION
fix this: Honest currently can be activated if the light monster attacks a face down monster before it is flipped face up, this shouldn't happen