### PR TITLE
fix Magical Hats

### DIFF
--- a/c81210420.lua
+++ b/c81210420.lua
@@ -15,7 +15,7 @@ function c81210420.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE)
 end
 function c81210420.filter(c)
-	return c:GetSequence()<5 and not c:IsType(TYPE_TOKEN)
+	return c:GetSequence()<5 and not c:IsType(TYPE_TOKEN+TYPE_LINK)
 end
 function c81210420.spfilter(c,e,tp)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP) and Duel.IsPlayerCanSpecialSummonMonster(tp,c:GetCode(),nil,0x11,0,0,0,0,0,POS_FACEDOWN)

--- a/c81210420.lua
+++ b/c81210420.lua
@@ -15,7 +15,7 @@ function c81210420.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE)
 end
 function c81210420.filter(c)
-	return not c:IsType(TYPE_TOKEN)
+	return c:GetSequence()<5 and not c:IsType(TYPE_TOKEN)
 end
 function c81210420.spfilter(c,e,tp)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP) and Duel.IsPlayerCanSpecialSummonMonster(tp,c:GetCode(),nil,0x11,0,0,0,0,0,POS_FACEDOWN)


### PR DESCRIPTION
Fix this: If player has only monster in Extra Monster Zone, player can activate _Magical Hats_.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6232&keyword=&tag=-1
Q.エクストラモンスターゾーンにのみ自分のモンスターが存在する場合、「マジカルシルクハット」を発動する事はできますか？
A.エクストラモンスターゾーンにのみ自分のモンスターが存在する場合、「マジカルシルクハット」を発動する事はできません。

なお、エクストラモンスターゾーンとメインモンスターゾーンに自分のモンスターが存在している場合には、自分のメインモンスターゾーンに存在するモンスターとデッキから選んだ魔法・罠カードを選んでシャッフルし、効果処理を行う事になります。 