### PR TITLE
add hint for Minerva, the Exalted Lightsworn, etc.

### DIFF
--- a/c15893860.lua
+++ b/c15893860.lua
@@ -38,6 +38,7 @@ function c15893860.operation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 		local dg=Duel.SelectMatchingCard(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,1,nil)
+		Duel.HintSelection(dg)
 		Duel.Destroy(dg,REASON_EFFECT)
 	end
 end

--- a/c21772453.lua
+++ b/c21772453.lua
@@ -51,6 +51,7 @@ function c21772453.operation(e,tp,eg,ep,ev,re,r,rp)
 			if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(21772453,1)) then
 				Duel.BreakEffect()
 				local sg=g:Select(tp,1,1,nil)
+				Duel.HintSelection(sg)
 				Duel.Destroy(sg,REASON_EFFECT)
 			end
 		else

--- a/c29515122.lua
+++ b/c29515122.lua
@@ -33,5 +33,6 @@ function c29515122.operation(e,tp,eg,ep,ev,re,r,rp)
 	if ct==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local dg=Duel.SelectMatchingCard(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,ct,nil)
+	Duel.HintSelection(dg)
 	Duel.Destroy(dg,REASON_EFFECT)
 end

--- a/c30100551.lua
+++ b/c30100551.lua
@@ -62,6 +62,7 @@ function c30100551.desop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 		local sdg=dg:Select(tp,1,ct,nil)
+		Duel.HintSelection(sdg)
 		Duel.Destroy(sdg,REASON_EFFECT)
 	end
 end

--- a/c65872270.lua
+++ b/c65872270.lua
@@ -65,6 +65,7 @@ function c65872270.desop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 		local rg=g:Select(tp,ct2,ct2,nil)
+		Duel.HintSelection(rg)
 		Duel.SendtoHand(rg,nil,REASON_EFFECT)
 	end
 end

--- a/c81278754.lua
+++ b/c81278754.lua
@@ -45,5 +45,6 @@ function c81278754.retop(e,tp,eg,ep,ev,re,r,rp)
 	if ct==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToHand,tp,0,LOCATION_MZONE,1,ct,nil)
+	Duel.HintSelection(g)
 	Duel.SendtoHand(g,nil,REASON_EFFECT)
 end

--- a/c89086566.lua
+++ b/c89086566.lua
@@ -27,6 +27,7 @@ function c89086566.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 		local sg=dg:Select(tp,1,dt,nil)
+		Duel.HintSelection(sg)
 		Duel.Destroy(sg,REASON_EFFECT)
 	end
 end

--- a/c92693205.lua
+++ b/c92693205.lua
@@ -47,6 +47,7 @@ function c92693205.desop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectMatchingCard(tp,aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,ct,nil)
 	if g:GetCount()>0 then
+		Duel.HintSelection(g)
 		Duel.Destroy(g,REASON_EFFECT)
 	end
 end

--- a/c92918648.lua
+++ b/c92918648.lua
@@ -36,5 +36,6 @@ function c92918648.operation(e,tp,eg,ep,ev,re,r,rp)
 	if ct==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectMatchingCard(tp,c92918648.filter,tp,0,LOCATION_ONFIELD,1,ct,nil)
+	Duel.HintSelection(g)
 	Duel.Destroy(g,REASON_EFFECT)
 end

--- a/c94388754.lua
+++ b/c94388754.lua
@@ -48,6 +48,7 @@ function c94388754.operation(e,tp,eg,ep,ev,re,r,rp)
 			if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(94388754,1)) then
 				Duel.BreakEffect()
 				local sg=g:Select(tp,1,1,nil)
+				Duel.HintSelection(sg)
 				Duel.Destroy(sg,REASON_EFFECT)
 			end
 		else


### PR DESCRIPTION
`● void Duel.HintSelection (Group g)`
`Manually displays the animated effect of the selected object for g and records that the card is selected as the object`

Since only targeting effects have animation , adding these hints will make it more clear which cards were selected for non-targeting effects

Same as : 
- https://github.com/Fluorohydride/ygopro-scripts/pull/361/files
- https://github.com/Fluorohydride/ygopro-scripts/blob/master/c20951752.lua#L82
- https://github.com/Fluorohydride/ygopro-scripts/blob/master/c52971673.lua#L33
- https://github.com/Fluorohydride/ygopro-scripts/blob/master/c16037007.lua#L45
- https://github.com/Fluorohydride/ygopro-scripts/blob/master/c19221310.lua#L57