### PR TITLE
fix Firewall Dragon

### DIFF
--- a/c5043010.lua
+++ b/c5043010.lua
@@ -39,6 +39,11 @@ function c5043010.initial_effect(c)
 	local e4=e3:Clone()
 	e4:SetCode(EVENT_TO_GRAVE)
 	c:RegisterEffect(e4)
+	local e5=e2:Clone()
+	e5:SetCode(EVENT_BE_PRE_MATERIAL)
+	e5:SetOperation(c5043010.regop2)
+	e5:SetLabelObject(e2)
+	c:RegisterEffect(e5)
 	--
 	if not Card.GetMutualLinkedGroup then
 		function aux.mutuallinkfilter(c,mc)
@@ -80,6 +85,13 @@ function c5043010.regop(e,tp,eg,ep,ev,re,r,rp)
 	local lg=g:Clone()
 	lg:KeepAlive()
 	e:SetLabelObject(lg)
+end
+function c5043010.regop2(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetLinkedGroup()
+	if not g then return end
+	local lg=g:Clone()
+	lg:KeepAlive()
+	e:GetLabelObject():SetLabelObject(lg)
 end
 function c5043010.cfilter(c,g)
 	return g:IsContains(c)


### PR DESCRIPTION
fix: The cached linked group don't get updated when XYZ summoning.

Way to reproduce the bug:
1. summon _Firewall Dragon_
2. summon _Elemental HERO Sparkman_ in its linked zone
3. send Sparkman to graveyard by link or sync summon
4. use _Call of the Haunted_ to summon Sparkman from graveyard
5. use Sparkman to XYZ summon _Daigusto Emeral_
6. activate the effect of Emeral, deattach Sparkman
7. the _Firewall Dragon_ will be able to activate effect
make sure no other card leave field in this procedure.

Is this PR a suitable way to fix it?