### PR TITLE
fix Kaiju Capture Mission

### DIFF
--- a/c81057455.lua
+++ b/c81057455.lua
@@ -72,7 +72,7 @@ function c81057455.posop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c81057455.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:GetPreviousControler()==tp and rp==1-tp and c:IsReason(REASON_DESTROY+REASON_EFFECT)
+	return c:GetPreviousControler()==tp and rp==1-tp and bit.band(r,0x41)==0x41
 end
 function c81057455.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) end


### PR DESCRIPTION
Fix: It should be REASON_DESTROY and REASON_EFFECT, but `IsReason(REASON_DESTROY+REASON_EFFECT)` mean or.