### PR TITLE
fix Parasite Fusioner

### DIFF
--- a/c6205579.lua
+++ b/c6205579.lua
@@ -21,6 +21,7 @@ function c6205579.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e3:SetProperty(EFFECT_FLAG_DELAY)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetCondition(c6205579.spcon)
 	e3:SetTarget(c6205579.sptg)
 	e3:SetOperation(c6205579.spop)
 	c:RegisterEffect(e3)
@@ -31,6 +32,10 @@ function c6205579.splimit(e,c)
 end
 function c6205579.subcon(e)
 	return e:GetHandler():IsLocation(LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE)
+end
+function c6205579.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return ph~=PHASE_DAMAGE and ph~=PHASE_DAMAGE_CAL
 end
 function c6205579.spfilter1(c,e)
 	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)


### PR DESCRIPTION
Fix this: Parasite Fusioner's effect can activate in Damage Step.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12744
■『②：このカードが特殊召喚に成功した場合に発動できる。融合モンスターカードによって決められた、このカードを含む融合素材モンスターを自分フィールドから墓地へ送り、その融合モンスター１体をエクストラデッキから融合召喚する』モンスター効果は誘発効果です。（対象を取る効果ではありません。**ダメージステップに発動する事はできません**。）