### PR TITLE
add shuffle hand for Oracle of Zefra, etc.

### DIFF
--- a/c23979249.lua
+++ b/c23979249.lua
@@ -78,6 +78,7 @@ end
 function c23979249.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	if Duel.Draw(p,d,REASON_EFFECT)~=0 then
+		Duel.ShuffleHand(tp)
 		Duel.BreakEffect()
 		Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
 	end

--- a/c32354768.lua
+++ b/c32354768.lua
@@ -127,6 +127,7 @@ end
 function c32354768.drop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	if Duel.Draw(tp,1,REASON_EFFECT)~=0 then
+		Duel.ShuffleHand(tp)
 		Duel.BreakEffect()
 		Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
 	end

--- a/c40465719.lua
+++ b/c40465719.lua
@@ -19,6 +19,7 @@ end
 function c40465719.activate(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Draw(p,d,REASON_EFFECT)
+	Duel.ShuffleHand(p)
 	Duel.BreakEffect()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(p,Card.IsType,p,LOCATION_HAND,0,1,1,nil,TYPE_NORMAL)

--- a/c40465719.lua
+++ b/c40465719.lua
@@ -2,7 +2,7 @@
 function c40465719.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_TOGRAVE)
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_HANDES)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)

--- a/c40465719.lua
+++ b/c40465719.lua
@@ -2,7 +2,7 @@
 function c40465719.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_HANDES)
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_TOGRAVE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)

--- a/c40465719.lua
+++ b/c40465719.lua
@@ -2,7 +2,7 @@
 function c40465719.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetCategory(CATEGORY_DRAW+CATEGORY_REMOVE+CATEGORY_TOGRAVE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)

--- a/c45383307.lua
+++ b/c45383307.lua
@@ -60,6 +60,7 @@ end
 function c45383307.drop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	if Duel.Draw(tp,1,REASON_EFFECT)~=0 then
+		Duel.ShuffleHand(tp)
 		Duel.BreakEffect()
 		Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
 	end

--- a/c49328340.lua
+++ b/c49328340.lua
@@ -40,6 +40,7 @@ end
 function c49328340.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) or Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)==0 then return end
 	if Duel.Draw(tp,2,REASON_EFFECT)==2 then
+		Duel.ShuffleHand(tp)
 		Duel.BreakEffect()
 		Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
 	end

--- a/c56350972.lua
+++ b/c56350972.lua
@@ -87,6 +87,7 @@ function c56350972.operation(e,tp,eg,ep,ev,re,r,rp)
 	local sel=e:GetLabel()
 	if sel==1 then
 		Duel.Draw(tp,2,REASON_EFFECT)
+		Duel.ShuffleHand(tp)
 		Duel.BreakEffect()
 		Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
 	elseif sel==2 then


### PR DESCRIPTION
I was testing the new Zefra cards and noticed that most new scripts with the effects of "draw then discard" dont shuffle your hand
I remember official Yugioh games also auto-shuffling your hand as soon as the contents of your hand were modified , since most of them dont have hand shuffling buttons
and just like i explained here https://github.com/Fluorohydride/ygopro-scripts/pull/742 , why i think Fluoro added it in the first place for those types of effects
For eg. to stop your opponent from knowing cards in your hand , and you cant shuffle your hand in Ygopro while resolving an effect , unless the script does it for you

Most new scripts are missing it , but older scripts have that function : 
- [Shaddoll Beast](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c3717252.lua#L42)
- [Dark World Dealings
](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c74117290.lua#L22)