### PR TITLE
Update King's Knight and so on (Conditions of "Cards exists on your field")

### DIFF
--- a/c64788463.lua
+++ b/c64788463.lua
@@ -15,7 +15,7 @@ function c64788463.cfilter(c)
 	return c:IsFaceup() and c:IsCode(25652259)
 end
 function c64788463.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c64788463.cfilter,tp,LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c64788463.cfilter,tp,LOCATION_ONFIELD,0,1,nil)
 end
 function c64788463.filter(c,e,tp)
 	return c:IsCode(90876561) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)


### PR DESCRIPTION
The OCG effect reads:

> ①: "Queen's Night" **exists in your field** and can be activated when this card is successfully summoned. Special summon 1 "Jacks Night" from the deck.

Lets say Queen's Knight in your MZone becomes an Equip Card , then its no longer in the MZone , and you wont be able to SpSummon , right ? if this is true , then alot of old cards need to get changed to LOCATION_ONFIELD that have conditions of "exists on your field" , and if their rulings agree

But i think the rulings might be diffrent on King's Knight ( i couldnt find any on Wikia )
since its an old card and when it got released , i assume there were not any effects that turned monsters into Equip Cards that time
i could contact the OCG office to make sure , but i cant speak japanese , sorry