### PR TITLE
fix Spirit's Invitation

### DIFF
--- a/c92394653.lua
+++ b/c92394653.lua
@@ -9,7 +9,6 @@ function c92394653.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(92394653,0))
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetCode(EVENT_TO_HAND)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCondition(c92394653.condition)
@@ -32,17 +31,21 @@ function c92394653.filter(c,tp)
 		and c:IsControler(tp) and c:IsType(TYPE_SPIRIT)
 end
 function c92394653.condition(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c92394653.filter,1,nil,tp)
+	return eg:IsExists(c92394653.filter,1,nil,tp) and e:GetHandler():IsStatus(STATUS_ACTIVATED)
 end
-function c92394653.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsAbleToHand() end 
+function c92394653.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(1-tp,Card.IsAbleToHand,tp,0,LOCATION_MZONE,1,1,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
+	local g=Duel.GetMatchingGroup(Card.IsAbleToHand,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
 end
 function c92394653.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
+	Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_RTOHAND)
+	local g=Duel.SelectMatchingCard(1-tp,Card.IsAbleToHand,tp,0,LOCATION_MZONE,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+	end
+
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)


### PR DESCRIPTION
Fix 1: Player cannot activate and use effect in the same Chain.
Fix 2: Spirit's Invitation's effect target cards.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5402
（ダメージステップでも発動します。**対象を取る効果ではありません**。手札に戻すモンスターは、「スピリットの誘い」を発動したプレイヤーから見て相手となるプレイヤーが効果処理時に選びます。）
■『フィールド上に表側表示で存在するスピリットモンスターが自分の手札に戻った時、相手フィールド上に存在するモンスター１体を相手が選択して持ち主の手札に戻す』効果は、**カードの発動と同一のチェーンブロックにて効果を発動する事はできません**。