### PR TITLE
Update c45960523.lua

### DIFF
--- a/c45960523.lua
+++ b/c45960523.lua
@@ -26,7 +26,7 @@ function c45960523.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c45960523.rmcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:IsActiveType(TYPE_MONSTER+TYPE_PENDULUM) and re:GetHandler():IsSetCard(0x105)
+	return re and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
 end
 function c45960523.rmfilter(c)
 	return c:IsSummonType(SUMMON_TYPE_SPECIAL) and c:IsAbleToRemove() and c:IsFaceup()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13626&keyword=&tag=-1

「メタファイズ・デコイドラゴン」のモンスター効果によって特殊召喚された「メタファイズ・ダイダロス」は、「メタファイズ」と名のついたモンスターの効果によって特殊召喚されていますので、『このカード以外のフィールドの特殊召喚された表側表示モンスターを全て除外する』モンスター効果を発動する事はできます。
また、「メタファイズ・デコイドラゴン」のペンデュラム効果によって特殊召喚された「メタファイズ・ダイダロス」は、「メタファイズ」と名のついたモンスターの効果によって特殊召喚されていませんので、『このカード以外のフィールドの特殊召喚された表側表示モンスターを全て除外する』モンスター効果を発動する事は**できません**。

lol