### PR TITLE
fix SPYRAL Resort

### DIFF
--- a/c54631665.lua
+++ b/c54631665.lua
@@ -59,7 +59,7 @@ function c54631665.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c54631665.cfilter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsAbleToDeckAsCost()
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToDeckOrExtraAsCost()
 end
 function c54631665.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix: It don't say "into the Main Deck" like _Caam, Serenity of Gusto_, so it should be able to return extra monster.