### PR TITLE
fix Dark Calling, Super Polymerization etc. & update Miracle Fusion, Void Imagination etc.

### DIFF
--- a/c12071500.lua
+++ b/c12071500.lua
@@ -9,25 +9,33 @@ function c12071500.initial_effect(c)
 	e1:SetOperation(c12071500.activate)
 	c:RegisterEffect(e1)
 end
+function c12071500.filter0(c)
+	return c:IsLocation(LOCATION_HAND) and c:IsAbleToRemove()
+end
 function c12071500.filter1(c,e)
-	return c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+	return c:IsLocation(LOCATION_HAND) and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
 end
 function c12071500.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c.dark_calling and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION+0x10,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
+function c12071500.filter3(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
 function c12071500.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToRemove,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c12071500.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c12071500.filter3,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c12071500.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c12071500.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c12071500.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -37,15 +45,17 @@ end
 function c12071500.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c12071500.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c12071500.filter3,tp,LOCATION_GRAVE,0,nil)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c12071500.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c12071500.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c12071500.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -60,7 +70,7 @@ function c12071500.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION+0x10,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2,SUMMON_TYPE_FUSION+0x10)
 		end

--- a/c31444249.lua
+++ b/c31444249.lua
@@ -46,8 +46,11 @@ function c31444249.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
 end
+function c31444249.filter0(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave()
+end
 function c31444249.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave() and not c:IsImmuneToEffect(e)
+	return not c:IsImmuneToEffect(e)
 end
 function c31444249.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0xbb) and (not f or f(c))
@@ -60,9 +63,9 @@ end
 function c31444249.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c31444249.filter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
+		local mg1=Duel.GetFusionMaterial(tp)
 		if c31444249.dmcon(e,tp,eg,ep,ev,re,r,rp) then
-			local sg=Duel.GetMatchingGroup(c31444249.filter1,tp,LOCATION_DECK,0,nil,e)
+			local sg=Duel.GetMatchingGroup(c31444249.filter0,tp,LOCATION_DECK,0,nil)
 			mg1:Merge(sg)
 		end
 		local res=Duel.IsExistingMatchingCard(c31444249.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
@@ -81,9 +84,9 @@ function c31444249.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c31444249.spop(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c31444249.filter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c31444249.filter1,nil,e)
 	if c31444249.dmcon(e,tp,eg,ep,ev,re,r,rp) then
-		local dmg=Duel.GetMatchingGroup(c31444249.filter1,tp,LOCATION_DECK,0,nil,e)
+		local dmg=Duel.GetMatchingGroup(c31444249.filter0,tp,LOCATION_DECK,0,nil)
 		mg1:Merge(dmg)
 	end
 	local sg1=Duel.GetMatchingGroup(c31444249.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
@@ -104,7 +107,7 @@ function c31444249.spop(e,tp,eg,ep,ev,re,r,rp)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
 			if c31444249.dmcon(e,tp,eg,ep,ev,re,r,rp) then
-				local mgd=Duel.GetMatchingGroup(c31444249.filter1,tp,LOCATION_DECK,0,nil,e)
+				local mgd=Duel.GetMatchingGroup(c31444249.filter0,tp,LOCATION_DECK,0,nil)
 				mg1:Merge(mgd)
 				tc:RegisterFlagEffect(31444249,RESET_CHAIN,0,1)
 			end

--- a/c36484016.lua
+++ b/c36484016.lua
@@ -21,10 +21,10 @@ function c36484016.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c36484016.filter0(c)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+	return c:IsOnField() and c:IsAbleToRemove()
 end
 function c36484016.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
 end
 function c36484016.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c.miracle_synchro_fusion and (not f or f(c))
@@ -33,18 +33,23 @@ end
 function c36484016.filter3(c,fusc,m,chkf)
 	return c:IsType(TYPE_SYNCHRO) and fusc:CheckFusionMaterial(m,c,chkf)
 end
+function c36484016.filter4(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
 function c36484016.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c36484016.filter0,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c36484016.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c36484016.filter4,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c36484016.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c36484016.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c36484016.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -53,16 +58,18 @@ function c36484016.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c36484016.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c36484016.filter1,tp,LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c36484016.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c36484016.filter4,tp,LOCATION_GRAVE,0,nil)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c36484016.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c36484016.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c36484016.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -81,8 +88,8 @@ function c36484016.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-			local gc=mg2:FilterSelect(tp,c36484016.filter3,1,1,nil,tc,mg2,chkf):GetFirst()
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,gc,chkf)
+			local gc=mg3:FilterSelect(tp,c36484016.filter3,1,1,nil,tc,mg3,chkf):GetFirst()
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,gc,chkf)
 			mat2:AddCard(gc)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)

