### PR TITLE
fix Lost World

### DIFF
--- a/c17228908.lua
+++ b/c17228908.lua
@@ -81,7 +81,7 @@ function c17228908.tkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c17228908.tgcon(e)
-	return Duel.IsExistingMatchingCard(Card.IsType,e:GetHandlerPlayer(),0,LOCATION_MZONE,1,nil,TYPE_TOKEN)
+	return Duel.IsExistingMatchingCard(Card.IsType,e:GetHandlerPlayer(),0,LOCATION_ONFIELD,1,nil,TYPE_TOKEN)
 end
 function c17228908.tglimit(e,c)
 	return not c:IsType(TYPE_TOKEN)


### PR DESCRIPTION
Fix this: If opponent has Token in Spell&Trap Zone, _Lost World_ don't apply effect.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9999&keyword=&tag=-1
Q.相手の発動した「サクリファイス」の『①：１ターンに１度、相手フィールドのモンスター１体を対象として発動できる。その相手モンスターを装備カード扱いとしてこのカードに装備する（１体のみ装備可能）』モンスター効果によって、自分のモンスターゾーンに存在していた「ジュラックトークン」が装備カード扱いとして装備されています。

この状況で自分のフィールドゾーンに「ロストワールド」が表側表示で存在する場合、『③：相手フィールドにトークンがある限り、相手はトークン以外のフィールドのモンスターを効果の対象にできない』効果は適用されますか？
A.質問の状況の場合、「ジュラックトークン」は装備カード扱いとして装備されていますが、相手フィールドにトークンが存在する状態である事に変わりはありませんので、自分の「ロストワールド」の『相手はトークン以外のフィールドのモンスターを効果の対象にできない』効果が適用される事になります。 