### PR TITLE
fix Iris Magician

### DIFF
--- a/c49684352.lua
+++ b/c49684352.lua
@@ -29,7 +29,7 @@ function c49684352.dbcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()
 end
 function c49684352.dbfilter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_SPELLCASTER)
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_SPELLCASTER) and c:GetFlagEffect(49684352)==0
 end
 function c49684352.dbtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c49684352.dbfilter(chkc) end
@@ -41,7 +41,8 @@ end
 function c49684352.dbop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
+		tc:RegisterFlagEffect(49684352,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,0)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PRE_BATTLE_DAMAGE)


### PR DESCRIPTION
Fix 1: If target monster was face-down, _Iris Magician_'s Pendulum Effect doesn't apply.
Fix 2: Player can target the monster what applied _Iris Magician_'s Pendulum Effect by another _Iris Magician_'s Pendulum Effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12626&keyword=&tag=-1
Q自分のモンスターゾーンに表側表示で存在する「アストログラフ・マジシャン」を対象として、自分は「虹彩の魔術師」の『①：１ターンに１度、自分フィールドの魔法使い族・闇属性モンスター１体を対象として発動できる。このターンそのモンスターが相手モンスターとの戦闘で相手に与える戦闘ダメージは倍になる。その後、このカードを破壊する』ペンデュラム効果を発動しました。

その発動にチェーンして「月の書」が発動し、対象の「アストログラフ・マジシャン」が裏側守備表示になった場合、処理はどうなりますか？
A.「虹彩の魔術師」のペンデュラム効果の処理時に、対象の魔法使い族・闇属性モンスターが裏側守備表示になっている場合になっている場合でも、その効果処理は通常通り適用され、『その後、このカードを破壊する』処理も適用されます。
（質問の状況の場合、対象となった「アストログラフ・マジシャン」が、その後に「太陽の書」等の効果によって、そのターンに再び表側攻撃表示になり、相手モンスターと戦闘を行う場合には、その戦闘で相手に与える戦闘ダメージは倍になります。） 

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8634&keyword=&tag=-1
Q.自分のペンデュラムゾーンに2枚の「虹彩の魔術師」が存在し、自分のモンスターゾーンに「覚醒の魔導剣士」が表側表示で存在しています。

この状況で、その「覚醒の魔導剣士」を対象に、2枚の「虹彩の魔術師」の『①：１ターンに１度、自分フィールドの魔法使い族・闇属性モンスター１体を対象として発動できる。このターンそのモンスターが相手モンスターとの戦闘で相手に与える戦闘ダメージは倍になる。その後、このカードを破壊する』ペンデュラム効果をそれぞれ発動する事はできますか？
A.「虹彩の魔術師」の『このターンそのモンスターが相手モンスターとの戦闘で相手に与える戦闘ダメージは倍になる』ペンデュラム効果が適用されているモンスターを対象として、2枚目の「虹彩の魔術師」のペンデュラム効果を発動する事はできません。

（質問の状況の場合、対象となる『自分フィールドの魔法使い族・闇属性モンスター』は「覚醒の魔導剣士」1体のみですので、1枚目の「虹彩の魔術師」のペンデュラム効果が「覚醒の魔導剣士」に適用された場合には、2枚目の「虹彩の魔術師」のペンデュラム効果を発動する事はできません。） 