### PR TITLE
fix Gigantic Cephalotus

### DIFF
--- a/c82116191.lua
+++ b/c82116191.lua
@@ -13,7 +13,7 @@ function c82116191.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c82116191.filter(c)
-	return c:IsRace(RACE_PLANT) and c:IsPreviousLocation(LOCATION_ONFIELD)
+	return c:IsPreviousPosition(POS_FACEUP) and bit.band(c:GetPreviousRaceOnField(),RACE_PLANT)~=0 and c:IsRace(RACE_PLANT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c82116191.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c82116191.filter,1,nil)
@@ -28,7 +28,7 @@ function c82116191.atkop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetValue(200)
-		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
 		c:RegisterEffect(e1)
 	end
 end


### PR DESCRIPTION
Fix 1: If face-down Plant monster send to graveyard, _Gigantic Cephalotus_ activate effect.
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7666
■裏側守備表示の植物族モンスターが戦闘によってリバースした後に破壊され墓地へ送られた場合には、「ギガント・セファロタス」の効果が発動しますが、**裏側守備表示の植物族モンスターが、「サンダー・ブレイク」等のカードの効果によって破壊され墓地へ送られた場合には、「ギガント・セファロタス」の効果は発動しません**。

Fix 2: If Plant monster send to graveyard while _DNA Surgery_(declar Warrior) has on the field, _Gigantic Cephalotus_ activate effect.

Fix 3: If _Gigantic Cephalotus_'s effect is negated, _Gigantic Cephalotus_ don't become original ATK.