### PR TITLE
fix&update Supreme King Dragon

### DIFF
--- a/c42160203.lua
+++ b/c42160203.lua
@@ -74,7 +74,7 @@ function c42160203.spfilter(c,e,tp)
 		and c:IsType(TYPE_PENDULUM) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c42160203.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return (Duel.GetLocationCountFromEx(tp)>0 or e:GetHandler():CheckMZoneFromEx(tp))
+	if chk==0 then return Duel.GetLocationCountFromEx(tp,tp,e:GetHandler())>0
 		and Duel.IsExistingMatchingCard(c42160203.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end

--- a/c43387895.lua
+++ b/c43387895.lua
@@ -40,34 +40,28 @@ end
 function c43387895.spfilter(c,fc)
 	return c43387895.ffilter(c) and c:IsCanBeFusionMaterial(fc)
 end
+function c43387895.spfilter1(c,tp,g)
+	return g:IsExists(c43387895.spfilter2,1,c,tp,c)
+end
+function c43387895.spfilter2(c,tp,mc)
+	return Duel.GetLocationCountFromEx(tp,tp,Group.FromCards(c,mc))>0
+end
 function c43387895.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	local ft=Duel.GetLocationCountFromEx(tp,PLAYER_NONE)
-	local ct=-ft+1
 	local g=Duel.GetReleaseGroup(tp):Filter(c43387895.spfilter,nil,c)
-	return g:GetCount()>1 and (Duel.GetLocationCountFromEx(tp)>0 or g:IsExists(Card.CheckMZoneFromEx,ct,nil,tp))
+	return g:IsExists(c43387895.spfilter1,1,nil,tp,g)
 end
 function c43387895.spop(e,tp,eg,ep,ev,re,r,rp,c)
-	local ft=Duel.GetLocationCountFromEx(tp,PLAYER_NONE)
-	local ct=-ft+1
 	local g=Duel.GetReleaseGroup(tp):Filter(c43387895.spfilter,nil,c)
-	local sg=nil
-	if Duel.GetLocationCountFromEx(tp)<=0 then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-		sg=g:FilterSelect(tp,Card.CheckMZoneFromEx,ct,ct,nil,tp)
-		if ct<2 then
-			g:Sub(sg)
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-			local g1=g:Select(tp,2-ct,2-ct,nil)
-			sg:Merge(g1)
-		end
-	else
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-		sg=g:Select(tp,2,2,nil)
-	end
-	c:SetMaterial(sg)
-	Duel.Release(sg,REASON_COST+REASON_FUSION+REASON_MATERIAL)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+	local g1=g:FilterSelect(tp,c43387895.spfilter1,1,1,nil,tp,g)
+	local mc=g1:GetFirst()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+	local g2=g:FilterSelect(tp,c43387895.spfilter2,1,1,mc,tp,mc)
+	g1:Merge(g2)
+	c:SetMaterial(g1)
+	Duel.Release(g1,REASON_COST+REASON_FUSION+REASON_MATERIAL)
 end
 function c43387895.copycost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetFlagEffect(41209827)==0 end

--- a/c96733134.lua
+++ b/c96733134.lua
@@ -66,15 +66,36 @@ function c96733134.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 	end
 end
+function c96733134.rfilter(c,tp)
+	return c:IsSetCard(0x20f8) and (c:IsControler(tp) or c:IsFaceup())
+end
+function c96733134.mzfilter(c,tp)
+	return c:IsControler(tp) and c:GetSequence()<5
+end
 function c96733134.hspcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsSetCard,2,nil,0x20f8) end
-	local sg=Duel.SelectReleaseGroup(tp,Card.IsSetCard,2,2,nil,0x20f8)
-	Duel.Release(sg,REASON_COST)
+	local rg=Duel.GetReleaseGroup(tp):Filter(c96733134.rfilter,nil,tp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local ct=-ft+1
+	if chk==0 then return ft>-2 and rg:GetCount()>1 and (ft>0 or rg:IsExists(c96733134.mzfilter,ct,nil,tp)) end
+	local g=nil
+	if ft>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		g=rg:Select(tp,2,2,nil)
+	elseif ft==0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		g=rg:FilterSelect(tp,c96733134.mzfilter,1,1,nil,tp)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		local g2=rg:Select(tp,1,1,g:GetFirst())
+		g:Merge(g2)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		g=rg:FilterSelect(tp,c96733134.mzfilter,2,2,nil,tp)
+	end
+	Duel.Release(g,REASON_COST)
 end
 function c96733134.hsptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	if chk==0 then return c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
 function c96733134.hspop(e,tp,eg,ep,ev,re,r,rp)
@@ -104,7 +125,7 @@ function c96733134.spfilter(c,e,tp)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c96733134.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return (Duel.GetLocationCountFromEx(tp)>0 or e:GetHandler():CheckMZoneFromEx(tp))
+	if chk==0 then return Duel.GetLocationCountFromEx(tp,tp,e:GetHandler())>0
 		and Duel.IsExistingMatchingCard(c96733134.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end


### PR DESCRIPTION
Fix: If player have no space in Main Monster Zone, player can Tribute monster in Extra Monster Zone.(_Supreme King Dragon Odd-Eyes_ only)
Update: Replace `CheckMZoneFromEx` for `GetLocationCountFromEx`.