### PR TITLE
fix Fusion Tag

### DIFF
--- a/c59432181.lua
+++ b/c59432181.lua
@@ -10,12 +10,14 @@ function c59432181.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c59432181.filter(c)
-	return c:IsType(TYPE_FUSION)
+	return c:IsFaceup() and Duel.IsExistingMatchingCard(c59432181.cfilter,tp,LOCATION_EXTRA,0,1,nil,c)
+end
+function c59432181.cfilter(c,tc)
+	return c:IsType(TYPE_FUSION) and not c:IsCode(tc:GetFusionCode())
 end
 function c59432181.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.IsExistingMatchingCard(c59432181.filter,tp,LOCATION_EXTRA,0,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c59432181.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
 end
@@ -23,7 +25,7 @@ function c59432181.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
-	local cg=Duel.SelectMatchingCard(tp,c59432181.filter,tp,LOCATION_EXTRA,0,1,1,nil)
+	local cg=Duel.SelectMatchingCard(tp,c59432181.cfilter,tp,LOCATION_EXTRA,0,1,1,nil,tc)
 	if cg:GetCount()==0 then return end
 	Duel.ConfirmCards(1-tp,cg)
 	local code1,code2=cg:GetFirst():GetOriginalCodeRule()


### PR DESCRIPTION
mail:
>Q. 
同一のモンスターを対象として、2枚の「融合識別」を発動した場合、エクストラデッキの同一融合モンスターを相手に見せる事ができますか？ 
A. 
「融合識別」を発動する際に、同じモンスターを対象とする事はできますが、エクストラデッキに存在する同じ融合モンスターを相手に見せる事はできません。 