### PR TITLE
fix The True Name, Lullaby of Obedience and so on

### DIFF
--- a/c10406322.lua
+++ b/c10406322.lua
@@ -30,8 +30,9 @@ function c10406322.initial_effect(c)
 end
 function c10406322.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
-	Duel.Hint(HINT_SELECTMSG,tp,0)
-	local ac=Duel.AnnounceCard(tp)
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	c10406322.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c10406322.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c10809984.lua
+++ b/c10809984.lua
@@ -17,7 +17,8 @@ end
 function c10809984.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local ac=Duel.AnnounceCard(tp)
+	c10809984.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c10809984.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c15800838.lua
+++ b/c15800838.lua
@@ -14,7 +14,8 @@ function c15800838.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0
 		and Duel.IsExistingMatchingCard(nil,tp,LOCATION_HAND,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local ac=Duel.AnnounceCard(tp)
+	c15800838.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c15800838.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c18631392.lua
+++ b/c18631392.lua
@@ -46,17 +46,18 @@ function c18631392.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.SendtoGrave(g1,REASON_COST)
 end
 function c18631392.anctg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then 
+	if chk==0 then
 		if not Duel.IsPlayerCanDiscardDeck(tp,3) then return false end
 		local g=Duel.GetDecktopGroup(tp,3)
 		return g:FilterCount(Card.IsAbleToHand,nil)>0
 	end
-	Duel.Hint(HINT_SELECTMSG,tp,0)
-	local ac1=Duel.AnnounceCard(tp)
-	Duel.Hint(HINT_SELECTMSG,tp,0)
-	local ac2=Duel.AnnounceCard(tp)
-	Duel.Hint(HINT_SELECTMSG,tp,0)
-	local ac3=Duel.AnnounceCard(tp)
+	c18631392.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	local ac1=Duel.AnnounceCardFilter(tp,table.unpack(c18631392.announce_filter))
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	local ac2=Duel.AnnounceCardFilter(tp,table.unpack(c18631392.announce_filter))
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	local ac3=Duel.AnnounceCardFilter(tp,table.unpack(c18631392.announce_filter))
 	e:SetOperation(c18631392.retop(ac1,ac2,ac3))
 end
 function c18631392.hfilter(c,code1,code2,code3)

--- a/c24413299.lua
+++ b/c24413299.lua
@@ -19,7 +19,8 @@ function c24413299.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		and (Duel.IsExistingMatchingCard(Card.IsControlerCanBeChanged,tp,0,LOCATION_MZONE,1,nil)
 		or Duel.IsExistingMatchingCard(c24413299.desfilter,tp,0,LOCATION_ONFIELD,1,nil)) end
 	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local ac=Duel.AnnounceCard(tp)
+	c24413299.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c24413299.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c33423043.lua
+++ b/c33423043.lua
@@ -13,7 +13,8 @@ function c33423043.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0
 		and Duel.IsExistingMatchingCard(nil,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local ac=Duel.AnnounceCard(tp)
+	c33423043.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c33423043.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c39238953.lua
+++ b/c39238953.lua
@@ -18,7 +18,8 @@ function c39238953.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,0,LOCATION_DECK,1,nil)
 		or Duel.IsPlayerCanSpecialSummon(tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local ac=Duel.AnnounceCard(tp,TYPE_MONSTER)
+	c39238953.announce_filter={TYPE_MONSTER,OPCODE_ISTYPE,TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT,OPCODE_AND}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c39238953.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c39913299.lua
+++ b/c39913299.lua
@@ -16,8 +16,9 @@ end
 function c39913299.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1)
 		and Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,LOCATION_DECK,0,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,0)
-	local ac=Duel.AnnounceCard(tp)
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	c39913299.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c39913299.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c72403299.lua
+++ b/c72403299.lua
@@ -13,8 +13,9 @@ function c72403299.initial_effect(c)
 end
 function c72403299.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,LOCATION_DECK,0,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,0)
-	local ac=Duel.AnnounceCard(tp)
+	Duel.Hint(HINT_SELECTMSG,tp,564)
+	c72403299.announce_filter={TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT}
+	local ac=Duel.AnnounceCardFilter(tp,table.unpack(c72403299.announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
 end

--- a/c78053598.lua
+++ b/c78053598.lua
@@ -12,7 +12,8 @@ end
 function c78053598.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,0,LOCATION_DECK,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,564)
-	local code=Duel.AnnounceCard(tp,TYPE_MONSTER)
+	c78053598.announce_filter={TYPE_MONSTER,OPCODE_ISTYPE,TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK,OPCODE_ISTYPE,OPCODE_NOT,OPCODE_AND}
+	local code=Duel.AnnounceCardFilter(tp,table.unpack(c78053598.announce_filter))
 	Duel.SetTargetParam(code)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,TYPE_MONSTER)
 end


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/issues/1794

Fix this: Player can declare Fusion, Synchro, Xyz, Link Monster name.
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19411
Q.「天声の服従」を発動し、モンスターカード名を1つ宣言する際に、融合・シンクロ・エクシーズ・リンクモンスターのカード名を宣言できますか？
A.「天声の服従」は『相手は自身のデッキを確認し、宣言されたモンスターがあった場合、その内の１体をお互いに確認し以下の効果から1つを選択して適用する』効果です。

デッキに存在しない融合・シンクロ・エクシーズ・リンクモンスターのカード名を宣言する事はできません。 