### PR TITLE
fix Bountiful Artemis and so on

### DIFF
--- a/c16946849.lua
+++ b/c16946849.lua
@@ -15,7 +15,7 @@ function c16946849.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c16946849.tokencon(e,tp,eg,ep,ev,re,r,rp)
-	return re:IsActiveType(TYPE_COUNTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_COUNTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,16946850,0,0x4011,300,300,1,RACE_FAIRY,ATTRIBUTE_LIGHT)
 end
 function c16946849.tokenop(e,tp,eg,ep,ev,re,r,rp)

--- a/c20951752.lua
+++ b/c20951752.lua
@@ -44,7 +44,7 @@ function c20951752.chop1(e,tp,eg,ep,ev,re,r,rp)
 	e:GetLabelObject():SetLabel(0)
 end
 function c20951752.chop2(e,tp,eg,ep,ev,re,r,rp)
-	if rp~=tp or not re:IsActiveType(TYPE_COUNTER) then return end
+	if rp~=tp or not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not re:IsActiveType(TYPE_COUNTER) then return end
 	e:GetLabelObject():SetLabel(1)
 end
 function c20951752.sumcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c32296881.lua
+++ b/c32296881.lua
@@ -9,7 +9,7 @@ function c32296881.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c32296881.drop(e,tp,eg,ep,ev,re,r,rp)
-	if not re:GetHandler():IsType(TYPE_COUNTER) then return end
+	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not re:IsActiveType(TYPE_COUNTER) then return end
 	Duel.Hint(HINT_CARD,0,32296881)
 	Duel.BreakEffect()
 	Duel.Draw(tp,1,REASON_EFFECT)

--- a/c49905576.lua
+++ b/c49905576.lua
@@ -10,7 +10,7 @@ function c49905576.initial_effect(c)
 end
 function c49905576.drop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not re:GetHandler():IsType(TYPE_COUNTER) or not c:IsLocation(LOCATION_MZONE) or not c:IsFaceup() then return end
+	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not re:IsActiveType(TYPE_COUNTER) or not c:IsLocation(LOCATION_MZONE) or not c:IsFaceup() then return end
 	Duel.Recover(tp,1000,REASON_EFFECT)
 	if not Duel.IsEnvironment(56433456) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)

--- a/c65282484.lua
+++ b/c65282484.lua
@@ -44,7 +44,7 @@ function c65282484.chop1(e,tp,eg,ep,ev,re,r,rp)
 	e:GetLabelObject():SetLabel(0)
 end
 function c65282484.chop2(e,tp,eg,ep,ev,re,r,rp)
-	if rp~=tp or not re:IsActiveType(TYPE_COUNTER) then return end
+	if rp~=tp or not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not re:IsActiveType(TYPE_COUNTER) then return end
 	e:GetLabelObject():SetLabel(1)
 end
 function c65282484.spcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c67468948.lua
+++ b/c67468948.lua
@@ -12,7 +12,7 @@ function c67468948.filter(c)
 	return c:IsFaceup() and c:IsRace(RACE_FAIRY) and c:IsAbleToHand()
 end
 function c67468948.drop(e,tp,eg,ep,ev,re,r,rp)
-	if not re:GetHandler():IsType(TYPE_COUNTER) then return end
+	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not re:IsActiveType(TYPE_COUNTER) then return end
 	Duel.BreakEffect()
 	local g=Duel.GetMatchingGroup(c67468948.filter,tp,LOCATION_REMOVED,0,nil)
 	if g:GetCount()<2 then return end


### PR DESCRIPTION
Fix this: If _Super Soldier Shield_ in graveyard activated effect, _Bountiful Artemis_'s effect apply.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6908&keyword=&tag=-1
Q.「豊穣のアルテミス」が自分のモンスターゾーンに表側表示で存在しています。

自分が墓地の「超戦士の盾」の『②：このカードが墓地に存在する場合、自分フィールドの魔力カウンターを１つ取り除いて発動できる。墓地のこのカードを自分フィールドにセットする。この効果でセットしたこのカードはフィールドから離れた場合に除外される』効果を発動し、自分の魔法＆罠ゾーンにセットしました。

この場合、「豊穣のアルテミス」の『このカードがフィールド上に表側表示で存在する限り、カウンター罠が発動される度に自分のデッキからカードを１枚ドローする』効果は適用されますか？
A.「豊穣のアルテミス」の効果は、カウンター罠カードの**カードの発動が行われた場合に適用され**、ドローする処理を行います。

質問の状況のように、墓地の「超戦士の盾」の効果の発動が行われた際には、カウンター罠カードのカードの発動が行われていませんので、「豊穣のアルテミス」の効果は適用されません。 