### PR TITLE
Fixed "White Wing Magician"

### DIFF
--- a/c11067666.lua
+++ b/c11067666.lua
@@ -28,7 +28,7 @@ function c11067666.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c11067666.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.SelectYesNo(tp,aux.Stringid(11067666,0)) then
-		e:GetHandler():RegisterFlagEffect(11067666,RESET_EVENT+0x1fe0000,0,1)
+		e:GetHandler():RegisterFlagEffect(11067666,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		if Duel.NegateEffect(ev) then
 			Duel.BreakEffect()
 			Duel.Destroy(e:GetHandler(),REASON_EFFECT)


### PR DESCRIPTION
If "White Wing Magician" activates its Pendulum effect, but its destruction is stopped by an effect like "Startime Magician"'s, that Pendulum effect can't be used anymore on following turns. This patch should reset the flag at the end of the turn and fix the problem.