### PR TITLE
fix Crystal Seer

### DIFF
--- a/c82099401.lua
+++ b/c82099401.lua
@@ -23,6 +23,7 @@ function c82099401.operation(e,tp,eg,ep,ev,re,r,rp)
 		else
 			Duel.SendtoGrave(add,REASON_EFFECT)
 		end
+		Duel.BreakEffect()
 		local back=Duel.GetDecktopGroup(tp,1)
 		Duel.MoveSequence(back:GetFirst(),1)
 	end


### PR DESCRIPTION
Fix this: The "Excavate the top 2 cards of your Deck, add 1 of them to your hand" and the "place the other on the bottom of your Deck" are the same.
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7208
■『自分のデッキの上からカードを２枚めくり、その中から１枚を選んで手札に加える』処理と、『その後、残りのカードをデッキの一番下に戻す』処理は**同時に行われる扱いではありません**。