### PR TITLE
fix The White Stone of Ancients and so on

### DIFF
--- a/c1315120.lua
+++ b/c1315120.lua
@@ -11,6 +11,7 @@ function c1315120.initial_effect(c)
 	--to grave
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c1315120.regop)
 	c:RegisterEffect(e2)

--- a/c19462747.lua
+++ b/c19462747.lua
@@ -16,6 +16,7 @@ function c19462747.initial_effect(c)
 	--to grave
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e3:SetCode(EVENT_TO_GRAVE)
 	e3:SetOperation(c19462747.regop)
 	c:RegisterEffect(e3)

--- a/c23015896.lua
+++ b/c23015896.lua
@@ -3,6 +3,7 @@ function c23015896.initial_effect(c)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c23015896.spreg)
 	c:RegisterEffect(e1)

--- a/c24919805.lua
+++ b/c24919805.lua
@@ -14,6 +14,7 @@ function c24919805.initial_effect(c)
 	--to grave
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c24919805.regop)
 	c:RegisterEffect(e2)

--- a/c2542230.lua
+++ b/c2542230.lua
@@ -12,6 +12,7 @@ function c2542230.initial_effect(c)
 	--to grave
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c2542230.regop)
 	c:RegisterEffect(e2)

--- a/c28355718.lua
+++ b/c28355718.lua
@@ -15,6 +15,7 @@ function c28355718.initial_effect(c)
 	--token
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e3:SetCode(EVENT_TO_GRAVE)
 	e3:SetOperation(c28355718.regop)
 	c:RegisterEffect(e3)

--- a/c293542.lua
+++ b/c293542.lua
@@ -14,6 +14,7 @@ function c293542.initial_effect(c)
 	--to grave
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c293542.regop)
 	c:RegisterEffect(e2)

--- a/c30604579.lua
+++ b/c30604579.lua
@@ -16,6 +16,7 @@ function c30604579.initial_effect(c)
 	--special summon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c30604579.regop)
 	c:RegisterEffect(e2)

--- a/c31383545.lua
+++ b/c31383545.lua
@@ -3,6 +3,7 @@ function c31383545.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c31383545.regop)
 	c:RegisterEffect(e1)

--- a/c33282498.lua
+++ b/c33282498.lua
@@ -13,6 +13,7 @@ function c33282498.initial_effect(c)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c33282498.regop)
 	c:RegisterEffect(e2)

--- a/c34796454.lua
+++ b/c34796454.lua
@@ -3,6 +3,7 @@ function c34796454.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c34796454.regop)
 	c:RegisterEffect(e1)

--- a/c36687247.lua
+++ b/c36687247.lua
@@ -12,6 +12,7 @@ function c36687247.initial_effect(c)
 	--to grave
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c36687247.regop)
 	c:RegisterEffect(e2)

--- a/c37534148.lua
+++ b/c37534148.lua
@@ -19,6 +19,7 @@ function c37534148.initial_effect(c)
 	--special summon
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e3:SetCode(EVENT_TO_GRAVE)
 	e3:SetCondition(c37534148.regcon)
 	e3:SetOperation(c37534148.regop)

--- a/c38250531.lua
+++ b/c38250531.lua
@@ -18,6 +18,7 @@ function c38250531.initial_effect(c)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c38250531.spreg)
 	c:RegisterEffect(e2)

--- a/c39823987.lua
+++ b/c39823987.lua
@@ -16,6 +16,7 @@ function c39823987.initial_effect(c)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_DESTROYED)
 	e2:SetCondition(c39823987.regcon)
 	e2:SetOperation(c39823987.regop)

--- a/c43586926.lua
+++ b/c43586926.lua
@@ -3,6 +3,7 @@ function c43586926.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c43586926.regop)
 	c:RegisterEffect(e1)

--- a/c50065971.lua
+++ b/c50065971.lua
@@ -20,6 +20,7 @@ function c50065971.initial_effect(c)
 	--spsummon
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e3:SetCode(EVENT_TO_GRAVE)
 	e3:SetOperation(c50065971.spreg)
 	c:RegisterEffect(e3)

--- a/c51402908.lua
+++ b/c51402908.lua
@@ -10,6 +10,7 @@ function c51402908.initial_effect(c)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c51402908.spr)
 	c:RegisterEffect(e2)

