### PR TITLE
fix Geomancer of the Ice Barrier

### DIFF
--- a/c56704140.lua
+++ b/c56704140.lua
@@ -30,7 +30,7 @@ function c56704140.operation(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
 	e1:SetLabel(e:GetLabel())
 	e1:SetValue(c56704140.tgval)
-	e1:SetReset(RESET_EVENT+0x1ff0000)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
 	c:RegisterEffect(e1)
 end
 function c56704140.tgval(e,c)

--- a/c56704140.lua
+++ b/c56704140.lua
@@ -27,6 +27,7 @@ function c56704140.operation(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e1:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
 	e1:SetLabel(e:GetLabel())
 	e1:SetValue(c56704140.tgval)


### PR DESCRIPTION
If Skill Drain leave the field, Geomancer of the Ice Barrier's effect don't apply.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10007&keyword=&tag=-1
Q.光属性を宣言して発動した「氷結界の風水師」の『手札を１枚捨て、属性を１つ宣言して発動できる。宣言した属性のモンスターはこのカードを攻撃対象に選択できない。この効果はこのカードがフィールド上に表側表示で存在する限り１度しか使用できない』モンスター効果が適用されています。

この状況で、「スキルドレイン」が発動し、「氷結界の風水師」のモンスター効果が無効化された場合、適用されている効果はどうなりますか？
A.「氷結界の風水師」のモンスター効果は起動効果です。

質問の状況の場合、光属性を宣言して発動した「氷結界の風水師」のモンスター効果が既に適用されていますので、その後に「スキルドレイン」が発動し、「氷結界の風水師」のモンスター効果が無効化された場合でも、既に適用されている効果の適用がなくなる事はありません。
（質問の状況の場合、光属性のモンスターは「氷結界の風水師」を攻撃対象に選択できない状態のままです。） 