### PR TITLE
fix Mirror of Oaths

### DIFF
--- a/c46656406.lua
+++ b/c46656406.lua
@@ -25,7 +25,6 @@ end
 function c46656406.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=eg:Filter(c46656406.filter2,nil,e,tp)
 	if Duel.Destroy(g,REASON_EFFECT)~=0 then
-		Duel.BreakEffect()
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix this: The "Destroy that monster(s)" and the "draw 1 card" are not the same.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8232
■『そのモンスターを破壊し』の処理と、『自分はデッキからカードを１枚ドローする』処理は**同時に行われる扱いとなります**。