### PR TITLE
fix Ryu-Kishin Clown

### DIFF
--- a/c42647539.lua
+++ b/c42647539.lua
@@ -5,7 +5,7 @@ function c42647539.initial_effect(c)
 	e1:SetDescription(aux.Stringid(42647539,0))
 	e1:SetCategory(CATEGORY_POSITION)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_SINGLE)
+	e1:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_SINGLE)
 	e1:SetCode(EVENT_SUMMON_SUCCESS)
 	e1:SetTarget(c42647539.postg)
 	e1:SetOperation(c42647539.posop)
@@ -19,7 +19,7 @@ function c42647539.initial_effect(c)
 end
 function c42647539.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,1,0,0)

--- a/c42647539.lua
+++ b/c42647539.lua
@@ -26,7 +26,7 @@ function c42647539.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c42647539.posop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.ChangePosition(tc,POS_FACEUP_DEFENSE,0,POS_FACEUP_ATTACK,0)
 	end
 end


### PR DESCRIPTION
Fix this: _Ryu-Kishin Clown_'s effect is not Mandatory effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5307
■「ガーゴイルの道化師」自身が召喚・反転召喚・特殊召喚に成功した時に必ず発動する効果です。（ダメージステップでも発動します。）