### PR TITLE
fix Burning Bamboo Sword

### DIFF
--- a/c55870497.lua
+++ b/c55870497.lua
@@ -34,6 +34,6 @@ function c55870497.skipop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCode(EFFECT_SKIP_M1)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetTargetRange(0,1)
-	e1:SetReset(RESET_PHASE+PHASE_BATTLE+RESET_OPPO_TURN)
+	e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
 	Duel.RegisterEffect(e1,tp)
 end


### PR DESCRIPTION
If the player chooses to go directly to the end phase instead of the battle phase the effect is not reset and continues to skip M1, this shouldn't happen.