### PR TITLE
fix Angel O7, Ancient Gear

### DIFF
--- a/c44874522.lua
+++ b/c44874522.lua
@@ -9,6 +9,7 @@ function c44874522.initial_effect(c)
 	--summon success
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetCondition(c44874522.regcon)
 	e2:SetOperation(c44874522.regop)

--- a/c50933533.lua
+++ b/c50933533.lua
@@ -9,6 +9,7 @@ function c50933533.initial_effect(c)
 	--summon success
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetCondition(c50933533.regcon)
 	e2:SetOperation(c50933533.regop)
@@ -55,7 +56,7 @@ function c50933533.regop(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_PIERCE)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 	if bit.band(flag,0x2)~=0 then
@@ -68,7 +69,7 @@ function c50933533.regop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCondition(c50933533.damcon1)
 		e1:SetTarget(c50933533.damtg1)
 		e1:SetOperation(c50933533.damop)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 	if bit.band(flag,0x4)~=0 then
@@ -80,7 +81,7 @@ function c50933533.regop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EVENT_BATTLE_DESTROYING)
 		e1:SetTarget(c50933533.damtg2)
 		e1:SetOperation(c50933533.damop)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 end

--- a/c56784842.lua
+++ b/c56784842.lua
@@ -3,6 +3,7 @@ function c56784842.initial_effect(c)
 	--act limit
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_SUMMON_SUCCESS)
 	e1:SetOperation(c56784842.regop)
 	c:RegisterEffect(e1)

--- a/c81269231.lua
+++ b/c81269231.lua
@@ -9,6 +9,7 @@ function c81269231.initial_effect(c)
 	--summon success
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetCondition(c81269231.regcon)
 	e2:SetOperation(c81269231.regop)

--- a/c86321248.lua
+++ b/c86321248.lua
@@ -9,6 +9,7 @@ function c86321248.initial_effect(c)
 	--summon success
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetCondition(c86321248.regcon)
 	e2:SetOperation(c86321248.regop)
@@ -40,7 +41,7 @@ function c86321248.regop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetValue(300)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 	if bit.band(flag,0x2)~=0 then
@@ -53,7 +54,7 @@ function c86321248.regop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCondition(c86321248.damcon1)
 		e1:SetTarget(c86321248.damtg1)
 		e1:SetOperation(c86321248.damop)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 	if bit.band(flag,0x4)~=0 then
@@ -64,7 +65,7 @@ function c86321248.regop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EVENT_BATTLE_DESTROYING)
 		e1:SetTarget(c86321248.damtg2)
 		e1:SetOperation(c86321248.damop)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e1)
 	end
 end


### PR DESCRIPTION
Fix this: If Angel O7 and Ancient Gear were Special Summoned while Skill Drain has on the field, Angel O7 and Ancient Gear don't gain effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8783&keyword=&tag=-1
「スキルドレイン」の適用中は、その得ている効果は無効化されますが、その後に「スキルドレイン」の効果の適用がなくなったのであれば、『●』のモンスター効果が適用される事になります。

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10624&keyword=&tag=-1
「スキルドレイン」の適用中は、それぞれの効果は無効化されますが、その後に「スキルドレイン」の効果の適用がなくなったのであれば、『このカードが守備表示モンスターを攻撃した場合、その守備力を攻撃力が超えた分だけ戦闘ダメージを与える』モンスター効果、『このカードは１度のバトルフェイズ中に２回攻撃できる』モンスター効果はどちらも適用される事になります。