### PR TITLE
fix Skydive Scorcher

### DIFF
--- a/c40522482.lua
+++ b/c40522482.lua
@@ -39,7 +39,7 @@ function c40522482.ffilter(c)
 end
 function c40522482.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) then return end
+	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
 	local g=Duel.GetMatchingGroup(c40522482.desfilter,tp,0,LOCATION_MZONE,nil,tc:GetAttack())
 	if g:GetCount()>0 and Duel.Destroy(g,REASON_EFFECT)>0 then
 		local og=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_GRAVE)


### PR DESCRIPTION
Fix this: If target monster is face-down after chain solved, _Skydive Scorcher_'s effect apply.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20339&keyword=&tag=-1
Q.自分のモンスターゾーンに表側表示で存在する「E・HERO フレイム・ウィングマン」を対象として、自分が「スカイスクレイパー・シュート」を発動しました。

その発動にチェーンして、「月の書」が発動し、対象の「E・HERO フレイム・ウィングマン」が裏側守備表示になった場合、効果処理はどうなりますか？
A.「スカイスクレイパー・シュート」の効果処理時に、対象とした「E・HERO」と名のついた融合モンスターが裏側守備表示になっている場合、『そのモンスターより攻撃力が高い相手フィールドの表側表示モンスターを全て破壊する』処理を適用する事はできず、『その後、』の処理を適用する事もできません。 