### PR TITLE
add missing category & shuffle hand for Allure of Darkness

### DIFF
--- a/c1475311.lua
+++ b/c1475311.lua
@@ -2,7 +2,7 @@
 function c1475311.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)
@@ -24,6 +24,7 @@ function c1475311.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(p,Card.IsAttribute,p,LOCATION_HAND,0,1,1,nil,ATTRIBUTE_DARK)
 	local tg=g:GetFirst()
 	if tg then
+		Duel.ShuffleHand(p)
 		if Duel.Remove(tg,POS_FACEUP,REASON_EFFECT)==0 then
 			Duel.ConfirmCards(1-p,tg)
 			Duel.ShuffleHand(p)

--- a/c1475311.lua
+++ b/c1475311.lua
@@ -19,12 +19,12 @@ end
 function c1475311.activate(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Draw(p,d,REASON_EFFECT)
+	Duel.ShuffleHand(p)
 	Duel.BreakEffect()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(p,Card.IsAttribute,p,LOCATION_HAND,0,1,1,nil,ATTRIBUTE_DARK)
 	local tg=g:GetFirst()
 	if tg then
-		Duel.ShuffleHand(p)
 		if Duel.Remove(tg,POS_FACEUP,REASON_EFFECT)==0 then
 			Duel.ConfirmCards(1-p,tg)
 			Duel.ShuffleHand(p)

--- a/c1475311.lua
+++ b/c1475311.lua
@@ -2,7 +2,7 @@
 function c1475311.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE)
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_TOGRAVE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)

--- a/c1475311.lua
+++ b/c1475311.lua
@@ -2,7 +2,7 @@
 function c1475311.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_TOGRAVE)
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_HANDES)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)


### PR DESCRIPTION
- Added `CATEGORY_REMOVE` because the effect includes you banishing a DARK monster

- Added `Duel.ShuffleHand(p)`
just like before the discard in [Dark World Dealings](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c74117290.lua#L22) , etc.

You are shuffling your hand cus if your opponent knows about a card in your hand , and they see you banishing / discarding another card of the same name you just drawn with Allure , they still know that the other card is in your hand since you did not shuffle

I dont know how many Ygopro games have the shuffle hand button , but cus it all happens while resolving 1 effect , you dont get a chance to shuffle your hand before you discard / banish , so the script does it for you
# 
**Updated 2017-01-12**
- Added `CATEGORY_TOGRAVE` too
like [Laval the Greater](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c12986807.lua#L9): "When this card is Synchro Summoned: Send 1 card from your hand to the Graveyard."
# 
**Updated 2017-01-18**
- `CATEGORY_HANDES` should be used instead of `CATEGORY_TOGRAVE`
See : #763