### PR TITLE
fix Disenchanter

### DIFF
--- a/c76137614.lua
+++ b/c76137614.lua
@@ -8,28 +8,27 @@ function c76137614.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)
-	e1:SetCost(c76137614.thcost)
 	e1:SetTarget(c76137614.thtg)
 	e1:SetOperation(c76137614.thop)
 	c:RegisterEffect(e1)
-end
-function c76137614.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsCanRemoveCounter(tp,1,1,0x1,1,REASON_COST) end
-	Duel.RemoveCounter(tp,1,1,0x1,1,REASON_COST)
 end
 function c76137614.filter(c)
 	return c:IsType(TYPE_SPELL) and c:IsFaceup() and c:IsAbleToHand()
 end
 function c76137614.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and c76137614.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c76137614.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	if chk==0 then return Duel.IsCanRemoveCounter(tp,1,1,0x1,1,REASON_EFFECT)
+		and Duel.IsExistingTarget(c76137614.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 	local g=Duel.SelectTarget(tp,c76137614.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
 end
 function c76137614.thop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
-		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+	if Duel.IsCanRemoveCounter(tp,1,1,0x1,1,REASON_EFFECT) then
+		Duel.RemoveCounter(tp,1,1,0x1,1,REASON_EFFECT)
+		local tc=Duel.GetFirstTarget()
+		if tc:IsRelateToEffect(e) then
+			Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		end
 	end
 end


### PR DESCRIPTION
Fix this: "remove 1 Spell Counter from anywhere on the field" is cost.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8133
■『フィールド上に存在する魔力カウンターを１つ取り除き』の**効果処理**の際に、自分または相手フィールドに存在する魔力カウンターを1つ選び、取り除きます。