### PR TITLE
Better Nirvana check

### DIFF
--- a/c80896940.lua
+++ b/c80896940.lua
@@ -124,7 +124,7 @@ function c80896940.thop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c80896940.mfilter(c)
-	return c:IsType(TYPE_PENDULUM) and c:IsSummonType(SUMMON_TYPE_PENDULUM) and c:IsType(TYPE_TUNER)
+	return c:IsType(TYPE_PENDULUM) and c:IsSummonType(SUMMON_TYPE_PENDULUM)
 end
 function c80896940.valcheck(e,c)
 	local g=c:GetMaterial()

--- a/c80896940.lua
+++ b/c80896940.lua
@@ -66,8 +66,7 @@ function c80896940.initial_effect(c)
 	c:RegisterEffect(e7)
 end
 function c80896940.matfilter1(c)
-	return c:IsType(TYPE_TUNER)
-		or (c:IsType(TYPE_PENDULUM) and c:IsSummonType(SUMMON_TYPE_PENDULUM) and c:IsNotTuner())
+	return c:IsType(TYPE_TUNER) or (c:IsType(TYPE_PENDULUM) and c:IsSummonType(SUMMON_TYPE_PENDULUM))
 end
 function c80896940.indcon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()

--- a/c80896940.lua
+++ b/c80896940.lua
@@ -128,11 +128,17 @@ function c80896940.mfilter(c)
 end
 function c80896940.valcheck(e,c)
 	local g=c:GetMaterial()
-	if c:GetFlagEffect(80896940)~=0 or g:IsExists(c80896940.mfilter,1,nil) then
-		e:GetLabelObject():SetLabel(1)
-	else
-		e:GetLabelObject():SetLabel(0)
+	local tg=g:Filter(c80896940.mfilter,nil)
+	for tc in aux.Next(tg) do
+		g:RemoveCard(tc)
+		local flag=g:FilterCount(aux.NonTuner(Card.IsType,TYPE_SYNCHRO),nil)==g:GetCount()
+		g:AddCard(tc)
+		if flag then
+			e:GetLabelObject():SetLabel(1)
+			return
+		end
 	end
+	e:GetLabelObject():SetLabel(0)
 end
 function c80896940.lpop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SetLP(1-tp,math.ceil(Duel.GetLP(1-tp)/2))

--- a/utility.lua
+++ b/utility.lua
@@ -425,9 +425,6 @@ end
 function Auxiliary.SynMixOperation(f1,f2,f3,f4,minct,maxc)
 	return	function(e,tp,eg,ep,ev,re,r,rp,c,smat,mg)
 				local g=e:GetLabelObject()
-				if not g:IsExists(Card.IsType,1,nil,TYPE_TUNER) and c:IsHasEffect(80896940) then
-					c:RegisterFlagEffect(80896940,RESET_EVENT+0x1fe0000,0,1)
-				end
 				c:SetMaterial(g)
 				Duel.SendtoGrave(g,REASON_MATERIAL+REASON_SYNCHRO)
 				g:DeleteGroup()


### PR DESCRIPTION
Procedure:
1. Use the effect of "Hundred Eyes Dragon" to copy "Phantom King Hydride" in my graveyard.
2. Pendulum summon "Double Resonator" and "Metalfoes Steelen".
3. Use the effect of "Double Resonator" to turn "Hundred Eyes Dragon" into tuner.
4. Use "Metalfoes Steelen" and "Hundred Eyes Dragon" to synchro summon "Nirvana High Paladin".

Issue:
In this situation, there is at least one tuner has been chosen for synchro material, so "Nirvana High Paladin" won't get that flag effect. Also, there is no pendulum summoned pendulum-tuners has been chosen for synchro material, so "Nirvana High Paladin" won't have it's label set to 1. Afterall, "Nirvana High Paladin" will strangely unable to salvage card.

After:
"Metalfoes Steelen" is a pendulum sommoned pendulum monster. Each of the other synchro material(s) is a synchro monster that can be used as a non-tuner synchro material. In this situation, "Nirvana High Paladin" will be able to salvage anyway.