### PR TITLE
fix Dance Princess of the Ice Barrier

### DIFF
--- a/c59546528.lua
+++ b/c59546528.lua
@@ -9,6 +9,7 @@ function c59546528.initial_effect(c)
 	e1:SetCountLimit(1)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCondition(c59546528.condition)
+	e1:SetCost(c59546528.cost)
 	e1:SetTarget(c59546528.target)
 	e1:SetOperation(c59546528.operation)
 	c:RegisterEffect(e1)
@@ -22,28 +23,28 @@ end
 function c59546528.cfilter2(c)
 	return c:IsSetCard(0x2f) and c:IsType(TYPE_MONSTER) and not c:IsPublic()
 end
-function c59546528.filter(c,e)
-	return c:IsFacedown() and c:IsAbleToHand() and (not e or c:IsRelateToEffect(e))
+function c59546528.filter(c)
+	return c:IsFacedown() and c:IsAbleToHand()
+end
+function c59546528.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c59546528.cfilter2,tp,LOCATION_HAND,0,1,nil) end
+	local ct=Duel.GetTargetCount(c59546528.filter,tp,0,LOCATION_SZONE,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
+	local cg=Duel.SelectMatchingCard(tp,c59546528.cfilter2,tp,LOCATION_HAND,0,1,ct,nil)
+	Duel.ConfirmCards(1-tp,cg)
+	Duel.ShuffleHand(tp)
+	e:SetLabel(cg:GetCount())
 end
 function c59546528.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsControler(1-tp) and c59546528.filter(chkc) end
-	if chk==0 then return Duel.IsExistingMatchingCard(c59546528.cfilter2,tp,LOCATION_HAND,0,1,nil)
-		and Duel.IsExistingTarget(c59546528.filter,tp,0,LOCATION_SZONE,1,nil) end
-	local ht=Duel.GetMatchingGroupCount(c59546528.cfilter2,tp,LOCATION_HAND,0,nil)
+	if chk==0 then return Duel.IsExistingTarget(c59546528.filter,tp,0,LOCATION_SZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,c59546528.filter,tp,0,LOCATION_SZONE,1,ht,nil)
+	local g=Duel.SelectTarget(tp,c59546528.filter,tp,0,LOCATION_SZONE,e:GetLabel(),e:GetLabel(),nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
 function c59546528.operation(e,tp,eg,ep,ev,re,r,rp,chk)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local hg=Duel.GetMatchingGroup(c59546528.cfilter2,tp,LOCATION_HAND,0,nil)
-	if hg:GetCount()<g:GetCount() then return end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
-	local cg=hg:Select(tp,g:GetCount(),g:GetCount(),nil)
-	Duel.ConfirmCards(1-tp,cg)
-	Duel.ShuffleHand(tp)
-	local rg=g:Filter(c59546528.filter,nil,e)
-	if rg:GetCount()>0 then
-		Duel.SendtoHand(rg,nil,REASON_EFFECT)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix this: _Dance Princess of the Ice Barrier_'s "You can reveal any number of "Ice Barrier" monsters in your hand" is effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9110
■この効果を発動する際に、**コストとして**、手札の「氷結界」と名のついたモンスターを1体以上、任意の枚数だけ相手に見せます。