--- a/c3659803.lua
+++ b/c3659803.lua
@@ -10,27 +10,32 @@ function c3659803.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c3659803.filter0(c)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+	return c:IsOnField() and c:IsAbleToRemove()
 end
 function c3659803.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
 end
 function c3659803.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_MACHINE) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
+function c3659803.filter3(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
 function c3659803.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c3659803.filter0,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c3659803.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c3659803.filter3,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c3659803.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c3659803.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c3659803.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -39,16 +44,18 @@ function c3659803.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c3659803.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c3659803.filter1,tp,LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c3659803.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c3659803.filter3,tp,LOCATION_GRAVE,0,nil)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c3659803.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c3659803.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c3659803.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -63,7 +70,7 @@ function c3659803.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c41940225.lua
+++ b/c41940225.lua
@@ -22,15 +22,18 @@ function c41940225.initial_effect(c)
 	e2:SetOperation(c41940225.thop)
 	c:RegisterEffect(e2)
 end
-function c41940225.filter0(c,tp)
-	return (c:IsControler(tp) or c:IsFaceup()) and c:IsCanBeFusionMaterial()
+function c41940225.filter0(c)
+	return c:IsFaceup() and c:IsCanBeFusionMaterial()
 end
-function c41940225.filter1(c,e,tp)
-	return (c:IsControler(tp) or c:IsFaceup()) and c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+function c41940225.filter1(c,e)
+	return c:IsFaceup() and c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
 end
 function c41940225.filter2(c,e,tp,m,f,chkf)
 	return c41940225.spfilter(c) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function c41940225.filter3(c,e)
+	return not c:IsImmuneToEffect(e)
 end
 function c41940225.spfilter(c)
 	return aux.IsMaterialListCode(c,78193831)
@@ -38,15 +41,17 @@ end
 function c41940225.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c41940225.filter0,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,tp)
+		local mg1=Duel.GetFusionMaterial(tp)
+		local mg2=Duel.GetMatchingGroup(c41940225.filter0,tp,0,LOCATION_MZONE,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c41940225.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c41940225.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c41940225.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -55,16 +60,18 @@ function c41940225.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c41940225.filter1,tp,LOCATION_MZONE+LOCATION_HAND,LOCATION_MZONE,nil,e,tp)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c41940225.filter3,nil,e)
+	local mg2=Duel.GetMatchingGroup(c41940225.filter1,tp,0,LOCATION_MZONE,nil,e)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c41940225.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c41940225.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c41940225.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -79,7 +86,7 @@ function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c44394295.lua
+++ b/c44394295.lua
@@ -14,7 +14,7 @@ function c44394295.filter0(c)
 	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave()
 end
 function c44394295.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave() and not c:IsImmuneToEffect(e)
+	return not c:IsImmuneToEffect(e)
 end
 function c44394295.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x9d) and (not f or f(c))
@@ -26,19 +26,19 @@ end
 function c44394295.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local loc=LOCATION_HAND+LOCATION_MZONE
+		local mg1=Duel.GetFusionMaterial(tp)
 		if Duel.IsExistingMatchingCard(c44394295.cfilter,tp,0,LOCATION_MZONE,1,nil) then
-			loc=loc+LOCATION_DECK
+			local mg2=Duel.GetMatchingGroup(c44394295.filter0,tp,LOCATION_DECK,0,nil)
+			mg1:Merge(mg2)
 		end
-		local mg1=Duel.GetMatchingGroup(c44394295.filter0,tp,loc,0,nil)
 		local res=Duel.IsExistingMatchingCard(c44394295.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c44394295.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c44394295.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -47,20 +47,20 @@ function c44394295.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c44394295.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local loc=LOCATION_HAND+LOCATION_MZONE
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c44394295.filter1,nil,e)
 	if Duel.IsExistingMatchingCard(c44394295.cfilter,tp,0,LOCATION_MZONE,1,nil) then
