### PR TITLE
fix ritual summon

### DIFF
--- a/c11398951.lua
+++ b/c11398951.lua
@@ -21,7 +21,7 @@ function c11398951.filter(c,e,tp,m1,m2,ft)
 	end
 end
 function c11398951.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
 	else return false end

--- a/c14735698.lua
+++ b/c14735698.lua
@@ -36,7 +36,7 @@ function c14735698.filter(c,e,tp,m1,m2,ft)
 	end
 end
 function c14735698.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
 	else return false end

--- a/c16494704.lua
+++ b/c16494704.lua
@@ -27,7 +27,7 @@ function c16494704.filter(c,e,tp,m,ft)
 	end
 end
 function c16494704.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumGreater(Card.GetRitualLevel,rc:GetLevel(),rc)
 	else return false end

--- a/c21082832.lua
+++ b/c21082832.lua
@@ -22,7 +22,7 @@ function c21082832.filter(c,e,tp,m1,m2,ft)
 	end
 end
 function c21082832.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
 	else return false end

--- a/c23160024.lua
+++ b/c23160024.lua
@@ -61,7 +61,7 @@ function c23160024.spfilter(c,e,tp,m,ft)
 	end
 end
 function c23160024.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,8,0,99,rc)
 	else return false end

--- a/c27383110.lua
+++ b/c27383110.lua
@@ -42,7 +42,7 @@ function c27383110.filter(c,e,tp,m,ft)
 	end
 end
 function c27383110.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,6,0,99,rc)
 	else return false end

--- a/c37626500.lua
+++ b/c37626500.lua
@@ -9,7 +9,7 @@ function c37626500.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37626500.ritual_filter(c)
-	return c:IsType(TYPE_RITUAL) and c:IsAttribute(ATTRIBUTE_LIGHT) 
+	return c:IsType(TYPE_RITUAL) and c:IsAttribute(ATTRIBUTE_LIGHT)
 end
 function c37626500.filter(c,e,tp,m,ft)
 	if not c37626500.ritual_filter(c) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
@@ -22,7 +22,7 @@ function c37626500.filter(c,e,tp,m,ft)
 	end
 end
 function c37626500.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
 	else return false end

--- a/c39996157.lua
+++ b/c39996157.lua
@@ -29,7 +29,7 @@ function c39996157.filter(c,e,tp,m,ft)
 	end
 end
 function c39996157.filterF(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumGreater(Card.GetRitualLevel,rc:GetLevel(),rc)
 	else return false end

--- a/c45410988.lua
+++ b/c45410988.lua
@@ -21,7 +21,7 @@ function c45410988.filter(c,e,tp,m1,m2,ft)
 	end
 end
 function c45410988.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumGreater(Card.GetRitualLevel,8,rc)
 	else return false end

--- a/c51124303.lua
+++ b/c51124303.lua
@@ -42,7 +42,7 @@ function c51124303.mfilter(c)
 	return c:GetLevel()>0 and c:IsAbleToGrave()
 end
 function c51124303.mzfilter(c,tp)
-	return c:IsLocation(LOCATION_MZONE) and c:IsControler(tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:GetSequence()<5
 end
 function c51124303.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c73055622.lua
+++ b/c73055622.lua
@@ -22,7 +22,7 @@ function c73055622.filter(c,e,tp,m1,m2,ft)
 	end
 end
 function c73055622.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumGreater(Card.GetRitualLevel,rc:GetLevel(),rc)
 	else return false end

--- a/c79306385.lua
+++ b/c79306385.lua
@@ -20,7 +20,7 @@ function c79306385.filter(c,e,tp,m,ft)
 	end
 end
 function c79306385.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumGreater(Card.GetRitualLevel,12,rc)
 	else return false end

--- a/c84388461.lua
+++ b/c84388461.lua
@@ -42,7 +42,7 @@ function c84388461.filter(c,e,tp,m,ft)
 	end
 end
 function c84388461.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
 	else return false end

--- a/c97211663.lua
+++ b/c97211663.lua
@@ -35,7 +35,7 @@ function c97211663.filter(c,e,tp,m,ft)
 	end
 end
 function c97211663.mfilterf(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
 	else return false end

--- a/utility.lua
+++ b/utility.lua
@@ -829,7 +829,7 @@ function Auxiliary.RPGFilter(c,filter,e,tp,m,ft)
 	end
 end
 function Auxiliary.RPGFilterF(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumGreater(Card.GetRitualLevel,rc:GetOriginalLevel(),rc)
 	else return false end
@@ -901,7 +901,7 @@ function Auxiliary.RPEFilter(c,filter,e,tp,m,ft)
 	end
 end
 function Auxiliary.RPEFilterF(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetOriginalLevel(),0,99,rc)
 	else return false end
@@ -973,7 +973,7 @@ function Auxiliary.RPEFilter2(c,filter,e,tp,m,ft)
 	end
 end
 function Auxiliary.RPEFilter2F(c,tp,mg,rc)
-	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) then
+	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
 		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
 	else return false end


### PR DESCRIPTION
Fix this: If player have no space in Main Monster Zone, player can Tribute monster in Extra Monster Zone.