### PR TITLE
fix Synchro Ejection

### DIFF
--- a/c75105429.lua
+++ b/c75105429.lua
@@ -15,7 +15,8 @@ function c75105429.filter(c)
 end
 function c75105429.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and c75105429.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c75105429.filter,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c75105429.filter,tp,0,LOCATION_MZONE,1,nil)
+		and Duel.IsPlayerCanDraw(1-tp,1) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectTarget(tp,c75105429.filter,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
@@ -24,7 +25,6 @@ end
 function c75105429.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.Remove(tc,0,REASON_EFFECT)~=0 then
-		Duel.BreakEffect()
 		Duel.Draw(1-tp,1,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix 1: The "remove it from play" and the "your opponent draws 1 card" are not the same.
Fix 2: If opponent has no cards in Deck, _Synchro Ejection_ can activate.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8854
■『相手フィールド上に表側表示で存在するシンクロモンスター１体を選択してゲームから除外し』の処理と、『相手はデッキからカードを１枚ドローする』処理は同時に行われる扱いとなります。
■相手のデッキが0枚の場合、「シンクロ・イジェクション」を発動する事はできません。