### PR TITLE
fix Masked HERO Divine Wind

### DIFF
--- a/c22093873.lua
+++ b/c22093873.lua
@@ -56,7 +56,7 @@ function c22093873.checkop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetLabelObject():SetLabel(fid)
 end
 function c22093873.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(1)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)


### PR DESCRIPTION
Fix this: If player has no cards in player's Deck, Masked HERO Divine Wind's effect can activate.