### PR TITLE
fix Metaphys Ragnarok and so on

### DIFF
--- a/c19476824.lua
+++ b/c19476824.lua
@@ -34,6 +34,7 @@ end
 function c19476824.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetDecktopGroup(tp,3)
+	Duel.DisableShuffleCheck()
 	if g:GetCount()>0 and Duel.Remove(g,POS_FACEUP,REASON_EFFECT)~=0
 		and c:IsFaceup() and c:IsRelateToEffect(e) then
 		local og=Duel.GetOperatedGroup()

--- a/c19476824.lua
+++ b/c19476824.lua
@@ -34,8 +34,9 @@ end
 function c19476824.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetDecktopGroup(tp,3)
+	if #g<=0 then return end
 	Duel.DisableShuffleCheck()
-	if g:GetCount()>0 and Duel.Remove(g,POS_FACEUP,REASON_EFFECT)~=0
+	if Duel.Remove(g,POS_FACEUP,REASON_EFFECT)~=0
 		and c:IsFaceup() and c:IsRelateToEffect(e) then
 		local og=Duel.GetOperatedGroup()
 		local oc=og:FilterCount(Card.IsSetCard,nil,0x105)

--- a/c24037702.lua
+++ b/c24037702.lua
@@ -32,6 +32,7 @@ function c24037702.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.BreakEffect()
 		local ol=tc:GetOriginalLevel()
 		local rg=Duel.GetDecktopGroup(tp,ol)
+		Duel.DisableShuffleCheck()
 		Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	end
 end

--- a/c60431417.lua
+++ b/c60431417.lua
@@ -67,6 +67,7 @@ function c60431417.thop(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 then
 		Duel.BreakEffect()
 		local rg=Duel.GetDecktopGroup(tp,4)
+		Duel.DisableShuffleCheck()
 		Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix this: If player use "banish the top N cards of your Deck" effect, player's deck shuffle.