### PR TITLE
fix Phantasm Spiral Grip and so on

### DIFF
--- a/c12174035.lua
+++ b/c12174035.lua
@@ -49,7 +49,8 @@ function c12174035.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c12174035.hdcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:GetFirst()==e:GetHandler():GetEquipTarget() and eg:GetFirst():IsStatus(STATUS_OPPO_BATTLE)
+	local ec=eg:GetFirst()
+	return ec==e:GetHandler():GetEquipTarget() and ec:IsStatus(STATUS_OPPO_BATTLE) and ec:IsControler(tp)
 end
 function c12174035.hdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c12927849.lua
+++ b/c12927849.lua
@@ -83,7 +83,8 @@ end
 function c12927849.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=eg:GetFirst()
 	local bc=ec:GetBattleTarget()
-	return ec==e:GetHandler():GetEquipTarget() and ec:IsStatus(STATUS_OPPO_BATTLE) and bc:IsLocation(LOCATION_GRAVE) and bc:IsType(TYPE_MONSTER)
+	return ec==e:GetHandler():GetEquipTarget() and ec:IsStatus(STATUS_OPPO_BATTLE) and ec:IsControler(tp)
+		and bc:IsLocation(LOCATION_GRAVE) and bc:IsType(TYPE_MONSTER)
 end
 function c12927849.thfilter(c)
 	return c:IsSetCard(0x7e) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()

--- a/c20007374.lua
+++ b/c20007374.lua
@@ -100,7 +100,7 @@ function c20007374.atkval(e,c)
 end
 function c20007374.cacon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()
-	return ec and eg:IsContains(ec)
+	return ec and eg:IsContains(ec) and ec:IsControler(tp)
 end
 function c20007374.cafilter(c)
 	return c20007374.cfilter(c) and c:IsAbleToRemoveAsCost()

--- a/c21350571.lua
+++ b/c21350571.lua
@@ -65,11 +65,12 @@ end
 function c21350571.eqlimit(e,c)
 	return c:IsRace(RACE_BEAST+RACE_BEASTWARRIOR)
 end
-function c21350571.drfilter(c,rc)
-	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc
+function c21350571.drfilter(c,rc,tp)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE)
+		and c:GetReasonCard()==rc and rc:IsControler(tp)
 end
 function c21350571.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c21350571.drfilter,1,nil,e:GetHandler():GetEquipTarget())
+	return eg:IsExists(c21350571.drfilter,1,nil,e:GetHandler():GetEquipTarget(),tp)
 end
 function c21350571.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c31768112.lua
+++ b/c31768112.lua
@@ -87,7 +87,8 @@ function c31768112.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
 end
 function c31768112.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==eg:GetFirst()
+	local ec=eg:GetFirst()
+	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 end
 function c31768112.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c43405287.lua
+++ b/c43405287.lua
@@ -69,7 +69,8 @@ function c43405287.damfilter(c,rc)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc
 end
 function c43405287.damcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c43405287.damfilter,1,nil,e:GetHandler():GetEquipTarget())
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and ec:IsControler(tp) and eg:IsExists(c43405287.damfilter,1,nil,ec)
 end
 function c43405287.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c47228077.lua
+++ b/c47228077.lua
@@ -87,7 +87,8 @@ function c47228077.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
 end
 function c47228077.descon(e,tp,eg,ep,ev,re,r,rp)
-	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==eg:GetFirst()
+	local ec=eg:GetFirst()
+	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 end
 function c47228077.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) end

--- a/c48447192.lua
+++ b/c48447192.lua
@@ -61,7 +61,7 @@ function c48447192.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c48447192.descon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()
-	return ec and eg:IsContains(ec)
+	return ec and eg:IsContains(ec) and ec:IsControler(tp)
 end
 function c48447192.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) end

--- a/c48568432.lua
+++ b/c48568432.lua
@@ -84,7 +84,8 @@ function c48568432.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
 end
 function c48568432.spcon2(e,tp,eg,ep,ev,re,r,rp)
-	return aux.IsUnionState(e) and eg:GetFirst()==e:GetHandler():GetEquipTarget()
+	local ec=eg:GetFirst()
+	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 end
 function c48568432.spfilter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)

--- a/c49306994.lua
+++ b/c49306994.lua
@@ -113,7 +113,8 @@ function c49306994.disop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c49306994.descon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetEquipTarget()==eg:GetFirst()
+	local ec=eg:GetFirst()
+	return e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 end
 function c49306994.filter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP)

--- a/c58272005.lua
+++ b/c58272005.lua
@@ -64,7 +64,7 @@ function c58272005.eqlimit(e,c)
 end
 function c58272005.atcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()
-	if not eg:IsContains(ec) then return false end
+	if not eg:IsContains(ec) or not ec:IsControler(tp) then return false end
 	local bc=ec:GetBattleTarget()
 	return bc:IsLocation(LOCATION_GRAVE) and bc:IsType(TYPE_MONSTER) and ec:IsChainAttackable(2,true) and ec:IsStatus(STATUS_OPPO_BATTLE)
 end

