### PR TITLE
fix Zoodiac Tigress

### DIFF
--- a/c11510448.lua
+++ b/c11510448.lua
@@ -73,7 +73,7 @@ function c11510448.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	local tc1=g:Filter(Card.IsLocation,nil,LOCATION_MZONE):GetFirst()
 	local g2=g:Filter(Card.IsLocation,nil,LOCATION_GRAVE)
-	if tc1 and not tc1:IsImmuneToEffect(e) and g2:GetCount()>0 then
+	if tc1 and tc1:IsFaceup() and not tc1:IsImmuneToEffect(e) and g2:GetCount()>0 then
 		Duel.Overlay(tc1,g2)
 	end
 end


### PR DESCRIPTION
Fix this: If target Xyz monster is face-down after chain solved, _Zoodiac Tigress_'s effect apply.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7804&keyword=&tag=-1
Q.「十二獣タイグリス」の『②：１ターンに１度、このカードのX素材を１つ取り除き、自分フィールドのXモンスター１体と自分の墓地の「十二獣」モンスター１体を対象として発動できる。その「十二獣」モンスターをそのXモンスターの下に重ねてX素材とする』モンスター効果を発動する際に、対象とする『自分フィールドのXモンスター１体』として、「十二獣ドランシア」を選択しました。

その発動にチェーンして「月の書」が発動し、対象の「十二獣ドランシア」が裏側守備表示になった場合、処理はどうなりますか？
A.自分の墓地の「十二獣」と名のついたモンスターをエクシーズ素材とする「十二獣タイグリス」のモンスター効果の処理時に、対象として選択されたエクシーズモンスターが裏側守備表示になっている場合には、『その「十二獣」モンスターをそのXモンスターの下に重ねてX素材とする』処理を適用する事はできません。

対象とした、自分の墓地の「十二獣」と名のついたモンスター1体はそのまま墓地に残ります。 