### PR TITLE
Add Auxiliary.AddXyzProcedureLevelFree

### DIFF
--- a/c23187256.lua
+++ b/c23187256.lua
@@ -2,15 +2,7 @@
 function c23187256.initial_effect(c)
 	--xyz summon
 	c:EnableReviveLimit()
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
-	e1:SetRange(LOCATION_EXTRA)
-	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCondition(c23187256.xyzcon)
-	e1:SetOperation(c23187256.xyzop)
-	e1:SetValue(SUMMON_TYPE_XYZ)
-	c:RegisterEffect(e1)
+	aux.AddXyzProcedureLevelFree(c,c23187256.mfilter,c23187256.xyzcheck,2,99)	
 	--spsummon
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(23187256,0))
@@ -36,67 +28,10 @@ function c23187256.initial_effect(c)
 end
 c23187256.xyz_number=93
 function c23187256.mfilter(c,xyzc)
-	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and c:IsSetCard(0x48) and c:GetOverlayCount()>0 and c:IsCanBeXyzMaterial(xyzc)
+	return c:IsXyzType(TYPE_XYZ) and c:IsSetCard(0x48) and c:GetOverlayCount()>0
 end
-function c23187256.xyzfilter1(c,g,ct)
-	return g:IsExists(c23187256.xyzfilter2,ct,c,c:GetRank())
-end
-function c23187256.xyzfilter2(c,rk)
-	return c:GetRank()==rk
-end
-function c23187256.xyzcon(e,c,og,min,max)
-	if c==nil then return true end
-	local tp=c:GetControler()
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local minc=2
-	local maxc=64
-	if min then
-		minc=math.max(minc,min)
-		maxc=max
-	end
-	local ct=math.max(minc-1,-ft)
-	local mg=nil
-	if og then
-		mg=og:Filter(c23187256.mfilter,nil,c)
-	else
-		mg=Duel.GetMatchingGroup(c23187256.mfilter,tp,LOCATION_MZONE,0,nil,c)
-	end
-	return maxc>=2 and mg:IsExists(c23187256.xyzfilter1,1,nil,mg,ct)
-end
-function c23187256.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
-	local g=nil
-	if og and not min then
-		g=og
-	else
-		local mg=nil
-		if og then
-			mg=og:Filter(c23187256.mfilter,nil,c)
-		else
-			mg=Duel.GetMatchingGroup(c23187256.mfilter,tp,LOCATION_MZONE,0,nil,c)
-		end
-		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-		local minc=2
-		local maxc=64
-		if min then
-			minc=math.max(minc,min)
-			maxc=max
-		end
-		local ct=math.max(minc-1,-ft)
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		g=mg:FilterSelect(tp,c23187256.xyzfilter1,1,1,nil,mg,ct)
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		local g2=mg:FilterSelect(tp,c23187256.xyzfilter2,ct,maxc-1,g:GetFirst(),g:GetFirst():GetRank())
-		g:Merge(g2)
-	end
-	local sg=Group.CreateGroup()
-	local tc=g:GetFirst()
-	while tc do
-		sg:Merge(tc:GetOverlayGroup())
-		tc=g:GetNext()
-	end
-	Duel.SendtoGrave(sg,REASON_RULE)
-	c:SetMaterial(g)
-	Duel.Overlay(c,g)
+function c23187256.xyzcheck(g,xyzc)
+	return g:GetClassCount(Card.GetRank)==1
 end
 function c23187256.filter(c,e,tp)
 	return c:IsRankBelow(9) and c:IsAttackBelow(3000) and c:IsSetCard(0x48)

--- a/c43490025.lua
+++ b/c43490025.lua
@@ -2,15 +2,7 @@
 function c43490025.initial_effect(c)
 	--xyz summon
 	c:EnableReviveLimit()
-	local e1=Effect.CreateEffect(c)
-	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
-	e1:SetRange(LOCATION_EXTRA)
-	e1:SetCondition(c43490025.xyzcon)
-	e1:SetOperation(c43490025.xyzop)
-	e1:SetValue(SUMMON_TYPE_XYZ)
-	c:RegisterEffect(e1)
+	aux.AddXyzProcedureLevelFree(c,c43490025.mfilter,c43490025.xyzcheck,1,2)
 	--atkup
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
@@ -38,89 +30,18 @@ function c43490025.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 c43490025.xyz_number=0
-function c43490025.ovfilter(c,xyzc)
-	return c:IsFaceup() and (c:IsSetCard(0x107f) or c:IsCode(65305468)) and c:IsCanBeXyzMaterial(xyzc)
-end
 function c43490025.mfilter(c,xyzc)
