### PR TITLE
fix Pot of Desires

### DIFF
--- a/c35261759.lua
+++ b/c35261759.lua
@@ -14,7 +14,7 @@ function c35261759.initial_effect(c)
 end
 function c35261759.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetDecktopGroup(tp,10)
-	if chk==0 then return g:FilterCount(Card.IsAbleToRemove,nil)==10
+	if chk==0 then return g:FilterCount(Card.IsAbleToRemoveAsCost,nil)==10
 		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=12 end
 	Duel.DisableShuffleCheck()
 	Duel.Remove(g,POS_FACEDOWN,REASON_COST)


### PR DESCRIPTION
I dont know if it makes a difference or not , or because of the way the Cost function is scripted , maybe its not needed..
But between the two different Cost functions , i have always seen `Card.IsAbleToRemoveAsCost` being used when banishing for a Cost

Same as : 
https://github.com/Fluorohydride/ygopro-scripts/blob/master/c6713443.lua#L14
https://github.com/Fluorohydride/ygopro-scripts/blob/master/c6625096.lua#L20
https://github.com/Fluorohydride/ygopro-scripts/blob/master/c191749.lua#L14
etc.