### PR TITLE
eratta Witch of the Black Forest, Ryko, Lightsworn Hunter, Darkness Approaches

### DIFF
--- a/c21502796.lua
+++ b/c21502796.lua
@@ -3,29 +3,23 @@ function c21502796.initial_effect(c)
 	--flip
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(21502796,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCategory(CATEGORY_DECKDES+CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP)
 	e1:SetTarget(c21502796.target)
 	e1:SetOperation(c21502796.operation)
 	c:RegisterEffect(e1)
 end
-function c21502796.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() end
+function c21502796.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	if Duel.IsExistingTarget(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
-		and Duel.SelectYesNo(tp,aux.Stringid(21502796,1)) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-		local g=Duel.SelectTarget(tp,aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
-		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	end
 	Duel.SetOperationInfo(0,CATEGORY_DECKDES,nil,0,tp,3)
 end
 function c21502796.operation(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
-		Duel.Destroy(tc,REASON_EFFECT)
-		Duel.BreakEffect()
+	local g=Duel.GetMatchingGroup(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(21502796,1)) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		local sg=g:Select(tp,1,1,nil)
+		Duel.HintSelection(sg)
+		Duel.Destroy(sg,REASON_EFFECT)
 	end
 	Duel.DiscardDeck(tp,3,REASON_EFFECT)
 end

--- a/c78010363.lua
+++ b/c78010363.lua
@@ -6,13 +6,14 @@ function c78010363.initial_effect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetCountLimit(1,78010363)
 	e1:SetCondition(c78010363.condition)
 	e1:SetTarget(c78010363.target)
 	e1:SetOperation(c78010363.operation)
 	c:RegisterEffect(e1)
 end
 function c78010363.condition(e,tp,eg,ep,ev,re,r,rp)
-	return bit.band(e:GetHandler():GetPreviousLocation(),LOCATION_ONFIELD)>0
+	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c78010363.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
@@ -27,5 +28,21 @@ function c78010363.operation(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
+		local tc=g:GetFirst()
+		if tc:IsLocation(LOCATION_HAND) then
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_FIELD)
+			e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+			e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+			e1:SetTargetRange(1,0)
+			e1:SetValue(c78010363.aclimit)
+			e1:SetLabelObject(tc)
+			e1:SetReset(RESET_PHASE+PHASE_END)
+			Duel.RegisterEffect(e1,tp)
+		end
 	end
+end
+function c78010363.aclimit(e,re,tp)
+	local tc=e:GetLabelObject()
+	return re:GetHandler():IsCode(tc:GetCode()) and not re:GetHandler():IsImmuneToEffect(e)
 end

--- a/c80168720.lua
+++ b/c80168720.lua
@@ -28,6 +28,6 @@ end
 function c80168720.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
-		Duel.ChangePosition(tc,POS_FACEDOWN_ATTACK,0,POS_FACEDOWN_DEFENSE,0)
+		Duel.ChangePosition(tc,POS_FACEDOWN_DEFENSE)
 	end
 end


### PR DESCRIPTION
http://www.yugioh-card.com/japan/notice/revision/#date20170324
このカード名の効果は1ターンに1度のみの使用となり、その効果を使用したターン、自分はこの効果で手札に加えたカード及びその同名カードの発動ができなくなります。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7595
■「ライトロード・ハンター ライコウ」のモンスター効果は、「ライトロード・ハンター ライコウ」自身がリバースした場合に必ず発動する誘発効果です。（**対象を取る効果ではありません。**ダメージステップでも発動します。）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4902
■『表側表示のモンスター１体を選択し、表示形式はそのままで裏側表示にする』の『表示形式はそのままで裏側表示にする』は『**裏側守備表示にする**』に読み替えます。　（2017年3月25日より適用）