### PR TITLE
Fixed Cards that Copy the original name

### DIFF
--- a/c11522979.lua
+++ b/c11522979.lua
@@ -47,14 +47,14 @@ function c11522979.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
-function c11522979.filter(c)
-	return c:IsFaceup() and c:IsType(TYPE_XYZ)
+function c11522979.filter(c,code)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:GetOriginalCode()~=code
 end
 function c11522979.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c11522979.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c11522979.filter,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c11522979.filter,tp,0,LOCATION_MZONE,1,nil,e:GetHandler():GetCode()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c11522979.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c11522979.filter,tp,0,LOCATION_MZONE,1,1,nil,e:GetHandler():GetCode())
 end
 function c11522979.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c2067935.lua
+++ b/c2067935.lua
@@ -28,14 +28,14 @@ function c2067935.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	local st=e:GetHandler():GetSummonType()
 	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
 end
-function c2067935.rmfilter(c)
-	return c:IsSetCard(0x19) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
+function c2067935.rmfilter(c,code)
+	return c:IsSetCard(0x19) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemove() and c:GetOriginalCode()~=code
 end
 function c2067935.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c2067935.rmfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c2067935.rmfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c2067935.rmfilter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectTarget(tp,c2067935.rmfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local g=Duel.SelectTarget(tp,c2067935.rmfilter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
 end
 function c2067935.rmop(e,tp,eg,ep,ev,re,r,rp)

--- a/c2407234.lua
+++ b/c2407234.lua
@@ -43,14 +43,14 @@ function c2407234.negop(e,tp,eg,ep,ev,re,r,rp)
 		tc=g:GetNext()
 	end
 end
-function c2407234.filter(c)
-	return c:IsFaceup() and c:IsType(TYPE_XYZ)
+function c2407234.filter(c,code)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:GetCode()~=code
 end
 function c2407234.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c2407234.filter(chkc) and chkc~=e:GetHandler() end
-	if chk==0 then return Duel.IsExistingTarget(c2407234.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler()) end
+	if chk==0 then return Duel.IsExistingTarget(c2407234.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler(),e:GetHandler():GetCode())  end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c2407234.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,e:GetHandler())
+	Duel.SelectTarget(tp,c2407234.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,e:GetHandler(),e:GetHandler():GetCode()) 
 end
 function c2407234.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -64,6 +64,6 @@ function c2407234.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetValue(code)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		c:RegisterEffect(e1)
-		c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+		c:ReplaceEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
 	end
 end

--- a/c25793414.lua
+++ b/c25793414.lua
@@ -26,11 +26,14 @@ function c25793414.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 c25793414.miracle_synchro_fusion=true
+function c25793414.copyfilter(c,code)
+	return c:IsType(TYPE_MONSTER) and c:GetOriginalCode()~=code
+end
 function c25793414.cptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsType(TYPE_MONSTER) end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsType,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,TYPE_MONSTER) end
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and c25793414.copyfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c25793414.copyfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(25793414)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,Card.IsType,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,TYPE_MONSTER)
+	Duel.SelectTarget(tp,c25793414.copyfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,e:GetHandler():GetCode())
 end
 function c25793414.cpop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -47,6 +50,7 @@ function c25793414.cpop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 		if not tc:IsType(TYPE_TRAPMONSTER) then
 			cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+			e:GetHandler():RegisterFlagEffect(25793414,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		end
 		local e2=Effect.CreateEffect(c)
 		e2:SetDescription(aux.Stringid(25793414,2))

--- a/c30312361.lua
+++ b/c30312361.lua
@@ -8,7 +8,6 @@ function c30312361.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCountLimit(1)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetCost(c30312361.cost)
 	e1:SetTarget(c30312361.target)
 	e1:SetOperation(c30312361.operation)
 	c:RegisterEffect(e1)
@@ -18,18 +17,14 @@ function c30312361.initial_effect(c)
 	e2:SetCode(EFFECT_NO_BATTLE_DAMAGE)
 	c:RegisterEffect(e2)
 end
-function c30312361.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetFlagEffect(30312361)==0 end
-	e:GetHandler():RegisterFlagEffect(30312361,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c30312361.filter(c)
-	return c:IsType(TYPE_EFFECT) and c:IsAbleToRemove()
+function c30312361.filter(c,code)
+	return c:IsType(TYPE_EFFECT) and c:IsAbleToRemove() and c:GetOriginalCode()~=code
 end
 function c30312361.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c30312361.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c30312361.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c30312361.filter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(30312361)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectTarget(tp,c30312361.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local g=Duel.SelectTarget(tp,c30312361.filter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
 end
 function c30312361.operation(e,tp,eg,ep,ev,re,r,rp)
@@ -37,7 +32,7 @@ function c30312361.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsRelateToEffect(e) then
 		if Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)~=1 then return end
-		local code=tc:GetOriginalCode()
+		local code=tc:GetOriginalCodeRule()
 		local ba=tc:GetBaseAttack()
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -55,6 +50,7 @@ function c30312361.operation(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetValue(ba)
 		c:RegisterEffect(e2)
 		local cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+		e:GetHandler():RegisterFlagEffect(30312361,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		local e3=Effect.CreateEffect(c)
 		e3:SetDescription(aux.Stringid(30312361,1))
 		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c39512984.lua
+++ b/c39512984.lua
@@ -37,13 +37,13 @@ end
 function c39512984.atkup(e,c)
 	return Duel.GetMatchingGroupCount(c39512984.atkfilter,c:GetControler(),LOCATION_GRAVE,0,nil)*100
 end
-function c39512984.filter(c)
-	return c:IsLevelBelow(7) and c:IsSetCard(0x1047) and c:IsType(TYPE_FUSION) and c:IsAbleToRemoveAsCost()
+function c39512984.filter(c,code)
+	return c:IsLevelBelow(7) and c:IsSetCard(0x1047) and c:IsType(TYPE_FUSION) and c:IsAbleToRemoveAsCost() and c:GetOriginalCode()~=code
 end
 function c39512984.cost(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chk==0 then return Duel.IsExistingMatchingCard(c39512984.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c39512984.filter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c39512984.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c39512984.filter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 	e:SetLabel(g:GetFirst():GetOriginalCode())
 end

--- a/c4068622.lua
+++ b/c4068622.lua
@@ -54,22 +54,23 @@ function c4068622.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.Remove(g1,POS_FACEUP,REASON_COST)
 end
 function c4068622.filter(c)
-	return c:IsSetCard(0x33) and c:IsAbleToRemove()
+	return c:IsSetCard(0x33) and c:IsAbleToRemove() and (c:GetCode()~=code or c:GetBaseAttack()>0)
 end
 function c4068622.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c4068622.filter,tp,LOCATION_EXTRA,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c4068622.filter,tp,LOCATION_EXTRA,0,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(4068622)==0 end
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,0,tp,LOCATION_EXTRA)
 end
 function c4068622.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c4068622.filter,tp,LOCATION_EXTRA,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c4068622.filter,tp,LOCATION_EXTRA,0,1,1,nil,e:GetHandler():GetCode()) 
 	local tc=g:GetFirst()
 	local c=e:GetHandler()
 	if tc and c:IsFaceup() and c:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)>0 then
 		local code=tc:GetOriginalCode()
 		local ba=tc:GetBaseAttack()
 		local reset_flag=RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END
-		c:CopyEffect(code, reset_flag, 1)
+		c:CopyEffect(code,reset_flag,1)
+		e:GetHandler():RegisterFlagEffect(4068622,reset_flag,0,1)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)

--- a/c41209827.lua
+++ b/c41209827.lua
@@ -21,7 +21,6 @@ function c41209827.initial_effect(c)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetCountLimit(1)
-	e2:SetCost(c41209827.copycost)
 	e2:SetTarget(c41209827.copytg)
 	e2:SetOperation(c41209827.copyop)
 	c:RegisterEffect(e2)
@@ -64,18 +63,14 @@ function c41209827.atkop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 	end
 end
-function c41209827.copycost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetFlagEffect(41209827)==0 end
-	e:GetHandler():RegisterFlagEffect(41209827,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c41209827.copyfilter(c)
-	return c:IsFaceup() and c:IsLevelAbove(5)
+function c41209827.copyfilter(c,code)
+	return c:IsFaceup() and c:IsLevelAbove(5) and c:GetOriginalCode()~=code
 end
 function c41209827.copytg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and c41209827.copyfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c41209827.copyfilter,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c41209827.copyfilter,tp,0,LOCATION_MZONE,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(41209827)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c41209827.copyfilter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c41209827.copyfilter,tp,0,LOCATION_MZONE,1,1,nil,e:GetHandler():GetCode())
 end
 function c41209827.copyop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -91,6 +86,7 @@ function c41209827.copyop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 		if not tc:IsType(TYPE_TRAPMONSTER) then
 			c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+			e:GetHandler():RegisterFlagEffect(41209827,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		end
 	end
 end

--- a/c43237273.lua
+++ b/c43237273.lua
@@ -11,11 +11,14 @@ function c43237273.initial_effect(c)
 	e1:SetOperation(c43237273.operation)
 	c:RegisterEffect(e1)
 end
+function c43237273.filter(c,code)
+	return c:IsFaceup() and c:IsType(TYPE_EFFECT) and c:GetCode()~=code
+end
 function c43237273.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and c43237273.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c43237273.filter,tp,0,LOCATION_MZONE,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(43237273)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c43237273.filter,tp,0,LOCATION_MZONE,1,1,nil,e:GetHandler():GetCode())
 end
 function c43237273.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -31,7 +34,8 @@ function c43237273.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetValue(code)
 		c:RegisterEffect(e1)
 		if not tc:IsType(TYPE_TRAPMONSTER) then
-			cid=c:CopyEffect(code, RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END, 1)
+			cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+			e:GetHandler():RegisterFlagEffect(43237273,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		end
 		local e2=Effect.CreateEffect(c)
 		e2:SetDescription(aux.Stringid(43237273,1))

--- a/c43387895.lua
+++ b/c43387895.lua
@@ -26,7 +26,6 @@ function c43387895.initial_effect(c)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e3:SetCountLimit(1)
-	e3:SetCost(c43387895.copycost)
 	e3:SetTarget(c43387895.copytg)
 	e3:SetOperation(c43387895.copyop)
 	c:RegisterEffect(e3)
@@ -69,19 +68,15 @@ function c43387895.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	c:SetMaterial(sg)
 	Duel.Release(sg,REASON_COST+REASON_FUSION+REASON_MATERIAL)
 end
-function c43387895.copycost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetFlagEffect(41209827)==0 end
-	e:GetHandler():RegisterFlagEffect(41209827,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c43387895.copyfilter(c)
-	return c:IsType(TYPE_MONSTER) and not c:IsType(TYPE_TOKEN) and (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE))
+function c43387895.copyfilter(c,code)
+	return c:IsType(TYPE_MONSTER) and not c:IsType(TYPE_TOKEN) and c:GetOriginalCode()~=code and (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE))
 end
 function c43387895.copytg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
 	if chkc then return chkc:IsLocation(LOCATION_MZONE+LOCATION_GRAVE) and c43387895.copyfilter(chkc) and chkc~=c end
-	if chk==0 then return Duel.IsExistingTarget(c43387895.copyfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,c) end
+	if chk==0 then return Duel.IsExistingTarget(c43387895.copyfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,c,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(41209827)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c43387895.copyfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,1,c)
+	Duel.SelectTarget(tp,c43387895.copyfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,1,c,e:GetHandler():GetCode())
 end
 function c43387895.copyop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -97,6 +92,7 @@ function c43387895.copyop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 		if not tc:IsType(TYPE_TRAPMONSTER) then
 			local cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+			e:GetHandler():RegisterFlagEffect(41209827,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 			local e3=Effect.CreateEffect(c)
 			e3:SetDescription(aux.Stringid(43387895,1))
 			e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c47387961.lua
+++ b/c47387961.lua
@@ -16,14 +16,14 @@ function c47387961.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c47387961.xyz_number=8
-function c47387961.filter(c)
-	return c:IsFaceup() and c:IsType(TYPE_XYZ)
+function c47387961.filter(c,code)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:GetCode()~=code
 end
 function c47387961.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and c47387961.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c47387961.filter,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c47387961.filter,tp,0,LOCATION_MZONE,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(43237273)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c47387961.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c47387961.filter,tp,0,LOCATION_MZONE,1,1,nil,e:GetHandler():GetCode())
 end
 function c47387961.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -34,7 +34,7 @@ function c47387961.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetCode(EFFECT_CHANGE_CODE)
-		e1:SetValue(code)
+		e1:SetValue(tc:GetCode())
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		c:RegisterEffect(e1)
 		local e2=e1:Clone()
@@ -43,6 +43,7 @@ function c47387961.operation(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetLabelObject(e1)
 		c:RegisterEffect(e2)
 		local cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+		e:GetHandler():RegisterFlagEffect(47387961,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		local e4=Effect.CreateEffect(c)
 		e4:SetType(EFFECT_TYPE_SINGLE)
 		e4:SetCode(EFFECT_SET_ATTACK_FINAL)

--- a/c51827737.lua
+++ b/c51827737.lua
@@ -11,11 +11,14 @@ function c51827737.initial_effect(c)
 	e1:SetOperation(c51827737.operation)
 	c:RegisterEffect(e1)
 end
+function c51827737.copyfilter(c,code)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x2) and c:GetCode()~=code
+end
 function c51827737.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and chkc:IsSetCard(0x2) end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsSetCard,tp,LOCATION_GRAVE,0,1,nil,0x2) end
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c51827737.copyfilter(chkc) end
+	if chk==0 then return (c51827737.copyfilter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode())  end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(51827737,1))
-	Duel.SelectTarget(tp,Card.IsSetCard,tp,LOCATION_GRAVE,0,1,1,nil,0x2)
+	Duel.SelectTarget(tp,c51827737.copyfilter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 end
 function c51827737.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c67926903.lua
+++ b/c67926903.lua
@@ -32,14 +32,14 @@ end
 function c67926903.atkval(e,c)
 	return c:GetOverlayCount()*1000
 end
-function c67926903.filter(c)
-	return c:IsSetCard(0x48) and c:IsType(TYPE_EFFECT)
+function c67926903.filter(c,code)
+	return c:IsSetCard(0x48) and c:IsType(TYPE_EFFECT) and c:GetOriginalCode()~=code
 end
 function c67926903.copytg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c67926903.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c67926903.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c67926903.filter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(67926903)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c67926903.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SelectTarget(tp,c67926903.filter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 end
 function c67926903.copyop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -55,6 +55,7 @@ function c67926903.copyop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
 		c:RegisterEffect(e1)
 		local cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
+		e:GetHandler():RegisterFlagEffect(67926903,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END+RESET_OPPO_TURN,0,1)
 		local e2=Effect.CreateEffect(c)
 		e2:SetDescription(aux.Stringid(67926903,2))
 		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c75198893.lua
+++ b/c75198893.lua
@@ -13,13 +13,13 @@ function c75198893.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c75198893.filter(c)
-	return c:IsFaceup() and c:IsType(TYPE_MONSTER) and not c:IsType(TYPE_XYZ) and not c:IsForbidden()
+	return c:IsFaceup() and c:IsType(TYPE_MONSTER) and not c:IsType(TYPE_XYZ) and not c:IsForbidden() and c:GetCode()~=code
 end
 function c75198893.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_REMOVED) and chkc:IsControler(1-tp) and c75198893.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c75198893.filter,tp,0,LOCATION_REMOVED,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c75198893.filter,tp,0,LOCATION_REMOVED,1,nil,e:GetHandler():GetCode() end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c75198893.filter,tp,0,LOCATION_REMOVED,1,1,nil)
+	Duel.SelectTarget(tp,c75198893.filter,tp,0,LOCATION_REMOVED,1,1,nil,e:GetHandler():GetCode()
 end
 function c75198893.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c75620895.lua
+++ b/c75620895.lua
@@ -20,14 +20,14 @@ function c75620895.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
-function c75620895.filter(c)
-	return c:IsFaceup() and c:IsType(TYPE_XYZ)
+function c75620895.filter(c,code)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:GetCode()~=code
 end
 function c75620895.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and c75620895.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c75620895.filter,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c75620895.filter,tp,0,LOCATION_MZONE,1,nil,e:GetHandler():GetCode()) and e:GetHandler():GetFlagEffect(75620895)==0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c75620895.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c75620895.filter,tp,0,LOCATION_MZONE,1,1,nil,e:GetHandler():GetCode())
 end
 function c75620895.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -39,8 +39,9 @@ function c75620895.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetReset(RESET_EVENT+0x1fe0000)
 		e1:SetCode(EFFECT_CHANGE_CODE)
-		e1:SetValue(code)
+		e1:SetValue(tc:GetCode())
 		c:RegisterEffect(e1)
-		c:CopyEffect(code,RESET_EVENT+0x1fe0000,1)
+		c:ReplaceEffect(code,RESET_EVENT+0x1fe0000,1)
+		e:GetHandler():RegisterFlagEffect(75620895,RESET_EVENT+0x1fe0000,0,1)
 	end
 end

--- a/c77584012.lua
+++ b/c77584012.lua
@@ -16,17 +16,16 @@ function c77584012.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c77584012.filter(c)
-	return c:IsType(TYPE_FIELD) and c:IsAbleToRemoveAsCost()
+	return c:IsType(TYPE_FIELD) and c:IsAbleToRemoveAsCost() and c:GetOriginalCode()~=code
 end
 function c77584012.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetFlagEffect(77584012)==0
-		and Duel.IsExistingMatchingCard(c77584012.filter,tp,LOCATION_GRAVE,0,1,nil) end
+		and Duel.IsExistingMatchingCard(c77584012.filter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c77584012.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c77584012.filter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 	local code=g:GetFirst():GetOriginalCode()
 	e:SetLabel(code)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
-	e:GetHandler():RegisterFlagEffect(77584012,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 end
 function c77584012.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -40,6 +39,7 @@ function c77584012.operation(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(code)
 	c:RegisterEffect(e1)
 	local cid=c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+	e:GetHandler():RegisterFlagEffect(77584012,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(77584012,1))
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c84565800.lua
+++ b/c84565800.lua
@@ -44,14 +44,14 @@ function c84565800.rmop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
 	end
 end
-function c84565800.cpfilter(c)
-	return c:IsType(TYPE_EFFECT)
+function c84565800.cpfilter(c,code)
+	return c:IsType(TYPE_EFFECT) and c:GetOriginalCode()~=code
 end
 function c84565800.cptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c84565800.cpfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c84565800.cpfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c84565800.cpfilter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c84565800.cpfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SelectTarget(tp,c84565800.cpfilter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 end
 function c84565800.cpop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c88071625.lua
+++ b/c88071625.lua
@@ -90,7 +90,7 @@ function c88071625.copycon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_ADVANCE
 end
 function c88071625.filter(c,e)
-	return c:IsType(TYPE_EFFECT) and c:IsLocation(LOCATION_GRAVE) and c:IsCanBeEffectTarget(e)
+	return c:IsType(TYPE_EFFECT) and c:IsLocation(LOCATION_GRAVE) and c:IsCanBeEffectTarget(e) and c:GetOriginalCode()~=e:GetHandler():GetCode()
 end
 function c88071625.copytg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return e:GetHandler():GetMaterial():IsContains(chkc) and c88071625.filter(chkc,e) end

--- a/c89312388.lua
+++ b/c89312388.lua
@@ -10,15 +10,15 @@ function c89312388.initial_effect(c)
 	e1:SetOperation(c89312388.cosoperation)
 	c:RegisterEffect(e1)
 end
-function c89312388.filter2(c,fc)
-	if not c:IsAbleToGraveAsCost() then return false end
-	return c:IsCode(table.unpack(fc.material))
+function c89312388.filter2(c,fc,code)
+	if not c:GetCode()~=code or not c:IsAbleToGraveAsCost() then return false end
+	return c:IsCode(table.unpack(fc.material)) and 
 end
-function c89312388.filter1(c,tp)
-	return c.material and Duel.IsExistingMatchingCard(c89312388.filter2,tp,LOCATION_DECK,0,1,nil,c)
+function c89312388.filter1(c,tp,code)
+	return c.material and Duel.IsExistingMatchingCard(c89312388.filter2,tp,LOCATION_DECK,0,1,nil,c,code)
 end
 function c89312388.coscost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c89312388.filter1,tp,LOCATION_EXTRA,0,1,nil,tp) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c89312388.filter1,tp,LOCATION_EXTRA,0,1,nil,tp,e:GetHandler():GetCode() end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
 	local g=Duel.SelectMatchingCard(tp,c89312388.filter1,tp,LOCATION_EXTRA,0,1,1,nil,tp)
 	Duel.ConfirmCards(1-tp,g)

--- a/c95453143.lua
+++ b/c95453143.lua
@@ -23,13 +23,13 @@ function c95453143.initial_effect(c)
 	e2:SetOperation(c95453143.thop)
 	c:RegisterEffect(e2)
 end
-function c95453143.filter(c)
-	return c:IsLevelBelow(6) and c:IsType(TYPE_EFFECT) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToRemoveAsCost()
+function c95453143.filter(c,code)
+	return c:IsLevelBelow(6) and c:IsType(TYPE_EFFECT) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToRemoveAsCost() and c:GetOriginalCode()~=code
 end
 function c95453143.cost(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chk==0 then return Duel.IsExistingMatchingCard(c95453143.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c95453143.filter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler():GetCode()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c95453143.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c95453143.filter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetHandler():GetCode())
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 	e:SetLabel(g:GetFirst():GetOriginalCode())
 end


### PR DESCRIPTION
Q.
スターヴ・ヴェノム・フュージョン・ドラゴン
相手が同じモンスターに（2）の効果を与えた場合。 ループを作成できますか？ または、1ターンに1度はまだ有効ですか？
A.
相手フィールドの「スターヴ・ヴェノム・フュージョン・ドラゴン」を対象に、「スターヴ・ヴェノム・フュージョン・ドラゴン」の『②』の効果を発動する事はできません。

Q.
Stave, Venom, Fusion, Dragon
When the opponent gives effect (2) to the same monster. Can I create a loop? Or is it still valid once per turn?
A.
You can not activate the effect of "②" of "Stave, Venom, Fusion, Dragon" for the opponent's field "Stave, Venom, Fusion, Dragon".

Ruling provided by Steeldarkeangel

Note:
Red Supremacy already applies that ruling and it's not a BKSS ruling because
the effect text says `.......this card's name becomes that target's original name, and .......`
the name can't become the target's original name if it already is with that same name
it's the same reason you can't target a monster with 0 ATK and (no negatable effect or if it's effects are already negated) using Clear Wing Fast Dragon
also the same reason you can't declare the current level in the effect of gagaga magician