-	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and not c:IsSetCard(0x48) and c:IsCanBeXyzMaterial(xyzc)
+	return (not c:IsSetCard(0x48) and c:IsXyzType(TYPE_XYZ)) or (c:IsSetCard(0x107f) or c:IsCode(65305468))
 end
-function c43490025.xyzfilter1(c,g)
-	return g:IsExists(c43490025.xyzfilter2,1,c,c:GetRank())
+function c43490025.gfilter(c)
+	return c:IsSetCard(0x48) or not c:IsXyzType(TYPE_XYZ)
 end
-function c43490025.xyzfilter2(c,rk)
-	return c:GetRank()==rk
-end
-function c43490025.xyzcon(e,c,og,min,max)
-	if c==nil then return true end
-	local tp=c:GetControler()
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local ct=-ft
-	if 2<=ct then return false end
-	if min and (min>2 or max<2) then return false end
-	local mg=nil
-	local altmg=nil
-	if og then
-		mg=og:Filter(c43490025.mfilter,nil,c)
-		altmg=og
+function c43490025.xyzcheck(g,xyzc)
+	if g:GetCount()==1 then
+		local tc=g:GetFirst()
+		return tc:IsSetCard(0x107f) or tc:IsCode(65305468)
 	else
-		mg=Duel.GetMatchingGroup(c43490025.mfilter,tp,LOCATION_MZONE,0,nil,c)
-		altmg=Duel.GetFieldGroup(tp,LOCATION_MZONE,0)
-	end
-	if ct<1 and (not min or min<=1) and altmg:IsExists(c43490025.ovfilter,1,nil,c) then
-		return true
-	end
-	return mg:IsExists(c43490025.xyzfilter1,1,nil,mg)
-end
-function c43490025.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
-	local g=nil
-	local sg=Group.CreateGroup()
-	if og and not min then
-		g=og
-		local tc=og:GetFirst()
-		while tc do
-			sg:Merge(tc:GetOverlayGroup())
-			tc=og:GetNext()
-		end
-		Duel.SendtoGrave(sg,REASON_RULE)
-		c:SetMaterial(g)
-		Duel.Overlay(c,g)
-	else
-		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-		local ct=-ft
-		local mg=nil
-		local altmg=nil
-		if og then
-			mg=og:Filter(c43490025.mfilter,nil,c)
-			altmg=og
-		else
-			mg=Duel.GetMatchingGroup(c43490025.mfilter,tp,LOCATION_MZONE,0,nil,c)
-			altmg=Duel.GetFieldGroup(tp,LOCATION_MZONE,0)
-		end
-		local b1=mg:IsExists(c43490025.xyzfilter1,1,nil,mg)
-		local b2=ct<1 and (not min or min<=1) and altmg:IsExists(c43490025.ovfilter,1,nil,c)
-		local g=nil
-		if b2 and (not b1 or Duel.SelectYesNo(tp,aux.Stringid(43490025,1))) then
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-			g=altmg:FilterSelect(tp,c43490025.ovfilter,1,1,nil,c)
-			local g2=g:GetFirst():GetOverlayGroup()
-			if g2:GetCount()~=0 then
-				Duel.Overlay(c,g2)
-			end
-			c:SetMaterial(g)
-			Duel.Overlay(c,g)
-		else
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-			g=mg:FilterSelect(tp,c43490025.xyzfilter1,1,1,nil,mg)
-			local tc1=g:GetFirst()
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-			local g2=mg:FilterSelect(tp,c43490025.xyzfilter2,1,1,tc1,tc1:GetRank())
-			local tc2=g2:GetFirst()
-			g:Merge(g2)
-			sg:Merge(tc1:GetOverlayGroup())
-			sg:Merge(tc2:GetOverlayGroup())
-			Duel.SendtoGrave(sg,REASON_RULE)
-			Duel.Overlay(c,g)
-		end
+		return g:GetClassCount(Card.GetRank)==1 and not g:IsExists(c43490025.gfilter,1,nil)
 	end
 end
 function c43490025.atkfilter(c)

--- a/c57314798.lua
+++ b/c57314798.lua
@@ -2,15 +2,7 @@
 function c57314798.initial_effect(c)
 	c:EnableReviveLimit()
 	--xyz summon
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
-	e1:SetRange(LOCATION_EXTRA)
-	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCondition(c57314798.xyzcon)
-	e1:SetOperation(c57314798.xyzop)
-	e1:SetValue(SUMMON_TYPE_XYZ)
-	c:RegisterEffect(e1)
+	aux.AddXyzProcedureLevelFree(c,c57314798.mfilter,c57314798.xyzcheck,2,2)
 	--atk up
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(57314798,0))
@@ -46,57 +38,10 @@ function c57314798.initial_effect(c)
 end
 c57314798.xyz_number=100
 function c57314798.mfilter(c,xyzc)
