### PR TITLE
fix SPYRAL Resort

### DIFF
--- a/c54631665.lua
+++ b/c54631665.lua
@@ -58,7 +58,7 @@ function c54631665.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c54631665.cfilter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsAbleToDeckAsCost()
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToDeckOrExtraAsCost()
 end
 function c54631665.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Not 100% sure about that one.
This card only refers to the deck an not only main deck like Infestation Infection or Raptor Wing Strike and thus should also be able to recycle extra deck monsters as its maintenance cost.