### PR TITLE
fix strings

### DIFF
--- a/c35125879.lua
+++ b/c35125879.lua
@@ -87,7 +87,7 @@ function c35125879.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and Duel.IsExistingTarget(c35125879.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
 		and Duel.GetFlagEffect(tp,35125879)==0 end
 	Duel.RegisterFlagEffect(tp,35125879,RESET_PHASE+PHASE_END,0,1)
-	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(35125879,0))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectTarget(tp,c35125879.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
@@ -117,7 +117,7 @@ function c35125879.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c35125879.sumfilter,tp,LOCATION_HAND,0,1,nil)
 		and Duel.GetFlagEffect(tp,35125880)==0 end
 	Duel.RegisterFlagEffect(tp,35125880,RESET_PHASE+PHASE_END,0,1)
-	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(35125879,1))
 	Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
 end
 function c35125879.sumop(e,tp,eg,ep,ev,re,r,rp)

--- a/c61529473.lua
+++ b/c61529473.lua
@@ -92,7 +92,7 @@ function c61529473.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil)
 		and Duel.GetFlagEffect(tp,61529473)==0 end
 	Duel.RegisterFlagEffect(tp,61529473,RESET_PHASE+PHASE_END,0,1)
-	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(61529473,0))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c61529473.tgfilter,tp,LOCATION_ONFIELD,0,1,1,c)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
@@ -130,7 +130,7 @@ function c61529473.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c61529473.sumfilter,tp,LOCATION_HAND,0,1,nil)
 		and Duel.GetFlagEffect(tp,61529474)==0 end
 	Duel.RegisterFlagEffect(tp,61529474,RESET_PHASE+PHASE_END,0,1)
-	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(61529473,1))
 	Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
 end
 function c61529473.sumop(e,tp,eg,ep,ev,re,r,rp)

--- a/c78765160.lua
+++ b/c78765160.lua
@@ -74,6 +74,7 @@ function c78765160.cfilter(c)
 end
 function c78765160.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c78765160.cfilter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(78765160,0))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(tp,c78765160.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
@@ -105,6 +106,7 @@ function c78765160.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return e:GetHandler():GetFlagEffect(78765160)==0
 		and Duel.IsPlayerCanDraw(tp,1)
 		and Duel.IsExistingTarget(c78765160.tdfilter,tp,LOCATION_REMOVED,0,2,nil) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(78765160,1))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 	local g=Duel.SelectTarget(tp,c78765160.tdfilter,tp,LOCATION_REMOVED,0,2,2,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,2,0,0)

--- a/c92266279.lua
+++ b/c92266279.lua
@@ -9,7 +9,7 @@ function c92266279.initial_effect(c)
 	c:RegisterEffect(e1)
 	--to hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(92266279,1))
+	e2:SetDescription(aux.Stringid(92266279,0))
 	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_FREE_CHAIN)
@@ -22,7 +22,7 @@ function c92266279.initial_effect(c)
 	c:RegisterEffect(e2)
 	--recover
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(92266279,2))
+	e3:SetDescription(aux.Stringid(92266279,1))
 	e3:SetCategory(CATEGORY_RECOVER)
 	e3:SetType(EFFECT_TYPE_QUICK_O)
 	e3:SetCode(EVENT_FREE_CHAIN)
@@ -42,11 +42,11 @@ function c92266279.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if (b1 or b2) and Duel.SelectYesNo(tp,94) then
 		local opt=0
 		if b1 and b2 then
-			opt=Duel.SelectOption(tp,aux.Stringid(92266279,1),aux.Stringid(92266279,2))
+			opt=Duel.SelectOption(tp,aux.Stringid(92266279,0),aux.Stringid(92266279,1))
 		elseif b1 then
 			opt=Duel.SelectOption(tp,aux.Stringid(92266279,1))
 		else
-			opt=Duel.SelectOption(tp,aux.Stringid(92266279,2))+1
+			opt=Duel.SelectOption(tp,aux.Stringid(92266279,1))+1
 		end
 		if opt==0 then
 			e:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -68,6 +68,7 @@ function c92266279.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92266279.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,1000) and Duel.GetFlagEffect(tp,92266279)==0 end
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(92266279,0))
 	Duel.PayLPCost(tp,1000)
 	Duel.RegisterFlagEffect(tp,92266279,RESET_PHASE+PHASE_END,0,1)
 end
@@ -92,6 +93,7 @@ function c92266279.reccon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c92266279.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFlagEffect(tp,92266280)==0 end
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(92266279,1))
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(500)
 	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,500)

--- a/c96100333.lua
+++ b/c96100333.lua
@@ -52,6 +52,7 @@ end
 function c96100333.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetFlagEffect(96100333)==0
 		and Duel.IsExistingMatchingCard(c96100333.cfilter,tp,LOCATION_GRAVE,0,2,nil) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(96100333,1))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(tp,c96100333.cfilter,tp,LOCATION_GRAVE,0,2,2,nil)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
@@ -92,6 +93,7 @@ function c96100333.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return e:GetHandler():GetFlagEffect(96100333)==0
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and cg:IsExists(c96100333.spcfilter1,1,nil,cg,sg) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(96100333,2))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g1=cg:FilterSelect(tp,c96100333.spcfilter1,1,1,nil,cg,sg)
 	sg:RemoveCard(g1:GetFirst())
@@ -131,6 +133,7 @@ function c96100333.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return e:GetHandler():GetFlagEffect(96100333)==0
 		and Duel.IsPlayerCanDraw(tp,1)
 		and cg:IsExists(c96100333.tdcfilter1,1,nil,cg,sg) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(96100333,3))
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g1=cg:FilterSelect(tp,c96100333.tdcfilter1,1,1,nil,cg,sg)
 	sg:RemoveCard(g1:GetFirst())


### PR DESCRIPTION
e:GetDescription provides "???" on Revival of True Kings and Apocalypse of True Dracos upon the initial activation, there has to be the actual stringid for that

fix the string ids of Humid Winds, that didn't use the 0 string

added opp hints for Shiranui Style Reincarnation, Humid Winds and Tramid Pulse 