### PR TITLE
fix Gallis the Star Beast

### DIFF
--- a/c30915572.lua
+++ b/c30915572.lua
@@ -25,9 +25,14 @@ function c30915572.spoperation(e,tp,eg,ep,ev,re,r,rp,c)
 	local g=Duel.GetOperatedGroup()
 	local tc=g:GetFirst()
 	if tc then
+		Duel.BreakEffect()
 		if tc:IsType(TYPE_MONSTER) then
 			Duel.Damage(1-tp,tc:GetLevel()*200,REASON_EFFECT)
-			if c:IsRelateToEffect(e) then Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP) end
+			if not c:IsRelateToEffect(e) then return end
+			if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+				and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+				Duel.SendtoGrave(c,REASON_RULE)
+			end
 		else
 			if c:IsRelateToEffect(e) then Duel.Destroy(c,REASON_EFFECT) end
 		end


### PR DESCRIPTION
Fix 1: The "send the top card of your Deck to the Graveyard" and the "if it was a monster, inflict damage to your opponent equal to its Level x 200 and Special Summon this card from your hand, otherwise destroy this card" are the same.
Fix 2: If player have no space in monster zone, _Gallis the Star Beast_ don't send to graveyard.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7981
■『自分のデッキの一番上のカードを墓地へ送り』の処理と、『そのカードがモンスターだった場合、そのモンスターのレベル×２００ポイントダメージを相手ライフに与えこのカードを特殊召喚する。そのカードがモンスター以外だった場合、このカードを破壊する』処理は同時に行われる扱いではありません。

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分が手札の「星見獣ガリス」の効果を発動し、チェーンして相手が「おジャマトリオ」を発動しました。「星見獣ガリス」の効果によってモンスターカードを墓地へ送った場合、モンスターゾーンに空きがない場合はどうなるのでしょうか？ 
A. 
ご質問の状況の場合でも、デッキの一番上のカードを墓地へ送る効果処理は行います。 
なお、相手にダメージを与える事はできますが、手札の「星見獣ガリス」は特殊召喚できず墓地へ送ります。