### PR TITLE
add Auxiliary.EnableReviveLimitPendulumSummonable

### DIFF
--- a/c16306932.lua
+++ b/c16306932.lua
@@ -27,7 +27,7 @@ function c16306932.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e3:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e3:SetValue(c16306932.splimit)
+	e3:SetValue(aux.FALSE)
 	c:RegisterEffect(e3)
 	--special summon rule
 	local e4=Effect.CreateEffect(c)
@@ -90,9 +90,6 @@ function c16306932.spop(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsRelateToEffect(e) and Duel.Destroy(c,REASON_EFFECT)~=0 and tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
-end
-function c16306932.splimit(e,se,sp,st)
-	return bit.band(st,SUMMON_TYPE_PENDULUM)==SUMMON_TYPE_PENDULUM and e:GetHandler():IsLocation(LOCATION_HAND)
 end
 function c16306932.hspfilter1(c,g,ft)
 	local rg=Group.FromCards(c)

--- a/c16306932.lua
+++ b/c16306932.lua
@@ -3,12 +3,7 @@ function c16306932.initial_effect(c)
 	aux.EnablePendulumAttribute(c)
 	--revive limit
 	c:EnableUnsummonable()
-	local e0=Effect.CreateEffect(c)
-	e0:SetType(EFFECT_TYPE_SINGLE)
-	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e0:SetCode(EFFECT_REVIVE_LIMIT)
-	e0:SetCondition(c16306932.rvlimit)
-	c:RegisterEffect(e0)
+	aux.EnableReviveLimitPendulumSummonable(c, LOCATION_HAND)
 	--splimit
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -75,9 +70,6 @@ function c16306932.initial_effect(c)
 	e8:SetTarget(c16306932.tdtg)
 	e8:SetOperation(c16306932.tdop)
 	c:RegisterEffect(e8)
-end
-function c16306932.rvlimit(e)
-	return not e:GetHandler():IsLocation(LOCATION_HAND)
 end
 function c16306932.psplimit(e,c,tp,sumtp,sumpos)
 	return not c:IsRace(RACE_DRAGON) and bit.band(sumtp,SUMMON_TYPE_PENDULUM)==SUMMON_TYPE_PENDULUM

--- a/c16306932.lua
+++ b/c16306932.lua
@@ -2,7 +2,6 @@
 function c16306932.initial_effect(c)
 	aux.EnablePendulumAttribute(c)
 	--revive limit
-	c:EnableUnsummonable()
 	aux.EnableReviveLimitPendulumSummonable(c, LOCATION_HAND)
 	--splimit
 	local e1=Effect.CreateEffect(c)

--- a/c16306932.lua
+++ b/c16306932.lua
@@ -2,7 +2,7 @@
 function c16306932.initial_effect(c)
 	aux.EnablePendulumAttribute(c)
 	--revive limit
-	aux.EnableReviveLimitPendulumSummonable(c, LOCATION_HAND)
+	aux.EnableReviveLimitPendulumSummonable(c,LOCATION_HAND)
 	--splimit
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c29432356.lua
+++ b/c29432356.lua
@@ -134,15 +134,7 @@ function c29432356.eftg2(e,c)
 		and rpz:GetFlagEffectLabel(31531170)==c:GetFieldID()
 end
 function c29432356.penfilter(c,e,tp,lscale,rscale)
-	local lv=0
-	if c.pendulum_level then
-		lv=c.pendulum_level
-	else
-		lv=c:GetLevel()
-	end
-	return (c:IsLocation(LOCATION_HAND) or (c:IsFaceup() and c:IsType(TYPE_PENDULUM)))
-		and lv>lscale and lv<rscale and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_PENDULUM,tp,false,false)
-		and not c:IsForbidden() and c:IsSetCard(0xc4)
+	return c:IsSetCard(0xc4) and aux.PConditionFilter(c,e,tp,lscale,rscale)
 end
 function c29432356.pencon1(e,c,og)
 	if c==nil then return true end

--- a/utility.lua
+++ b/utility.lua
@@ -1696,8 +1696,9 @@ function Auxiliary.PConditionFilter(c,e,tp,lscale,rscale)
 	else
 		lv=c:GetLevel()
 	end
+	local bool=Auxiliary.PendulumSummonableBool(c)
 	return (c:IsLocation(LOCATION_HAND) or (c:IsFaceup() and c:IsType(TYPE_PENDULUM)))
-		and lv>lscale and lv<rscale and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_PENDULUM,tp,false,false)
+		and lv>lscale and lv<rscale and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_PENDULUM,tp,bool,bool)
 		and not c:IsForbidden()
 end
 function Auxiliary.PendCondition()
@@ -1785,6 +1786,31 @@ function Auxiliary.PendOperation()
 				Duel.HintSelection(Group.FromCards(c))
 				Duel.HintSelection(Group.FromCards(rpz))
 			end
+end
+--enable revive limit for monsters that are also pendulum sumonable from certain locations (Odd-Eyes Revolution Dragon)
+function Auxiliary.EnableReviveLimitPendulumSummonable(c, loc)
+	if c:IsStatus(STATUS_COPYING_EFFECT) then return end
+	c:EnableReviveLimit()
+	local code=c:GetOriginalCode()
+	local mt=_G["c" .. code]
+	if loc==nil then loc=0xff end
+	mt.psummonable_location=loc
+	--complete procedure on pendulum summon success
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetOperation(Auxiliary.PSSCompleteProcedure)
+	c:RegisterEffect(e1)
+end
+function Auxiliary.PendulumSummonableBool(c)
+	return c.psummonable_location~=nil and c:GetLocation() & c.psummonable_location > 0
+end
+function Auxiliary.PSSCompleteProcedure(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsSummonType(SUMMON_TYPE_PENDULUM) then
+		c:CompleteProcedure()
+	end
 end
 --Link Summon
 function Auxiliary.AddLinkProcedure(c,f,min,max,gf)

--- a/utility.lua
+++ b/utility.lua
@@ -1797,7 +1797,7 @@ function Auxiliary.EnableReviveLimitPendulumSummonable(c, loc)
 	mt.psummonable_location=loc
 	--complete procedure on pendulum summon success
 	local e1=Effect.CreateEffect(c)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetOperation(Auxiliary.PSSCompleteProcedure)


### PR DESCRIPTION
"Odd-Eyes Revolution Dragon" in extra that was once pendulum summoned can be special summoned with "Super Quantal Alphan Spike", because pendulum summon is also it's regular summon method.

Reference: https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13462
■『このカードは通常召喚できない。手札からのP召喚、または自分フィールドのドラゴン族の融合・S・Xモンスターを１体ずつリリースした場合のみ特殊召喚できる』は効果の扱いではありません。特殊召喚モンスターの特殊召喚の手順となります。（**特殊召喚の手順**として、**手札からのペンデュラム召喚**、または、自分のモンスターゾーンに存在する、ドラゴン族の融合モンスター1体、ドラゴン族のシンクロモンスター1体、ドラゴン族のエクシーズモンスター1体の合計3体のモンスターをリリースして、手札から特殊召喚します。どちらの方法による特殊召喚を行う際にもチェーンブロックは作られません。）