### PR TITLE
fix Ms. Judge

### DIFF
--- a/c86767655.lua
+++ b/c86767655.lua
@@ -1,6 +1,13 @@
 --Ms.JUDGE
 function c86767655.initial_effect(c)
 	--disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e0:SetCode(EVENT_CHAINING)
+	e0:SetRange(LOCATION_MZONE)
+	e0:SetOperation(aux.chainreg)
+	c:RegisterEffect(e0)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(EVENT_CHAIN_SOLVING)
@@ -11,7 +18,7 @@ function c86767655.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c86767655.discon(e,tp,eg,ep,ev,re,r,rp)
-	return rp~=tp and Duel.IsChainDisablable(ev)
+	return rp~=tp and Duel.IsChainDisablable(ev) and e:GetHandler():GetFlagEffect(1)>0
 end
 function c86767655.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c1,c2=Duel.TossCoin(tp,2)


### PR DESCRIPTION
Fix this:
- Chain 1: opponent's card effect
- Chain 2: _Call of the Haunted_(target _Ms. Judge_)

In this situation, _Ms. Judge_ apply effect.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10330&keyword=&tag=-1
Q.自分の魔法＆罠ゾーンにセットされている「リビングデッドの呼び声」を対象として、相手が「サイクロン」を発動しました。

この時、チェーンして、その対象となった「リビングデッドの呼び声」を発動し、墓地から「Ms.JUDGE」を特殊召喚した場合、『①：このカードがモンスターゾーンに存在する限り、相手のカードの効果が発動した場合、その処理を行う時にコイントスを２回行い、２回とも表だった場合、その効果を無効にする』モンスター効果を適用する事はできますか？
A.質問の状況の場合、相手の「サイクロン」の発動は、「Ms.JUDGE」がモンスターゾーンに存在していない状態にて行われています。

したがって、質問の状況のように、チェーンして発動した「リビングデッドの呼び声」の効果によって「Ms.JUDGE」を特殊召喚したとしても、その「Ms.JUDGE」のモンスター効果を適用する事はできません。
（「サイクロン」の効果は通常通り適用され、「リビングデッドの呼び声」が破壊されますので、その効果で特殊召喚されている「Ms.JUDGE」も破壊され、処理が完了する事になります。） 