### PR TITLE
Update Buster Whelp of the Destruction Swordsman and so on ( Added Commits 01-05-2017 )

### DIFF
--- a/c21414674.lua
+++ b/c21414674.lua
@@ -15,5 +15,5 @@ end
 function c21414674.spcon(e,c)
 	if c==nil then return true end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c21414674.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c21414674.filter,c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end

--- a/c49823708.lua
+++ b/c49823708.lua
@@ -71,7 +71,7 @@ function c49823708.cfilter(c)
 	return c:IsFaceup() and c:IsCode(78193831)
 end
 function c49823708.spcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c49823708.cfilter,tp,LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c49823708.cfilter,tp,LOCATION_ONFIELD,0,1,nil)
 end
 function c49823708.costfilter(c)
 	return c:IsSetCard(0xd6) and c:IsAbleToGraveAsCost()

--- a/c69058960.lua
+++ b/c69058960.lua
@@ -72,10 +72,10 @@ function c69058960.filter(c)
 	return c:IsFaceup() and c:IsCode(95442074)
 end
 function c69058960.indcon(e)
-	return Duel.IsExistingMatchingCard(c69058960.filter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c69058960.filter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,1,nil)
 		and e:GetHandler():GetOverlayCount()~=0
 end
 function c69058960.refcon(e)
-	return Duel.IsExistingMatchingCard(c69058960.filter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c69058960.filter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,1,nil)
 		and Duel.GetAttackTarget()==e:GetHandler()
 end

--- a/c70101178.lua
+++ b/c70101178.lua
@@ -29,5 +29,5 @@ end
 function c70101178.spcon(e,c)
 	if c==nil then return true end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c70101178.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c70101178.filter,c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end

--- a/c7500772.lua
+++ b/c7500772.lua
@@ -29,5 +29,5 @@ end
 function c7500772.spcon(e,c)
 	if c==nil then return true end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c7500772.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c7500772.filter,c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end

--- a/c95442074.lua
+++ b/c95442074.lua
@@ -72,10 +72,10 @@ function c95442074.filter(c)
 	return c:IsFaceup() and c:IsCode(69058960)
 end
 function c95442074.indcon(e)
-	return Duel.IsExistingMatchingCard(c95442074.filter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c95442074.filter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,1,nil)
 		and e:GetHandler():GetOverlayCount()~=0
 end
 function c95442074.refcon(e)
-	return Duel.IsExistingMatchingCard(c95442074.filter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c95442074.filter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,1,nil)
 		and Duel.GetAttackTarget()==e:GetHandler()
 end


### PR DESCRIPTION
The OCG effect is translated as :

> ③: If this card is in the Graveyard and "Buster · Braider" **exists in your field**, you can cast it by discarding 1 "Destroyed Sword" card from your hand. Special summon this card from the Graveyard.

If Buster Blader is an Equip Card , and is your only Buster Blader , u should still be able to SpSummon Buster Whelp