-		loc=loc+LOCATION_DECK
+		local mg2=Duel.GetMatchingGroup(c44394295.filter0,tp,LOCATION_DECK,0,nil)
+		mg1:Merge(mg2)
 	end
-	local mg1=Duel.GetMatchingGroup(c44394295.filter1,tp,loc,0,nil,e)
 	local sg1=Duel.GetMatchingGroup(c44394295.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c44394295.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c44394295.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -75,7 +75,7 @@ function c44394295.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c45206713.lua
+++ b/c45206713.lua
@@ -21,7 +21,7 @@ function c45206713.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c45206713.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+	return c:IsLocation(LOCATION_HAND) and not c:IsImmuneToEffect(e)
 end
 function c45206713.filter2(c,e,tp,m,f,gc)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x10af) and (not f or f(c))
@@ -30,7 +30,7 @@ end
 function c45206713.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_HAND,0,c)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsLocation,c,LOCATION_HAND)
 		local res=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 			and Duel.IsExistingMatchingCard(c45206713.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,c)
 		if not res then
@@ -49,7 +49,7 @@ end
 function c45206713.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
-	local mg1=Duel.GetMatchingGroup(c45206713.filter1,tp,LOCATION_HAND,0,c,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c45206713.filter1,c,e)
 	local sg1=Duel.GetMatchingGroup(c45206713.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c)
 	local mg2=nil
 	local sg2=nil

--- a/c45906428.lua
+++ b/c45906428.lua
@@ -10,27 +10,32 @@ function c45906428.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c45906428.filter0(c)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+	return c:IsOnField() and c:IsAbleToRemove()
 end
 function c45906428.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
 end
 function c45906428.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x3008) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
+function c45906428.filter3(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
 function c45906428.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c45906428.filter0,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c45906428.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c45906428.filter3,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c45906428.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c45906428.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c45906428.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -39,16 +44,18 @@ function c45906428.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c45906428.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c45906428.filter1,tp,LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c45906428.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c45906428.filter3,tp,LOCATION_GRAVE,0,nil)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c45906428.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c45906428.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c45906428.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -63,7 +70,7 @@ function c45906428.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c47705572.lua
+++ b/c47705572.lua
@@ -32,25 +32,33 @@ end
 function c47705572.splimit(e,c,sump,sumtype,sumpos,targetp)
 	return not (c:IsSetCard(0xdf) and c:IsType(TYPE_MONSTER)) and bit.band(sumtype,SUMMON_TYPE_PENDULUM)==SUMMON_TYPE_PENDULUM
 end
+function c47705572.filter0(c)
+	return c:IsOnField() and c:IsAbleToRemove()
+end
 function c47705572.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e) and c:IsAbleToRemove()
+	return c:IsOnField() and not c:IsImmuneToEffect(e) and c:IsAbleToRemove()
 end
 function c47705572.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0xdf) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
+function c47705572.filter3(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
 function c47705572.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c47705572.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c47705572.filter3,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c47705572.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c47705572.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c47705572.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -60,16 +68,18 @@ end
 function c47705572.spop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c47705572.filter1,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c47705572.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c47705572.filter3,tp,LOCATION_GRAVE,0,nil)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c47705572.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c47705572.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c47705572.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -84,7 +94,7 @@ function c47705572.spop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c48130397.lua
+++ b/c48130397.lua
@@ -12,14 +12,17 @@ function c48130397.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c48130397.filter0(c,tp)
-	return (c:IsControler(tp) or c:IsFaceup()) and c:IsCanBeFusionMaterial()
+	return c:IsFaceup() and c:IsCanBeFusionMaterial()
 end
 function c48130397.filter1(c,e,tp)
-	return (c:IsControler(tp) or c:IsFaceup()) and c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+	return c:IsFaceup() and c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
 end
 function c48130397.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function c48130397.filter3(c,e)
+	return not c:IsImmuneToEffect(e)
 end
 function c48130397.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
@@ -28,15 +31,17 @@ end
 function c48130397.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c48130397.filter0,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
