### PR TITLE
fix Overtex Qoatlus

### DIFF
--- a/c41782653.lua
+++ b/c41782653.lua
@@ -43,7 +43,7 @@ function c41782653.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c41782653.sprfilter(c)
-	return c:IsFaceup() and c:IsRace(RACE_DINOSAUR) and c:IsAbleToDeckOrExtraAsCost()
+	return c:IsFaceup() and c:IsRace(RACE_DINOSAUR) and c:IsAbleToDeckAsCost()
 end
 function c41782653.sprcon(e,c)
 	if c==nil then return true end


### PR DESCRIPTION
Fix this: _Overtex Qoatlus_ can return Fusion, Synchro, Xyz and/or Link monster.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13406
■「オーバーテクス・ゴアトルス」を特殊召喚する際に、デッキに戻すモンスターとして、恐竜族の融合・シンクロ・エクシーズモンスターを含める事はできません。