### PR TITLE
fix Curse of Royal

### DIFF
--- a/c2926176.lua
+++ b/c2926176.lua
@@ -15,6 +15,8 @@ function c2926176.cfilter(c)
 end
 function c2926176.condition(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not Duel.IsChainNegatable(ev) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()~=1 then return false end
 	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)
 	return ex and tg~=nil and tc==1 and tg:FilterCount(c2926176.cfilter,nil)==tg:GetCount()
 end

--- a/c2926176.lua
+++ b/c2926176.lua
@@ -14,7 +14,7 @@ function c2926176.cfilter(c)
 	return c:IsOnField() and c:IsType(TYPE_SPELL+TYPE_TRAP)
 end
 function c2926176.condition(e,tp,eg,ep,ev,re,r,rp)
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not Duel.IsChainNegatable(ev) then return false end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) or not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not Duel.IsChainNegatable(ev) then return false end
 	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
 	if not g or g:GetCount()~=1 then return false end
 	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)


### PR DESCRIPTION
Fix this: _Curse of Royal_ can negete activation _My Body as a Shield_.

http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16600&keyword=&tag=-1
Q.自分が相手のモンスターゾーンに存在するモンスターを対象として「サンダー・ブレイク」を発動しました。
相手がその発動にチェーンして、「我が身を盾に」の『１５００ライフポイントを払って発動する。相手が発動した「フィールド上のモンスターを破壊する効果」を持つカードの発動を無効にし破壊する』効果を発動した場合、自分はさらにチェーンして「王家の呪い」の『魔法・罠カード１枚を破壊する効果を含む魔法・罠カードの発動を無効にし破壊する』効果を発動する事はできますか？
A.質問の状況のように、罠カードの発動にチェーンして「我が身を盾に」が発動するような場合でも、「我が身を盾に」は対象に取って発動する効果ではありませんので、チェーンして「王家の呪い」を発動する事はできません。 