### PR TITLE
fix Memory Crush King

### DIFF
--- a/c75675029.lua
+++ b/c75675029.lua
@@ -29,7 +29,6 @@ function c75675029.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c75675029.filter,tp,0,LOCATION_GRAVE,nil)
 	local ct=Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
 	if ct~=0 then
-		Duel.BreakEffect()
 		Duel.Damage(1-tp,ct*1000,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix this: The "remove from play all Synchro Monsters in your opponent's Graveyard" and the "inflict 1000 damage to your opponent for each monster removed" are not the same.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8805
■『相手の墓地に存在するシンクロモンスターを全てゲームから除外し』の処理と、『その数×１０００ポイントダメージを相手ライフに与える』処理は同時に行われる扱いとなります。