### PR TITLE
Added Missing Category - Sinister Shadow Games

### DIFF
--- a/c77505534.lua
+++ b/c77505534.lua
@@ -2,6 +2,7 @@
 function c77505534.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOGRAVE+CATEGORY_POSITION)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetHintTiming(0,0x11e8)


### PR DESCRIPTION
I based my edits on Magical Dimension's script,
https://github.com/Fluorohydride/ygopro-scripts/blob/master/c28553439.lua#L5.

Both Sinister Shadow Games and Magical Dimension have categorized effects on activation, and both have an optional categorized effect after "then".