### PR TITLE
fix Unions equip op

### DIFF
--- a/c30012506.lua
+++ b/c30012506.lua
@@ -69,7 +69,7 @@ function c30012506.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
 	if not tc:IsRelateToEffect(e) or not c30012506.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
+		Duel.SendtoGrave(c,REASON_RULE)
 		return
 	end
 	if not Duel.Equip(tp,c,tc,false) then return end


### PR DESCRIPTION
Like i said here - https://github.com/Fluorohydride/ygopro-scripts/issues/599

Before i modify the others , i just wanna make sure that it should be `REASON_RULE` and not `REASON_EFFECT`
i understand it as follows - it sends the equipped monster to the grave as a **rule ( a game mechanic )** because its the wrong target `not c30012506.filter(tc)` or if its not in the same instance as it was when "A-Assault Core" targeted it `not tc:IsRelateToEffect(e)`