### PR TITLE
fix Fengsheng Mirror

### DIFF
--- a/c37406863.lua
+++ b/c37406863.lua
@@ -11,7 +11,7 @@ function c37406863.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37406863.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0 end
 	Duel.SetTargetPlayer(tp)
 end
 function c37406863.activate(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix this: If opponent has no cards in hand, _Fengsheng Mirror_ can activate.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5385
■相手の手札が0枚の場合に「封神鏡」を**発動する事はできません**。