### PR TITLE
fix True King

### DIFF
--- a/c30539496.lua
+++ b/c30539496.lua
@@ -70,10 +70,14 @@ function c30539496.spop(e,tp,eg,ep,ev,re,r,rp)
 	local rm=g1:IsExists(Card.IsAttribute,2,nil,ATTRIBUTE_EARTH)
 	if Duel.Destroy(g1,REASON_EFFECT)==2 then
 		if not c:IsRelateToEffect(e) then return end
-		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-			and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
-			Duel.SendtoGrave(c,REASON_RULE)
-			return
+		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 then
+			if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+				and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+				Duel.SendtoGrave(c,REASON_RULE)
+				return
+			else
+				return
+			end
 		end
 		local rg=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_EXTRA,nil)
 		if rm and rg:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(30539496,2)) then

--- a/c82321037.lua
+++ b/c82321037.lua
@@ -71,10 +71,14 @@ function c82321037.spop(e,tp,eg,ep,ev,re,r,rp)
 	local rm=g1:IsExists(Card.IsAttribute,2,nil,ATTRIBUTE_WATER)
 	if Duel.Destroy(g1,REASON_EFFECT)==2 then
 		if not c:IsRelateToEffect(e) then return end
-		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-			and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
-			Duel.SendtoGrave(c,REASON_RULE)
-			return
+		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 then
+			if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+				and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+				Duel.SendtoGrave(c,REASON_RULE)
+				return
+			else
+				return
+			end
 		end
 		local rg=Duel.GetMatchingGroup(c82321037.rmfilter,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
 		if rm and rg:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(82321037,0)) then

--- a/c94160895.lua
+++ b/c94160895.lua
@@ -70,10 +70,14 @@ function c94160895.spop(e,tp,eg,ep,ev,re,r,rp)
 	local rm=g1:IsExists(Card.IsAttribute,2,nil,ATTRIBUTE_WIND)
 	if Duel.Destroy(g1,REASON_EFFECT)==2 then
 		if not c:IsRelateToEffect(e) then return end
-		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-			and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
-			Duel.SendtoGrave(c,REASON_RULE)
-			return
+		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 then
+			if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+				and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+				Duel.SendtoGrave(c,REASON_RULE)
+				return
+			else
+				return
+			end
 		end
 		local rg=Duel.GetDecktopGroup(1-tp,4)
 		if rm and rg:GetCount()>0 and rg:FilterCount(Card.IsAbleToRemove,nil)==4

--- a/c96746083.lua
+++ b/c96746083.lua
@@ -71,10 +71,14 @@ function c96746083.spop(e,tp,eg,ep,ev,re,r,rp)
 	local rm=g1:IsExists(Card.IsAttribute,2,nil,ATTRIBUTE_FIRE)
 	if Duel.Destroy(g1,REASON_EFFECT)==2 then
 		if not c:IsRelateToEffect(e) then return end
-		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-			and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
-			Duel.SendtoGrave(c,REASON_RULE)
-			return
+		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 then
+			if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+				and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
+				Duel.SendtoGrave(c,REASON_RULE)
+				return
+			else
+				return
+			end
 		end
 		local rg=Duel.GetMatchingGroup(c96746083.rmfilter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,nil,tp)
 		if rm and rg:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(96746083,0)) then


### PR DESCRIPTION
The effects to banish different things after destroying 2 monsters of a certain attribute can currently be activated if the monster is not special summoned (e.g. if Vanities is chained), this shouldn't happen.