--- a/c53839837.lua
+++ b/c53839837.lua
@@ -3,6 +3,7 @@ function c53839837.initial_effect(c)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c53839837.spr)
 	c:RegisterEffect(e1)

--- a/c55610595.lua
+++ b/c55610595.lua
@@ -10,6 +10,7 @@ function c55610595.initial_effect(c)
 	--to grave
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c55610595.regop)
 	c:RegisterEffect(e2)

--- a/c58132856.lua
+++ b/c58132856.lua
@@ -9,6 +9,7 @@ function c58132856.initial_effect(c)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c58132856.regop)
 	c:RegisterEffect(e2)

--- a/c61441708.lua
+++ b/c61441708.lua
@@ -3,6 +3,7 @@ function c61441708.initial_effect(c)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c61441708.spr)
 	c:RegisterEffect(e1)

--- a/c62953041.lua
+++ b/c62953041.lua
@@ -12,6 +12,7 @@ function c62953041.initial_effect(c)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c62953041.spreg)
 	c:RegisterEffect(e2)

--- a/c64910482.lua
+++ b/c64910482.lua
@@ -12,6 +12,7 @@ function c64910482.initial_effect(c)
 	--to grave
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c64910482.regop)
 	c:RegisterEffect(e2)

--- a/c67098114.lua
+++ b/c67098114.lua
@@ -19,6 +19,7 @@ function c67098114.initial_effect(c)
 	--special summon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c67098114.regop)
 	c:RegisterEffect(e2)

--- a/c69000994.lua
+++ b/c69000994.lua
@@ -15,6 +15,7 @@ function c69000994.initial_effect(c)
 	--search
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c69000994.threg)
 	c:RegisterEffect(e2)

--- a/c71039903.lua
+++ b/c71039903.lua
@@ -3,6 +3,7 @@ function c71039903.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c71039903.regop)
 	c:RegisterEffect(e1)

--- a/c77121851.lua
+++ b/c77121851.lua
@@ -3,6 +3,7 @@ function c77121851.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c77121851.tgop)
 	c:RegisterEffect(e1)

--- a/c77936940.lua
+++ b/c77936940.lua
@@ -3,6 +3,7 @@ function c77936940.initial_effect(c)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c77936940.reg)
 	c:RegisterEffect(e1)

--- a/c80744121.lua
+++ b/c80744121.lua
@@ -3,6 +3,7 @@ function c80744121.initial_effect(c)
 	--reg
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_BATTLE_DESTROYED)
 	e1:SetOperation(c80744121.regop)
 	c:RegisterEffect(e1)

--- a/c88753985.lua
+++ b/c88753985.lua
@@ -3,6 +3,7 @@ function c88753985.initial_effect(c)
 	--register
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_BATTLE_DESTROYED)
 	e1:SetOperation(c88753985.regop)
 	c:RegisterEffect(e1)

--- a/c93483212.lua
+++ b/c93483212.lua
@@ -14,6 +14,7 @@ function c93483212.initial_effect(c)
 	--special summon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c93483212.regop)
 	c:RegisterEffect(e2)

--- a/c93751476.lua
+++ b/c93751476.lua
@@ -3,6 +3,7 @@ function c93751476.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c93751476.regop)
 	c:RegisterEffect(e1)

--- a/c95816395.lua
+++ b/c95816395.lua
@@ -3,6 +3,7 @@ function c95816395.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetOperation(c95816395.regop)
 	c:RegisterEffect(e1)

--- a/c9791914.lua
+++ b/c9791914.lua
@@ -9,6 +9,7 @@ function c9791914.initial_effect(c)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetOperation(c9791914.regop)
 	c:RegisterEffect(e2)


### PR DESCRIPTION
Fix this: If _The White Stone of Ancients_ be destroyed by _Ancient Gear Beast_'s attack, _The White Stone of Ancients_ cannot activate effect.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「太古の白石」が「古代の機械獣」に戦闘で破壊された場合、そのターンのエンドフェイズに「太古の白石」の①の効果を発動できますか？ 
A. 
ご質問の状況の場合でも、「太古の白石」は『①』の効果を発動する事はできますが、その効果は無効化されます。