### PR TITLE
fix Gladiator Beast Nerokius

### DIFF
--- a/c29357956.lua
+++ b/c29357956.lua
@@ -37,7 +37,7 @@ function c29357956.initial_effect(c)
 	c:RegisterEffect(e4)
 	--special summon
 	local e6=Effect.CreateEffect(c)
-	e6:SetDescription(aux.Stringid(29357956,1))
+	e6:SetDescription(aux.Stringid(29357956,0))
 	e6:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e6:SetCode(EVENT_PHASE+PHASE_BATTLE)


### PR DESCRIPTION
fixed stringid

29357956,0 was also skipped here

Some English databases show str0 translated as "can't activate effects", which is its Continous Effect , but in my experience Continous Effects generally don't use string texts anymore , only in cases of `EFFECT_FLAG_CLIENT_HINT` , where it needs to display the effect to the user , or when multiple Continous Effects are applied at the same time in the same effect , which is very rare
