### PR TITLE
fix Call of the Earthbound

### DIFF
--- a/c65743242.lua
+++ b/c65743242.lua
@@ -14,15 +14,28 @@ function c65743242.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c65743242.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local ag=eg:GetFirst():GetAttackableTarget()
+		local ag,da=eg:GetFirst():GetAttackableTarget()
 		local at=Duel.GetAttackTarget()
-		return ag:IsExists(aux.TRUE,1,at)
+		return ag:IsExists(aux.TRUE,1,at) or (at~=nil and da)
 	end
 end
 function c65743242.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ag=eg:GetFirst():GetAttackableTarget()
+	local ag,da=eg:GetFirst():GetAttackableTarget()
 	local at=Duel.GetAttackTarget()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	if da and at~=nil then
+		local sel=0
+		Duel.Hint(HINT_SELECTMSG,tp,31)
+		if ag:IsExists(aux.TRUE,1,at) then
+			sel=Duel.SelectOption(tp,1213,1214)
+		else
+			sel=Duel.SelectOption(tp,1213)
+		end
+		if sel==0 then
+			Duel.ChangeAttackTarget(nil)
+			return
+		end
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,549)
 	local g=ag:Select(tp,1,1,at)
 	local tc=g:GetFirst()
 	if tc then


### PR DESCRIPTION
> ■「地縛霊の誘い」は、相手モンスターがモンスターを対象に攻撃を宣言した時だけでなく、プレイヤーへの直接攻撃を宣言した時にも発動する事ができます。
■「地縛霊の誘い」の効果によって選び直す攻撃対象は、その相手の攻撃モンスターが攻撃を行う際の攻撃対象として正しいものでなければなりません。（カードの効果によって直接攻撃を行える状態のモンスターであれば、選び直す攻撃対象をプレイヤーとする事もできます。）
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6010

Fix: It should be able to select direct attack.