-	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and c:IsSetCard(0x48) and c:IsCanBeXyzMaterial(xyzc)
+	return c:IsSetCard(0x48) and c:IsXyzType(TYPE_XYZ)
 end
-function c57314798.xyzfilter1(c,g)
-	return g:IsExists(c57314798.xyzfilter2,1,c,c:GetRank(),c:GetCode())
-end
-function c57314798.xyzfilter2(c,rk,code)
-	return c:GetRank()==rk and c:IsCode(code)
-end
-function c57314798.xyzcon(e,c,og,min,max)
-	if c==nil then return true end
-	local tp=c:GetControler()
-	local mg=nil
-	if og then
-		mg=og:Filter(c57314798.mfilter,nil,c)
-	else
-		mg=Duel.GetMatchingGroup(c57314798.mfilter,tp,LOCATION_MZONE,0,nil,c)
-	end
-	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
-		and (not min or min<=2 and max>=2)
-		and mg:IsExists(c57314798.xyzfilter1,1,nil,mg)
-end
-function c57314798.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
-	local g=nil
-	local sg=Group.CreateGroup()
-	if og and not min then
-		g=og
-		local tc=og:GetFirst()
-		while tc do
-			sg:Merge(tc:GetOverlayGroup())
-			tc=og:GetNext()
-		end
-	else
-		local mg=nil
-		if og then
-			mg=og:Filter(c57314798.mfilter,nil,c)
-		else
-			mg=Duel.GetMatchingGroup(c57314798.mfilter,tp,LOCATION_MZONE,0,nil,c)
-		end
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		g=mg:FilterSelect(tp,c57314798.xyzfilter1,1,1,nil,mg)
-		local tc1=g:GetFirst()
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		local g2=mg:FilterSelect(tp,c57314798.xyzfilter2,1,1,tc1,tc1:GetRank(),tc1:GetCode())
-		local tc2=g2:GetFirst()
-		g:Merge(g2)
-		sg:Merge(tc1:GetOverlayGroup())
-		sg:Merge(tc2:GetOverlayGroup())
-	end
-	Duel.SendtoGrave(sg,REASON_RULE)
-	c:SetMaterial(g)
-	Duel.Overlay(c,g)
+function c57314798.xyzcheck(g,xyzc)
+	return g:GetClassCount(Card.GetCode)==1 and g:GetClassCount(Card.GetRank)==1
 end
 function c57314798.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/c65305468.lua
+++ b/c65305468.lua
@@ -2,15 +2,7 @@
 function c65305468.initial_effect(c)
 	--xyz summon
 	c:EnableReviveLimit()
-	local e1=Effect.CreateEffect(c)
-	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
-	e1:SetRange(LOCATION_EXTRA)
-	e1:SetCondition(c65305468.xyzcon)
-	e1:SetOperation(c65305468.xyzop)
-	e1:SetValue(SUMMON_TYPE_XYZ)
-	c:RegisterEffect(e1)
+	aux.AddXyzProcedureLevelFree(c,c65305468.mfilter,c65305468.xyzcheck,2,2)
 	--indes
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
@@ -47,57 +39,10 @@ function c65305468.initial_effect(c)
 end
 c65305468.xyz_number=0
 function c65305468.mfilter(c,xyzc)
-	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and not c:IsSetCard(0x48) and c:IsCanBeXyzMaterial(xyzc)
+	return c:IsXyzType(TYPE_XYZ) and not c:IsSetCard(0x48)
 end
