### PR TITLE
Added function Card.IsOnSameColumn

### DIFF
--- a/c3784434.lua
+++ b/c3784434.lua
@@ -52,6 +52,6 @@ function c3784434.atkcon(e)
 	local c=e:GetHandler()
 	local at=Duel.GetAttackTarget()
 	if (ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL) and Duel.GetAttacker()==c and at then
-		return c:IsOnSameColumn(at)
+		return aux.checksamecolumn(c,at)
 	else return false end
 end

--- a/c3784434.lua
+++ b/c3784434.lua
@@ -52,10 +52,6 @@ function c3784434.atkcon(e)
 	local c=e:GetHandler()
 	local at=Duel.GetAttackTarget()
 	if (ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL) and Duel.GetAttacker()==c and at then
-		local s1=c:GetSequence()
-		local s2=at:GetSequence()
-		if s1==5 then s1=1 elseif s1==6 then s1=3 end
-		if s2==5 then s2=1 elseif s2==6 then s2=3 end
-		return s1+s2==4
+		return c:IsOnSameColumn(at)
 	else return false end
 end

--- a/c39188539.lua
+++ b/c39188539.lua
@@ -56,7 +56,7 @@ function c39188539.seqop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c39188539.filter(c,sc)
-	return c:IsOnSameColumn(sc) and c:IsAbleToHand()
+	return aux.checksamecolumn(c,sc) and c:IsAbleToHand()
 end
 function c39188539.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and c39188539.filter(chkc,e:GetHandler()) end

--- a/c39188539.lua
+++ b/c39188539.lua
@@ -55,19 +55,14 @@ function c39188539.seqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.MoveSequence(c,nseq)
 	end
 end
-function c39188539.filter(c,s1)
-	if not c:IsAbleToHand() then return false end
-	local s2=c:GetSequence()
-	if c:IsLocation(LOCATION_SZONE) and s2>=5 then return false end
-	if s1==5 then s1=1 elseif s1==6 then s1=3 end
-	if s2==5 then s2=1 elseif s2==6 then s2=3 end
-	return s1+s2==4
+function c39188539.filter(c,sc)
+	return c:IsOnSameColumn(sc) and c:IsAbleToHand()
 end
 function c39188539.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and c39188539.filter(chkc,e:GetHandler():GetSequence()) end
-	if chk==0 then return Duel.IsExistingTarget(c39188539.filter,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler():GetSequence()) end
+	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and c39188539.filter(chkc,e:GetHandler()) end
+	if chk==0 then return Duel.IsExistingTarget(c39188539.filter,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,c39188539.filter,tp,0,LOCATION_ONFIELD,1,1,nil,e:GetHandler():GetSequence())
+	local g=Duel.SelectTarget(tp,c39188539.filter,tp,0,LOCATION_ONFIELD,1,1,nil,e:GetHandler())
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
 end
 function c39188539.thop(e,tp,eg,ep,ev,re,r,rp)

--- a/c76573247.lua
+++ b/c76573247.lua
@@ -46,5 +46,5 @@ function c76573247.seqop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c76573247.dircon(e)
 	local tp=e:GetHandlerPlayer()
-	return not Duel.IsExistingMatchingCard(Card.IsOnSameColumn,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler())
+	return not Duel.IsExistingMatchingCard(aux.checksamecolumn,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler())
 end

--- a/c76573247.lua
+++ b/c76573247.lua
@@ -44,14 +44,7 @@ function c76573247.seqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.MoveSequence(c,nseq)
 	end
 end
-function c76573247.filter(c,s1)
-	local s2=c:GetSequence()
-	if c:IsLocation(LOCATION_SZONE) and s2>=5 then return false end
-	if s1==5 then s1=1 elseif s1==6 then s1=3 end
-	if s2==5 then s2=1 elseif s2==6 then s2=3 end
-	return s1+s2==4
-end
 function c76573247.dircon(e)
 	local tp=e:GetHandlerPlayer()
-	return not Duel.IsExistingMatchingCard(c76573247.filter,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler():GetSequence())
+	return not Duel.IsExistingMatchingCard(Card.IsOnSameColumn,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler())
 end

--- a/c99788587.lua
+++ b/c99788587.lua
@@ -12,17 +12,18 @@ function c99788587.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c99788587.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e:GetHandler(),true)==3
+	local c=e:GetHandler()
+	return Duel.GetMatchingGroupCount(aux.checksamecolumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)==3
 end
 function c99788587.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end
 	local c=e:GetHandler()
