### PR TITLE
fix Hiro's Shadow Scout

### DIFF
--- a/c81863068.lua
+++ b/c81863068.lua
@@ -19,6 +19,7 @@ end
 function c81863068.operation(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	if Duel.Draw(p,d,REASON_EFFECT)==0 then return end
+	Duel.BreakEffect()
 	local g=Duel.GetOperatedGroup()
 	Duel.ConfirmCards(1-p,g)
 	local dg=g:Filter(Card.IsType,nil,TYPE_SPELL)


### PR DESCRIPTION
Fix this: The "Your opponent draws 3 cards" and the "If there are any Spell Cards among them, discard all those Spell Card(s) to the Graveyard" are the same.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4617
■『相手はデッキからカードを３枚ドローする』処理と『この効果でドローしたカードをお互いに確認し、その中から魔法カードを全て墓地へ捨てる』処理は同時に行われる扱いではありません。