### PR TITLE
errata & fix Armored Cybern

### DIFF
--- a/c67159705.lua
+++ b/c67159705.lua
@@ -16,7 +16,6 @@ function c67159705.initial_effect(c)
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_SZONE)
-	e2:SetCondition(aux.IsUnionState)
 	e2:SetTarget(c67159705.sptg)
 	e2:SetOperation(c67159705.spop)
 	c:RegisterEffect(e2)
@@ -25,7 +24,6 @@ function c67159705.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
 	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
-	e3:SetCondition(aux.IsUnionState)
 	e3:SetValue(1)
 	c:RegisterEffect(e3)
 	--eqlimit
@@ -43,20 +41,19 @@ function c67159705.initial_effect(c)
 	e5:SetType(EFFECT_TYPE_IGNITION)
 	e5:SetRange(LOCATION_SZONE)
 	e5:SetCountLimit(1)
-	e5:SetCondition(aux.IsUnionState)
 	e5:SetTarget(c67159705.destg)
 	e5:SetOperation(c67159705.desop)
 	c:RegisterEffect(e5)
 end
-c67159705.old_union=true
 function c67159705.repval(e,re,r,rp)
 	return bit.band(r,REASON_BATTLE)~=0
 end
 function c67159705.eqlimit(e,c)
-	return c:IsCode(70095154) or aux.IsMaterialListCode(c,70095154)
+	return c:IsCode(70095154) or aux.IsMaterialListCode(c,70095154) or e:GetHandler():GetEquipTarget()==c
 end
 function c67159705.filter(c)
-	return c:IsFaceup() and (c:IsCode(70095154) or aux.IsMaterialListCode(c,70095154)) and c:GetUnionCount()==0
+	local ct1,ct2=c:GetUnionCount()
+	return c:IsFaceup() and (c:IsCode(70095154) or aux.IsMaterialListCode(c,70095154)) and ct2==0
 end
 function c67159705.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c67159705.filter(chkc) end
@@ -103,15 +100,16 @@ end
 function c67159705.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	if c:GetEquipTarget():GetAttack()<1000 then return end
+	local ec=c:GetEquipTarget()
+	if ec:GetAttack()<1000 then return end
 	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_EQUIP)
+	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_ATTACK)
 	e1:SetValue(-1000)
 	e1:SetReset(RESET_EVENT+0x1fe0000)
-	c:RegisterEffect(e1)
+	ec:RegisterEffect(e1)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and not ec:IsHasEffect(EFFECT_REVERSE_UPDATE) then
 		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Errata: https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7412

Fix 1: During _Reverse Trap_ applied turn, _Armored Cybern_ destroy the monster by _Armored Cybern_'s effect.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=5&keyword=&tag=-1
> Q.「あまのじゃくの呪い」の効果適用中、装備された「アーマード・サイバーン」の『この効果で装備カード扱いになっている場合のみ、装備モンスターの攻撃力を１０００ポイントダウンさせる事で、表側表示で存在するモンスター１体を破壊する』効果を発動する事はできますか？
> A.「アーマード・サイバーン」の装備モンスターの攻撃力が1000未満の場合、『装備モンスターの攻撃力を1000ポイントダウンし、フィールド上に表側表示で存在するモンスター1体を破壊できる』効果を発動する事はできません。
> （「アーマード・サイバーン」の装備モンスターの攻撃力が1000以上であれば効果を発動する事ができます。）
> 
> なお、「アーマード・サイバーン」の『フィールド上に表側表示で存在するモンスター1体を破壊できる』効果処理が行われる際に、「あまのじゃくの呪い」が適用されている場合には、攻撃力が1000ダウンする代わりに攻撃力が1000アップします。その場合、攻撃力がダウンしていませんので、選択したカードは破壊されません。
> （既に「あまのじゃくの呪い」が適用されている場合、「アーマード・サイバーン」の効果の発動にチェーンして「あまのじゃくの呪い」が発動した場合、どちらも同じ処理となります。）

Fix 2: If _Armored Cybern_ unequipped, equipped monster become original ATK.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7091&keyword=&tag=-1
> Q.自分のモンスターゾーンに表側表示で存在する「サイバー・ドラゴン」に「アーマード・サイバーン」が装備されています。
> 
> その「アーマード・サイバーン」の『１ターンに１度、この効果でこのカードを装備したモンスターの攻撃力を１０００ポイントダウンし、フィールド上に表側表示で存在するモンスター１体を選択して破壊できる』効果を適用し、「サイバー・ドラゴン」の攻撃力が1000ダウンした後、その「アーマード・サイバーン」を『装備を解除して表側攻撃表示で特殊召喚できる』効果によって特殊召喚しました。
> 
> この場合、「サイバー・ドラゴン」の攻撃力はどうなりますか？
> A.「アーマード・サイバーン」の『この効果でこのカードを装備したモンスターの攻撃力を１０００ポイントダウンし、フィールド上に表側表示で存在するモンスター１体を選択して破壊できる』効果によってダウンした攻撃力は、そのモンスターが表側表示で存在する限り適用されたままとなります。
> 
> 質問の状況の場合、「アーマード・サイバーン」がモンスターとして特殊召喚された後も、「サイバー・ドラゴン」の攻撃力は1000ダウンした状態（＝1100）のままです。 