### PR TITLE
fix Yang Zing Brutality

### DIFF
--- a/c67249508.lua
+++ b/c67249508.lua
@@ -19,29 +19,44 @@ end
 function c67249508.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=e:GetLabelObject()
-	if tc:IsRelateToBattle() then
+	if tc:IsRelateToBattle() and not tc:IsImmuneToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
 		e1:SetValue(tc:GetBaseAttack()*2)
-		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE_CAL)
 		tc:RegisterEffect(e1)
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
 		e2:SetCode(EFFECT_SET_DEFENSE_FINAL)
 		e2:SetValue(tc:GetBaseDefense()*2)
-		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE_CAL)
 		tc:RegisterEffect(e2)
+		local fid=c:GetFieldID()
+		tc:RegisterFlagEffect(67249508,RESET_EVENT+0x1fe0000,0,1,fid)
 		local e3=Effect.CreateEffect(c)
 		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		e3:SetRange(LOCATION_MZONE)
+		e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 		e3:SetCode(EVENT_DAMAGE_STEP_END)
 		e3:SetCountLimit(1)
+		e3:SetLabel(fid)
+		e3:SetLabelObject(tc)
+		e3:SetCondition(c67249508.descon)
 		e3:SetOperation(c67249508.desop)
-		e3:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE)
-		tc:RegisterEffect(e3)
+		e3:SetReset(RESET_PHASE+PHASE_DAMAGE)
+		Duel.RegisterEffect(e3,tp)
+	end
+end
+function c67249508.descon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:GetFlagEffectLabel(67249508)==e:GetLabel() then
+		return true
+	else
+		e:Reset()
+		return false
 	end
 end
 function c67249508.desop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+	local tc=e:GetLabelObject()
+	Duel.Destroy(tc,REASON_EFFECT)
 end


### PR DESCRIPTION
Fix 1: Use global effect to do the destroy.
Fix 2: This card should be like _Limiter Removal_ , the destroy should ignore immune if the card is not immune to the effect.
Fix 3: Update the reset to keep same with _Number S39: Utopia the Lightning_.