### PR TITLE
fix Superheavy Samurai General Coral

### DIFF
--- a/c78274190.lua
+++ b/c78274190.lua
@@ -46,7 +46,7 @@ function c78274190.cacon(e,tp,eg,ep,ev,re,r,rp)
 	local d=Duel.GetAttackTarget()
 	if not d then return false end
 	if a:IsStatus(STATUS_OPPO_BATTLE) and d:IsControler(tp) then a,d=d,a end
-	if a:IsSetCard(0x9a) and a:IsChainAttackable() then
+	if a:IsSetCard(0x9a) and a:IsChainAttackable() and a:IsControler(tp) then
 		e:SetLabelObject(a)
 		return true
 	else return false end


### PR DESCRIPTION
Fix: It shouldn't be able to activate pendulum effect if the attacker is opponent's monster.