### PR TITLE
fix Ring of Defense

### DIFF
--- a/c58641905.lua
+++ b/c58641905.lua
@@ -3,7 +3,6 @@ function c58641905.initial_effect(c)
 	--reflect
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetCode(EVENT_CHAINING)
 	e1:SetCondition(c58641905.condition)
 	e1:SetOperation(c58641905.operation)
@@ -11,10 +10,7 @@ function c58641905.initial_effect(c)
 end
 function c58641905.condition(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsActiveType(TYPE_TRAP) then return false end
-	local ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_DAMAGE)
-	if ex then return true end
-	ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_RECOVER)
-	return ex
+	return aux.damcon1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c58641905.operation(e,tp,eg,ep,ev,re,r,rp)
 	local cid=Duel.GetChainInfo(ev,CHAININFO_CHAIN_ID)


### PR DESCRIPTION
Fix 1: When a card or effect is activated that would recover LP, _Ring of Defense_ can activate.
Fix 2: _Ring of Defense_ can activate in Damage Step.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6543
■ダメージステップに発動する事はできません。

@Fluorohydride
This repository has many old scripts.
So, it's difficult to fix through Pull Request...
Would you get me access to this repository?