### PR TITLE
fix Splendid Venus, Traptrix Atrax

### DIFF
--- a/c55428242.lua
+++ b/c55428242.lua
@@ -51,6 +51,5 @@ end
 function c55428242.chainfilter(e,ct)
 	local p=e:GetHandlerPlayer()
 	local te,tp=Duel.GetChainInfo(ct,CHAININFO_TRIGGERING_EFFECT,CHAININFO_TRIGGERING_PLAYER)
-	local tc=te:GetHandler()
-	return p==tp and tc:GetType()==TYPE_TRAP
+	return p==tp and te:GetActiveType()==TYPE_TRAP
 end

--- a/c5645210.lua
+++ b/c5645210.lua
@@ -46,8 +46,7 @@ end
 function c5645210.effectfilter(e,ct)
 	local p=e:GetHandler():GetControler()
 	local te,tp=Duel.GetChainInfo(ct,CHAININFO_TRIGGERING_EFFECT,CHAININFO_TRIGGERING_PLAYER)
-	local tc=te:GetHandler()
-	return p==tp and tc:IsType(TYPE_SPELL+TYPE_TRAP)
+	return p==tp and te:IsActiveType(TYPE_SPELL+TYPE_TRAP)
 end
 function c5645210.distarget(e,c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP)


### PR DESCRIPTION
Fix this: If _Splendid Venus_ has on the field, Igknight is disabled its effects by _Necrovalley_.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分フィールドに「王家の眠る谷－ネクロバレー」「The splendid VENUS」が存在し、自分のデッキ及び墓地にの戦士族・炎属性モンスターが存在する場合、自分は「イグナイト・イーグル」のペンデュラム効果で、墓地の戦士族・炎属性モンスター１体を選ぶ事はできますか？できる場合「イグナイト・イーグル」の効果は無効化されますか？ 
A. 
ご質問の状況の場合、自分は「The splendid VENUS」の効果により、「イグナイト・イーグル」のペンデュラム効果は無効になりません。 
よって、「イグナイト・イーグル」の効果で、墓地の戦士族・炎属性モンスターを選んで手札に加える事ができます。
