### PR TITLE
update category for Ghost Ash & Spring Flowers Rulings

### DIFF
--- a/c31444249.lua
+++ b/c31444249.lua
@@ -24,7 +24,7 @@ function c31444249.initial_effect(c)
 	c:RegisterEffect(e3)
 	--spsummon
 	local e4=Effect.CreateEffect(c)
-	e4:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON+CATEGORY_DECKDES)
 	e4:SetType(EFFECT_TYPE_IGNITION)
 	e4:SetRange(LOCATION_SZONE)
 	e4:SetCost(c31444249.spcost)

--- a/c35480699.lua
+++ b/c35480699.lua
@@ -2,7 +2,7 @@
 function c35480699.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetCategory(CATEGORY_POSITION+CATEGORY_DRAW)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetHintTiming(0,0x1e0)

--- a/c58577036.lua
+++ b/c58577036.lua
@@ -1,7 +1,7 @@
 --名推理
 function c58577036.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_DECKDES)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetTarget(c58577036.target)


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro-scripts/pull/771

_Void Imagination_ also sends cards from the Main Deck to the Graveyard : 

> If your opponent controls a monster that was Special Summoned from the Extra Deck, and you do not, you can also use up to 6 monsters in your Deck as Fusion Materials.