### PR TITLE
fix defense related effects vs link monsters

### DIFF
--- a/c14731897.lua
+++ b/c14731897.lua
@@ -16,7 +16,7 @@ function c14731897.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
 function c14731897.filter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c14731897.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c14731897.filter(chkc) end

--- a/c14731897.lua
+++ b/c14731897.lua
@@ -15,11 +15,14 @@ end
 function c14731897.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
+function c14731897.filter(c)
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
 function c14731897.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c14731897.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c14731897.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c14731897.filter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c14731897.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c18190572.lua
+++ b/c18190572.lua
@@ -15,11 +15,14 @@ end
 function c18190572.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
+function c18190572.filter(c)
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
 function c18190572.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c18190572.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c18190572.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c18190572.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 end
 function c18190572.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c18190572.lua
+++ b/c18190572.lua
@@ -16,7 +16,7 @@ function c18190572.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
 function c18190572.filter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c18190572.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c18190572.filter(chkc) end

--- a/c32065885.lua
+++ b/c32065885.lua
@@ -13,17 +13,24 @@ end
 function c32065885.ctlcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and Duel.GetAttackTarget()==nil and Duel.GetAttacker():IsControler(1-tp)
 end
+function c32065885.filter(c)
+	return c:IsFaceup() and c:IsControlerCanBeChanged() and not c:IsType(TYPE_LINK)
+end
 function c32065885.ctltg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsControlerCanBeChanged,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c32065885.filter,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_CONTROL,nil,1,1-tp,LOCATION_MZONE)
 end
+function c32065885.filter1(c)
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
 function c32065885.ctlop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+	local g=Duel.GetMatchingGroup(c32065885.filter1,tp,0,LOCATION_MZONE,nil)
 	if g:GetCount()==0 then return end
 	local sg=g:GetMaxGroup(Card.GetDefense)
 	if sg:GetCount()>1 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
 		sg=sg:Select(tp,1,1,nil)
+		Duel.HintSelection(sg)
 	end
 	local tc=sg:GetFirst()
 	if Duel.GetControl(tc,tp,PHASE_END,2)~=0 then

--- a/c32065885.lua
+++ b/c32065885.lua
@@ -14,14 +14,14 @@ function c32065885.ctlcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and Duel.GetAttackTarget()==nil and Duel.GetAttacker():IsControler(1-tp)
 end
 function c32065885.filter(c)
-	return c:IsFaceup() and c:IsControlerCanBeChanged() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsControlerCanBeChanged() and c:IsDefenseAbove(0)
 end
 function c32065885.ctltg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c32065885.filter,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_CONTROL,nil,1,1-tp,LOCATION_MZONE)
 end
 function c32065885.filter1(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c32065885.ctlop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c32065885.filter1,tp,0,LOCATION_MZONE,nil)

--- a/c38552107.lua
+++ b/c38552107.lua
@@ -36,7 +36,7 @@ function c38552107.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c38552107.filter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c38552107.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c38552107.filter(chkc) end

--- a/c38552107.lua
+++ b/c38552107.lua
@@ -35,11 +35,14 @@ function c38552107.initial_effect(c)
 	e4:SetOperation(c38552107.tdop)
 	c:RegisterEffect(e4)
 end
+function c38552107.filter(c)
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
 function c38552107.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c38552107.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c38552107.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c38552107.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
 end
 function c38552107.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c44209392.lua
+++ b/c44209392.lua
@@ -16,7 +16,7 @@ function c44209392.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
 function c44209392.filter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c44209392.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c44209392.filter(chkc) end

--- a/c44209392.lua
+++ b/c44209392.lua
@@ -15,11 +15,14 @@ end
 function c44209392.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
+function c44209392.filter(c)
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
 function c44209392.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c44209392.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c44209392.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c44209392.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 end
 function c44209392.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c85004150.lua
