### PR TITLE
Update Stronghold the Moving Fortress

### DIFF
--- a/c13955608.lua
+++ b/c13955608.lua
@@ -37,7 +37,7 @@ end
 function c13955608.atkcon(e)
 	local con=0
 	for i=0,4 do
-		local tc=Duel.GetFieldCard(e:GetHandlerPlayer(),LOCATION_MZONE,i)
+		local tc=Duel.GetFieldCard(e:GetHandlerPlayer(),LOCATION_ONFIELD,i)
 		if tc and tc:IsFaceup() then
 			local code=tc:GetCode()
 			if code==13839120 then con=bit.bor(con,1)


### PR DESCRIPTION
The OCG effect is translated as : 

> ②: If "Green Gadget", "Red Gadget", "Yellow Gadget" **exists in your field**, the attack power of this card special summoned by the effect of this card will be increased by 3000.

If any 1 of the Gadgets are a Equip Card , Stronghold should get a power up too

Same as : 
https://github.com/Fluorohydride/ygopro-scripts/pull/739