### PR TITLE
fix The Unfriendly Amazon

### DIFF
--- a/c65475294.lua
+++ b/c65475294.lua
@@ -16,7 +16,7 @@ function c65475294.costcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c65475294.costop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if Duel.CheckReleaseGroup(tp,nil,1,c) and Duel.SelectYesNo(tp,aux.Stringid(65475294,0)) then
+	if Duel.CheckReleaseGroup(tp,nil,1,c) then
 		local g=Duel.SelectReleaseGroup(tp,nil,1,1,c)
 		Duel.Release(g,REASON_COST)
 	else


### PR DESCRIPTION
Fix this: If player have other monster, player can destroy _The Unfriendly Amazon_.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5194
■自分のモンスターゾーンに「味方殺しの女騎士」自身以外のモンスターが存在する場合、自分のスタンバイフェイズ毎に必ず1体をリリースします。（その他のモンスターが裏側守備表示で存在するモンスターだった場合でもリリースします。）