### PR TITLE
fix Psychic Commander

### DIFF
--- a/c21454943.lua
+++ b/c21454943.lua
@@ -25,7 +25,7 @@ function c21454943.condition(e,tp,eg,ep,ev,re,r,rp)
 		return a:IsFaceup() and a:IsRace(RACE_PSYCHO) and a:IsRelateToBattle() and d and d:IsFaceup() and d:IsRelateToBattle()
 	else
 		e:SetLabelObject(a)
-		return d:IsFaceup() and d:IsRace(RACE_PSYCHO) and d:IsRelateToBattle() and a and a:IsFaceup() and a:IsRelateToBattle()
+		return d and d:IsFaceup() and d:IsRace(RACE_PSYCHO) and d:IsRelateToBattle() and a and a:IsFaceup() and a:IsRelateToBattle()
 	end
 end
 function c21454943.cost(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/13391795/21080306/ab1bdbce-bfe6-11e6-853e-ae496fb8eff7.png)

Fix: If the player use _Astral Barrier_ to make opponent monster attack directly, _Psychic Commander_ will show error.