### PR TITLE
fix Swordsman of Revealing Light and Bachibachibachi

### DIFF
--- a/c64605089.lua
+++ b/c64605089.lua
@@ -58,7 +58,7 @@ function c64605089.efop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCountLimit(1)
 	e1:SetValue(c64605089.valcon)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
-	rc:RegisterEffect(e1)
+	rc:RegisterEffect(e1,true)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)

--- a/c83272895.lua
+++ b/c83272895.lua
@@ -20,7 +20,7 @@ function c83272895.efop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetProperty(EFFECT_FLAG_CLIENT_HINT)
 	e1:SetCode(EFFECT_PIERCE)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
-	rc:RegisterEffect(e1)
+	rc:RegisterEffect(e1,true)
 	if not rc:IsType(TYPE_EFFECT) then
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
Fix: It shouldn't fail to add effect to monster which is immune to this effect.