### PR TITLE
fix Traptrix Trap Hole Nightmare

### DIFF
--- a/c29616929.lua
+++ b/c29616929.lua
@@ -9,27 +9,11 @@ function c29616929.initial_effect(c)
 	e1:SetTarget(c29616929.target)
 	e1:SetOperation(c29616929.activate)
 	c:RegisterEffect(e1)
-	if not c29616929.global_check then
-		c29616929.global_check=true
-		local ge1=Effect.CreateEffect(c)
-		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge1:SetCode(EVENT_SPSUMMON_SUCCESS)
-		ge1:SetOperation(c29616929.checkop)
-		Duel.RegisterEffect(ge1,0)
-	end
-end
-function c29616929.checkop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=eg:GetFirst()
-	while tc do
-		if tc:GetFlagEffect(29616929)==0 then
-			tc:RegisterFlagEffect(29616929,RESET_PHASE+PHASE_END,0,1)
-		end
-		tc=eg:GetNext()
-	end
 end
 function c29616929.condition(e,tp,eg,ep,ev,re,r,rp)
 	local loc=Duel.GetChainInfo(0,CHAININFO_TRIGGERING_LOCATION)
-	return ep~=tp and loc==LOCATION_MZONE and re:GetHandler():GetFlagEffect(29616929)>0 and Duel.IsChainDisablable(ev)
+	local tc=re:GetHandler()
+	return tc:IsControler(1-tp) and loc==LOCATION_MZONE and tc:IsStatus(STATUS_SPSUMMON_TURN) and Duel.IsChainDisablable(ev)
 end
 function c29616929.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
Fix: The spsummon status should reset when the monster leave field and summon again.

Require https://github.com/Fluorohydride/ygopro/issues/1895 fixed to work. 