### PR TITLE
fix Dragonic Diagram

### DIFF
--- a/c13035077.lua
+++ b/c13035077.lua
@@ -51,7 +51,8 @@ end
 function c13035077.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(nil,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,e:GetHandler())
 		and Duel.IsExistingMatchingCard(c13035077.thfilter,tp,LOCATION_DECK,0,1,nil) end
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,nil,1,tp,LOCATION_HAND+LOCATION_ONFIELD)
+	local g=Duel.GetMatchingGroup(nil,tp,LOCATION_HAND+LOCATION_ONFIELD,0,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,tp,LOCATION_HAND+LOCATION_ONFIELD)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c13035077.desop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
fix interaction with cards like Stardust Dragon
if there are no cards in the players hand, Stardust Dragon should be able to negate the search effect of Dragonic Diagram, since there are only cards on the field to destroy