### PR TITLE
fix Ancient Pixie Dragon

### DIFF
--- a/c4179255.lua
+++ b/c4179255.lua
@@ -4,6 +4,13 @@ function c4179255.initial_effect(c)
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()
 	--draw
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e0:SetCode(EVENT_CHAINING)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e0:SetRange(LOCATION_MZONE)
+	e0:SetOperation(aux.chainreg)
+	c:RegisterEffect(e0)
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DRAW)
 	e1:SetDescription(aux.Stringid(4179255,0))
@@ -31,6 +38,7 @@ function c4179255.initial_effect(c)
 end
 function c4179255.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp and re and re:IsActiveType(TYPE_FIELD) and re:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and e:GetHandler():GetFlagEffect(1)>0
 end
 function c4179255.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and e:GetHandler():IsFaceup() end


### PR DESCRIPTION
Fux this:
- Chain 1: Field Spell Card
- Chain 2: _Call of the Haunted_(target _Ancient Pixie Dragon_)

In this situation, _Ancient Pixie Dragon_ activate effect.

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただき誠にありがとうございます。 
ゲームルールについてお問い合わせいただいた件、下記のとおりご案内申し上げます。 

Q. 
自分の「祝福の教会－リチューアル・チャーチ」のカードの発動にチェーンして、自分の墓地の「妖精竜 エンシェント」を対象に「リビングデッドの呼び声」を発動しその「妖精竜 エンシェント」を特殊召喚した場合、特殊召喚した「妖精竜 エンシェント」の『自分のターンにフィールド魔法カードが発動した場合、デッキからカードを１枚ドローする』効果は発動しますか？ 
A. 
ご質問の状況の場合、「妖精竜 エンシェント」の『自分のターンにフィールド魔法カードが発動した場合、デッキからカードを１枚ドローする』効果は発動しません。