### PR TITLE
fix Elemental Triangle of the Zoodiac

### DIFF
--- a/c46060017.lua
+++ b/c46060017.lua
@@ -73,7 +73,7 @@ end
 function c46060017.matop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) then
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() and not tc:IsImmuneToEffect(e) then
 		Duel.Overlay(tc,Group.FromCards(c))
 	end
 end


### PR DESCRIPTION
Fix this: If target Xyz monster is face-down after chain solved, _Elemental Triangle of the Zoodiac_'s effect apply.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12714&keyword=&tag=-1
Q.「十二獣の会局」がカードの効果で破壊され墓地へ送られた際に、『②：このカードが効果で破壊され墓地へ送られた場合、自分フィールドの「十二獣」Xモンスター１体を対象として発動できる。墓地のこのカードをそのXモンスターの下に重ねてX素材とする』効果を発動し、自分のモンスターゾーンに表側表示で存在する「十二獣ブルホーン」を対象としました。

その発動にチェーンして「月の書」が発動し、対象の「十二獣ブルホーン」が裏側守備表示になった場合、処理はどうなりますか？
A.カードの効果で破壊され墓地へ送られた「十二獣の会局」の対象として選択されたエクシーズモンスターが効果処理時に裏側守備表示になっている場合には、『墓地のこのカードをそのXモンスターの下に重ねてX素材とする』処理を適用する事はできません。

その「十二獣の会局」はそのまま墓地に残ります。 