### PR TITLE
Fixed "Subterror Nemesis Warrior"

### DIFF
--- a/c16719140.lua
+++ b/c16719140.lua
@@ -1,4 +1,4 @@
---Subterror Nemesis Warrior
+--サブテラーの戦士
 function c16719140.initial_effect(c)
 	--special summon
 	local e1=Effect.CreateEffect(c)
@@ -30,18 +30,17 @@ function c16719140.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(100)
 	if chk==0 then return true end
 end
-function c16719140.rfilter(c)
-	return c:GetOriginalLevel()>0
-end
 function c16719140.costfilter(c,e,tp,mg,rlv)
+	if c:GetLevel()==0 then return false end
 	local lv=c:GetLevel()-rlv
-	return lv>0 and c:IsSetCard(0xed) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
-		and mg:CheckWithSumGreater(Card.GetOriginalLevel,lv)
+	if c:IsSetCard(0xed) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
+		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN)) then
+		return (lv<0 and mg:GetCount()>0) or mg:CheckWithSumGreater(Card.GetOriginalLevel,lv)
+	else return false end
 end
 function c16719140.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	local mg=Duel.GetReleaseGroup(tp):Filter(c16719140.rfilter,nil)
+	local mg=Duel.GetReleaseGroup(tp):Filter(Card.IsLevelAbove,nil,1)
 	if chk==0 then
 		if e:GetLabel()~=100 then return false end
 		e:SetLabel(0)
@@ -63,20 +62,24 @@ function c16719140.spop1(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<-1 then return end
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) then return end
-	local mg=Duel.GetReleaseGroup(tp):Filter(c16719140.rfilter,nil)
+	local mg=Duel.GetReleaseGroup(tp):Filter(Card.IsLevelAbove,nil,1)
 	if not mg:IsContains(c) then return end
 	mg:RemoveCard(c)
+	if mg:GetCount()==0 then return end
 	local spos=0
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) then spos=spos+POS_FACEUP_DEFENSE end
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
+	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false) then spos=spos+POS_FACEUP_DEFENSE end
+	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN) then spos=spos+POS_FACEDOWN_DEFENSE end
 	if spos~=0 then
-		local g=mg:SelectWithSumGreater(tp,Card.GetOriginalLevel,tc:GetLevel()-c:GetOriginalLevel())
+		local lv=tc:GetLevel()-c:GetOriginalLevel()
+		local g=Group.CreateGroup()
+		if lv<0 then
+			g=mg:Select(tp,1,1,nil)
+		else
+			g=mg:SelectWithSumGreater(tp,Card.GetOriginalLevel,lv)
+		end
 		g:AddCard(c)
 		if g:GetCount()>=2 and Duel.Release(g,REASON_EFFECT)~=0 then
 			Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
-			if tc:IsFacedown() then
-				Duel.ConfirmCards(1-tp,tc)
-			end
 		end
 	end
 end


### PR DESCRIPTION
Official rulings for the Extra Pack 2017 confirm that its (1) effect can also be used to Special Summon monsters with a Level below Warrior's original Level.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21399&keyword=&tag=-1