--- a/c6112401.lua
+++ b/c6112401.lua
@@ -66,7 +66,8 @@ function c6112401.eqlimit(e,c)
 	return c:IsSetCard(0x100d)
 end
 function c6112401.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsContains(e:GetHandler():GetEquipTarget())
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and eg:IsContains(ec) and ec:IsControler(tp)
 end
 function c6112401.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c63676256.lua
+++ b/c63676256.lua
@@ -93,7 +93,8 @@ function c63676256.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
 end
 function c63676256.descon(e,tp,eg,ep,ev,re,r,rp)
-	return aux.IsUnionState(e) and eg:GetCount()==1 and eg:GetFirst()==e:GetHandler():GetEquipTarget()
+	local ec=eg:GetFirst()
+	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 end
 function c63676256.dfilter(c,rac)
 	return c:IsFaceup() and c:IsRace(rac)

--- a/c63851864.lua
+++ b/c63851864.lua
@@ -77,7 +77,7 @@ end
 function c63851864.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=eg:GetFirst()
 	local bc=ec:GetBattleTarget()
-	return e:GetHandler():GetEquipTarget()==eg:GetFirst() and ec:IsControler(tp)
+	return e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 		and bc:IsLocation(LOCATION_GRAVE) and bc:IsReason(REASON_BATTLE)
 end
 function c63851864.drtg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c65685470.lua
+++ b/c65685470.lua
@@ -101,7 +101,8 @@ function c65685470.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
 end
 function c65685470.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==eg:GetFirst()
+	local ec=eg:GetFirst()
+	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 end
 function c65685470.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c73828446.lua
+++ b/c73828446.lua
@@ -66,7 +66,8 @@ function c73828446.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c73828446.rmcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:GetFirst()==e:GetHandler():GetEquipTarget()
+	local ec=eg:GetFirst()
+	return ec==e:GetHandler():GetEquipTarget() and ec:IsControler(tp)
 end
 function c73828446.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local bc=eg:GetFirst():GetBattleTarget()

--- a/c74115234.lua
+++ b/c74115234.lua
@@ -62,7 +62,7 @@ function c74115234.recon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=eg:GetFirst()
 	local bc=ec:GetBattleTarget()
 	e:SetLabelObject(bc)
-	return e:GetHandler():GetEquipTarget()==eg:GetFirst() and ec:IsControler(tp)
+	return e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 		and bc:IsLocation(LOCATION_GRAVE) and bc:IsType(TYPE_MONSTER) and bc:IsReason(REASON_BATTLE) 
 end
 function c74115234.retg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c75702749.lua
+++ b/c75702749.lua
@@ -57,7 +57,7 @@ function c75702749.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c75702749.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()
-	return ec and eg:IsContains(ec)
+	return ec and eg:IsContains(ec) and ec:IsControler(tp)
 end
 function c75702749.spfilter(c,e,tp)
 	return c:IsCode(56649609) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c84313685.lua
+++ b/c84313685.lua
@@ -87,7 +87,8 @@ function c84313685.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
 end
 function c84313685.gspcon(e,tp,eg,ep,ev,re,r,rp)
-	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==eg:GetFirst()
+	local ec=eg:GetFirst()
+	return aux.IsUnionState(e) and e:GetHandler():GetEquipTarget()==ec and ec:IsControler(tp)
 end
 function c84313685.gfilter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsSetCard(0x30) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c87008374.lua
+++ b/c87008374.lua
@@ -62,7 +62,7 @@ function c87008374.eqop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c87008374.damcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()
-	return ec and eg:IsContains(ec)
+	return ec and eg:IsContains(ec) and ec:IsControler(tp)
 end
 function c87008374.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c96458440.lua
+++ b/c96458440.lua
@@ -51,7 +51,8 @@ end
 function c96458440.damcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=eg:GetFirst()
 	local bc=ec:GetBattleTarget()
-	return ec==e:GetHandler():GetEquipTarget() and bc:IsLocation(LOCATION_GRAVE) and bc:IsReason(REASON_BATTLE)
+	return ec==e:GetHandler():GetEquipTarget() and ec:IsControler(tp)
+		and bc:IsLocation(LOCATION_GRAVE) and bc:IsReason(REASON_BATTLE)
 end
 function c96458440.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c99594764.lua
+++ b/c99594764.lua
@@ -13,7 +13,8 @@ function c99594764.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c99594764.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:GetCount()==1 and eg:GetFirst()==e:GetHandler():GetEquipTarget()
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and eg:IsContains(ec) and ec:IsControler(tp)
 end
 function c99594764.filter(c,race,att)
 	return c:IsRace(race) and c:IsAttribute(att) and c:GetLevel()<=4 and c:IsAbleToHand()


### PR DESCRIPTION
added missing checks to several equip cards to make sure, that the equipped monster is controlled by the same player who controls the equip card
effects of equip cards that activate upon destroying an opponents monster by battle should not activate if the player who controls the monster is not the same player who controls the equip card