### PR TITLE
fix Cynet Storm

### DIFF
--- a/c42461852.lua
+++ b/c42461852.lua
@@ -41,12 +41,10 @@ end
 function c42461852.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and ev>=2000
 end
-function c42461852.spfilter(c,e,tp)
-	return c:IsFacedown() and c:IsType(TYPE_LINK) and c:IsRace(RACE_CYBERSE)
-		and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-end
 function c42461852.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c42461852.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFacedown,tp,LOCATION_EXTRA,0,1,nil)
+		and Duel.IsPlayerCanSpecialSummon(tp)
+		and Duel.GetLocationCountFromEx(tp)>0 end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c42461852.spop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix this: If player has no Cyberse Monster in player's Extra Deck, _Cynet Storm_'s effect cannot activate.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12767&keyword=&tag=-1
Q.自分のエクストラデッキに存在する裏側表示のカードの中にサイバース族のリンクモンスターが存在しない場合、「サイバネット・ストーム」の『③：自分が２０００以上の戦闘・効果ダメージを受けた場合に発動できる。自分のEXデッキの裏側表示のカードだけをシャッフルし、その一番上のカードをめくる。めくったカードがサイバース族リンクモンスターだった場合、そのモンスターを特殊召喚する。違った場合は元に戻す』効果を発動する事はできますか？
A.自分のエクストラデッキに裏側表示のカードが存在するのであれば、**その中にサイバース族のリンクモンスターが存在しない場合でも、「サイバネット・ストーム」の効果を発動する事ができます**。

その場合、『自分のEXデッキの裏側表示のカードだけをシャッフルし、その一番上のカードをめくる』処理は通常通り適用されますが、結果として『違った場合は元に戻す』処理が行われる事になります。 