### PR TITLE
Fixed "Predaplant Spinodionaea"

### DIFF
--- a/c52792430.lua
+++ b/c52792430.lua
@@ -25,7 +25,7 @@ function c52792430.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c52792430.cttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsCanAddCounter(0x1041,1) end
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsCanAddCounter(0x1041,1) end
 	if chk==0 then return Duel.IsExistingTarget(Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,nil,0x1041,1) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,Card.IsCanAddCounter,tp,0,LOCATION_MZONE,1,1,nil,0x1041,1)


### PR DESCRIPTION
Spinodionaea's first effect can only target the opponent's monsters, but, if redirected using Cairngorgon's effect, it can target any face-up card on the opponent's field. The extra check should fix this.