### PR TITLE
fix Intercept Wave

### DIFF
--- a/c39440937.lua
+++ b/c39440937.lua
@@ -19,17 +19,16 @@ function c39440937.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c39440937.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c39440937.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	if g:GetCount()>0 then
-		Duel.ChangePosition(g,POS_FACEUP_DEFENSE)
+	if g:GetCount()>0 and Duel.ChangePosition(g,POS_FACEUP_DEFENSE)~=0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_PHASE+PHASE_END)
+		e1:SetCountLimit(1)
+		e1:SetReset(RESET_PHASE+PHASE_END)
+		e1:SetCondition(c39440937.tdcon)
+		e1:SetOperation(c39440937.tdop)
+		Duel.RegisterEffect(e1,tp)
 	end
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_PHASE+PHASE_END)
-	e1:SetCountLimit(1)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	e1:SetCondition(c39440937.tdcon)
-	e1:SetOperation(c39440937.tdop)
-	Duel.RegisterEffect(e1,tp)
 end
 function c39440937.tdfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_SYNCHRO) and c:IsAbleToExtra()


### PR DESCRIPTION
Fix this: If _Intercept Wave_ didn't change the Synchro Monster(s) position, _Intercept Wave_'s effect apply during End Phase.
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13191&keyword=&tag=-1
Q.相手のモンスターゾーンに表側守備表示の「超重剣聖ムサ－C」が存在し、自分のモンスターゾーンに表側攻撃表示の「ゴヨウ・ガーディアン」が存在しています。

この状況で、自分が「妨害電波」を発動した際に、相手がチェーンして「月の書」を発動し、「ゴヨウ・ガーディアン」を裏側守備表示にした場合、効果処理はどうなりますか？
A.質問の状況の場合、チェーンして発動した「月の書」の効果によって、モンスターゾーンに表側攻撃表示で存在するシンクロモンスターは1体も存在しない状態となっており、『フィールド上のシンクロモンスターを全て表側守備表示にする』処理を適用する事ができません。

この場合には、**『このターンのエンドフェイズ時にフィールド上のシンクロモンスターを全てエクストラデッキに戻す』処理も適用されません**。