### PR TITLE
fix Raremetalfoes Bismugear

### DIFF
--- a/c18716735.lua
+++ b/c18716735.lua
@@ -15,7 +15,7 @@ function c18716735.initial_effect(c)
 	c:RegisterEffect(e1)
 	--to hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(18716735,0))
+	e2:SetDescription(aux.Stringid(18716735,1))
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetCode(EVENT_DESTROYED)


### PR DESCRIPTION
fixed stringid

note : cards.zh-CN.cdb (Ygopro Chinese MyCard, i think) , has no strings texts for Raremetalfoes Bismugear[18716735] in their database
yugioh continues to evolve , more complecated effects are introduced , string texts will become more important , and shouldn't be ignored , especially with more " Copy effects " existing now