### PR TITLE
fix Deck Devastation Virus etc.

### DIFF
--- a/c22804644.lua
+++ b/c22804644.lua
@@ -57,6 +57,7 @@ function c22804644.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c22804644.desop(e,tp,eg,ep,ev,re,r,rp)
 	if ep==e:GetOwnerPlayer() then return end
+	if not eg then return end
 	local hg=eg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 	if hg:GetCount()==0 then return end
 	Duel.ConfirmCards(1-ep,hg)

--- a/c35027493.lua
+++ b/c35027493.lua
@@ -59,6 +59,7 @@ function c35027493.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c35027493.desop(e,tp,eg,ep,ev,re,r,rp)
 	if ep==e:GetOwnerPlayer() then return end
+	if not eg then return end
 	local hg=eg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 	if hg:GetCount()==0 then return end
 	Duel.ConfirmCards(1-ep,hg)

--- a/c4931121.lua
+++ b/c4931121.lua
@@ -59,6 +59,7 @@ function c4931121.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c4931121.desop(e,tp,eg,ep,ev,re,r,rp)
 	if ep==e:GetOwnerPlayer() then return end
+	if not eg then return end
 	local hg=eg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 	if hg:GetCount()==0 then return end
 	Duel.ConfirmCards(1-ep,hg)

--- a/c54974237.lua
+++ b/c54974237.lua
@@ -67,6 +67,7 @@ function c54974237.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c54974237.desop(e,tp,eg,ep,ev,re,r,rp)
 	if ep==e:GetOwnerPlayer() then return end
+	if not eg then return end
 	local hg=eg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 	if hg:GetCount()==0 then return end
 	Duel.ConfirmCards(1-ep,hg)

--- a/c91663373.lua
+++ b/c91663373.lua
@@ -16,7 +16,7 @@ function c91663373.filter(c)
 	return c:IsLocation(LOCATION_HAND) and not c:IsPublic()
 end
 function c91663373.cfop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetHandler():IsRelateToEffect(e) and e:GetHandler():IsPosition(POS_FACEUP_ATTACK) then
+	if eg and e:GetHandler():IsRelateToEffect(e) and e:GetHandler():IsPosition(POS_FACEUP_ATTACK) then
 		local cg=eg:Filter(c91663373.filter,nil)
 		Duel.ConfirmCards(tp,cg)
 		Duel.ShuffleHand(1-tp)


### PR DESCRIPTION
Fix: If the player activate _Dark World Dealings_ and discard the card just draw, those cards will throw error.