-	local g=Duel.GetFieldGroup(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
+	local g=Duel.GetMatchingGroup(aux.checksamecolumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c99788587.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local g=Duel.GetFieldGroup(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
+	local g=Duel.GetMatchingGroup(aux.checksamecolumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
 	if g:GetCount()>0 then
 		Duel.Destroy(g,REASON_EFFECT)
 	end

--- a/c99788587.lua
+++ b/c99788587.lua
@@ -18,12 +18,12 @@ function c99788587.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end
 	local c=e:GetHandler()
 	local g=Duel.GetFieldGroup(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
-	g:AddCard(c)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c99788587.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetFieldGroup(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
-	if c then g:AddCard(c) end	
-	Duel.Destroy(g,REASON_EFFECT)
+	if g:GetCount()>0 then
+		Duel.Destroy(g,REASON_EFFECT)
+	end
 end

--- a/c99788587.lua
+++ b/c99788587.lua
@@ -12,33 +12,18 @@ function c99788587.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c99788587.condition(e,tp,eg,ep,ev,re,r,rp)
-	local seq=e:GetHandler():GetSequence()
-	return e:GetHandler():IsFacedown()
-		and Duel.GetFieldCard(tp,LOCATION_MZONE,seq)
-		and Duel.GetFieldCard(tp,LOCATION_SZONE,seq)
-		and Duel.GetFieldCard(1-tp,LOCATION_MZONE,4-seq)
-		and Duel.GetFieldCard(1-tp,LOCATION_SZONE,4-seq)
+	return Duel.GetFieldGroupCount(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e:GetHandler(),true)==3
 end
 function c99788587.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end
-	local seq=e:GetHandler():GetSequence()
-	local g=Group.CreateGroup()
-	g:AddCard(Duel.GetFieldCard(tp,LOCATION_MZONE,seq))
-	g:AddCard(Duel.GetFieldCard(tp,LOCATION_SZONE,seq))
-	g:AddCard(Duel.GetFieldCard(1-tp,LOCATION_MZONE,4-seq))
-	g:AddCard(Duel.GetFieldCard(1-tp,LOCATION_SZONE,4-seq))
+	local c=e:GetHandler()
+	local g=Duel.GetFieldGroup(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
+	g:AddCard(c)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c99788587.activate(e,tp,eg,ep,ev,re,r,rp)
-	local seq=e:GetHandler():GetSequence()
-	local g=Group.CreateGroup()
-	local tc=Duel.GetFieldCard(tp,LOCATION_MZONE,seq)
-	if tc then g:AddCard(tc) end
-	tc=Duel.GetFieldCard(tp,LOCATION_SZONE,seq)
-	if tc then g:AddCard(tc) end
-	tc=Duel.GetFieldCard(1-tp,LOCATION_MZONE,4-seq)
-	if tc then g:AddCard(tc) end
-	tc=Duel.GetFieldCard(1-tp,LOCATION_SZONE,4-seq)
-	if tc then g:AddCard(tc) end
+	local c=e:GetHandler()
+	local g=Duel.GetFieldGroup(Card.IsOnSameColumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
+	if c then g:AddCard(c) end	
 	Duel.Destroy(g,REASON_EFFECT)
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1369,3 +1369,26 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
+--Checks whether 2 cards are on the same column
+--skip_ex is optional, indicates whether the Extra Monster Zone should be ignored (used in Blasting Fuse)
+function Card.IsOnSameColumn(c1,c2,skip_ex)
+	if not c1 or not c1:IsOnField() or not c2 or not c2:IsOnField() then return false end
+	if c1==c2 then return false end
+	local s1=c1:GetSequence()
+	local s2=c2:GetSequence()
+	if (c1:IsLocation(LOCATION_SZONE) and s1>=5)
+		or (c2:IsLocation(LOCATION_SZONE) and s2>=5) then return false end
+	if c1:GetControler()==c2:GetControler() then
+		if skip_ex then
+			return s2==s1
+		else
+			return s2==s1 or (s1==1 and s2==5) or (s1==3 and s2==6)
+		else
+	else
+		if skip_ex then
+			return s2==4-s1
+		else
+			return s2==4-s1 or (s1==1 and s2==6) or (s1==3 and s2==5)
+		end
+	end
+end

--- a/utility.lua
+++ b/utility.lua
@@ -1371,7 +1371,7 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 --Checks whether 2 cards are on the same column
 --skip_ex is optional, indicates whether the Extra Monster Zone should be ignored (used in Blasting Fuse)
-function Card.IsOnSameColumn(c1,c2,skip_ex)
+function Auxiliary.checksamecolumn(c1,c2,skip_ex)
 	if not c1 or not c1:IsOnField() or not c2 or not c2:IsOnField() then return false end
 	if c1==c2 then return false end
 	local s1=c1:GetSequence()
@@ -1383,7 +1383,7 @@ function Card.IsOnSameColumn(c1,c2,skip_ex)
 			return s2==s1
 		else
 			return s2==s1 or (s1==1 and s2==5) or (s1==3 and s2==6)
-		else
+		end
 	else
 		if skip_ex then
 			return s2==4-s1


### PR DESCRIPTION
This new function is a shortcut for the filter that checks whether two cards are in the same column. Given the new importance of positioning in MR4, and the fact that 2 cards in Circuit Break so far required this check, I figured it'd be better to have a shortcut in the utilities, similar to the ones for self-banishing cost and whether a card was sent to the Graveyard during that turn. The function includes an optional parameter to indicate whether the Extra Monster Zone should be checked (required for Blasting Fuse): by default, the Extra Monster Zone will always be checked.