-function c65305468.xyzfilter1(c,g)
-	return g:IsExists(c65305468.xyzfilter2,1,c,c:GetRank())
-end
-function c65305468.xyzfilter2(c,rk)
-	return c:GetRank()==rk
-end
-function c65305468.xyzcon(e,c,og,min,max)
-	if c==nil then return true end
-	local tp=c:GetControler()
-	local mg=nil
-	if og then
-		mg=og:Filter(c65305468.mfilter,nil,c)
-	else
-		mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil,c)
-	end
-	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
-		and (not min or min<=2 and max>=2)
-		and mg:IsExists(c65305468.xyzfilter1,1,nil,mg)
-end
-function c65305468.xyzop(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
-	local g=nil
-	local sg=Group.CreateGroup()
-	if og and not min then
-		g=og
-		local tc=og:GetFirst()
-		while tc do
-			sg:Merge(tc:GetOverlayGroup())
-			tc=og:GetNext()
-		end
-	else
-		local mg=nil
-		if og then
-			mg=og:Filter(c65305468.mfilter,nil,c)
-		else
-			mg=Duel.GetMatchingGroup(c65305468.mfilter,tp,LOCATION_MZONE,0,nil,c)
-		end
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		g=mg:FilterSelect(tp,c65305468.xyzfilter1,1,1,nil,mg)
-		local tc1=g:GetFirst()
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		local g2=mg:FilterSelect(tp,c65305468.xyzfilter2,1,1,tc1,tc1:GetRank())
-		local tc2=g2:GetFirst()
-		g:Merge(g2)
-		sg:Merge(tc1:GetOverlayGroup())
-		sg:Merge(tc2:GetOverlayGroup())
-	end
-	Duel.SendtoGrave(sg,REASON_RULE)
-	c:SetMaterial(g)
-	Duel.Overlay(c,g)
+function c65305468.xyzcheck(g,xyzc)
+	return g:GetClassCount(Card.GetRank)==1
 end
 function c65305468.cttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=e:GetHandler():GetBattleTarget()

--- a/utility.lua
+++ b/utility.lua
@@ -437,6 +437,97 @@ function Auxiliary.XyzOperation2(f,lv,minc,maxc,alterf,desc,op)
 				end
 			end
 end
+function Auxiliary.AddXyzProcedureLevelFree(c,func,gf,minc,maxc)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetRange(LOCATION_EXTRA)
+	e1:SetCondition(Auxiliary.XyzProcedureLevelFreeCondition(func,gf,minc,maxc))
+	e1:SetOperation(Auxiliary.XyzProcedureLevelFreeOperation(func,gf,minc,maxc))
+	e1:SetValue(SUMMON_TYPE_XYZ)
+	c:RegisterEffect(e1)
+end
+function Auxiliary.XyzProcedureLevelFreeFilter(c,xyzcard,func)
+	return c:IsFaceup() and c:IsCanBeXyzMaterial(xyzcard) and (not func or func(c,xyzcard))
+end
+function Auxiliary.XyzProcedureLevelFreeCheck(c,tp,xyzcard,mg,sg,gf,minc,maxc)
+	sg:AddCard(c)
+	local ct=sg:GetCount()
+	local res=(ct>=minc and Auxiliary.XyzProcedureLevelFreeGoal(sg,tp,xyzcard,gf))
+		or (ct<maxc and mg:IsExists(Auxiliary.XyzProcedureLevelFreeCheck,1,sg,tp,xyzcard,mg,sg,gf,minc,maxc))
+	sg:RemoveCard(c)
+	return res
+end
+function Auxiliary.XyzProcedureLevelFreeGoal(g,tp,xyzcard,gf)
+	return (not gf or gf(g,xyzc)) and Duel.GetLocationCountFromEx(tp,tp,g,xyzcard)>0
+end
+function Auxiliary.XyzProcedureLevelFreeCondition(func,gf,minct,maxct)
+	return function(e,c,og,min,max)
+		if c==nil then return true end
+		if c:IsType(TYPE_PENDULUM) and c:IsFaceup() then return false end
+		local tp=c:GetControler()
+		local minc=minct
+		local maxc=maxct
+		if min then
+			minc=math.max(minc,min)
+			maxc=math.min(maxc,max)
+		end
+		local mg=nil
+		if og then
+			mg=og:Filter(Auxiliary.XyzProcedureLevelFreeFilter,nil,c,func,ext_params)
+		else
+			mg=Duel.GetMatchingGroup(Auxiliary.XyzProcedureLevelFreeFilter,tp,LOCATION_MZONE,0,nil,c,func)
+		end
+		local sg=Group.CreateGroup()
+		return maxc>=minc and mg:IsExists(Auxiliary.XyzProcedureLevelFreeCheck,1,sg,tp,c,mg,sg,gf,minc,maxc)
+	end
+end
+function Auxiliary.XyzProcedureLevelFreeOperation(func,gf,minct,maxct)
+	return function(e,tp,eg,ep,ev,re,r,rp,c,og,min,max)
+		local g=nil
+		if og and not min then
+			g=og
+		else
+			g=Group.CreateGroup()
+			local mg=nil
+			if og then
+				mg=og:Filter(Auxiliary.XyzProcedureLevelFreeFilter,nil,c,func)
+			else
+				mg=Duel.GetMatchingGroup(Auxiliary.XyzProcedureLevelFreeFilter,tp,LOCATION_MZONE,0,nil,c,func)
+			end
+			local minc=minct
+			local maxc=maxct
+			if min then
+				minc=math.max(minc,min)
+				maxc=math.min(maxc,max)
+			end
+			local ag=mg:Filter(Auxiliary.XyzProcedureLevelFreeCheck,g,tp,c,mg,g,gf,minc,maxc)
+			local ct=g:GetCount()
+			while ct<max and ag:GetCount()>0 do
+				local minsct=1
+				local finish=(ct>=min and f(g,tp,c,gf))
+				if finish then
+					minsct=0
+					if not Duel.SelectYesNo(tp,210) then break end
+				end
+				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+				local tg=ag:Select(tp,minsct,1,nil)
+				if tg:GetCount()==0 then break end
+				g:Merge(tg)
+				ct=g:GetCount()
+				ag=mg:Filter(Auxiliary.XyzProcedureLevelFreeCheck,g,tp,c,mg,g,gf,minc,maxc)
+			end
+		end
+		local sg=Group.CreateGroup()
+		for tc in aux.Next(g) do
+			sg:Merge(tc:GetOverlayGroup())
+		end
+		Duel.SendtoGrave(sg,REASON_RULE)
+		c:SetMaterial(g)
+		Duel.Overlay(c,g)
+	end
+end
 function Auxiliary.FConditionFilterF2(c,g2)
 	return g2:IsExists(aux.TRUE,1,c)
 end

--- a/utility.lua
+++ b/utility.lua
@@ -475,7 +475,7 @@ function Auxiliary.XyzProcedureLevelFreeCondition(func,gf,minct,maxct)
 		end
 		local mg=nil
 		if og then
-			mg=og:Filter(Auxiliary.XyzProcedureLevelFreeFilter,nil,c,func,ext_params)
+			mg=og:Filter(Auxiliary.XyzProcedureLevelFreeFilter,nil,c,func)
 		else
 			mg=Duel.GetMatchingGroup(Auxiliary.XyzProcedureLevelFreeFilter,tp,LOCATION_MZONE,0,nil,c,func)
 		end
@@ -506,7 +506,7 @@ function Auxiliary.XyzProcedureLevelFreeOperation(func,gf,minct,maxct)
 			local ct=g:GetCount()
 			while ct<maxc and ag:GetCount()>0 do
 				local minsct=1
-				local finish=(ct>=minc and f(g,tp,c,gf))
+				local finish=(ct>=minc and Auxiliary.XyzProcedureLevelFreeGoal(g,tp,c,gf))
 				if finish then
 					minsct=0
 					if not Duel.SelectYesNo(tp,210) then break end

--- a/utility.lua
+++ b/utility.lua
@@ -504,9 +504,9 @@ function Auxiliary.XyzProcedureLevelFreeOperation(func,gf,minct,maxct)
 			end
 			local ag=mg:Filter(Auxiliary.XyzProcedureLevelFreeCheck,g,tp,c,mg,g,gf,minc,maxc)
 			local ct=g:GetCount()
-			while ct<max and ag:GetCount()>0 do
+			while ct<maxc and ag:GetCount()>0 do
 				local minsct=1
-				local finish=(ct>=min and f(g,tp,c,gf))
+				local finish=(ct>=minc and f(g,tp,c,gf))
 				if finish then
 					minsct=0
 					if not Duel.SelectYesNo(tp,210) then break end

--- a/utility.lua
+++ b/utility.lua
@@ -519,11 +519,18 @@ function Auxiliary.XyzProcedureLevelFreeOperation(func,gf,minct,maxct)
 				ag=mg:Filter(Auxiliary.XyzProcedureLevelFreeCheck,g,tp,c,mg,g,gf,minc,maxc)
 			end
 		end
-		local sg=Group.CreateGroup()
-		for tc in aux.Next(g) do
-			sg:Merge(tc:GetOverlayGroup())
+		if g:GetCount()>1 then
+			local sg=Group.CreateGroup()
+			for tc in aux.Next(g) do
+				sg:Merge(tc:GetOverlayGroup())
+			end
+			Duel.SendtoGrave(sg,REASON_RULE)
+		else
+			local sg=g:GetFirst():GetOverlayGroup()
+			if sg:GetCount()~=0 then
+				Duel.Overlay(c,sg)
+			end
 		end
-		Duel.SendtoGrave(sg,REASON_RULE)
 		c:SetMaterial(g)
 		Duel.Overlay(c,g)
 	end


### PR DESCRIPTION
Auxiliary.AddXyzProcedureLevelFree(c,function,group_function,min,max)
This Xyz Procedure is used to deal with irregular Xyz summons, like No.0, No.93, etc
the 1st function is the filter of the material as usual, and the 2nd function is a group check, to check the same rank or same name, or sth others