### PR TITLE
Update Dark Magic Expanded and so on

### DIFF
--- a/c111280.lua
+++ b/c111280.lua
@@ -17,7 +17,7 @@ function c111280.cfilter(c)
 	return c:IsFaceup() and c:IsCode(46986414,38033121)
 end
 function c111280.condition(e,tp,eg,ep,ev,re,r,rp)
-	local ct=Duel.GetMatchingGroupCount(c111280.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,nil)
+	local ct=Duel.GetMatchingGroupCount(c111280.cfilter,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
 	return ct>0 and (Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
 end
 function c111280.filter(c)
@@ -25,13 +25,13 @@ function c111280.filter(c)
 end
 function c111280.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local ct=Duel.GetMatchingGroupCount(c111280.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,nil)
+		local ct=Duel.GetMatchingGroupCount(c111280.cfilter,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
 		if ct<=1 then return Duel.IsExistingMatchingCard(c111280.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 		return true
 	end
 end
 function c111280.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c111280.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,nil)
+	local g=Duel.GetMatchingGroup(c111280.cfilter,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
 	local ct=g:GetCount()
 	if ct>=1 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)


### PR DESCRIPTION
The OCG effect is translated as :

> ①: The following effects are applied depending on the number of "black magician" "black magician girl" **in each other field** · cemetery. 

This effect also is " in each other field " , so make it LOCATION_ONFIELD in case of Dark Magicians being treated as Equip Cards , same as here : https://github.com/Fluorohydride/ygopro-scripts/pull/732

If an Condition needs a specific named card , then most of the time it will read "on the field" , so its most cards with that Condition that need an update

Thank You!