### PR TITLE
fix Abyss Actor - Twinkle Littlestar

### DIFF
--- a/c7279373.lua
+++ b/c7279373.lua
@@ -56,7 +56,7 @@ end
 function c7279373.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_EXTRA_ATTACK_MONSTER)


### PR DESCRIPTION
Fix this: Unaffected monster apply _Twinkle Littlestar_'s effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11198&keyword=&tag=-1
Q.自分のモンスターゾーンに表側表示で存在する「魔界劇団－プリティ・ヒロイン」を対象として、「魔界劇団－ティンクル・リトルスター」の『②：１ターンに１度、自分フィールドの「魔界劇団」モンスター１体を対象として発動できる。このターン、そのモンスターは１度のバトルフェイズ中に３回までモンスターに攻撃でき、対象のモンスター以外の自分のモンスターは攻撃できない』ペンデュラム効果を発動しました。

その発動にチェーンして「禁じられた聖槍」が発動し、対象の「魔界劇団－プリティ・ヒロイン」に『そのモンスターはターン終了時まで、攻撃力が８００ダウンし、このカード以外の魔法・罠カードの効果を受けない』効果が適用された場合、効果処理はどうなりますか？
A.「魔界劇団－ティンクル・リトルスター」のペンデュラム効果の処理時に、対象のモンスターが魔法カードの効果を受けない場合、『そのモンスターは１度のバトルフェイズ中に３回までモンスターに攻撃でき』の処理は適用されません。

その場合でも、『対象のモンスター以外の自分のモンスターは攻撃できない』の処理は通常通り適用されます。 