### PR TITLE
fix Light End Dragon

### DIFF
--- a/c25132288.lua
+++ b/c25132288.lua
@@ -28,8 +28,7 @@ end
 function c25132288.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=e:GetLabelObject()
-	if c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsFaceup()
-		and c:GetAttack()>=500 and c:GetDefense()>=500 then
+	if c:IsRelateToEffect(e) and c:IsFaceup() and c:GetAttack()>=500 and c:GetDefense()>=500 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
@@ -40,14 +39,16 @@ function c25132288.operation(e,tp,eg,ep,ev,re,r,rp)
 		local e2=e1:Clone()
 		e2:SetCode(EFFECT_UPDATE_DEFENSE)
 		c:RegisterEffect(e2)
-		local e3=Effect.CreateEffect(c)
-		e3:SetType(EFFECT_TYPE_SINGLE)
-		e3:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
-		e3:SetCode(EFFECT_UPDATE_ATTACK)
-		e3:SetValue(-1500)
-		tc:RegisterEffect(e3)
-		local e4=e3:Clone()
-		e4:SetCode(EFFECT_UPDATE_DEFENSE)
-		tc:RegisterEffect(e4)
+		if tc:IsRelateToEffect(e) and tc:IsFaceup() and not c:IsHasEffect(EFFECT_REVERSE_UPDATE) then
+			local e3=Effect.CreateEffect(c)
+			e3:SetType(EFFECT_TYPE_SINGLE)
+			e3:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+			e3:SetCode(EFFECT_UPDATE_ATTACK)
+			e3:SetValue(-1500)
+			tc:RegisterEffect(e3)
+			local e4=e3:Clone()
+			e4:SetCode(EFFECT_UPDATE_DEFENSE)
+			tc:RegisterEffect(e4)
+		end
 	end
 end


### PR DESCRIPTION
Fix 1: If opponent monster leaves the field, Light End Dragon don't lose 500 ATK and DEF.
Fix 2: During Reverse Trap applied turn, opponent monster gain ATK and DEF by Light End Dragon's effect.

Mail:
いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「ライトエンド・ドラゴン」の効果処理時に戦闘を行う相手モンスターがフィールドから離れている場合、「ライトエンド・ドラゴン」の『このカードの攻撃力・守備力を５００ポイントダウンし』の効果は適用されますか？ 
A. 
戦闘を行う相手モンスターが存在しない場合でも、「ライトエンド・ドラゴン」の攻撃力と守備力は500ポイントダウンします。

Q. 
「あまのじゃくの呪い」の効果が適用されているターンに、「ライトエンド・ドラゴン」の効果を発動し、 
「ライトエンド・ドラゴン」の攻撃力・守備力がダウンする代わりにアップした場合、 
『戦闘を行う相手モンスターの攻撃力・守備力はエンドフェイズ時まで１５００ポイントダウンする』効果は適用されますか？ 
A. 
ご質問の状況の場合、「ライトエンド・ドラゴン」の効果は適用できません。