### PR TITLE
fix Crystron Sulphafnir

### DIFF
--- a/c3422200.lua
+++ b/c3422200.lua
@@ -35,6 +35,10 @@ function c3422200.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	local g=Duel.GetFieldGroup(tp,LOCATION_ONFIELD,0)
+	if g:GetCount()>0 then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	end
 end
 function c3422200.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix this: If _Crystron Sulphafnir_ activate effect while player have cards on the field, _Stardust Dragon_ cannor activate effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20074&keyword=&tag=-1
Q.自分が「水晶機巧－サルファフナー」の『①：このカードが手札・墓地に存在する場合、「水晶機巧－サルファフナー」以外の「クリストロン」カード１枚を手札から捨てて発動できる。このカードを守備表示で特殊召喚する。その後、自分フィールドのカード１枚を選んで破壊する』モンスター効果を発動しました。

相手はチェーンして「スターダスト・ドラゴン」の『①：フィールドのカードを破壊する魔法・罠・モンスターの効果が発動した時、このカードをリリースして発動できる。その発動を無効にし破壊する』モンスター効果を発動する事はできますか？
A.質問の状況の場合、「水晶機巧－サルファフナー」のモンスター効果を発動したプレイヤーのフィールドに、カードが1枚でも存在しているのであれば、フィールドのカードを破壊するモンスター効果が発動した扱いとなりますので、相手はチェーンして「スターダスト・ドラゴン」の『その発動を無効にし破壊する』モンスター効果を発動する事ができます。

なお、「水晶機巧－サルファフナー」のモンスター効果を発動したプレイヤーのフィールドに、カードが1枚も存在していない場合には、フィールドのカードを破壊するモンスター効果が発動した扱いにはなりませんので、相手はチェーンして「スターダスト・ドラゴン」の『その発動を無効にし破壊する』モンスター効果を発動する事はできません。 