### PR TITLE
fix Senet Switch

### DIFF
--- a/c63394872.lua
+++ b/c63394872.lua
@@ -18,6 +18,7 @@ function c63394872.initial_effect(c)
 end
 function c63394872.filter(c,tp)
 	local seq=c:GetSequence()
+	if seq>4 then return false end
 	return (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1))
 end
@@ -32,6 +33,7 @@ function c63394872.seqop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) then return end
 	local seq=tc:GetSequence()
+	if seq>4 then return false end
 	if (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1)) then
 		local flag=0

--- a/c63394872.lua
+++ b/c63394872.lua
@@ -33,7 +33,7 @@ function c63394872.seqop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) then return end
 	local seq=tc:GetSequence()
-	if seq>4 then return false end
+	if seq>4 then return end
 	if (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1)) then
 		local flag=0


### PR DESCRIPTION
Fix this: _Senet Switch_ can target monster in Extra Monster Zone.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20729&keyword=&tag=-1
Q.「ポジションチェンジ」における「隣のモンスターカードゾーン」とは、左右のみを指しますか？

例えば、EXモンスターゾーンのモンスターを対象にして、真下のメインモンスターゾーンに移動、はできますか？
A.「ポジションチェンジ」は対象としたモンスターの左右どちらかのモンスターゾーンが使用されておらず空いている場合、その空いているモンスターゾーンに移動させる事ができる効果です。

つまり、エクストラモンスターゾーンのモンスターを対象として効果を発動する事はできず、メインモンスターゾーンのモンスターを対象として発動する効果という事になります。 