### PR TITLE
fix Predaplant Chimera Rafflesia

### DIFF
--- a/c25586143.lua
+++ b/c25586143.lua
@@ -74,7 +74,7 @@ end
 function c25586143.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=e:GetLabelObject()
-	if  tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if  tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(1-tp) and not tc:IsImmuneToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)


### PR DESCRIPTION
fix 1: if control of the attack target changes, the effect should not alter the atk of the monsters
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13096&keyword=&tag=-1

fix 2: if the atk of the monster can't be lowered the atk of Rafflesia shouldn't change. This should not only affect if the opponents monster is face down but also if the opponents monster is immune
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6136&keyword=&tag=-1