### PR TITLE
fix Spellstone Sorcerer Karood

### DIFF
--- a/c20630765.lua
+++ b/c20630765.lua
@@ -1,5 +1,6 @@
 --魔石術師 クルード
 function c20630765.initial_effect(c)
+	c:EnableCounterPermit(0x16)
 	c:SetCounterLimit(0x16,1)
 	--Add counter
 	local e0=Effect.CreateEffect(c)


### PR DESCRIPTION
Fix this: If monster effect activated while _Spellstone Sorcerer Karood_ has on the field, Spellstone Counter don't place on _Spellstone Sorcerer Karood_.