### PR TITLE
fix Ritual Buster

### DIFF
--- a/c54094821.lua
+++ b/c54094821.lua
@@ -21,7 +21,9 @@ function c54094821.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
 	e1:SetTargetRange(0,1)
 	e1:SetValue(c54094821.aclimit)
-	if Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()>PHASE_STANDBY
+	if Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()<=PHASE_STANDBY then
+		e1:SetReset(RESET_PHASE+PHASE_STANDBY,3)
+	elseif Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()>PHASE_STANDBY
 		or Duel.GetTurnPlayer()==1-tp and Duel.GetCurrentPhase()<=PHASE_STANDBY then
 		e1:SetReset(RESET_PHASE+PHASE_STANDBY,2)
 	else

--- a/c54094821.lua
+++ b/c54094821.lua
@@ -21,7 +21,8 @@ function c54094821.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
 	e1:SetTargetRange(0,1)
 	e1:SetValue(c54094821.aclimit)
-	if Duel.GetTurnPlayer()==tp then
+	if Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()>PHASE_STANDBY
+		or Duel.GetTurnPlayer()==1-tp and Duel.GetCurrentPhase()<=PHASE_STANDBY then
 		e1:SetReset(RESET_PHASE+PHASE_STANDBY,2)
 	else
 		e1:SetReset(RESET_PHASE+PHASE_STANDBY,1)


### PR DESCRIPTION
fix: If Ritual Buster is activated during your opponents Draw Phase the effect currently resets during the opponents same turn. If it is activated during your own Draw Phase the effect resets during your opponents next turn.