### PR TITLE
Fixed "Destiny HERO - Dusktopia"

### DIFF
--- a/c93657021.lua
+++ b/c93657021.lua
@@ -25,6 +25,7 @@ function c93657021.initial_effect(c)
 	e2:SetOperation(c93657021.indop)
 	c:RegisterEffect(e2)
 end
+c93657021.material_setcode=0x8
 function c93657021.matfilter(c)
 	return c:IsFusionType(TYPE_FUSION) and c:IsFusionSetCard(0xc008)
 end


### PR DESCRIPTION
The card was missing the material_setcode clause needed for "Legacy of a HERO".