### PR TITLE
fix Phantasmal Martyrs

### DIFF
--- a/c93224848.lua
+++ b/c93224848.lua
@@ -15,7 +15,7 @@ function c93224848.filter(c)
 	return c:IsFaceup() and c:IsCode(6007213,32491822)
 end
 function c93224848.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)>=2
+	return Duel.IsExistingMatchingCard(nil,tp,LOCATION_HAND,0,2,e:GetHandler())
 		and Duel.IsExistingMatchingCard(c93224848.filter,tp,LOCATION_ONFIELD,0,1,nil)
 end
 function c93224848.cfilter(c)


### PR DESCRIPTION
Fix this: If player have 2 cards in hand, _Phantasmal Martyrs_ can activate from hand.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6575
■「幻魔の殉教者」が魔法＆罠ゾーンにセットされている場合には自分の手札が2枚以上の時に発動する事ができます。また、「幻魔の殉教者」が手札にある場合には、「幻魔の殉教者」を含めて自分の手札が3枚以上の時に発動する事ができます。