+		local mg1=Duel.GetFusionMaterial(tp)
+		local mg2=Duel.GetMatchingGroup(c48130397.filter0,tp,0,LOCATION_MZONE,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c48130397.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c48130397.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c48130397.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -48,16 +53,18 @@ function c48130397.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c48130397.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c48130397.filter1,tp,LOCATION_MZONE,LOCATION_MZONE,nil,e,tp)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c48130397.filter3,nil,e)
+	local mg2=Duel.GetMatchingGroup(c48130397.filter1,tp,0,LOCATION_MZONE,nil,e)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c48130397.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c48130397.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c48130397.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -72,7 +79,7 @@ function c48130397.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c6077601.lua
+++ b/c6077601.lua
@@ -11,27 +11,32 @@ function c6077601.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c6077601.filter0(c)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+	return c:IsOnField() and c:IsAbleToRemove()
 end
 function c6077601.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
 end
 function c6077601.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0xad) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
+function c6077601.filter3(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
 function c6077601.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c6077601.filter0,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c6077601.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c6077601.filter3,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c6077601.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg2=fgroup(ce,e,tp)
+				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c6077601.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c6077601.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
 		return res
@@ -40,16 +45,18 @@ function c6077601.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c6077601.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c6077601.filter1,tp,LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c6077601.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c6077601.filter3,tp,LOCATION_GRAVE,0,nil)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c6077601.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c6077601.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c6077601.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -64,7 +71,7 @@ function c6077601.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c6172122.lua
+++ b/c6172122.lua
@@ -29,8 +29,11 @@ end
 function c6172122.splimit(e,c,sump,sumtype,sumpos,targetp,se)
 	return se~=e:GetLabelObject()
 end
+function c6172122.filter0(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave()
+end
 function c6172122.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToGrave() and not c:IsImmuneToEffect(e)
+	return not c:IsImmuneToEffect(e)
 end
 function c6172122.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and aux.IsMaterialListSetCard(c,0x3b) and (not f or f(c))
@@ -39,7 +42,9 @@ end
 function c6172122.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c6172122.filter1,tp,0x07,0,nil,e)
+		local mg1=Duel.GetFusionMaterial(tp)
+		local mg2=Duel.GetMatchingGroup(c6172122.filter0,tp,LOCATION_DECK,0,nil)
+		mg1:Merge(mg2)
 		local res=Duel.IsExistingMatchingCard(c6172122.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -56,16 +61,18 @@ function c6172122.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c6172122.filter1,tp,0x07,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c6172122.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c6172122.filter0,tp,LOCATION_DECK,0,nil)
+	mg1:Merge(mg2)
 	local sg1=Duel.GetMatchingGroup(c6172122.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=nil
+	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg2=fgroup(ce,e,tp)
+		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg2=Duel.GetMatchingGroup(c6172122.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+		sg2=Duel.GetMatchingGroup(c6172122.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -80,7 +87,7 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c6205579.lua
+++ b/c6205579.lua
@@ -31,7 +31,7 @@ function c6205579.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return ph~=PHASE_DAMAGE and ph~=PHASE_DAMAGE_CAL
 end
 function c6205579.spfilter1(c,e)
-	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and not c:IsImmuneToEffect(e)
 end
 function c6205579.spfilter2(c,e,tp,m,f,gc)
 	return c:IsType(TYPE_FUSION) and (not f or f(c))
@@ -40,7 +40,7 @@ end
 function c6205579.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_MZONE,0,c)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsOnField,c)
 		local res=Duel.IsExistingMatchingCard(c6205579.spfilter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,c)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -58,7 +58,7 @@ end
 function c6205579.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
-	local mg1=Duel.GetMatchingGroup(c6205579.spfilter1,tp,LOCATION_MZONE,0,c,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c6205579.spfilter1,c,e)
 	local sg1=Duel.GetMatchingGroup(c6205579.spfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c)
 	local mg2=nil
 	local sg2=nil

--- a/c62895219.lua
+++ b/c62895219.lua
@@ -37,7 +37,7 @@ function c62895219.thop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c62895219.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and not c:IsImmuneToEffect(e)
 end
 function c62895219.filter2(c,e,tp,m,f,gc)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x9b) and (not f or f(c))
@@ -46,7 +46,7 @@ end
 function c62895219.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_MZONE,0,c)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsOnField,c)
 		local res=Duel.IsExistingMatchingCard(c62895219.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,c)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -64,7 +64,7 @@ end
 function c62895219.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
