### PR TITLE
fix Victory Viper XX03, Power Capsule

### DIFF
--- a/c54289683.lua
+++ b/c54289683.lua
@@ -15,14 +15,18 @@ function c54289683.desfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_SPELL+TYPE_TRAP)
 end
 function c54289683.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return false end
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c54289683.filter(chkc) end
 	if chk==0 then return Duel.IsExistingTarget(c54289683.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local cg=Duel.SelectTarget(tp,c54289683.filter,tp,LOCATION_MZONE,0,1,1,nil)
-	local c=cg:GetFirst()
-	local t1=Duel.IsExistingTarget(c54289683.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler())
+	Duel.SelectTarget(tp,c54289683.filter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c54289683.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) then return end
+	local t1=Duel.IsExistingMatchingCard(c54289683.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler())
 	local t2=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsPlayerCanSpecialSummonMonster(tp,93130022,0,0x4011,c:GetAttack(),c:GetDefense(),c:GetLevel(),c:GetRace(),c:GetAttribute())
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,93130022,0,0x4011,tc:GetAttack(),tc:GetDefense(),tc:GetLevel(),tc:GetRace(),tc:GetAttribute())
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(93130021,0))
 	if t1 and t2 then
 		op=Duel.SelectOption(tp,aux.Stringid(93130021,1),aux.Stringid(93130021,2),aux.Stringid(93130021,3))
@@ -32,41 +36,19 @@ function c54289683.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		op=Duel.SelectOption(tp,aux.Stringid(93130021,1),aux.Stringid(93130021,3))
 		if op==1 then op=2 end
 	else op=Duel.SelectOption(tp,aux.Stringid(93130021,1)) end
-	e:SetLabel(op)
 	if op==1 then
-		e:SetCategory(CATEGORY_DESTROY)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-		local g=Duel.SelectTarget(tp,c54289683.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
-		e:SetLabelObject(g:GetFirst())
-		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	elseif op==2 then
-		e:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
-		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
-		Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
-	else
-		e:SetCategory(CATEGORY_ATKCHANGE)
-	end
-end
-function c54289683.operation(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if e:GetLabel()==1 then
-		local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-		local dc=e:GetLabelObject()
-		tc=g:GetFirst()
-		if tc==dc then tc=g:GetNext() end
-		if tc:IsFaceup() and tc:IsRelateToEffect(e) and dc:IsRelateToEffect(e) then
-			Duel.Destroy(dc,REASON_EFFECT)
+		local g=Duel.SelectMatchingCard(tp,c54289683.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.HintSelection(g)
+			Duel.Destroy(g,REASON_EFFECT)
 		end
-	elseif e:GetLabel()==2 then
-		if tc:IsFacedown() or not tc:IsRelateToEffect(e) then return end
+	elseif op==2 then
 		local atk=tc:GetAttack()
 		local def=tc:GetDefense()
 		local lv=tc:GetLevel()
 		local race=tc:GetRace()
 		local att=tc:GetAttribute()
-		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-			or not Duel.IsPlayerCanSpecialSummonMonster(tp,93130022,0,0x4011,atk,def,lv,race,att) then return end
 		local token=Duel.CreateToken(tp,93130022)
 		tc:CreateRelation(token,RESET_EVENT+0x1fe0000)
 		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
@@ -114,15 +96,12 @@ function c54289683.operation(e,tp,eg,ep,ev,re,r,rp)
 		token:RegisterEffect(e6,true)
 		Duel.SpecialSummonComplete()
 	else
-		if tc:IsFacedown() or not tc:IsRelateToEffect(e) then return end
-		if tc:IsRelateToEffect(e) and tc:IsFaceup() then
-			local e1=Effect.CreateEffect(c)
-			e1:SetType(EFFECT_TYPE_SINGLE)
-			e1:SetCode(EFFECT_UPDATE_ATTACK)
-			e1:SetValue(400)
-			e1:SetReset(RESET_EVENT+0x1ff0000)
-			tc:RegisterEffect(e1)
-		end
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(400)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		tc:RegisterEffect(e1)
 	end
 end
 function c54289683.tokenatk(e,c)

--- a/c93130021.lua
+++ b/c93130021.lua
@@ -16,11 +16,10 @@ end
 function c93130021.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_SPELL+TYPE_TRAP)
 end
-function c93130021.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and c93130021.filter(chkc) end
+function c93130021.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local c=e:GetHandler()
-	local t1=Duel.IsExistingTarget(c93130021.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
+	local t1=Duel.IsExistingMatchingCard(c93130021.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
 	local t2=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,93130022,0,0x4011,c:GetAttack(),c:GetDefense(),c:GetLevel(),c:GetRace(),c:GetAttribute())
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(93130021,0))
@@ -34,27 +33,25 @@ function c93130021.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	else op=Duel.SelectOption(tp,aux.Stringid(93130021,1)) end
 	e:SetLabel(op)
 	if op==1 then
-		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
 		e:SetCategory(CATEGORY_DESTROY)
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-		local g=Duel.SelectTarget(tp,c93130021.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+		local g=Duel.GetMatchingGroup(c93130021.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 	elseif op==2 then
-		e:SetProperty(0)
 		e:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
 		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
 		Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
 	else
-		e:SetProperty(0)
 		e:SetCategory(CATEGORY_ATKCHANGE)
 	end
 end
 function c93130021.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if e:GetLabel()==1 then
-		local tc=Duel.GetFirstTarget()
-		if tc:IsRelateToEffect(e) then
-			Duel.Destroy(tc,REASON_EFFECT)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		local g=Duel.SelectMatchingCard(tp,c93130021.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.HintSelection(g)
+			Duel.Destroy(g,REASON_EFFECT)
 		end
 	elseif e:GetLabel()==2 then
 		local atk=c:GetAttack()


### PR DESCRIPTION
Fix 1: _Victory Viper XX03_'s effect is target effect.
Fix 2: _Power Capsule_'s destroying effect is target effect.
Fix 3: Player select 1 effect of _Victory Viper XX03_ in activated timing.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6706
■効果処理時に「ビクトリー・バイパー XX０３」のカードテキストに記されている『●』の3つの効果の中から1つを選び、このカードの効果として適用します。

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分フィールドの「ビクトリー・バイパー XX０３」を対象に「パワーカプセル」を発動し、『●フィールド上に表側表示で存在する魔法または罠カード１枚を破壊する』効果を選んで適用する場合、『●フィールド上に表側表示で存在する魔法または罠カード１枚を破壊する』効果に対して「暗遷士 カンゴルゴーム」の効果を発動して別の魔法・罠カード1枚に対象を移し替えれますか？ 
移し替えれる場合、どのタイミングで「暗遷士 カンゴルゴーム」の効果を発動することになりますか？ 
A. 
「パワーカプセル」で適用する「ビクトリー・バイパー XX０３」の『●フィールド上に表側表示で存在する魔法または罠カード１枚を破壊する。』効果は対象を取りません。 
よって「暗遷士 カンゴルゴーム」の効果を発動することはできません。

Q. 
「ビクトリー・バイパー XX０３」の『●フィールド上に表側表示で存在する魔法または罠カード１枚を破壊する』効果は対象に取る効果ですか？ 
A. 
対象を取らない効果となります。
