### PR TITLE
Neglect target for field activation

### DIFF
--- a/c15248873.lua
+++ b/c15248873.lua
@@ -30,6 +30,7 @@ function c15248873.operation(e,tp,eg,ep,ev,re,r,rp)
 		end
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 		local te=tc:GetActivateEffect()
+		te:UseCountLimit(tp,1,true)
 		local tep=tc:GetControler()
 		local cost=te:GetCost()
 		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c15248873.lua
+++ b/c15248873.lua
@@ -14,7 +14,7 @@ function c15248873.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldCard(tp,LOCATION_SZONE,5)==nil and Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)~=nil
 end
 function c15248873.filter(c,tp)
-	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp)
+	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function c15248873.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c15248873.filter,tp,LOCATION_DECK,0,1,nil,tp) end

--- a/c19089195.lua
+++ b/c19089195.lua
@@ -45,6 +45,7 @@ function c19089195.activate(e,tp,eg,ep,ev,re,r,rp)
 			end
 			Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 			local te=tc:GetActivateEffect()
+			te:UseCountLimit(tp,1,true)
 			local tep=tc:GetControler()
 			local cost=te:GetCost()
 			if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c19089195.lua
+++ b/c19089195.lua
@@ -29,7 +29,7 @@ function c19089195.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c19089195.filter(c,tp)
-	return c:IsCode(22702055) and c:GetActivateEffect() and c:GetActivateEffect():IsActivatable(tp,true)
+	return c:IsCode(22702055) and c:GetActivateEffect() and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function c19089195.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end

--- a/c22900598.lua
+++ b/c22900598.lua
@@ -30,6 +30,7 @@ function c22900598.activate(e,tp,eg,ep,ev,re,r,rp)
 	if tc then
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 		local te=tc:GetActivateEffect()
+		te:UseCountLimit(tp,1,true)
 		local tep=tc:GetControler()
 		local cost=te:GetCost()
 		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c22900598.lua
+++ b/c22900598.lua
@@ -17,7 +17,7 @@ function c22900598.condition(e,tp,eg,ep,ev,re,r,rp)
 	return g:GetCount()>0 and g:FilterCount(Card.IsRace,nil,RACE_ZOMBIE)==g:GetCount()
 end
 function c22900598.filter(c,tp)
-	return c:IsCode(62188962) and c:GetActivateEffect():IsActivatable(tp)
+	return c:IsCode(62188962) and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function c22900598.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c22900598.filter,tp,LOCATION_DECK,0,1,nil,tp) end

--- a/c26920296.lua
+++ b/c26920296.lua
@@ -4,7 +4,7 @@ function c26920296.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetCountLimit(1,26920296)
+	e1:SetCountLimit(1,26920296+EFFECT_COUNT_CODE_OATH)
 	c:RegisterEffect(e1)
 	--draw
 	local e2=Effect.CreateEffect(c)

--- a/c32912040.lua
+++ b/c32912040.lua
@@ -51,7 +51,7 @@ function c32912040.desop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c32912040.filter(c,tp,code)
-	return c:IsType(TYPE_FIELD) and c:IsSetCard(0xe2) and c:GetActivateEffect():IsActivatable(tp) and not c:IsCode(code)
+	return c:IsType(TYPE_FIELD) and c:IsSetCard(0xe2) and c:GetActivateEffect():IsActivatable(tp,true,true) and not c:IsCode(code)
 end
 function c32912040.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp

--- a/c32912040.lua
+++ b/c32912040.lua
@@ -73,6 +73,7 @@ function c32912040.operation(e,tp,eg,ep,ev,re,r,rp)
 			local tc=g:GetFirst()
 			Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 			local te=tc:GetActivateEffect()
+			te:UseCountLimit(tp,1,true)
 			local tep=tc:GetControler()
 			local cost=te:GetCost()
 			if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c48934760.lua
+++ b/c48934760.lua
@@ -16,7 +16,7 @@ function c48934760.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c48934760.cfilter,1,nil,tp)
 end
 function c48934760.filter(c,tp)
-	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp)
+	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function c48934760.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c48934760.filter,tp,LOCATION_DECK,0,1,nil,tp) end

--- a/c48934760.lua
+++ b/c48934760.lua
@@ -32,6 +32,7 @@ function c48934760.activate(e,tp,eg,ep,ev,re,r,rp)
 		end
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 		local te=tc:GetActivateEffect()
+		te:UseCountLimit(tp,1,true)
 		local tep=tc:GetControler()
 		local cost=te:GetCost()
 		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c61818176.lua
+++ b/c61818176.lua
@@ -31,7 +31,7 @@ function c61818176.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,tc,1,0,0)
 end
 function c61818176.actfilter(c,tp)
