### PR TITLE
fix Destiny Mirage

### DIFF
--- a/c15294090.lua
+++ b/c15294090.lua
@@ -11,7 +11,7 @@ function c15294090.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c15294090.cfilter(c,tp)
-	return c:IsSetCard(0xc008) and c:IsPreviousLocation(LOCATION_ONFIELD) and c:GetPreviousControler()==tp
+	return c:IsPreviousSetCard(0xc008) and c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousControler()==tp
 end
 function c15294090.condition(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT)~=0 and rp~=tp and eg:IsExists(c15294090.cfilter,1,nil,tp)
@@ -21,16 +21,15 @@ function c15294090.spfilter(c,e,tp)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c15294090.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c15294090.spfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,e,tp) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,PLAYER_ALL,LOCATION_GRAVE)
+	local g=Duel.GetMatchingGroup(c15294090.spfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil,e,tp)
+	if chk==0 then return g:GetCount()>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>=g:GetCount() end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,g:GetCount(),0,0)
 end
 function c15294090.operation(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c15294090.spfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil,e,tp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if ft<=0 then return end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c15294090.spfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,ft,nil,e,tp)
-	if g:GetCount()~=0 then
+	if ft<=0 or ft<g:GetCount() or (g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
Fix 1: When a face-down Destiny HERO is destroyed, _Destiny Mirage_ can activate.
Fix 2: If player have more monsters destroyed this turn than space in monster zone, _Destiny Mirage_ can activate.
Fix 3: If _Blue-Eyes Spirit Dragon_ has on the field, Special Summon as many monsters destroyed this turn by _Destiny Mirage_'s effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6763
■自分のモンスターゾーンに表側表示で存在する「D-HERO」と名のついたモンスターが相手のカードの効果によって破壊され墓地へ送られた時に発動する事ができるカードです。（裏側守備表示の「D-HERO」と名のついたモンスターが効果で破壊された際に発動する事はできません。）
■そのターンに破壊され墓地へ送られた「D-HERO」と名のついたモンスターの数が、自分のモンスターゾーンの空きの数よりも多く破壊され墓地へ送られているターンには「デステニー・ミラージュ」を発動する事はできません。

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
「D-HERO ドリルガイ」「D-HERO ダイヤモンドガイ」が既に破壊されているターンに「D-HERO ディストピアガイ」が相手の「サンダー・ブレイク」の効果で破壊されたので、自分は「デステニー・ミラージュ」を発動しました。 
その際に以下の内どれかの状況になった場合、「デステニー・ミラージュ」の処理はそれぞれどのように適用されるのでしょうか？ 
・チェーンして相手が「おジャマトリオ」を発動し、自分のモンスターゾーンの空きが2つになった 
・チェーンして相手が「リビングデッドの呼び声」を発動し、相手フィールドに「青眼の精霊龍」が特殊召喚された 
A. 
ご質問の状況の場合、「おジャマトリオ」の発動によりモンスターカードゾーンの空きが2カ所になる為、「デステニー・ミラージュ」の効果処理は適用されません。 
また、チェーンして「リビングデッドの呼び声」を発動し、「青眼の精霊龍」が特殊召喚された場合でも、「デステニー・ミラージュ」の効果処理時に「青眼の精霊龍」の『①』の効果が適用されている為、「デステニー・ミラージュ」の効果処理は適用されません。