### PR TITLE
fix Tyrant Red Dragon Archfiend and so on

### DIFF
--- a/c16172067.lua
+++ b/c16172067.lua
@@ -69,6 +69,7 @@ function c16172067.synfilter2(c,syncard,lv,g2,g4,f1,tuner1)
 	local f2=c.tuner_filter
 	if f1 and not f1(c) then return false end
 	if f2 and not f2(tuner1) then return false end
+	g2:RemoveCard(c)
 	if (tuner1:IsHasEffect(EFFECT_HAND_SYNCHRO) and not c:IsLocation(LOCATION_HAND)) or c:IsHasEffect(EFFECT_HAND_SYNCHRO) then
 		return g4:IsExists(c16172067.synfilter3,1,nil,syncard,lv-tlv,f1,f2,g2)
 	else

--- a/c62242678.lua
+++ b/c62242678.lua
@@ -71,6 +71,7 @@ function c62242678.synfilter2(c,syncard,lv,g2,f1,tuner1)
 	local f2=c.tuner_filter
 	if f1 and not f1(c) then return false end
 	if f2 and not f2(tuner1) then return false end
+	g2:RemoveCard(c)
 	return g2:IsExists(c62242678.synfilter3,1,nil,syncard,lv-tlv,f1,f2)
 end
 function c62242678.synfilter3(c,syncard,lv,f1,f2)

--- a/c93157004.lua
+++ b/c93157004.lua
@@ -73,6 +73,7 @@ function c93157004.synfilter2(c,syncard,lv,g2,g4,f1,tuner1)
 	local f2=c.tuner_filter
 	if f1 and not f1(c) then return false end
 	if f2 and not f2(tuner1) then return false end
+	g2:RemoveCard(c)
 	if (tuner1:IsHasEffect(EFFECT_HAND_SYNCHRO) and not c:IsLocation(LOCATION_HAND)) or c:IsHasEffect(EFFECT_HAND_SYNCHRO) then
 		return g4:IsExists(c93157004.synfilter3,1,nil,syncard,lv-tlv,f1,f2)
 	else

--- a/c97489701.lua
+++ b/c97489701.lua
@@ -80,6 +80,7 @@ function c97489701.synfilter2(c,syncard,lv,g2,f1,tuner1)
 	local f2=c.tuner_filter
 	if f1 and not f1(c) then return false end
 	if f2 and not f2(tuner1) then return false end
+	g2:RemoveCard(c)
 	return g2:IsExists(c97489701.synfilter3,1,nil,syncard,lv-tlv,f1,f2)
 end
 function c97489701.synfilter3(c,syncard,lv,f1,f2)


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/issues/1745
Fix this: _Tyrant Red Dragon Archfiend_ can use _Phantom King Hydride_ and Level 4 monster by Synchro Summon.