### PR TITLE
eratta Gilasaurus

### DIFF
--- a/c45894482.lua
+++ b/c45894482.lua
@@ -9,51 +9,32 @@ function c45894482.initial_effect(c)
 	e1:SetCondition(c45894482.spcon)
 	e1:SetValue(1)
 	c:RegisterEffect(e1)
-	--spsummon success
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
-	e2:SetOperation(c45894482.trigop)
-	c:RegisterEffect(e2)
 	--spsummon
 	local e3=Effect.CreateEffect(c)
 	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e3:SetDescription(aux.Stringid(45894482,0))
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
-	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e3:SetCode(EVENT_CUSTOM+45894482)
-	e3:SetTarget(c45894482.target)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetCondition(c45894482.condition)
 	e3:SetOperation(c45894482.operation)
 	c:RegisterEffect(e3)
-	e2:SetLabelObject(e3)
 end
 function c45894482.spcon(e,c)
 	if c==nil then return true end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
-function c45894482.trigop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if c:GetSummonType()==SUMMON_TYPE_SPECIAL+1
-		and e:GetLabelObject():IsActivatable(tp)
-		and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(c45894482.filter,1-tp,LOCATION_GRAVE,0,1,nil,e,1-tp)
-		and Duel.SelectEffectYesNo(1-tp,c) then
-		Duel.RaiseSingleEvent(c,EVENT_CUSTOM+45894482,e,r,rp,tp,0)
-	end
+function c45894482.condition(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL+1
 end
 function c45894482.filter(c,e,tp)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
-function c45894482.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_GRAVE) and c45894482.filter(chkc,e,1-tp) end
-	if chk==0 then return true end
-	Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectTarget(1-tp,c45894482.filter,1-tp,LOCATION_GRAVE,0,1,1,nil,e,1-tp)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
-end
 function c45894482.operation(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
-		Duel.SpecialSummon(tc,0,1-tp,1-tp,false,false,POS_FACEUP)
+	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c45894482.filter),1-tp,LOCATION_GRAVE,0,nil,e,1-tp)
+	if g:GetCount()>0 and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
+		and Duel.SelectYesNo(1-tp,aux.Stringid(45894482,1)) then
+		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_SPSUMMON)
+		local sg=g:Select(1-tp,1,1,nil)
+		Duel.SpecialSummon(sg,0,1-tp,1-tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5256
■『相手は自身の墓地のモンスター１体を選んで特殊召喚できる』モンスター効果は**対象を取る効果ではありません**。効果処理時に、相手は自身の墓地から特殊召喚するモンスターを選びます。 