### PR TITLE
fix Herald of Pure Light, Noble Knight Gwalchavad

### DIFF
--- a/c1249315.lua
+++ b/c1249315.lua
@@ -32,7 +32,7 @@ function c1249315.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c1249315.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 then
+	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 		local g=Duel.GetFieldGroup(tp,LOCATION_HAND,0):Select(tp,1,1,nil)
 		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)

--- a/c13391185.lua
+++ b/c13391185.lua
@@ -52,7 +52,7 @@ function c13391185.desfilter(c)
 end
 function c13391185.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 then
+	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 		local dg=Duel.SelectMatchingCard(tp,c13391185.desfilter,tp,LOCATION_SZONE,0,1,1,nil)
 		Duel.BreakEffect()


### PR DESCRIPTION
Fix this: If target monster returned into deck by Herald of Pure Light, player shuffle 1 card from self hand into the Deck.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=62&keyword=&tag=-1
その対象の融合・シンクロ・エクシーズモンスターは手札ではなくエクストラデッキに戻しますので、『その後、手札を１枚持ち主のデッキに戻す』処理は適用されません。

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11901&keyword=&tag=-1
その場合、『選択したモンスターを手札に加え』の処理の際に、その対象のエクシーズモンスターやシンクロモンスターは手札ではなくエクストラデッキに戻しますので、『自分フィールド上の「聖剣」と名のついた装備魔法カード１枚を選んで破壊する』処理は適用されません。