### PR TITLE
update Granmarg the Mega Monarch and Raiza the Mega Monarch

### DIFF
--- a/c15545291.lua
+++ b/c15545291.lua
@@ -16,7 +16,7 @@ function c15545291.initial_effect(c)
 	--destroy
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(15545291,1))
-	e3:SetCategory(CATEGORY_DESTROY+CATEGORY_DRAW)
+	e3:SetCategory(CATEGORY_DESTROY)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e3:SetCode(EVENT_SUMMON_SUCCESS)
@@ -58,6 +58,7 @@ function c15545291.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c15545291.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,2,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 	if e:GetLabel()==1 then
+		e:SetCategory(CATEGORY_DESTROY+CATEGORY_DRAW)
 		Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 	end
 end

--- a/c69327790.lua
+++ b/c69327790.lua
@@ -58,6 +58,7 @@ function c69327790.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if e:GetLabel()==1
 		and Duel.IsExistingTarget(Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,g1:GetFirst())
 		and Duel.SelectYesNo(tp,aux.Stringid(69327790,2)) then
+		e:SetCategory(CATEGORY_TODECK+CATEGORY_TOHAND)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 		local g3=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,g1:GetFirst())
 		Duel.SetOperationInfo(0,CATEGORY_TOHAND,g3,1,0,0)


### PR DESCRIPTION
update this: If _Granmarg the Mega Monarch_ don't Tribute EARTH monster, _Ghost Ash & Beautiful Spring_ cannot negate _Granmarg the Mega Monarch_'s effect.
So, if _Granmarg the Mega Monarch_ don't Tribute EARTH monster, _Granmarg the Mega Monarch_'s effect category is `CATEGORY_DESTROY` only.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20547&keyword=&tag=-1
Q.相手が地属性以外の属性のモンスターのみをリリースして、「剛地帝グランマーグ」をアドバンス召喚し、その『このカードがアドバンス召喚に成功した時、フィールド上にセットされたカードを２枚まで選択して破壊する。このカードが地属性モンスターをリリースしてアドバンス召喚に成功した場合、その時の効果に以下の効果を加える。●デッキからカードを１枚ドローする』モンスター効果を発動しました。

この時、自分は、手札の「灰流うらら」を捨てて、『①：以下のいずれかの効果を含む魔法・罠・モンスターの効果が発動した時、このカードを手札から捨てて発動できる。その効果を無効にする。この効果は相手ターンでも発動できる』効果を発動する事はできますか？
A.地属性以外の属性のモンスターのみをリリースしてアドバンス召喚された「剛地帝グランマーグ」のモンスター効果が発動した時、チェーンして手札の「灰流うらら」のモンスター効果を発動する事はできません。 