### PR TITLE
add missing category for Worm Hope, etc.

### DIFF
--- a/c11159464.lua
+++ b/c11159464.lua
@@ -10,6 +10,7 @@ function c11159464.initial_effect(c)
 	--discard
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(11159464,0))
+	e2:SetCategory(CATEGORY_TOGRAVE)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetCondition(c11159464.tgcon)

--- a/c11159464.lua
+++ b/c11159464.lua
@@ -10,7 +10,7 @@ function c11159464.initial_effect(c)
 	--discard
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(11159464,0))
-	e2:SetCategory(CATEGORY_TOGRAVE)
+	e2:SetCategory(CATEGORY_HANDES)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCode(EVENT_TO_GRAVE)
 	e2:SetCondition(c11159464.tgcon)

--- a/c12986807.lua
+++ b/c12986807.lua
@@ -6,7 +6,7 @@ function c12986807.initial_effect(c)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(12986807,0))
-	e1:SetCategory(CATEGORY_TOGRAVE)
+	e1:SetCategory(CATEGORY_HANDES)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetCondition(c12986807.condition)

--- a/c18175965.lua
+++ b/c18175965.lua
@@ -51,7 +51,7 @@ function c18175965.initial_effect(c)
 	--special summon 2
 	local e8=Effect.CreateEffect(c)
 	e8:SetDescription(aux.Stringid(18175965,2))
-	e8:SetCategory(CATEGORY_TOGRAVE+CATEGORY_SPECIAL_SUMMON)
+	e8:SetCategory(CATEGORY_HANDES+CATEGORY_SPECIAL_SUMMON)
 	e8:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e8:SetCode(EVENT_TO_GRAVE)
 	e8:SetCondition(c18175965.spcon2)

--- a/c18175965.lua
+++ b/c18175965.lua
@@ -51,7 +51,7 @@ function c18175965.initial_effect(c)
 	--special summon 2
 	local e8=Effect.CreateEffect(c)
 	e8:SetDescription(aux.Stringid(18175965,2))
-	e8:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e8:SetCategory(CATEGORY_TOGRAVE+CATEGORY_SPECIAL_SUMMON)
 	e8:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e8:SetCode(EVENT_TO_GRAVE)
 	e8:SetCondition(c18175965.spcon2)

--- a/c20374351.lua
+++ b/c20374351.lua
@@ -6,7 +6,7 @@ function c20374351.initial_effect(c)
 	--to grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(20374351,0))
-	e1:SetCategory(CATEGORY_TOGRAVE)
+	e1:SetCategory(CATEGORY_HANDES)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetCondition(c20374351.condition)

--- a/c32339440.lua
+++ b/c32339440.lua
@@ -4,7 +4,7 @@ function c32339440.initial_effect(c)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(32339440,0))
-	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH+CATEGORY_TOGRAVE)
 	e1:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_FIELD)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCode(EVENT_PHASE+PHASE_END)

--- a/c32339440.lua
+++ b/c32339440.lua
@@ -4,7 +4,7 @@ function c32339440.initial_effect(c)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(32339440,0))
-	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH+CATEGORY_TOGRAVE)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH+CATEGORY_HANDES)
 	e1:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_FIELD)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCode(EVENT_PHASE+PHASE_END)


### PR DESCRIPTION
OCG effect is :
リバース：このカードが相手モンスターの攻撃によってリバースした場合、デッキからカードを１枚ドローする。また、このカードがフィールド上から墓地へ送られた時、自分は手札を１枚選んで墓地へ送る。
Also, when this card is sent from the top of the field to the Graveyard, you choose 1 card and send it to the Graveyard.

Its an Effect that starts a Chain , so it needs a Category

Same as Laval the Greater ,
effects that includes sending a card from your hand to the Grave : 
https://github.com/Fluorohydride/ygopro-scripts/blob/master/c12986807.lua#L9
And Number 10: Illumiknight : 
https://github.com/Fluorohydride/ygopro-scripts/blob/master/c11411223.lua#L8
etc.