### PR TITLE
fix Cyberdark Impact!

### DIFF
--- a/c80033124.lua
+++ b/c80033124.lua
@@ -10,10 +10,10 @@ function c80033124.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c80033124.ffilter0(c)
-	return c:IsCode(41230939,77625948,3019642) and c:IsAbleToDeck()
+	return c:IsCode(41230939,77625948,3019642) and c:IsCanBeFusionMaterial(nil,true) and c:IsAbleToDeck()
 end
 function c80033124.ffilter(c,e)
-	return c:IsCode(41230939,77625948,3019642) and c:IsAbleToDeck()
+	return c:IsCode(41230939,77625948,3019642) and c:IsCanBeFusionMaterial(nil,true) and c:IsAbleToDeck()
 		and not c:IsImmuneToEffect(e)
 end
 function c80033124.spfilter(c,e,tp)


### PR DESCRIPTION
Fix this: Player can shuffle _Magicalized Duston Mop_ equipped monster into the Deck by _Cyberdark Impact!_.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「サイバーダーク・インパクト！」の効果で、「ダストンのモップ」を装備した「サイバー・ダーク・ホーン」をデッキに戻すことはできますか？ 
A. 
ご質問の状況の場合、「ダストンのモップ」を装備した「サイバー・ダーク・ホーン」は融合素材にできませんので、「サイバーダーク・インパクト！」によってデッキに戻すことができません。