### PR TITLE
update moving effects on master rule 4 & The Wicked Avatar

### DIFF
--- a/c21208154.lua
+++ b/c21208154.lua
@@ -35,6 +35,13 @@ function c21208154.initial_effect(c)
 	e6:SetCode(EVENT_SUMMON_SUCCESS)
 	e6:SetOperation(c21208154.regop)
 	c:RegisterEffect(e6)
+	--for checking for copying effect
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(21208154)
+	e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	c:RegisterEffect(e4)
 end
 function c21208154.ttcon(e,c,minc)
 	if c==nil then return true end
@@ -46,7 +53,7 @@ function c21208154.ttop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.Release(g,REASON_SUMMON+REASON_MATERIAL)
 end
 function c21208154.filter(c)
-	return c:IsFaceup() and c:GetCode()~=21208154
+	return c:IsFaceup() and c:GetCode()~=21208154 and not c:IsHasEffect(21208154)
 end
 function c21208154.adval(e,c)
 	local g=Duel.GetMatchingGroup(c21208154.filter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c21208154.lua
+++ b/c21208154.lua
@@ -36,12 +36,12 @@ function c21208154.initial_effect(c)
 	e6:SetOperation(c21208154.regop)
 	c:RegisterEffect(e6)
 	--for checking for copying effect
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_SINGLE)
-	e4:SetCode(21208154)
-	e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e4:SetRange(LOCATION_MZONE)
-	c:RegisterEffect(e4)
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE)
+	e7:SetCode(21208154)
+	e7:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e7:SetRange(LOCATION_MZONE)
+	c:RegisterEffect(e7)
 end
 function c21208154.ttcon(e,c,minc)
 	if c==nil then return true end

--- a/c3784434.lua
+++ b/c3784434.lua
@@ -21,6 +21,7 @@ function c3784434.initial_effect(c)
 end
 function c3784434.seqcon(e,tp,eg,ep,ev,re,r,rp)
 	local seq=e:GetHandler():GetSequence()
+	if seq>4 then return false end
 	return (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1))
 end
@@ -28,6 +29,7 @@ function c3784434.seqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) then return end
 	local seq=c:GetSequence()
+	if seq>4 then return end
 	if (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1)) then
 		local flag=0
@@ -44,14 +46,25 @@ function c3784434.seqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.MoveSequence(c,nseq)
 	end
 end
-function c3784434.dircon(e,tp)
-	local seq=4-e:GetHandler():GetSequence()
-	return Duel.GetFieldCard(e:GetOwnerPlayer(),LOCATION_MZONE,seq)==nil
-		and Duel.GetFieldCard(e:GetOwnerPlayer(),LOCATION_SZONE,seq)==nil
-end
 function c3784434.atkcon(e)
 	local ph=Duel.GetCurrentPhase()
-	return (ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL)
-		and Duel.GetAttacker()==e:GetHandler() and Duel.GetAttackTarget()~=nil
-		and e:GetHandler():GetSequence()+Duel.GetAttackTarget():GetSequence()==4
+	if ph=~PHASE_DAMAGE and ph~=PHASE_DAMAGE_CAL then return false end
+	if Duel.GetAttacker()~=e:GetHandler() then return false end
+	local tc=Duel.GetAttackTarget()
+	if not tc then return false end
+	local s1=e:GetHandler():GetSequence()
+	local s2=tc:GetSequence()
+	if s1<5 then
+ +		if s2<5 then
+ +			return s1+s2==4
+ +		else
+ +			return (s2==5 and s1==3) or (s2==6 and s1==1)
+ +		end
+ +	else
+ +		if s2<5 then
+ +			return (s1==5 and s2==3) or (s1==6 and s2==1)
+ +		else
+ +			return false
+ +        	end
+ +	end
 end

--- a/c3784434.lua
+++ b/c3784434.lua
@@ -48,7 +48,7 @@ function c3784434.seqop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c3784434.atkcon(e)
 	local ph=Duel.GetCurrentPhase()
-	if ph=~PHASE_DAMAGE and ph~=PHASE_DAMAGE_CAL then return false end
+	if ph~=PHASE_DAMAGE and ph~=PHASE_DAMAGE_CAL then return false end
 	if Duel.GetAttacker()~=e:GetHandler() then return false end
 	local tc=Duel.GetAttackTarget()
 	if not tc then return false end

--- a/c76573247.lua
+++ b/c76573247.lua
@@ -45,6 +45,14 @@ function c76573247.seqop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c76573247.dircon(e)
 	local p=1-e:GetHandlerPlayer()
-	local seq=4-e:GetHandler():GetSequence()
-	return Duel.GetFieldCard(p,LOCATION_MZONE,seq)==nil and Duel.GetFieldCard(p,LOCATION_SZONE,seq)==nil
+	local seq=e:GetHandler():GetSequence()
+	if seq<5 then
+		if seq==1 and Duel.GetFieldCard(p,LOCATION_MZONE,6)=~nil then return false end
+		if seq==3 and Duel.GetFieldCard(p,LOCATION_MZONE,5)=~nil then return false end
+		return Duel.GetFieldCard(p,LOCATION_MZONE,4-seq)==nil and Duel.GetFieldCard(p,LOCATION_SZONE,4-seq)==nil
+	elseif seq==5 then
+		return Duel.GetFieldCard(p,LOCATION_MZONE,3)==nil and Duel.GetFieldCard(p,LOCATION_SZONE,3)==nil
+	else
+		return Duel.GetFieldCard(p,LOCATION_MZONE,1)==nil and Duel.GetFieldCard(p,LOCATION_SZONE,1)==nil
+	end
 end

--- a/c76573247.lua
+++ b/c76573247.lua
@@ -18,6 +18,7 @@ function c76573247.initial_effect(c)
 end
 function c76573247.seqcon(e,tp,eg,ep,ev,re,r,rp)
 	local seq=e:GetHandler():GetSequence()
+	if seq>4 then return false end
 	return (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1))
 end
@@ -25,6 +26,7 @@ function c76573247.seqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) then return end
 	local seq=c:GetSequence()
+	if seq>4 then return end
 	if (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1)) then
 		local flag=0


### PR DESCRIPTION
these changed cards are related to effect of moving sequence. these should be changed in the master 4 rule because of the ex monster zone

when there are more than one The Wicked Avatar on the field and one of them changed its name by Hero Mask, there will be some problems when calculating attack.