### PR TITLE
fix D/D/D Wave High King Executive Caesar

### DIFF
--- a/c79559912.lua
+++ b/c79559912.lua
@@ -28,7 +28,7 @@ function c79559912.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c79559912.discon(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsChainNegatable(ev) then return false end
+	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) or not Duel.IsChainNegatable(ev) then return false end
 	if not re:IsActiveType(TYPE_MONSTER) and not re:IsHasType(EFFECT_TYPE_ACTIVATE) then return false end
 	return re:IsHasCategory(CATEGORY_SPECIAL_SUMMON)
 end


### PR DESCRIPTION
fix: it shouldn't be able to activate if it is destroyed by battle