### PR TITLE
fix 醒めない悪夢, 真竜皇の復活 etc.

### DIFF
--- a/c35125879.lua
+++ b/c35125879.lua
@@ -51,8 +51,11 @@ end
 function c35125879.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return c35125879.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc) end
 	if chk==0 then return true end
-	local b1=c35125879.sptg(e,tp,eg,ep,ev,re,r,rp,0)
-	local b2=c35125879.sumcon(e,tp,eg,ep,ev,re,r,rp) and c35125879.sumtg(e,tp,eg,ep,ev,re,r,rp,0)
+	local b1=c35125879.cost(e,tp,eg,ep,ev,re,r,rp,0)
+		and c35125879.sptg(e,tp,eg,ep,ev,re,r,rp,0)
+	local b2=c35125879.sumcon(e,tp,eg,ep,ev,re,r,rp)
+		and c35125879.cost(e,tp,eg,ep,ev,re,r,rp,0)
+		and c35125879.sumtg(e,tp,eg,ep,ev,re,r,rp,0)
 	if (b1 or b2) and Duel.SelectYesNo(tp,94) then
 		local op=0
 		if b1 and b2 then op=Duel.SelectOption(tp,aux.Stringid(35125879,0),aux.Stringid(35125879,1))
@@ -62,11 +65,13 @@ function c35125879.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 			e:SetCategory(CATEGORY_SPECIAL_SUMMON)
 			e:SetProperty(EFFECT_FLAG_CARD_TARGET)
 			e:SetOperation(c35125879.spop)
+			c35125879.cost(e,tp,eg,ep,ev,re,r,rp,1)
 			c35125879.sptg(e,tp,eg,ep,ev,re,r,rp,1)
 		else
 			e:SetCategory(CATEGORY_SUMMON)
 			e:SetProperty(0)
 			e:SetOperation(c35125879.sumop)
+			c35125879.cost(e,tp,eg,ep,ev,re,r,rp,1)
 			c35125879.sumtg(e,tp,eg,ep,ev,re,r,rp,1)
 		end
 	else
@@ -76,7 +81,8 @@ function c35125879.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	end
 end
 function c35125879.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING) end
+	if chk==0 then return Duel.GetFlagEffect(tp,35125879)==0 end
+	Duel.RegisterFlagEffect(tp,35125879,RESET_CHAIN,0,1)
 end
 function c35125879.spfilter(c,e,tp)
 	return c:IsSetCard(0xf9) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
@@ -85,8 +91,8 @@ function c35125879.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c35125879.spfilter(chkc,e,tp) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingTarget(c35125879.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
-		and Duel.GetFlagEffect(tp,35125879)==0 end
-	Duel.RegisterFlagEffect(tp,35125879,RESET_PHASE+PHASE_END,0,1)
+		and Duel.GetFlagEffect(tp,35125880)==0 end
+	Duel.RegisterFlagEffect(tp,35125880,RESET_PHASE+PHASE_END,0,1)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectTarget(tp,c35125879.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
@@ -114,8 +120,8 @@ function c35125879.sumfilter(c)
 end
 function c35125879.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c35125879.sumfilter,tp,LOCATION_HAND,0,1,nil)
-		and Duel.GetFlagEffect(tp,35125880)==0 end
-	Duel.RegisterFlagEffect(tp,35125880,RESET_PHASE+PHASE_END,0,1)
+		and Duel.GetFlagEffect(tp,35125881)==0 end
+	Duel.RegisterFlagEffect(tp,35125881,RESET_PHASE+PHASE_END,0,1)
 	Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
 end
 function c35125879.sumop(e,tp,eg,ep,ev,re,r,rp)

--- a/c61529473.lua
+++ b/c61529473.lua
@@ -52,8 +52,12 @@ end
 function c61529473.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return c61529473.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc) end
 	if chk==0 then return true end
-	local b1=c61529473.atkcon(e,tp,eg,ep,ev,re,r,rp) and c61529473.atktg(e,tp,eg,ep,ev,re,r,rp,0)
-	local b2=c61529473.sumcon(e,tp,eg,ep,ev,re,r,rp) and c61529473.sumtg(e,tp,eg,ep,ev,re,r,rp,0)
+	local b1=c61529473.atkcon(e,tp,eg,ep,ev,re,r,rp)
+		and c61529473.cost(e,tp,eg,ep,ev,re,r,rp,0)
+		and c61529473.atktg(e,tp,eg,ep,ev,re,r,rp,0)
+	local b2=c61529473.sumcon(e,tp,eg,ep,ev,re,r,rp)
+		and c61529473.cost(e,tp,eg,ep,ev,re,r,rp,0)
+		and c61529473.sumtg(e,tp,eg,ep,ev,re,r,rp,0)
 	if (b1 or b2) and Duel.SelectYesNo(tp,94) then
 		local op=0
 		if b1 and b2 then op=Duel.SelectOption(tp,aux.Stringid(61529473,0),aux.Stringid(61529473,1))
