### PR TITLE
fix Formation Union

### DIFF
--- a/c26931058.lua
+++ b/c26931058.lua
@@ -11,7 +11,7 @@ function c26931058.initial_effect(c)
 end
 function c26931058.filter1(c,tp)
 	return c:IsFaceup() and c:IsType(TYPE_UNION)
-		and Duel.IsExistingTarget(c26931058.filter2,tp,LOCATION_MZONE,0,1,c,c)
+		and Duel.IsExistingMatchingCard(c26931058.filter2,tp,LOCATION_MZONE,0,1,c,c)
 end
 function c26931058.filter2(c,ec)
 	return c:IsFaceup() and ec:CheckEquipTarget(c) and aux.CheckUnionEquip(ec,c)
@@ -20,9 +20,12 @@ function c26931058.filter3(c,e,tp)
 	return c:IsFaceup() and c:IsHasEffect(EFFECT_UNION_STATUS) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c26931058.eftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return false end
-	local b1=Duel.IsExistingMatchingCard(c26931058.filter1,tp,LOCATION_MZONE,0,1,nil,tp) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-	local b2=Duel.IsExistingMatchingCard(c26931058.filter3,tp,LOCATION_SZONE,0,1,nil,e,tp) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chkc then
+		if e:GetLabel()==0 then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c26931058.filter1(chkc,tp)
+		else return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_SZONE) and c26931058.filter3(chkc,e,tp) end
+	end
+	local b1=Duel.IsExistingTarget(c26931058.filter1,tp,LOCATION_MZONE,0,1,nil,tp) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+	local b2=Duel.IsExistingTarget(c26931058.filter3,tp,LOCATION_SZONE,0,1,nil,e,tp) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 	if chk==0 then return b1 or b2 end
 	local op=0
 	if b1 and b2 then
@@ -34,10 +37,7 @@ function c26931058.eftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if op==0 then
 		e:SetCategory(CATEGORY_EQUIP)
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(26931058,2))
-		local g1=Duel.SelectTarget(tp,c26931058.filter1,tp,LOCATION_MZONE,0,1,1,nil,tp)
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-		local g2=Duel.SelectTarget(tp,c26931058.filter2,tp,LOCATION_MZONE,0,1,1,g1:GetFirst(),g1:GetFirst())
-		e:SetLabelObject(g1:GetFirst())
+		Duel.SelectTarget(tp,c26931058.filter1,tp,LOCATION_MZONE,0,1,1,nil,tp)
 	else
 		e:SetCategory(CATEGORY_SPECIAL_SUMMON)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
@@ -47,12 +47,12 @@ function c26931058.eftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c26931058.efop(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetLabel()==0 then
-		local tc1=e:GetLabelObject()
-		local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-		local tc2=g:GetFirst()
-		if tc1==tc2 then tc2=g:GetNext() end
-		if tc1:IsFaceup() and tc2:IsFaceup() and tc1:IsRelateToEffect(e) and tc2:IsRelateToEffect(e)
-			and aux.CheckUnionEquip(tc1,tc2) and Duel.Equip(tp,tc1,tc2,false) then
+		local tc=Duel.GetFirstTarget()
+		if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+		local g=Duel.SelectTarget(tp,c26931058.filter2,tp,LOCATION_MZONE,0,1,1,tc,tc)
+		local ec=g:GetFirst()
+		if ec and Duel.Equip(tp,tc,ec,false) then
 			aux.SetUnionState(tc1)
 		end
 	else

--- a/c26931058.lua
+++ b/c26931058.lua
@@ -50,7 +50,7 @@ function c26931058.efop(e,tp,eg,ep,ev,re,r,rp)
 		local tc=Duel.GetFirstTarget()
 		if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-		local g=Duel.SelectTarget(tp,c26931058.filter2,tp,LOCATION_MZONE,0,1,1,tc,tc)
+		local g=Duel.SelectMatchingCard(tp,c26931058.filter2,tp,LOCATION_MZONE,0,1,1,tc,tc)
 		local ec=g:GetFirst()
 		if ec and Duel.Equip(tp,tc,ec,false) then
 			aux.SetUnionState(tc1)


### PR DESCRIPTION
Fix this: _Formation Union_'s effect target 2 monster.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5623
■『自分フィールド上に表側表示で存在する装備可能なモンスター』は対象に取りません。