### PR TITLE
fix Parasite Paracide

### DIFF
--- a/c27911549.lua
+++ b/c27911549.lua
@@ -52,8 +52,9 @@ function c27911549.spop(e,tp,eg,ep,ev,re,r,rp)
 			e1:SetValue(RACE_INSECT)
 			e1:SetReset(RESET_EVENT+0x1fe0000)
 			c:RegisterEffect(e1)
-		else
-			Duel.Destroy(c,REASON_RULE)
+		elseif Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+			and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+			Duel.SendtoGrave(c,REASON_RULE)
 		end
 	end
 end


### PR DESCRIPTION
Fix this: If player have no space in monster zone, _Parasite Paracide_ destroy.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分のモンスターゾーンに空きがない状況で、表側表示で加わっている「寄生虫パラサイド」をドローした場合どうなりますか？ 
A. 
モンスターゾーンに空きが無い場合は特殊召喚できませんので墓地へ送られます。 
また、その際に1000ポイントのダメージは与えません。

Q. 
相手フィールドに「虚無空間」が存在する状況で、表側表示で加わっている「寄生虫パラサイド」をドローした場合どうなりますか？ 
A. 
ドローした「寄生虫パラサイド」を特殊召喚する事ができませんので、その「寄生虫パラサイド」は手札に持ったままとなり、1000ポイントのダメージは与えません。