@@ -63,11 +67,13 @@ function c61529473.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 			e:SetCategory(CATEGORY_DESTROY+CATEGORY_ATKCHANGE+CATEGORY_DEFCHANGE)
 			e:SetProperty(EFFECT_FLAG_CARD_TARGET)
 			e:SetOperation(c61529473.atkop)
+			c61529473.cost(e,tp,eg,ep,ev,re,r,rp,1)
 			c61529473.atktg(e,tp,eg,ep,ev,re,r,rp,1)
 		else
 			e:SetCategory(CATEGORY_SUMMON)
 			e:SetProperty(0)
 			e:SetOperation(c61529473.sumop)
+			c61529473.cost(e,tp,eg,ep,ev,re,r,rp,1)
 			c61529473.sumtg(e,tp,eg,ep,ev,re,r,rp,1)
 		end
 	else
@@ -80,7 +86,8 @@ function c61529473.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
 function c61529473.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING) end
+	if chk==0 then return Duel.GetFlagEffect(tp,61529473)==0 end
+	Duel.RegisterFlagEffect(tp,61529473,RESET_CHAIN,0,1)
 end
 function c61529473.tgfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0xf9)
@@ -90,8 +97,8 @@ function c61529473.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_ONFIELD) and chkc:IsControler(tp) and c61529473.tgfilter(chkc) and chkc~=c end
 	if chk==0 then return Duel.IsExistingTarget(c61529473.tgfilter,tp,LOCATION_ONFIELD,0,1,c)
 		and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil)
-		and Duel.GetFlagEffect(tp,61529473)==0 end
-	Duel.RegisterFlagEffect(tp,61529473,RESET_PHASE+PHASE_END,0,1)
+		and Duel.GetFlagEffect(tp,61529474)==0 end
+	Duel.RegisterFlagEffect(tp,61529474,RESET_PHASE+PHASE_END,0,1)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c61529473.tgfilter,tp,LOCATION_ONFIELD,0,1,1,c)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
@@ -127,8 +134,8 @@ function c61529473.sumfilter(c)
 end
 function c61529473.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c61529473.sumfilter,tp,LOCATION_HAND,0,1,nil)
-		and Duel.GetFlagEffect(tp,61529474)==0 end
-	Duel.RegisterFlagEffect(tp,61529474,RESET_PHASE+PHASE_END,0,1)
+		and Duel.GetFlagEffect(tp,61529475)==0 end
+	Duel.RegisterFlagEffect(tp,61529475,RESET_PHASE+PHASE_END,0,1)
 	Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
 end
 function c61529473.sumop(e,tp,eg,ep,ev,re,r,rp)

--- a/c69452756.lua
+++ b/c69452756.lua
@@ -40,9 +40,9 @@ function c69452756.target1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	end
 end
 function c69452756.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckLPCost(tp,1000) and e:GetHandler():GetFlagEffect(69452756)==0 end
+	if chk==0 then return Duel.CheckLPCost(tp,1000) and Duel.GetFlagEffect(tp,69452756)==0 end
 	Duel.PayLPCost(tp,1000)
-	e:GetHandler():RegisterFlagEffect(69452756,RESET_CHAIN,0,1)
+	Duel.RegisterFlagEffect(tp,69452756,RESET_CHAIN,0,1)
 end
 function c69452756.target2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and c69452756.filter(chkc) end


### PR DESCRIPTION
> 「真竜皇の復活」は『①②の効果は同一チェーン上では発動できない』カードとなりますので、質問の状況のように、自分フィールドに2枚の「真竜皇の復活」が表側表示で存在する場合、フィールドの2枚の「真竜皇の復活」の効果を同一チェーン上で発動する事もできません。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20573&keyword=&tag=-1

> 「醒めない悪夢」の効果は、『同一チェーン上では１度しか発動できない』効果となりますが、同一チェーン上で2枚目の「醒めない悪夢」の効果を発動する事ができないのは、「醒めない悪夢」の効果を発動したプレイヤー自身のみとなります。
したがって、自分の「醒めない悪夢」の効果の発動にチェーンして、相手は「醒めない悪夢」の効果を発動する事はできます。
（以降は、このチェーン上にて自分も相手も「醒めない悪夢」の効果を発動する事はできません。）
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20513&keyword=&tag=-1

Fix: The effect of cards with same name shouldn't be able to active in a chain.