### PR TITLE
fix Mystic Piper

### DIFF
--- a/c14198496.lua
+++ b/c14198496.lua
@@ -26,6 +26,7 @@ function c14198496.operation(e,tp,eg,ep,ev,re,r,rp)
 	local dc=Duel.GetOperatedGroup():GetFirst()
 	Duel.ConfirmCards(1-tp,dc)
 	if dc:GetLevel()==1 then
+		Duel.BreakEffect()
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end
 	Duel.ShuffleHand(tp)


### PR DESCRIPTION
Fix this: The "draw and reveal 1 card" and the "If that card is a Level 1 Monster Card, draw 1 more card" are the same.
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9476
■『自分のデッキからカードを１枚ドローする』処理と、『この効果でドローしたカードをお互いに確認し、レベル１モンスターだった場合、自分はカードをもう１枚ドローする』処理は**同時に行われる扱いではありません**。（2回のドローが行われる扱いとなります。）