### PR TITLE
errata Mermail Abyssteus

### DIFF
--- a/c22446869.lua
+++ b/c22446869.lua
@@ -14,7 +14,7 @@ function c22446869.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(22446869,1))
 	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e2:SetCountLimit(1,22446869)
 	e2:SetCondition(c22446869.thcon)
@@ -46,7 +46,7 @@ function c22446869.thfilter(c)
 	return c:IsSetCard(0x74) and c:IsLevelBelow(4) and c:IsAbleToHand()
 end
 function c22446869.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.IsExistingMatchingCard(c22446869.thfilter,tp,LOCATION_DECK,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c22446869.thop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10471
②：このカードの①の効果で特殊召喚に成功した**時に発動できる**。デッキからレベル４以下の「水精鱗」モンスター１体を手札に加える。