### PR TITLE
fix Corruption Cell "A

### DIFF
--- a/c2561846.lua
+++ b/c2561846.lua
@@ -11,7 +11,7 @@ function c2561846.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c2561846.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end 
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
 	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
@@ -19,7 +19,7 @@ function c2561846.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c2561846.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
 		tc:AddCounter(0x100e,1)
 	end
 end


### PR DESCRIPTION
Fix this: If monster has changed control, _Corruption Cell "A"_'s effect apply.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6898
■効果処理時に、対象のモンスターのコントロールが自分に移っている場合、**Aカウンターを置く処理は適用されません**。