### PR TITLE
fix Poison Chain

### DIFF
--- a/c33302407.lua
+++ b/c33302407.lua
@@ -26,7 +26,7 @@ function c33302407.filter(c)
 end
 function c33302407.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=Duel.GetMatchingGroupCount(c33302407.filter,tp,LOCATION_MZONE,0,nil)
-	if chk==0 then return ct>0 and Duel.IsPlayerCanDiscardDeck(1-tp,0) end
+	if chk==0 then return ct>0 and Duel.IsPlayerCanDiscardDeck(1-tp,ct) end
 	Duel.SetOperationInfo(0,CATEGORY_DECKDES,nil,0,1-tp,ct)
 end
 function c33302407.disop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix this: If player controls more Iron Chain monsters than opponent's Deck, _Poison Chain_ can activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7909
■自分のモンスターゾーンに表側表示で存在する「C」と名のついたモンスターの数より、相手のデッキのカードの枚数の方が少ない場合には、エンドフェイズに「ポイズン・チェーン」の効果を発動する事はできません。