### PR TITLE
Update c48934760.lua

### DIFF
--- a/c48934760.lua
+++ b/c48934760.lua
@@ -35,6 +35,7 @@ function c48934760.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tep=tc:GetControler()
 		local cost=te:GetCost()
 		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end
+		te:UseCountLimit(tp)
 		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
 	end
 end


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro-core/pull/151

Field spell cards that can't be activated more than once per turn, for example, "Union Hangar", can be activated twice per turn with "Demise of the Land". If you have searched your deck for "Union Hangar" and activated it with "Demise of the Land", you shouldn't be possible to activate another "Union Hangar" from your hand this turn. To fix this, there shall be an interface that make count limit manually consumable.