### PR TITLE
fix Ancient Gear Reactor Dragon, Ancient Gear Engineer

### DIFF
--- a/c1953925.lua
+++ b/c1953925.lua
@@ -63,7 +63,7 @@ function c1953925.actcon(e)
 	return Duel.GetAttacker()==e:GetHandler()
 end
 function c1953925.descon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler()==Duel.GetAttacker() and e:GetHandler():IsRelateToBattle()
+	return e:GetHandler()==Duel.GetAttacker()
 end
 function c1953925.filter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP)

--- a/c44874522.lua
+++ b/c44874522.lua
@@ -75,7 +75,7 @@ function c44874522.actcon(e)
 	return Duel.GetAttacker()==e:GetHandler()
 end
 function c44874522.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetAttacker()==e:GetHandler() and e:GetHandler():IsRelateToBattle()
+	return Duel.GetAttacker()==e:GetHandler()
 end
 function c44874522.desfilter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP)


### PR DESCRIPTION
Fix this: If an attacking Reactor Dragon was destroyed by battle, Reactor Dragon cannot activate.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19982&keyword=&tag=-1
Q.自分が「古代の機械熱核竜」で、相手の「古代の機械巨竜」を攻撃し、お互いに戦闘で破壊されました。
この場合、「古代の機械熱核竜」の『④：このカードが攻撃したダメージステップ終了時に発動できる。フィールドの魔法・罠カード１枚を選んで破壊する』モンスター効果を発動する事はできますか？
A.質問の状況の場合でも、「古代の機械熱核竜」が攻撃を行っていますので、そのモンスター効果を発動する事ができます。
この場合、「古代の機械熱核竜」はダメージステップ終了時に戦闘で破壊され墓地へ送られていますので、そのモンスター効果は墓地で発動する事になります。 