### PR TITLE
fix Malevolent Mech - Goku En

### DIFF
--- a/c31571902.lua
+++ b/c31571902.lua
@@ -42,6 +42,7 @@ end
 function c31571902.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) and c:IsFaceup() and Duel.SendtoGrave(c,REASON_EFFECT)~=0 then
+		Duel.BreakEffect()
 		Duel.Damage(tp,2400,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix this: The "Send it to the Graveyard" and the "take damage equal to its ATK in the Graveyard" are the same.
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7855
■『この方法で召喚したこのカードは、エンドフェイズ時にフィールド上にこのカード以外のアンデット族モンスターが存在しない場合、墓地へ送られる』処理と、『この効果によって墓地へ送られた時、自分はこのカードの攻撃力分のダメージを受ける』処理は**同時に行われる扱いではありません**。