### PR TITLE
Update Blue-Eyes Alternative White Dragon

### DIFF
--- a/c38517737.lua
+++ b/c38517737.lua
@@ -16,7 +16,7 @@ function c38517737.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e2:SetCode(EFFECT_CHANGE_CODE)
-	e2:SetRange(LOCATION_MZONE+LOCATION_GRAVE)
+	e2:SetRange(LOCATION_ONFIELD+LOCATION_GRAVE)
 	e2:SetValue(89631139)
 	c:RegisterEffect(e2)
 	--destroy


### PR DESCRIPTION
OCG effect is : 

> ①: The card name of this card is treated as "blue eyes white dragon" as long as it **exists in the field** · graveyard

Same as : 
https://github.com/Fluorohydride/ygopro-scripts/pull/734 & https://github.com/Fluorohydride/ygopro-scripts/pull/732

[But Not same as](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c35191415.lua#L8) :
> ②: As long as this card is in the **monster zone**, treat the card name as "black magician". 

It looked like , if it does not say the Monster Zone , LOCATION_ONFIELD is used most of the time