### PR TITLE
fix 月光彩雛

### DIFF
--- a/c35618217.lua
+++ b/c35618217.lua
@@ -30,13 +30,14 @@ function c35618217.initial_effect(c)
 	e3:SetOperation(c35618217.actop)
 	c:RegisterEffect(e3)
 end
-function c35618217.costfilter(c)
-	return c:IsSetCard(0xdf) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
+function c35618217.costfilter(c,ec)
+	return c:IsSetCard(0xdf) and not c:IsFusionCode(ec:GetFusionCode()) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
 end
 function c35618217.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c35618217.costfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,nil) end
+	local c=e:GetHandler()
+	if chk==0 then return Duel.IsExistingMatchingCard(c35618217.costfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,nil,c) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local cg=Duel.SelectMatchingCard(tp,c35618217.costfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,1,nil)
+	local cg=Duel.SelectMatchingCard(tp,c35618217.costfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,1,nil,c)
 	Duel.SendtoGrave(cg,REASON_COST)
 	e:SetLabel(cg:GetFirst():GetCode())
 end


### PR DESCRIPTION
>Ｑ：メインデッキの《月光彩雛》をコストで墓地へ送ることはできますか？
Ａ：いいえ、できません。(16/11/30)
http://yugioh-wiki.net/index.php?%A1%D4%B7%EE%B8%F7%BA%CC%BF%F7%A1%D5

Fix: It shouldn't be able to send monster with the code it already have.