### PR TITLE
fix Flash of the Forbidden Spell

### DIFF
--- a/c39956951.lua
+++ b/c39956951.lua
@@ -10,8 +10,11 @@ function c39956951.initial_effect(c)
 	e1:SetOperation(c39956951.activate)
 	c:RegisterEffect(e1)
 end
+function c39956951.cfilter(c)
+	return c:GetSequence()<5
+end
 function c39956951.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>=5
+	return Duel.GetMatchingGroupCount(c39956951.cfilter,tp,0,LOCATION_MZONE,nil)>=5
 end
 function c39956951.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_MZONE,1,nil) end


### PR DESCRIPTION
Fix this: If opponent has 4 monsters in Main Monster Zone and 1 monster in Extra Monster Zone, player can activate _Flash of the Forbidden Spell_.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20722&keyword=&tag=-1
Q.相手のメインモンスターゾーンに4体のモンスターが存在し、エクストラモンスターゾーンに相手のリンクモンスターが1体存在しています。

この場合、相手フィールドには5体のモンスターが存在していますが、自分は「封魔一閃」を発動する事はできますか？
A.質問の状況の場合、自分は「封魔一閃」を発動する事はできません。

質問の状況の場合、相手のメインモンスターゾーンにモンスターが5体存在しているのであれば、エクストラモンスターゾーンに相手のモンスターが存在するかどうかに関わらず、自分は「封魔一閃」を発動する事ができます。

（なお、メインモンスターゾーンとエクストラモンスターゾーンの両方に相手のモンスターが存在している場合、「封魔一閃」の効果によって、それらのモンスターが全て破壊される事になります。） 