-	local mg1=Duel.GetMatchingGroup(c62895219.filter1,tp,LOCATION_MZONE,0,c,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c7241272.filter1,c,e)
 	local sg1=Duel.GetMatchingGroup(c62895219.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c)
 	local mg2=nil
 	local sg2=nil

--- a/c71422989.lua
+++ b/c71422989.lua
@@ -37,7 +37,7 @@ function c71422989.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c71422989.filter1(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+	return c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
 end
 function c71422989.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x1047) and (not f or f(c))
@@ -50,7 +50,7 @@ function c71422989.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c71422989.filter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c71422989.filter1,nil,e)
 		local sg1=Duel.GetMatchingGroup(c71422989.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
 		local mg2=nil
 		local sg2=nil

--- a/c7241272.lua
+++ b/c7241272.lua
@@ -41,7 +41,7 @@ function c7241272.desop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c7241272.spfilter1(c,e)
-	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and not c:IsImmuneToEffect(e)
 end
 function c7241272.spfilter2(c,e,tp,m,f,gc)
 	return c:IsType(TYPE_FUSION) and (not f or f(c))
@@ -50,7 +50,7 @@ end
 function c7241272.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_MZONE,0,c)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsOnField,c)
 		local res=Duel.IsExistingMatchingCard(c7241272.spfilter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,c)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -68,7 +68,7 @@ end
 function c7241272.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
-	local mg1=Duel.GetMatchingGroup(c7241272.spfilter1,tp,LOCATION_MZONE,0,c,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c7241272.spfilter1,c,e)
 	local sg1=Duel.GetMatchingGroup(c7241272.spfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c)
 	local mg2=nil
 	local sg2=nil

--- a/c73360025.lua
+++ b/c73360025.lua
@@ -31,7 +31,7 @@ function c73360025.mfilter0(c)
 	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
 end
 function c73360025.mfilter1(c,e)
-	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+	return not c:IsImmuneToEffect(e)
 end
 function c73360025.mfilter2(c,e)
 	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
