### PR TITLE
fix&update Rampaging Rhynos, Blasting Fuse and so on

### DIFF
--- a/c3784434.lua
+++ b/c3784434.lua
@@ -52,6 +52,6 @@ function c3784434.atkcon(e)
 	local c=e:GetHandler()
 	local at=Duel.GetAttackTarget()
 	if (ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL) and Duel.GetAttacker()==c and at then
-		return aux.checksamecolumn(c,at)
+		return c:GetColumnGroup():IsContains(at)
 	else return false end
 end

--- a/c39188539.lua
+++ b/c39188539.lua
@@ -55,14 +55,15 @@ function c39188539.seqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.MoveSequence(c,nseq)
 	end
 end
-function c39188539.filter(c,sc)
-	return aux.checksamecolumn(c,sc) and c:IsAbleToHand()
+function c39188539.filter(c,g)
+	return g:IsContains(c) and c:IsAbleToHand()
 end
 function c39188539.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and c39188539.filter(chkc,e:GetHandler()) end
-	if chk==0 then return Duel.IsExistingTarget(c39188539.filter,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler()) end
+	local cg=e:GetHandler():GetColumnGroup()
+	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and c39188539.filter(chkc,cg) end
+	if chk==0 then return Duel.IsExistingTarget(c39188539.filter,tp,0,LOCATION_ONFIELD,1,nil,cg) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,c39188539.filter,tp,0,LOCATION_ONFIELD,1,1,nil,e:GetHandler())
+	local g=Duel.SelectTarget(tp,c39188539.filter,tp,0,LOCATION_ONFIELD,1,1,nil,cg)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
 end
 function c39188539.thop(e,tp,eg,ep,ev,re,r,rp)

--- a/c59687381.lua
+++ b/c59687381.lua
@@ -31,7 +31,7 @@ function c59687381.tgfilter(c,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
 end
 function c59687381.tgtg(e,c)
-	return c:GetSequence()<5 and c:GetColumnGroup(false):FilterCount(c59687381.tgfilter,nil,c:GetControler())>0
+	return c:GetSequence()<5 and c:GetColumnGroup(0,0,false):FilterCount(c59687381.tgfilter,nil,c:GetControler())>0
 end
 function c59687381.tgvalue(e,re,rp)
 	return rp~=e:GetHandlerPlayer()

--- a/c59687381.lua
+++ b/c59687381.lua
@@ -28,10 +28,10 @@ function c59687381.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c59687381.tgfilter(c,tp)
-	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5
 end
 function c59687381.tgtg(e,c)
-	return c:GetSequence()<5 and c:GetColumnGroup(0,0,false):FilterCount(c59687381.tgfilter,nil,c:GetControler())>0
+	return c:GetSequence()<5 and c:GetColumnGroup():FilterCount(c59687381.tgfilter,nil,c:GetControler())>0
 end
 function c59687381.tgvalue(e,re,rp)
 	return rp~=e:GetHandlerPlayer()

--- a/c59687381.lua
+++ b/c59687381.lua
@@ -12,7 +12,7 @@ function c59687381.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_SET_AVAILABLE)
 	e1:SetRange(LOCATION_FZONE)
 	e1:SetTargetRange(LOCATION_SZONE,0)
-	e1:SetTarget(c59687381.filter)
+	e1:SetTarget(c59687381.tgtg)
 	e1:SetValue(aux.tgoval)
 	c:RegisterEffect(e1)
 	local e2=e1:Clone()
@@ -27,8 +27,11 @@ function c59687381.initial_effect(c)
 	e4:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
 	c:RegisterEffect(e4)
 end
-function c59687381.filter(e,c)
-	return c:GetSequence()<5 and Duel.GetFieldCard(c:GetControler(),LOCATION_MZONE,c:GetSequence())
+function c59687381.tgfilter(c,tp)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
+end
+function c59687381.tgtg(e,c)
+	return c:GetSequence()<5 and c:GetColumnGroup(false):FilterCount(c59687381.tgfilter,nil,c:GetControler())>0
 end
 function c59687381.tgvalue(e,re,rp)
 	return rp~=e:GetHandlerPlayer()

--- a/c76573247.lua
+++ b/c76573247.lua
@@ -45,6 +45,5 @@ function c76573247.seqop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c76573247.dircon(e)
-	local tp=e:GetHandlerPlayer()
-	return not Duel.IsExistingMatchingCard(aux.checksamecolumn,tp,0,LOCATION_ONFIELD,1,nil,e:GetHandler())
+	return e:GetHandler():GetColumnGroup():FilterCount(Card.IsControler,nil,1-e:GetHandlerPlayer())==0
 end

--- a/c99788587.lua
+++ b/c99788587.lua
@@ -12,18 +12,15 @@ function c99788587.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c99788587.condition(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	return Duel.GetMatchingGroupCount(aux.checksamecolumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)==3
+	return e:GetHandler():IsAllColumn()
 end
 function c99788587.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end
-	local c=e:GetHandler()
-	local g=Duel.GetMatchingGroup(aux.checksamecolumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
+	local g=e:GetHandler():GetColumnGroup()
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c99788587.activate(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local g=Duel.GetMatchingGroup(aux.checksamecolumn,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,c,true)
+	local g=e:GetHandler():GetColumnGroup()
 	if g:GetCount()>0 then
 		Duel.Destroy(g,REASON_EFFECT)
 	end

--- a/utility.lua
+++ b/utility.lua
@@ -1369,26 +1369,3 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
---Checks whether 2 cards are on the same column
---skip_ex is optional, indicates whether the Extra Monster Zone should be ignored (used in Blasting Fuse)
-function Auxiliary.checksamecolumn(c1,c2,skip_ex)
-	if not c1 or not c1:IsOnField() or not c2 or not c2:IsOnField() then return false end
-	if c1==c2 then return false end
-	local s1=c1:GetSequence()
-	local s2=c2:GetSequence()
-	if (c1:IsLocation(LOCATION_SZONE) and s1>=5)
-		or (c2:IsLocation(LOCATION_SZONE) and s2>=5) then return false end
-	if c1:GetControler()==c2:GetControler() then
-		if skip_ex then
-			return s2==s1
-		else
-			return s2==s1 or (s1==1 and s2==5) or (s1==3 and s2==6)
-		end
-	else
-		if skip_ex then
-			return s2==4-s1
-		else
-			return s2==4-s1 or (s1==1 and s2==6) or (s1==3 and s2==5)
-		end
-	end
-end


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro-core/pull/100
Fix: https://github.com/Fluorohydride/ygopro/issues/1951#issuecomment-292681691
If player has no monster in Extra Monster Zone, _Blasting Fuse_ in Extra Monster Zone's column can activate.
In OCG, if player has no monster in Extra Monster Zone, _Blasting Fuse_ in Extra Monster Zone's column cannot activate.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20730&keyword=&tag=-1
> Q.「爆導索」をエクストラモンスターゾーンがある列と同じ縦列に「爆導索」がセットされている場合、エクストラモンスターゾーンにもカードがないと発動する事はできませんか？
> A.エクストラモンスターゾーンのある縦列に「爆導索」をセットしている場合、4枚のカード（相手の魔法＆罠ゾーン、相手のメインモンスターゾーン、自分のメインモンスターゾーン、エクストラモンスターゾーン）が破壊される事になります。
> 
> **エクストラモンスターゾーンを含む、その縦列全てにカードが存在していなければ発動する事はできません**。 

Update: Use `Card.GetColumnGroup`.