### PR TITLE
Fixed "Chaos Scepter Blast" (plus notice for other possible bugs)

### DIFF
--- a/c15256925.lua
+++ b/c15256925.lua
@@ -28,14 +28,17 @@ end
 function c15256925.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c15256925.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
+function c15256925.filter(c)
+  return not c:IsType(TYPE_TOKEN) and c:IsAbleToRemove()
+end
 function c15256925.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
-	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,e:GetHandler())
+	if chk==0 then return Duel.IsExistingMatchingCard(c15256925.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
+	local g=Duel.GetMatchingGroup(c15256925.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,e:GetHandler())
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
 end
 function c15256925.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
+	local g=Duel.SelectMatchingCard(tp,c15256925.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
 	if g:GetCount()>0 then
 		Duel.HintSelection(g)
 		Duel.Remove(g,POS_FACEDOWN,REASON_EFFECT)


### PR DESCRIPTION
As explained in [this ruling](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19209&keyword=&tag=-1), translated [here](https://ygorganization.com/ocg-051817-weekly-rulings-update/) by the Organization, Tokens cannot be banished face-down, so they should be unaffected by this card's effect. The filter I added should be enough to fix the problem: that being said, would it be possible to alter the function Card.IsAbleToRemove() and Card.IsAbleToRemoveAsCost() by adding an optional parameter to check the position the card is going to be banished? By leaving it as POS_FACEUP by default, we'd be able to prevent issues like this and still keep the code short and clear. This isn't the only card with this issue: I can name "Eater of Millions", "PSY-Frame Overload" and "Transmission Gear" right now, there might be even more.