### PR TITLE
fix Nirvana High Paladin

### DIFF
--- a/c80896940.lua
+++ b/c80896940.lua
@@ -68,7 +68,6 @@ function c80896940.initial_effect(c)
 	--pendulum
 	local e7=Effect.CreateEffect(c)
 	e7:SetDescription(aux.Stringid(80896940,5))
-	e7:SetCategory(CATEGORY_DESTROY)
 	e7:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e7:SetCode(EVENT_DESTROYED)
 	e7:SetProperty(EFFECT_FLAG_DELAY)


### PR DESCRIPTION
fix cathegory, placing itself in the pendulum zone doesn't destroy anything