### PR TITLE
update Dragon Capture Jar

### DIFF
--- a/c55763552.lua
+++ b/c55763552.lua
@@ -14,14 +14,14 @@ function c55763552.filter(c)
 end
 function c55763552.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local g=Duel.GetMatchingGroup(c55763552.filter,tp,LOCATION_SZONE,LOCATION_SZONE,nil)
+	local g=Duel.GetMatchingGroup(c55763552.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c55763552.pfilter(c)
 	return c:IsPosition(POS_FACEUP_DEFENSE) and c:IsRace(RACE_DRAGON)
 end
 function c55763552.operation(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c55763552.filter,tp,LOCATION_SZONE,LOCATION_SZONE,nil)
+	local g=Duel.GetMatchingGroup(c55763552.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	if Duel.Destroy(g,REASON_EFFECT)>0 then
 		local pg=Duel.GetMatchingGroup(c55763552.pfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 		Duel.ChangePosition(pg,POS_FACEUP_ATTACK)


### PR DESCRIPTION
i want to help wherever i can in whatever capacity .. so ill start with an easy effect
the effect reads in ocg (translated) -

> Reverse: Destroy the "Dragon Tribe / Sealed Vase" existing **on the face side on the field.** When it is destroyed, all the Dragon family monsters that are face-up on the field are attacked.

it also says "on the field" like the english text

right now i cant think of any ocg&tcg effect exists that can sp summon a spell/trap from the spell & trap zone as a monster with custom stats .. all i can think of now is magical hats , but that gets the cards from the deck , and put them facedown to for a short time ..
but if there exists some effect like that the location needs to change , so this can be used as a pre-caution for now