### PR TITLE
fix Michizure

### DIFF
--- a/c37580756.lua
+++ b/c37580756.lua
@@ -11,18 +11,11 @@ function c37580756.initial_effect(c)
 	e1:SetOperation(c37580756.activate)
 	c:RegisterEffect(e1)
 end
-function c37580756.filter1(c,tp)
+function c37580756.filter(c,tp)
 	return c:IsType(TYPE_MONSTER) and c:IsControler(tp) and c:IsPreviousLocation(LOCATION_MZONE)
 end
-function c37580756.filter2(c,tp)
-	return c:IsType(TYPE_MONSTER) and c:IsControler(tp) and c:IsReason(REASON_BATTLE) and c:IsPreviousLocation(LOCATION_MZONE)
-end
 function c37580756.condition(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetCurrentPhase()~=PHASE_DAMAGE then
-		return eg:IsExists(c37580756.filter1,1,nil,tp)
-	else
-		return eg:IsExists(c37580756.filter2,1,nil,tp)
-	end
+	return eg:IsExists(c37580756.filter,1,nil,tp)
 end
 function c37580756.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) end


### PR DESCRIPTION
Fix this: If monster send to graveyard by card effects in Damage Step, _Michizure_ cannot activate.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4939
■ダメージステップに戦闘やカードの効果によって、モンスターゾーンに存在するモンスターが自分の墓地へ送られた時にも、「道連れ」を発動する事ができます。