### PR TITLE
Added Procedure for Persistent Trap cards Targeting by rule

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1708,6 +1708,82 @@ function Auxiliary.fuslimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
 end
 --sp_summon condition for ritual monster
+--add procedure to persistent traps
+function Auxiliary.AddPersistentProcedure(c,p,f,category,property,hint1,hint2,con,cost,tg,op)
+	--Note: p==0 is check persistent trap controler, p==1 for opponent's, PLAYER_ALL for both player's monsters
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(1068)
+	if category then
+		e1:SetCategory(category)
+	end
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	if hint1 or hint2 then
+		if hint1==hint2 then
+			e1:SetHintTiming(hint)
+		elseif hint1 and not hint2 then
+			e1:SetHintTiming(hint1,0)
+		elseif hint2 and not hint1 then
+			e1:SetHintTiming(0,hint2)
+		else
+			e1:SetHintTiming(hint1,hint2)
+		end
+	end
+	if property then
+		e1:SetProperty(EFFECT_FLAG_CARD_TARGET+property)
+	else
+		e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	end
+	if con then
+		e1:SetCondition(con)
+	end
+	if cost then
+		e1:SetCost(cost)
+	end
+	e1:SetTarget(Auxiliary.PersistentTarget(tg,p,f))
+	e1:SetOperation(op)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_CHAIN_SOLVED)
+	e2:SetLabelObject(e1)
+	e2:SetCondition(Auxiliary.PersistentTgCon)
+	e2:SetOperation(Auxiliary.PersistentTgOp)
+	c:RegisterEffect(e2)
+end
+function Auxiliary.PersistentFilter(c,p,f,e,tp)
+	return (p==PLAYER_ALL or c:IsControler(p)) and (not f or f(c,e,tp))
+end
+function Auxiliary.PersistentTarget(tg,p,f)
+	return	function(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+				local player=nil
+				if p==0 then
+					player=tp
+				elseif p==1 then
+					player=1-tp
+				elseif p==PLAYER_ALL or p==nil then
+					player=PLAYER_ALL
+				end
+				if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and Auxiliary.PersistentFilter(chkc,player,f,e,tp) end
+				if chk==0 then return player~=nil and Duel.IsExistingTarget(Auxiliary.PersistentFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,player,f,e,tp) end
+				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+				local g=Duel.SelectTarget(tp,Auxiliary.PersistentFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,player,f,e,tp)
+				if tg then tg(e,tp,eg,ep,ev,re,r,rp,g:GetFirst()) end
+			end
+end
+function Auxiliary.PersistentTgCon(e,tp,eg,ep,ev,re,r,rp)
+	return re==e:GetLabelObject()
+end
+function Auxiliary.PersistentTgOp(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS):GetFirst()
+	if c:IsRelateToEffect(re) and tc:IsFaceup() and tc:IsRelateToEffect(re) then
+		c:SetCardTarget(tc)
+	end
+end
 function Auxiliary.ritlimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_RITUAL)==SUMMON_TYPE_RITUAL
 end


### PR DESCRIPTION
Function By @MichaelLawrenceDee
this function is to be added to the Persistent Trap cards instead of the standard effects


`function Auxiliary.AddPersistentProcedure(c,p,f,category,property,hint1,hint2,function con,function  cost,function tg,function op) `
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17489&keyword=&tag=-1&request_locale=ja