+++ b/c85004150.lua
@@ -114,7 +114,7 @@ function c85004150.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
 	end
 end
 function c85004150.desfilter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c85004150.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/c85004150.lua
+++ b/c85004150.lua
@@ -114,7 +114,7 @@ function c85004150.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
 	end
 end
 function c85004150.desfilter(c)
-	return c:IsFaceup()
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
 end
 function c85004150.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/c96501677.lua
+++ b/c96501677.lua
@@ -27,11 +27,8 @@ end
 function c96501677.ccon(e)
 	return Duel.IsExistingMatchingCard(c96501677.cfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,e:GetHandler())
 end
-function c96501677.filter(c)
-	return c:IsFaceup() and c:IsDefenseAbove(0)
-end
 function c96501677.deftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return c96501677.filter(chkc) and chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) end
+	if chkc then return aux.nzdef(chkc) and chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) end
 	if chk==0 then return Duel.IsExistingTarget(aux.nzdef,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,aux.nzdef,tp,0,LOCATION_MZONE,1,1,nil)

--- a/c96501677.lua
+++ b/c96501677.lua
@@ -27,8 +27,11 @@ end
 function c96501677.ccon(e)
 	return Duel.IsExistingMatchingCard(c96501677.cfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,e:GetHandler())
 end
+function c96501677.filter(c)
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
 function c96501677.deftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsFaceup() and chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) end
+	if chkc then return c96501677.filter(chkc) and chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) end
 	if chk==0 then return Duel.IsExistingTarget(aux.nzdef,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,aux.nzdef,tp,0,LOCATION_MZONE,1,1,nil)

--- a/c96501677.lua
+++ b/c96501677.lua
@@ -28,7 +28,7 @@ function c96501677.ccon(e)
 	return Duel.IsExistingMatchingCard(c96501677.cfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,e:GetHandler())
 end
 function c96501677.filter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c96501677.deftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return c96501677.filter(chkc) and chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) end

--- a/c96631852.lua
+++ b/c96631852.lua
@@ -17,11 +17,14 @@ function c96631852.initial_effect(c)
 	e2:SetOperation(c96631852.desop)
 	c:RegisterEffect(e2)
 end
+function c96631852.filter(c)
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+end
 function c96631852.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c96631852.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c96631852.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c96631852.filter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c96631852.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c96631852.lua
+++ b/c96631852.lua
@@ -18,7 +18,7 @@ function c96631852.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c96631852.filter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c96631852.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c96631852.filter(chkc) end

--- a/c97169186.lua
+++ b/c97169186.lua
@@ -10,7 +10,7 @@ function c97169186.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c97169186.filter(c)
-	return c:IsFaceup()
+	return c:IsFaceup() and not c:IsType(TYPE_LINK)
 end
 function c97169186.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c97169186.filter,tp,0,LOCATION_MZONE,1,nil) end

--- a/c97169186.lua
+++ b/c97169186.lua
@@ -10,7 +10,7 @@ function c97169186.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c97169186.filter(c)
-	return c:IsFaceup() and not c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsDefenseAbove(0)
 end
 function c97169186.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c97169186.filter,tp,0,LOCATION_MZONE,1,nil) end


### PR DESCRIPTION
Fix: DEF up / down cards shouldn't target link monsters.

> 相手のモンスターゾーンに表側表示のモンスターがリンクモンスターのみの場合、守備力が一番高いモンスターが存在していませんので、「地砕き」を発動する事自体ができません。
なお、リンクモンスターとリンクモンスター以外のモンスターが相手のモンスターゾーンに表側表示で存在する場合には、守備力を持つモンスターの中から守備力が一番高いモンスターが破壊される事になります。
（なお、「地砕き」の効果処理時にリンクモンスターしか存在していない場合には、リンクモンスターは守備力を持ちませんので、「地砕き」の効果によって破壊される事はありません。）
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20773&keyword=&tag=-1

Fix: _Smashing Ground_ etc. shouldn't destroy link monsters.