-	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp)
+	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function c61818176.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
@@ -44,6 +44,7 @@ function c61818176.activate(e,tp,eg,ep,ev,re,r,rp)
 			local sc=sg:GetFirst()
 			Duel.MoveToField(sc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 			local te=sc:GetActivateEffect()
+			te:UseCountLimit(tp,1,true)
 			local tep=sc:GetControler()
 			local cost=te:GetCost()
 			if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c69529337.lua
+++ b/c69529337.lua
@@ -60,7 +60,7 @@ function c69529337.tdop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c69529337.filter(c,tp,code)
-	return c:IsType(TYPE_FIELD) and c:IsSetCard(0xe2) and c:GetActivateEffect():IsActivatable(tp) and not c:IsCode(code)
+	return c:IsType(TYPE_FIELD) and c:IsSetCard(0xe2) and c:GetActivateEffect():IsActivatable(tp,true,true) and not c:IsCode(code)
 end
 function c69529337.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp

--- a/c69529337.lua
+++ b/c69529337.lua
@@ -82,6 +82,7 @@ function c69529337.operation(e,tp,eg,ep,ev,re,r,rp)
 			local tc=g:GetFirst()
 			Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 			local te=tc:GetActivateEffect()
+			te:UseCountLimit(tp,1,true)
 			local tep=tc:GetControler()
 			local cost=te:GetCost()
 			if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c72332074.lua
+++ b/c72332074.lua
@@ -77,6 +77,8 @@ function c72332074.actop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 		end
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-		Duel.RaiseEvent(tc,4179255,tc:GetActivateEffect(),0,tp,tp,Duel.GetCurrentChain())
+		local te=tc:GetActivateEffect()
+		te:UseCountLimit(tp,1,true)
+		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
 	end
 end

--- a/c72332074.lua
+++ b/c72332074.lua
@@ -63,7 +63,7 @@ function c72332074.actcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c72332074.actfilter(c,tp)
-	return c:IsCode(10424147) and c:GetActivateEffect():IsActivatable(tp)
+	return c:IsCode(10424147) and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function c72332074.acttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c72332074.actfilter,tp,LOCATION_DECK,0,1,nil,tp) end

--- a/c89208725.lua
+++ b/c89208725.lua
@@ -34,6 +34,7 @@ function c89208725.activate(e,tp,eg,ep,ev,re,r,rp)
 				Duel.BreakEffect()
 			end
 			Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+			te:UseCountLimit(tp,1,true)
 			local tep=tc:GetControler()
 			local cost=te:GetCost()
 			if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c89208725.lua
+++ b/c89208725.lua
@@ -10,7 +10,7 @@ function c89208725.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c89208725.filter(c,tp)
-	return c:IsType(TYPE_FIELD) and (c:IsAbleToHand() or c:GetActivateEffect():IsActivatable(tp))
+	return c:IsType(TYPE_FIELD) and (c:IsAbleToHand() or c:GetActivateEffect():IsActivatable(tp,true,true))
 end
 function c89208725.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c89208725.filter,tp,LOCATION_DECK,0,1,nil,tp) end

--- a/c95923441.lua
+++ b/c95923441.lua
@@ -29,7 +29,7 @@ function c95923441.sumcon(e)
 	return tc and tc:IsFaceup()
 end
 function c95923441.filter(c,tp,code)
-	return c:IsType(TYPE_FIELD) and c:IsSetCard(0xe2) and c:GetActivateEffect():IsActivatable(tp) and not c:IsCode(code)
+	return c:IsType(TYPE_FIELD) and c:IsSetCard(0xe2) and c:GetActivateEffect():IsActivatable(tp,true,true) and not c:IsCode(code)
 end
 function c95923441.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp

--- a/c95923441.lua
+++ b/c95923441.lua
@@ -51,6 +51,7 @@ function c95923441.operation(e,tp,eg,ep,ev,re,r,rp)
 			local tc=g:GetFirst()
 			Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 			local te=tc:GetActivateEffect()
+			te:UseCountLimit(tp,1,true)
 			local tep=tc:GetControler()
 			local cost=te:GetCost()
 			if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end

--- a/c97970833.lua
+++ b/c97970833.lua
@@ -29,9 +29,11 @@ function c97970833.activate(e,tp,eg,ep,ev,re,r,rp)
 		end
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 		fc=Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)
+		local te=tc:GetActivateEffect()
+		te:UseCountLimit(tp,1,true)
 		if fc and fc:IsFaceup() and Duel.IsPlayerCanDraw(1-tp,1) and Duel.SelectYesNo(tp,aux.Stringid(97970833,0)) then
 			Duel.Draw(1-tp,1,REASON_EFFECT)
 		end
-		Duel.RaiseEvent(tc,4179255,tc:GetActivateEffect(),0,tp,tp,Duel.GetCurrentChain())
+		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
 	end
 end

--- a/c97970833.lua
+++ b/c97970833.lua
@@ -14,7 +14,7 @@ function c97970833.condition(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=Duel.GetTurnPlayer()
 end
 function c97970833.filter(c,tp)
-	return c:IsCode(34487429) and c:GetActivateEffect():IsActivatable(tp)
+	return c:IsCode(34487429) and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function c97970833.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c97970833.filter,tp,LOCATION_DECK,0,1,nil,tp) end


### PR DESCRIPTION
Targets of field spells like Oracle of Zefra should be neglected by field activation effects like Demise of the Land.
Together with a trap missed out last commit.
Based on Fluorohydride/ygopro-core#152