### PR TITLE
add category for Jenis, Lightsworn Mender

### DIFF
--- a/c83725008.lua
+++ b/c83725008.lua
@@ -2,8 +2,9 @@
 function c83725008.initial_effect(c)
 	--recover&damage
 	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e1:SetDescription(aux.Stringid(83725008,0))
+	e1:SetCategory(CATEGORY_DAMAGE+CATEGORY_RECOVER)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e1:SetCode(EVENT_PHASE+PHASE_END)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)


### PR DESCRIPTION
OCG&TCG effects are outdated , before Series 9 (before PSCT), the OCG effect is :

> At the End Phase of the turn where the card was sent from your deck to the Graveyard due to the effect of the card named "Light Road", 500 points of damage are given to your opponent's Life, **and** 500 Life Points are recovered by yourself.

Since the effect Triggers , it needs a Category that is listed/supported
Both Damage & Recover happens at the same time , so a Category is needed for both , no ?