### PR TITLE
fix Odd-Eyes Rebellion Dragon, Nirvana High Paladin

### DIFF
--- a/c45627618.lua
+++ b/c45627618.lua
@@ -92,7 +92,8 @@ function c45627618.valcheck(e,c)
 	end
 end
 function c45627618.pencon(e,tp,eg,ep,ev,re,r,rp)
-	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_MZONE)
+	local c=e:GetHandler()
+	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and c:IsPreviousLocation(LOCATION_MZONE) and c:IsFaceup()
 end
 function c45627618.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local lsc=Duel.GetFieldCard(tp,LOCATION_SZONE,6)

--- a/c80896940.lua
+++ b/c80896940.lua
@@ -240,7 +240,8 @@ function c80896940.lpop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SetLP(1-tp,math.ceil(Duel.GetLP(1-tp)/2))
 end
 function c80896940.pencon(e,tp,eg,ep,ev,re,r,rp)
-	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_MZONE)
+	local c=e:GetHandler()
+	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and c:IsPreviousLocation(LOCATION_MZONE) and c:IsFaceup()
 end
 function c80896940.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_SZONE,6) or Duel.CheckLocation(tp,LOCATION_SZONE,7) end


### PR DESCRIPTION
Fix this: If Odd-Eyes Rebellion Dragon is returned from the field to your Extra Deck face-down, Odd-Eyes Rebellion can activate effect.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「グレイヴ・キーパー」が存在する状況で「クリアウィング・ファスト・ドラゴン」が戦闘で破壊された場合、「クリアウィング・ファスト・ドラゴン」の②の効果を発動できますか？ 
A. 
戦闘で破壊された「クリアウィング・ファスト・ドラゴン」は、「グレイヴ・キーパー」の効果によってエクストラデッキに裏向きで戻りますので、この「クリアウィング・ファスト・ドラゴン」の『②』の効果を発動する事はできません。