### PR TITLE
fix Blast Sphere

### DIFF
--- a/c26302522.lua
+++ b/c26302522.lua
@@ -40,7 +40,7 @@ function c26302522.eqop(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetCondition(c26302522.descon)
 	e2:SetTarget(c26302522.destg)
 	e2:SetOperation(c26302522.desop)
-	e2:SetReset(RESET_EVENT+0x1fe0000)
+	e2:SetReset(RESET_EVENT+0x1fe0000+RESET_OPPO_TURN+RESET_PHASE+PHASE_STANDBY)
 	c:RegisterEffect(e2)
 end
 function c26302522.eqlimit(e,c)


### PR DESCRIPTION
> ①：裏側守備表示のこのカードが相手モンスターに攻撃されたダメージ計算前に発動する。このカードを装備カード扱いとしてその攻撃モンスターに装備する。②：このカードの効果でこのカードを**装備した次の相手スタンバイフェイズに発動する**。装備モンスターを破壊し、その攻撃力分のダメージを相手に与える。