@@ -47,7 +47,7 @@ end
 function c73360025.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_HAND+LOCATION_MZONE,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp)
 		local res=Duel.IsExistingMatchingCard(c73360025.spfilter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if res then return true end
 		local mg2=Duel.GetMatchingGroup(c73360025.mfilter0,tp,LOCATION_GRAVE,0,nil)
@@ -69,7 +69,7 @@ end
 function c73360025.spop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c73360025.mfilter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c73360025.filter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c73360025.spfilter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
 	local mg2=Duel.GetMatchingGroup(c73360025.mfilter2,tp,LOCATION_GRAVE,0,nil,e)
 	mg2:Merge(mg1)

--- a/c74063034.lua
+++ b/c74063034.lua
@@ -22,13 +22,16 @@ function c74063034.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c74063034.mfilter0(c)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+	return c:IsOnField() and c:IsAbleToRemove()
 end
 function c74063034.mfilter1(c,e)
-	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
+	return c:IsLocation(LOCATION_HAND) and not c:IsImmuneToEffect(e)
 end
 function c74063034.mfilter2(c,e)
-	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function c74063034.mfilter3(c)
+	return c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
 end
 function c74063034.spfilter1(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and (not f or f(c))
@@ -41,19 +44,21 @@ end
 function c74063034.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_HAND,0,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsLocation,nil,LOCATION_HAND)
 		local res=Duel.IsExistingMatchingCard(c74063034.spfilter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if res then return true end
-		local mg2=Duel.GetMatchingGroup(c74063034.mfilter0,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_GRAVE,nil)
+		local mg2=Duel.GetFusionMaterial(tp):Filter(c74063034.mfilter0,nil)
+		local mg3=Duel.GetMatchingGroup(c74063034.mfilter3,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil)
 		mg2:Merge(mg1)
+		mg2:Merge(mg3)
 		res=Duel.IsExistingMatchingCard(c74063034.spfilter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
-				local mg3=fgroup(ce,e,tp)
+				local mg4=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				res=Duel.IsExistingMatchingCard(c74063034.spfilter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
+				res=Duel.IsExistingMatchingCard(c74063034.spfilter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg4,mf,chkf)
 			end
 		end
 		return res
@@ -62,20 +67,22 @@ function c74063034.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c74063034.spop(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-	local mg1=Duel.GetMatchingGroup(c74063034.mfilter1,tp,LOCATION_HAND,0,nil,e)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c74063034.mfilter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c74063034.spfilter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	local mg2=Duel.GetMatchingGroup(c74063034.mfilter2,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_GRAVE,nil,e)
+	local mg2=Duel.GetFusionMaterial(tp):Filter(c74063034.mfilter2,nil,e)
+	local mg3=Duel.GetMatchingGroup(c74063034.mfilter3,tp,LOCATION_GRAVE,0,nil)
 	mg2:Merge(mg1)
+	mg2:Merge(mg3)
 	local sg2=Duel.GetMatchingGroup(c74063034.spfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,nil,chkf)
 	sg1:Merge(sg2)
-	local mg3=nil
+	local mg4=nil
 	local sg3=nil
 	local ce=Duel.GetChainMaterial(tp)
 	if ce~=nil then
 		local fgroup=ce:GetTarget()
-		mg3=fgroup(ce,e,tp)
+		mg4=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		sg3=Duel.GetMatchingGroup(c74063034.spfilter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+		sg3=Duel.GetMatchingGroup(c74063034.spfilter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg4,mf,chkf)
 	end
 	if sg1:GetCount()>0 or (sg3~=nil and sg3:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -87,7 +94,7 @@ function c74063034.spop(e,tp,eg,ep,ev,re,r,rp)
 			if tc:IsSetCard(0xf4) then
 				local mat1=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
 				tc:SetMaterial(mat1)
-				local mat2=mat1:Filter(Card.IsLocation,nil,LOCATION_MZONE+LOCATION_GRAVE)
+				local mat2=mat1:Filter(Card.IsLocation,nil,LOCATION_ONFIELD+LOCATION_GRAVE)
 				mat1:Sub(mat2)
 				Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 				Duel.Remove(mat2,POS_FACEUP,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
@@ -99,7 +106,7 @@ function c74063034.spop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
+			local mat=Duel.SelectFusionMaterial(tp,tc,mg4,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat)
 		end


### PR DESCRIPTION
Fix 1: Player can use monsters on the field as Fusion Materials by _Dark Calling_.
Fix 2: Player cannot use monsters player controls equipped to _Fullmetalfoes Alkahest_ as Fusion Materials by _Super Polymerization_.
Fix 3: If _Predaplant Sundew Kingii_ with a Predator Counter has changed control, _Predaplant Sundew Kingii_'s effect apply.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10424&keyword=&tag=-1
Q.自分の「捕食植物サンデウ・キンジー」の『②：自分メインフェイズに発動できる。闇属性の融合モンスターカードによって決められた、フィールドのこのカードを含む融合素材モンスターを自分の手札・フィールド及び相手フィールドの捕食カウンターが置かれたモンスターの中から選んで墓地へ送り、その融合モンスター１体をエクストラデッキから融合召喚する』モンスター効果の発動にチェーンして、相手が「エネミーコントローラー」の『●自分フィールドのモンスター１体をリリースし、相手フィールドの表側表示モンスター１体を対象として発動できる。その表側表示モンスターのコントロールをエンドフェイズまで得る』効果を発動し、その「捕食植物サンデウ・キンジー」のコントロールが相手に移りました。

この場合、効果処理はどうなりますか？
A.質問の状況の場合、モンスター効果を発動し、処理時にコントロールが相手に移っている「捕食植物サンデウ・キンジー」自身に捕食カウンターが置かれているかによって処理が異なります。

その「捕食植物サンデウ・キンジー」に捕食カウンターが置かれていない場合には、融合素材モンスターとなる一組が揃っていない状態となりますので、効果処理は適用されません。

また、その「捕食植物サンデウ・キンジー」に捕食カウンターが置かれている場合、そのコントロールが相手に移った「捕食植物サンデウ・キンジー」と、その他の『自分の手札・フィールド及び相手フィールドの捕食カウンターが置かれたモンスター』によって、融合素材モンスターとなる一組が揃っている状態であれば、効果処理は通常通り適用されます。
（なお、相手が「エネミーコントローラー」を発動した際に、捕食カウンターが置かれたモンスターをリリースした事によって、融合素材モンスターとなる一組が揃わない場合には、効果処理は適用されません。）

Update: use `Duel.GetFusionMaterial()`