### PR TITLE
update level/rank/link functions

### DIFF
--- a/c10026986.lua
+++ b/c10026986.lua
@@ -29,7 +29,7 @@ function c10026986.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c10026986.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c10026986.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c10026986.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c1003028.lua
+++ b/c1003028.lua
@@ -18,7 +18,7 @@ function c1003028.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c1003028.cfilter(c)
-	return c:IsFaceup() and c:GetLevel()~=4
+	return c:IsFaceup() and not c:IsLevel(4)
 end
 function c1003028.spcon(e,c)
 	if c==nil then return true end

--- a/c1003840.lua
+++ b/c1003840.lua
@@ -36,7 +36,7 @@ function c1003840.cfilter(c,e,tp,ft)
 		and Duel.IsExistingMatchingCard(c1003840.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp,lv)
 end
 function c1003840.spfilter(c,e,tp,lv)
-	return c:IsSetCard(0x1017) and c:GetLevel()~=lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x1017) and not c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c1003840.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c10060427.lua
+++ b/c10060427.lua
@@ -81,7 +81,7 @@ function c10060427.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c10060427.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c10060427.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c10060427.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c1006081.lua
+++ b/c1006081.lua
@@ -24,7 +24,7 @@ function c1006081.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c1006081.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	local op=0
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
-	if g:GetFirst():GetLevel()==1 then
+	if g:GetFirst():IsLevel(1) then
 		op=Duel.SelectOption(tp,aux.Stringid(1006081,1))
 	else
 		op=Duel.SelectOption(tp,aux.Stringid(1006081,1),aux.Stringid(1006081,2))

--- a/c10239627.lua
+++ b/c10239627.lua
@@ -67,7 +67,7 @@ function c10239627.thop1(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c10239627.thfilter2(c)
-	return c:IsRace(RACE_SPELLCASTER) and c:GetLevel()==1 and c:IsAbleToHand()
+	return c:IsRace(RACE_SPELLCASTER) and c:IsLevel(1) and c:IsAbleToHand()
 end
 function c10239627.thtg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c10239627.thfilter2,tp,LOCATION_DECK,0,1,nil) end

--- a/c10441498.lua
+++ b/c10441498.lua
@@ -29,7 +29,7 @@ function c10441498.cfilter(c,tp)
 	return c:IsLevelAbove(1) and not c:IsPublic() and Duel.IsExistingTarget(c10441498.lvfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,c:GetLevel())
 end
 function c10441498.lvfilter(c,lv)
-	return c:IsFaceup() and c:IsLevelAbove(1) and c:GetLevel()~=lv
+	return c:IsFaceup() and c:IsLevelAbove(1) and not c:IsLevel(lv)
 end
 function c10441498.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c10441498.lvfilter(chkc,e:GetLabel()) end

--- a/c10591919.lua
+++ b/c10591919.lua
@@ -22,7 +22,7 @@ function c10591919.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c10591919.filter(c,e,tp)
-	return c:IsSetCard(0x26) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x26) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c10591919.cona(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsDisabled() and e:GetHandler():IsAttackPos()

--- a/c10736540.lua
+++ b/c10736540.lua
@@ -60,7 +60,7 @@ function c10736540.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c10736540.spfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x107a) and c:GetLevel()==5
+	return c:IsFaceup() and c:IsSetCard(0x107a) and c:IsLevel(5)
 end
 function c10736540.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c10736540.spfilter(chkc) end
@@ -73,7 +73,7 @@ function c10736540.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c10736540.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsImmuneToEffect(e) or tc:GetLevel()<2 then return end
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsImmuneToEffect(e) or tc:IsLevel(1) then return end
 	local c=e:GetHandler()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c10753491.lua
+++ b/c10753491.lua
@@ -55,7 +55,7 @@ function c10753491.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsPreviousLocation(LOCATION_DECK) and c:IsReason(REASON_REVEAL)
 end
 function c10753491.filter(c,e,tp)
-	return c:GetLevel()==1 and c:IsRace(RACE_PLANT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(1) and c:IsRace(RACE_PLANT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c10753491.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c10802915.lua
+++ b/c10802915.lua
@@ -11,7 +11,7 @@ function c10802915.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c10802915.filter(c,e,tp)
-	return c:GetLevel()==3 and c:IsRace(RACE_FIEND) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsRace(RACE_FIEND) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c10802915.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c10971759.lua
+++ b/c10971759.lua
@@ -23,7 +23,7 @@ function c10971759.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c10971759.spfilter(c,e,tp)
-	return c:GetLevel()==3 and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c10971759.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c10971759.spfilter(chkc,e,tp) end
@@ -67,7 +67,7 @@ function c10971759.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c10971759.filter(c)
-	return c:IsFaceup() and c:GetLevel()==3 and c:IsRace(RACE_INSECT)
+	return c:IsFaceup() and c:IsLevel(3) and c:IsRace(RACE_INSECT)
 end
 function c10971759.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c10971759.filter,tp,LOCATION_MZONE,0,1,nil) end

--- a/c11047543.lua
+++ b/c11047543.lua
@@ -21,7 +21,7 @@ function c11047543.filter2(c,e,tp,lv)
 		and Duel.IsExistingMatchingCard(c11047543.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,lv+clv)
 end
 function c11047543.spfilter(c,e,tp,lv)
-	return c:IsRace(RACE_PSYCHO) and c:IsType(TYPE_SYNCHRO) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsRace(RACE_PSYCHO) and c:IsType(TYPE_SYNCHRO) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c11047543.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/c11109820.lua
+++ b/c11109820.lua
@@ -21,8 +21,7 @@ function c11109820.filter2(c,e,tp,mc,rk)
 		and Duel.GetLocationCountFromEx(tp,tp,Group.FromCards(c,mc))>0
 end
 function c11109820.spfilter(c,e,tp,rk)
-	local crk=c:GetRank()
-	return (crk==rk or crk==rk-1) and not c:IsSetCard(0x48) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return (c:IsRank(rk) or c:IsRank(rk-1)) and not c:IsSetCard(0x48) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c11109820.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/c11228035.lua
+++ b/c11228035.lua
@@ -15,15 +15,12 @@ end
 function c11228035.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
-function c11228035.filter(c)
-	return c:IsType(TYPE_XYZ)
-end
 function c11228035.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and c11228035.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c11228035.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsType(TYPE_XYZ) end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsType,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,TYPE_XYZ)
 		and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c11228035.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil)
+	Duel.SelectTarget(tp,Card.IsType,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,TYPE_XYZ)
 end
 function c11228035.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c11613567.lua
+++ b/c11613567.lua
@@ -24,7 +24,7 @@ function c11613567.ntfilter(c)
 end
 function c11613567.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c11613567.ntfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end
 function c11613567.filter(c)

--- a/c123709.lua
+++ b/c123709.lua
@@ -23,7 +23,7 @@ function c123709.initial_effect(c)
 end
 function c123709.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c123709.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--to grave

--- a/c12533811.lua
+++ b/c12533811.lua
@@ -23,7 +23,7 @@ function c12533811.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c12533811.filter(c)
-	return c:IsFaceup() and c:GetLevel()==1 and c:GetEffectCount(EFFECT_DIRECT_ATTACK)==0
+	return c:IsFaceup() and c:IsLevel(1) and c:GetEffectCount(EFFECT_DIRECT_ATTACK)==0
 end
 function c12533811.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c12533811.filter(chkc) end

--- a/c12948099.lua
+++ b/c12948099.lua
@@ -37,7 +37,7 @@ function c12948099.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
 end
 function c12948099.filter(c)
-	return c:IsType(TYPE_XYZ) and c:GetRank()==4 and c:IsAbleToExtra()
+	return c:IsType(TYPE_XYZ) and c:IsRank(4) and c:IsAbleToExtra()
 end
 function c12948099.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c12948099.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end

--- a/c13073850.lua
+++ b/c13073850.lua
@@ -75,7 +75,7 @@ function c13073850.splimit(e,c)
 end
 function c13073850.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c13073850.lvcon(e)
 	return e:GetHandler():GetMaterialCount()==0

--- a/c13536606.lua
+++ b/c13536606.lua
@@ -30,10 +30,10 @@ function c13536606.atkval(e,c)
 	return c:GetMutualLinkedGroupCount()*300
 end
 function c13536606.rfilter(c,tp,g)
-	local lk=c:GetLink()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	return c:IsFaceup() and c:IsType(TYPE_LINK) and c:IsLinkBelow(3) and c:IsReleasableByEffect() and g:IsContains(c)
-		and ft>=lk and (ft==1 or not Duel.IsPlayerAffectedByEffect(tp,59822133))
+	local lk=math.min(3,ft)
+	return c:IsFaceup() and c:IsType(TYPE_LINK) and c:IsLinkBelow(lk) and c:IsReleasableByEffect() and g:IsContains(c)
+		and (ft==1 or not Duel.IsPlayerAffectedByEffect(tp,59822133))
 end
 function c13536606.tktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
@@ -71,5 +71,5 @@ function c13536606.tkop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c13536606.splimit(e,c,sump,sumtype,sumpos,targetp,se)
-	return c:GetLink()==e:GetLabel()
+	return c:IsLink(e:GetLabel())
 end

--- a/c14198496.lua
+++ b/c14198496.lua
@@ -25,7 +25,7 @@ function c14198496.operation(e,tp,eg,ep,ev,re,r,rp)
 	if ct==0 then return end
 	local dc=Duel.GetOperatedGroup():GetFirst()
 	Duel.ConfirmCards(1-tp,dc)
-	if dc:GetLevel()==1 then
+	if dc:IsLevel(1) then
 		Duel.BreakEffect()
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end

--- a/c14506878.lua
+++ b/c14506878.lua
@@ -11,7 +11,7 @@ function c14506878.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c14506878.filter(c)
-	return c:GetLevel()==4 and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsAbleToHand()
 end
 function c14506878.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c14506878.filter(chkc) end

--- a/c14536035.lua
+++ b/c14536035.lua
@@ -23,7 +23,7 @@ function c14536035.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c14536035.spfilter(c)
-	return c:GetLevel()>=5 and c:IsAttribute(ATTRIBUTE_DARK)
+	return c:IsLevelAbove(5) and c:IsAttribute(ATTRIBUTE_DARK)
 end
 function c14536035.spcon(e,c)
 	if c==nil then return true end

--- a/c14882493.lua
+++ b/c14882493.lua
@@ -30,7 +30,7 @@ function c14882493.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c14882493.filter(c)
-	return c:GetLevel()==4 and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToHand()
 end
 function c14882493.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c14882493.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c14943837.lua
+++ b/c14943837.lua
@@ -29,7 +29,7 @@ function c14943837.synlimit(e,c)
 	return not c:IsRace(RACE_DRAGON)
 end
 function c14943837.synlimit2(e,c)
-	return c:GetLevel()~=4
+	return not c:IsLevel(4)
 end
 function c14943837.filter2(c,e,sp)
 	return c:IsAttackBelow(500) and c:IsCanBeSpecialSummoned(e,0,sp,false,false)

--- a/c15066114.lua
+++ b/c15066114.lua
@@ -28,7 +28,7 @@ function c15066114.initial_effect(c)
 end
 function c15066114.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c15066114.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	local e1=Effect.CreateEffect(c)

--- a/c15327215.lua
+++ b/c15327215.lua
@@ -44,7 +44,7 @@ function c15327215.spop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c15327215.filter(c,mc)
 	return c:IsLevelBelow(4) and c:IsSetCard(0x3d) and c:IsAbleToRemoveAsCost()
-		and not (c:GetLevel()==mc:GetLevel() and c:IsAttribute(mc:GetAttribute()) and c:GetAttack()==mc:GetAttack() and c:GetDefense()==mc:GetDefense())
+		and not (c:IsLevel(mc:GetLevel()) and c:IsAttribute(mc:GetAttribute()) and c:GetAttack()==mc:GetAttack() and c:GetDefense()==mc:GetDefense())
 end
 function c15327215.cost(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingMatchingCard(c15327215.filter,tp,LOCATION_GRAVE,0,1,nil,e:GetHandler()) end

--- a/c1533292.lua
+++ b/c1533292.lua
@@ -11,7 +11,7 @@ function c1533292.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c1533292.filter(c)
-	return c:GetLevel()==2 and c:IsSetCard(0x1002) and c:IsAbleToHand()
+	return c:IsLevel(2) and c:IsSetCard(0x1002) and c:IsAbleToHand()
 end
 function c1533292.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c1533292.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c15502037.lua
+++ b/c15502037.lua
@@ -52,7 +52,7 @@ function c15502037.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c15502037.spfilter(c,e,tp)
-	return c:IsSetCard(0x2066) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x2066) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c15502037.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1

--- a/c15545291.lua
+++ b/c15545291.lua
@@ -37,7 +37,7 @@ end
 function c15545291.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c15545291.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c15545291.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c15545291.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c15555120.lua
+++ b/c15555120.lua
@@ -23,8 +23,7 @@ function c15555120.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(g:GetFirst():GetLevel())
 end
 function c15555120.filter(c,lv)
-	local clv=c:GetLevel()
-	return c:IsFaceup() and clv>0 and clv~=lv and c:IsType(TYPE_SYNCHRO)
+	return c:IsFaceup() and not c:IsLevel(lv) and c:IsType(TYPE_SYNCHRO)
 end
 function c15555120.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c15555120.filter(chkc,e:GetLabel()) end
@@ -35,7 +34,7 @@ end
 function c15555120.activate(e,tp,eg,ep,ev,re,r,rp)
 	local lv=e:GetLabel()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetLevel()~=lv then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and not tc:IsLevel(lv) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)

--- a/c15576074.lua
+++ b/c15576074.lua
@@ -14,7 +14,7 @@ function c15576074.filter(c)
 	return c:IsSetCard(0x57) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
 end
 function c15576074.filter2(c)
-	return c:GetLevel()==4 and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsAbleToHand()
 end
 function c15576074.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c15576074.filter(chkc) end

--- a/c15605085.lua
+++ b/c15605085.lua
@@ -30,7 +30,7 @@ function c15605085.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c15605085.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c15605085.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c15605085.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c15871676.lua
+++ b/c15871676.lua
@@ -11,7 +11,7 @@ function c15871676.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c15871676.filter(c,e,tp)
-	return c:IsSetCard(0x53) and c:GetLevel()==3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x53) and c:IsLevel(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c15871676.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c16024176.lua
+++ b/c16024176.lua
@@ -32,7 +32,7 @@ function c16024176.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c16024176.hspfilter(c,ft,tp)
-	return c:IsSetCard(0xe6) and c:GetLevel()==1 and not c:IsCode(16024176)
+	return c:IsSetCard(0xe6) and c:IsLevel(1) and not c:IsCode(16024176)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5)) and (c:IsControler(tp) or c:IsFaceup())
 end
 function c16024176.hspcon(e,c)

--- a/c16135253.lua
+++ b/c16135253.lua
@@ -15,7 +15,7 @@ function c16135253.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c16135253.filter(c,e,tp,lv)
-	if (lv~=6 and c:GetLevel()~=lv) or (lv==6 and c:GetLevel()<6) then return false end
+	if (lv~=6 and not c:IsLevel(lv)) or (lv==6 and c:IsLevelBelow(5)) then return false end
 	return c:IsRace(RACE_FAIRY) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c16135253.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c16259549.lua
+++ b/c16259549.lua
@@ -70,7 +70,7 @@ function c16259549.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c16259549.filter(c,e)
-	return c:GetLevel()==3 and c:IsCanBeEffectTarget(e) and c:IsAbleToDeck()
+	return c:IsLevel(3) and c:IsCanBeEffectTarget(e) and c:IsAbleToDeck()
 end
 function c16259549.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c16259549.filter(chkc,e) end

--- a/c16494704.lua
+++ b/c16494704.lua
@@ -11,7 +11,7 @@ function c16494704.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c16494704.exfilter0(c)
-	return c:IsSetCard(0x99) and c:GetLevel()>=1 and c:IsAbleToGrave()
+	return c:IsSetCard(0x99) and c:IsLevelAbove(1) and c:IsAbleToGrave()
 end
 function c16494704.filter(c,e,tp,m,ft)
 	if not c:IsRace(RACE_DRAGON) or bit.band(c:GetType(),0x81)~=0x81

--- a/c16589042.lua
+++ b/c16589042.lua
@@ -11,6 +11,6 @@ function c16589042.initial_effect(c)
 end
 function c16589042.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_HAND,0)==1
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_HAND,0)==1
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end

--- a/c1662004.lua
+++ b/c1662004.lua
@@ -24,7 +24,7 @@ function c1662004.synlimit(e,c)
 	return not c:IsRace(RACE_BEASTWARRIOR)
 end
 function c1662004.spfilter(c,e,tp)
-	return c:IsDefenseBelow(200) and c:IsAttribute(ATTRIBUTE_FIRE) and c:GetLevel()==3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsDefenseBelow(200) and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsLevel(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c1662004.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c1662004.spfilter(chkc,e,tp) end 

--- a/c16802689.lua
+++ b/c16802689.lua
@@ -31,7 +31,7 @@ function c16802689.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c16802689.hspfilter(c,ft,tp)
-	return c:IsSetCard(0xe6) and c:GetLevel()==12 and not c:IsCode(16802689)
+	return c:IsSetCard(0xe6) and c:IsLevel(12) and not c:IsCode(16802689)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5)) and (c:IsControler(tp) or c:IsFaceup())
 end
 function c16802689.hspcon(e,c)

--- a/c1686814.lua
+++ b/c1686814.lua
@@ -42,7 +42,7 @@ function c1686814.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c1686814.sprfilter(c)
-	return c:IsFaceup() and c:GetLevel()>4 and c:IsAbleToGraveAsCost()
+	return c:IsFaceup() and c:IsLevelAbove(5) and c:IsAbleToGraveAsCost()
 end
 function c1686814.sprfilter1(c,tp,g,sc)
 	local lv=c:GetLevel()
@@ -50,7 +50,7 @@ function c1686814.sprfilter1(c,tp,g,sc)
 end
 function c1686814.sprfilter2(c,tp,mc,sc,lv)
 	local sg=Group.FromCards(c,mc)
-	return c:GetLevel()==lv and not c:IsType(TYPE_TUNER)
+	return c:IsLevel(lv) and not c:IsType(TYPE_TUNER)
 		and Duel.GetLocationCountFromEx(tp,tp,sg,sc)>0
 end
 function c1686814.sprcon(e,c)
@@ -73,7 +73,7 @@ function c1686814.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(Card.IsControler,1,nil,tp)
 end
 function c1686814.spfilter(c,e,tp)
-	return (c:IsSetCard(0xc2) or ((c:GetLevel()==7 or c:GetLevel()==8) and c:IsRace(RACE_DRAGON)))
+	return (c:IsSetCard(0xc2) or ((c:IsLevel(7) or c:IsLevel(8)) and c:IsRace(RACE_DRAGON)))
 		and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c1686814.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c16960351.lua
+++ b/c16960351.lua
@@ -24,7 +24,7 @@ function c16960351.rfilter(c,e,tp,ft)
 		and Duel.IsExistingMatchingCard(c16960351.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp,lv)
 end
 function c16960351.spfilter(c,e,tp,lv)
-	return c:GetLevel()==lv and c:IsRace(RACE_WYRM) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsRace(RACE_WYRM) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c16960351.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c17086528.lua
+++ b/c17086528.lua
@@ -44,7 +44,7 @@ function c17086528.rkfilter(c,tp)
 		and Duel.IsExistingTarget(c17086528.lvfilter,tp,LOCATION_MZONE,0,1,c,c:GetRank())
 end
 function c17086528.lvfilter(c,rk)
-	return c:IsFaceup() and c:IsLevelAbove(5) and c:GetLevel()~=rk
+	return c:IsFaceup() and c:IsLevelAbove(5) and not c:IsLevel(rk)
 end
 function c17086528.rktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/c17530001.lua
+++ b/c17530001.lua
@@ -34,5 +34,5 @@ function c17530001.operation(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c17530001.tglimit(e,c)
-	return c:GetLevel()==e:GetLabel()
+	return c:IsLevel(e:GetLabel())
 end

--- a/c17643265.lua
+++ b/c17643265.lua
@@ -16,7 +16,7 @@ function c17643265.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c17643265.filter(c)
-	return c:IsFaceup() and c:GetLevel()==4 and c:IsRace(RACE_FISH)
+	return c:IsFaceup() and c:IsLevel(4) and c:IsRace(RACE_FISH)
 end
 function c17643265.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c17643265.filter,tp,LOCATION_MZONE,0,1,nil) end

--- a/c18063928.lua
+++ b/c18063928.lua
@@ -11,7 +11,7 @@ function c18063928.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c18063928.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c18063928.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c18210764.lua
+++ b/c18210764.lua
@@ -65,7 +65,7 @@ function c18210764.teop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c18210764.spfilter(c,e,tp)
-	return c:IsFaceup() and c:IsType(TYPE_PENDULUM) and c:GetLevel()==1
+	return c:IsFaceup() and c:IsType(TYPE_PENDULUM) and c:IsLevel(1)
 		and not c:IsCode(18210764) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c18210764.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c18322364.lua
+++ b/c18322364.lua
@@ -20,7 +20,7 @@ function c18322364.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c18322364.spfilter(c,e,tp)
-	return c:GetLevel()==3 and c:IsAttribute(ATTRIBUTE_WATER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsAttribute(ATTRIBUTE_WATER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c18322364.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)

--- a/c18326736.lua
+++ b/c18326736.lua
@@ -42,13 +42,13 @@ function c18326736.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	c:RegisterFlagEffect(18326736,RESET_CHAIN,0,1)
 end
 function c18326736.filter(c,e,tp,rk)
-	return c:GetRank()==rk+1 and not c:IsSetCard(0x48) and e:GetHandler():IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and not c:IsSetCard(0x48) and e:GetHandler():IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c18326736.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCountFromEx(tp,tp,e:GetHandler())>0
 		and aux.MustMaterialCheck(e:GetHandler(),tp,EFFECT_MUST_BE_XMATERIAL)
-		and Duel.IsExistingMatchingCard(c18326736.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,e:GetHandler():GetRank()) end
+		and Duel.IsExistingMatchingCard(c18326736.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,e:GetHandler():GetRank()+1) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c18326736.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -56,7 +56,7 @@ function c18326736.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCountFromEx(tp,tp,c)<=0 or not aux.MustMaterialCheck(c,tp,EFFECT_MUST_BE_XMATERIAL) then return end
 	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsControler(1-tp) or c:IsImmuneToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c18326736.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,c:GetRank())
+	local g=Duel.SelectMatchingCard(tp,c18326736.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,c:GetRank()+1)
 	local sc=g:GetFirst()
 	if sc then
 		local mg=c:GetOverlayGroup()

--- a/c1834753.lua
+++ b/c1834753.lua
@@ -25,7 +25,7 @@ function c1834753.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,2000)
 end
 function c1834753.filter(c,e,tp)
-	return c:GetLevel()==3 and c:IsRace(RACE_PSYCHO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsRace(RACE_PSYCHO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c1834753.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)

--- a/c1845204.lua
+++ b/c1845204.lua
@@ -16,7 +16,7 @@ function c1845204.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,1000)
 end
 function c1845204.filter(c,e,tp)
-	return c:IsType(TYPE_FUSION) and c:GetLevel()<=5
+	return c:IsType(TYPE_FUSION) and c:IsLevelBelow(5)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial()
 end
 function c1845204.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c18634367.lua
+++ b/c18634367.lua
@@ -55,7 +55,7 @@ function c18634367.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.IsExistingMatchingCard(c18634367.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
 end
 function c18634367.filter(c,e,tp)
-	return c:GetLevel()==1 and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(1) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c18634367.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c18634367.filter(chkc,e,tp) end

--- a/c18809562.lua
+++ b/c18809562.lua
@@ -10,7 +10,7 @@ function c18809562.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c18809562.filter(c)
-	return (c:GetLevel()==7 or c:GetLevel()==8) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
+	return (c:IsLevel(7) or c:IsLevel(8)) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
 end
 function c18809562.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_HAND,0,1,e:GetHandler(),TYPE_SPELL)

--- a/c18842395.lua
+++ b/c18842395.lua
@@ -11,6 +11,6 @@ function c18842395.initial_effect(c)
 end
 function c18842395.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)>=2
 end

--- a/c18993198.lua
+++ b/c18993198.lua
@@ -32,7 +32,7 @@ function c18993198.spop(e,tp,eg,ep,ev,re,r,rp,chk)
 		local tg=Duel.GetMatchingGroup(c18993198.lvfilter,tp,LOCATION_MZONE,0,nil)
 		local tc=tg:GetFirst()
 		while tc do
-			if tc:GetLevel()~=lv then
+			if not tc:IsLevel(lv) then
 				local e1=Effect.CreateEffect(e:GetHandler())
 				e1:SetType(EFFECT_TYPE_SINGLE)
 				e1:SetCode(EFFECT_CHANGE_LEVEL_FINAL)

--- a/c19012345.lua
+++ b/c19012345.lua
@@ -10,7 +10,7 @@ function c19012345.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c19012345.condition(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp and e:GetHandler():GetLevel()<12
+	return ep~=tp and e:GetHandler():IsLevelBelow(11)
 end
 function c19012345.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c19353570.lua
+++ b/c19353570.lua
@@ -20,7 +20,7 @@ function c19353570.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c19353570.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return rp==tp and eg:GetFirst():GetLevel()==3
+	return rp==tp and eg:GetFirst():IsLevel(3)
 end
 function c19353570.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c19462747.lua
+++ b/c19462747.lua
@@ -42,7 +42,7 @@ function c19462747.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c19462747.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	local op=0
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
-	if g:GetFirst():GetLevel()==1 then
+	if g:GetFirst():IsLevel(1) then
 		op=Duel.SelectOption(tp,aux.Stringid(19462747,1))
 	else
 		op=Duel.SelectOption(tp,aux.Stringid(19462747,1),aux.Stringid(19462747,2))

--- a/c1969506.lua
+++ b/c1969506.lua
@@ -27,7 +27,7 @@ function c1969506.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c1969506.filter(c,e,tp)
-	return c:IsSetCard(0x83) and c:GetLevel()==8 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x83) and c:IsLevel(8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c1969506.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c1969506.filter(chkc,e,tp) end

--- a/c19801646.lua
+++ b/c19801646.lua
@@ -41,7 +41,7 @@ function c19801646.thcon(e,tp,eg,ep,ev,re,r,rp)
 		and c:IsPreviousPosition(POS_FACEUP) and not c:IsLocation(LOCATION_DECK)
 end
 function c19801646.thfilter(c)
-	return c:GetLevel()==7 and c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToHand()
+	return c:IsLevel(7) and c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToHand()
 end
 function c19801646.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c19801646.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c20003527.lua
+++ b/c20003527.lua
@@ -61,7 +61,7 @@ function c20003527.sumcon(e,c,minc)
 	if minc>=1 then min=minc end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c20003527.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>4 and Duel.CheckTribute(c,min,10,mg)
+	return c:IsLevelAbove(5) and Duel.CheckTribute(c,min,10,mg)
 end
 function c20003527.sumop(e,tp,eg,ep,ev,re,r,rp,c,minc)
 	local min=1

--- a/c20032555.lua
+++ b/c20032555.lua
@@ -17,7 +17,7 @@ function c20032555.efftg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c20032555.cfilter,tp,LOCATION_HAND,0,1,nil) end
 	Duel.DiscardHand(tp,c20032555.cfilter,1,1,REASON_COST+REASON_DISCARD)
 	local opt=0
-	if e:GetHandler():GetLevel()==8 then
+	if e:GetHandler():IsLevel(8) then
 		opt=Duel.SelectOption(tp,aux.Stringid(20032555,1))
 	else
 		opt=Duel.SelectOption(tp,aux.Stringid(20032555,1),aux.Stringid(20032555,2))

--- a/c20474741.lua
+++ b/c20474741.lua
@@ -11,7 +11,7 @@ function c20474741.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c20474741.filter(c,e,tp)
-	return c:GetLevel()==3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c20474741.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c20802187.lua
+++ b/c20802187.lua
@@ -31,7 +31,7 @@ function c20802187.xyzfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ)
 end
 function c20802187.matfilter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4 and not c:IsType(TYPE_TOKEN)
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4) and not c:IsType(TYPE_TOKEN)
 end
 function c20802187.mattg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c20802187.xyzfilter(chkc) end
@@ -55,7 +55,7 @@ function c20802187.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c20802187.thfilter(c,e)
-	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4 and c:IsCanBeEffectTarget(e)
+	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4) and c:IsCanBeEffectTarget(e)
 end
 function c20802187.thfilter2(c,g)
 	return g:IsExists(Card.IsCode,1,c,c:GetCode())

--- a/c2084239.lua
+++ b/c2084239.lua
@@ -16,6 +16,5 @@ function c2084239.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c2084239.tg(e,c)
-	local lv=c:GetLevel()
-	return lv>0 and lv<=2 and c:IsAttribute(ATTRIBUTE_WATER) and c:IsRace(RACE_AQUA)
+	return c:IsLevelBelow(2) and c:IsAttribute(ATTRIBUTE_WATER) and c:IsRace(RACE_AQUA)
 end

--- a/c21105106.lua
+++ b/c21105106.lua
@@ -111,10 +111,7 @@ function c21105106.ritfilter2(c,lv,mg)
 	if lv<1 then return false end
 	local mg2=mg:Clone()
 	mg2:Remove(Card.IsRace,nil,c:GetRace())
-	return mg2:IsExists(c21105106.ritfilter3,1,nil,lv)
-end
-function c21105106.ritfilter3(c,lv)
-	return c:GetLevel()==lv
+	return mg2:IsExists(Card.IsLevel,1,nil,lv)
 end
 function c21105106.ritual_custom_operation(c,mg)
 	local tp=c:GetControler()
@@ -131,7 +128,7 @@ function c21105106.ritual_custom_operation(c,mg)
 	lv=lv-tc2:GetLevel()
 	g:Remove(Card.IsRace,nil,tc2:GetRace())
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-	local g3=g:FilterSelect(tp,c21105106.ritfilter3,1,1,nil,lv)
+	local g3=g:FilterSelect(tp,Card.IsLevel,1,1,nil,lv)
 	g1:Merge(g2)
 	g1:Merge(g3)
 	c:SetMaterial(g1)

--- a/c21390858.lua
+++ b/c21390858.lua
@@ -50,8 +50,7 @@ function c21390858.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	c:RegisterEffect(e1)
 end
 function c21390858.tfilter(c)
-	local lv=c:GetLevel()
-	return (lv==3 or lv==4) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_SPELLCASTER) and c:IsAbleToHand()
+	return (c:IsLevel(3) or c:IsLevel(4)) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_SPELLCASTER) and c:IsAbleToHand()
 end
 function c21390858.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL+1

--- a/c21524779.lua
+++ b/c21524779.lua
@@ -12,7 +12,7 @@ function c21524779.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c21524779.filter(c)
-	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4
+	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4)
 		and c:GetCode()~=21524779 and c:IsSummonable(true,nil)
 end
 function c21524779.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c21620076.lua
+++ b/c21620076.lua
@@ -21,8 +21,7 @@ function c21620076.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c21620076.lvfilter(c)
-	local lv=c:GetLevel()
-	return c:IsFaceup() and c:IsRace(RACE_ZOMBIE) and lv>0 and lv~=2
+	return c:IsFaceup() and c:IsRace(RACE_ZOMBIE) and not c:IsLevel(2)
 end
 function c21620076.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c21620076.lvfilter(chkc) end

--- a/c22138839.lua
+++ b/c22138839.lua
@@ -41,7 +41,7 @@ function c22138839.cop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:GetFirst()
 	while tc do
 		tc:AddCounter(0x1041,1)
-		if tc:GetLevel()>1 then
+		if tc:IsLevelAbove(2) then
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_CHANGE_LEVEL)

--- a/c22227683.lua
+++ b/c22227683.lua
@@ -65,7 +65,7 @@ function c22227683.spfilter1(c,e,tp)
 		and Duel.IsExistingMatchingCard(c22227683.spfilter2,tp,LOCATION_GRAVE+LOCATION_HAND,0,1,c,e,tp,c:GetLevel())
 end
 function c22227683.spfilter2(c,e,tp,lv)
-	return c:IsSetCard(0xab) and c:IsType(TYPE_MONSTER) and c:GetLevel()~=lv
+	return c:IsSetCard(0xab) and c:IsType(TYPE_MONSTER) and not c:IsLevel(lv)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c22227683.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c2295440.lua
+++ b/c2295440.lua
@@ -15,7 +15,7 @@ function c2295440.costfilter(c,e,tp)
 		and Duel.IsExistingMatchingCard(c2295440.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,c,e,tp)
 end
 function c2295440.filter(c,e,tp)
-	return c:GetLevel()==1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c2295440.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)

--- a/c22996376.lua
+++ b/c22996376.lua
@@ -26,7 +26,7 @@ function c22996376.initial_effect(c)
 end
 function c22996376.otcon(e,c,minc)
 	if c==nil then return true end
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1)
 end
 function c22996376.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local g=Duel.SelectTribute(tp,c,1,1)

--- a/c23064604.lua
+++ b/c23064604.lua
@@ -45,7 +45,7 @@ end
 function c23064604.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c23064604.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c23064604.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c23064604.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c23168060.lua
+++ b/c23168060.lua
@@ -11,7 +11,7 @@ function c23168060.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c23168060.condition(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetLevel()~=3
+	return not e:GetHandler():IsLevel(3)
 end
 function c23168060.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c23187256.lua
+++ b/c23187256.lua
@@ -43,7 +43,7 @@ function c23187256.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c23187256.gfilter(c,rank)
-	return c:GetRank()==rank
+	return c:IsRank(rank)
 end
 function c23187256.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCountFromEx(tp)

--- a/c23269426.lua
+++ b/c23269426.lua
@@ -14,7 +14,7 @@ function c23269426.spfilter(c,e,tp,code)
 	return c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c23269426.filter(c,e,tp)
-	return c:IsFaceup() and c:GetLevel()==3
+	return c:IsFaceup() and c:IsLevel(3)
 		and Duel.IsExistingMatchingCard(c23269426.spfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,e,tp,c:GetCode())
 end
 function c23269426.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c23379054.lua
+++ b/c23379054.lua
@@ -40,7 +40,7 @@ function c23379054.filter1(c,e,tp,lv)
 		and Duel.IsExistingMatchingCard(c23379054.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,lv+c:GetLevel())
 end
 function c23379054.filter2(c,e,tp,lv)
-	return c:GetLevel()==lv and c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c23379054.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()

--- a/c23536866.lua
+++ b/c23536866.lua
@@ -14,7 +14,7 @@ function c23536866.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c23536866.filter(c,e,tp)
-	return c:GetLevel()==5 and c:IsAttribute(ATTRIBUTE_WATER) and not c:IsCode(23536866)
+	return c:IsLevel(5) and c:IsAttribute(ATTRIBUTE_WATER) and not c:IsCode(23536866)
 		and c:IsCanBeEffectTarget(e) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c23536866.xyzfilter(c,mg)

--- a/c23581825.lua
+++ b/c23581825.lua
@@ -21,7 +21,7 @@ function c23581825.filter1(c,e,tp)
 		and Duel.IsExistingMatchingCard(c23581825.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()+2)
 end
 function c23581825.filter2(c,e,tp,mc,rk)
-	return c:GetRank()==rk and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c23581825.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c23689697.lua
+++ b/c23689697.lua
@@ -37,7 +37,7 @@ end
 function c23689697.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c23689697.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c23689697.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c23689697.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c23756165.lua
+++ b/c23756165.lua
@@ -47,8 +47,7 @@ function c23756165.eqcon(e,tp,eg,ep,ev,re,r,rp)
 	return ec==nil or ec:GetFlagEffect(23756165)==0
 end
 function c23756165.filter(c)
-	local lv=c:GetLevel()
-	return lv>0 and lv<=5 and c:IsFaceup() and c:IsAbleToChangeControler()
+	return c:IsLevelBelow(5) and c:IsFaceup() and c:IsAbleToChangeControler()
 end
 function c23756165.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c23756165.filter(chkc) end

--- a/c23950192.lua
+++ b/c23950192.lua
@@ -17,5 +17,5 @@ function c23950192.con(e)
 	return Duel.IsExistingMatchingCard(c23950192.filter,e:GetHandler():GetControler(),LOCATION_MZONE,0,1,e:GetHandler())
 end
 function c23950192.tg(e,c)
-	return c:GetLevel()>=4
+	return c:IsLevelAbove(4)
 end

--- a/c24019261.lua
+++ b/c24019261.lua
@@ -16,7 +16,7 @@ function c24019261.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c24019261.filter(c,e,tp,tid)
 	return bit.band(c:GetReason(),0x41)==0x41 and c:GetTurnID()==tid
-		and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c24019261.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tid=Duel.GetTurnCount()

--- a/c24062258.lua
+++ b/c24062258.lua
@@ -13,7 +13,7 @@ function c24062258.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c24062258.filter(c,e,tp)
-	return c:GetCode()~=24062258 and c:GetLevel()==4 and c:IsAttribute(ATTRIBUTE_DARK) and (c:GetAttack()==0 or c:IsDefenseBelow(0))
+	return c:GetCode()~=24062258 and c:IsLevel(4) and c:IsAttribute(ATTRIBUTE_DARK) and (c:GetAttack()==0 or c:IsDefenseBelow(0))
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c24062258.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c24082387.lua
+++ b/c24082387.lua
@@ -42,7 +42,7 @@ function c24082387.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c24082387.filter2(c,e,tp,lv)
-	return c:IsSetCard(0xc) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0xc) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c24082387.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then Duel.Damage(tp,2000,REASON_EFFECT) return end

--- a/c24382602.lua
+++ b/c24382602.lua
@@ -33,7 +33,7 @@ function c24382602.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c24382602.extg(e,c)
-	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==1
+	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(1)
 end
 function c24382602.tgfilter(c)
 	return c:IsFaceup()

--- a/c24449083.lua
+++ b/c24449083.lua
@@ -18,7 +18,7 @@ function c24449083.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c24449083.cfilter(c)
-	return c:IsFaceup() and c:GetLevel()==1 and c:IsRace(RACE_FAIRY)
+	return c:IsFaceup() and c:IsLevel(1) and c:IsRace(RACE_FAIRY)
 end
 function c24449083.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c24449083.cfilter,tp,LOCATION_MZONE,0,1,nil)

--- a/c24919805.lua
+++ b/c24919805.lua
@@ -54,7 +54,7 @@ function c24919805.regop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e1)
 end
 function c24919805.filter(c)
-	return c:GetLevel()==10 and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsAbleToHand()
+	return c:IsLevel(10) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsAbleToHand()
 end
 function c24919805.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c24919805.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c25247218.lua
+++ b/c25247218.lua
@@ -11,7 +11,7 @@ function c25247218.initial_effect(c)
 end
 function c25247218.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)>0
 end

--- a/c2530830.lua
+++ b/c2530830.lua
@@ -35,7 +35,7 @@ function c2530830.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c2530830.ovfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x107b) and c:IsType(TYPE_XYZ) and c:GetRank()==8
+	return c:IsFaceup() and c:IsSetCard(0x107b) and c:IsType(TYPE_XYZ) and c:IsRank(8)
 end
 function c2530830.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/c25472513.lua
+++ b/c25472513.lua
@@ -19,7 +19,7 @@ function c25472513.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
 end
 function c25472513.spfilter(c,e,tp)
-	return c:GetLevel()==2 and not c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsLevel(2) and not c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c25472513.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c25524823.lua
+++ b/c25524823.lua
@@ -55,7 +55,7 @@ function c25524823.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c25524823.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c25524823.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c25524823.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c25578802.lua
+++ b/c25578802.lua
@@ -23,7 +23,7 @@ function c25578802.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c25578802.spfilter(c,e,tp)
-	return c:IsType(TYPE_NORMAL) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_NORMAL) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c25578802.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c25853045.lua
+++ b/c25853045.lua
@@ -32,7 +32,7 @@ function c25853045.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c25853045.ovfilter(c)
-	return c:IsFaceup() and c:GetRank()==3 and c:IsAttribute(ATTRIBUTE_WATER) and c:GetOverlayCount()==0
+	return c:IsFaceup() and c:IsRank(3) and c:IsAttribute(ATTRIBUTE_WATER) and c:GetOverlayCount()==0
 end
 function c25853045.atkval(e,c)
 	return c:GetOverlayCount()*200

--- a/c25857246.lua
+++ b/c25857246.lua
@@ -31,7 +31,7 @@ function c25857246.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c25857246.mat_filter(c)
-	return c:GetLevel()~=8
+	return not c:IsLevel(8)
 end
 function c25857246.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetAttacker():IsControler(1-tp)

--- a/c26864586.lua
+++ b/c26864586.lua
@@ -10,12 +10,11 @@ function c26864586.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c26864586.filter1(c,tp)
-	local lv1=c:GetLevel()
-	return lv1>0 and c:IsFaceup() and Duel.IsExistingTarget(c26864586.filter2,tp,LOCATION_MZONE,0,1,c,c:GetRace(),c:GetAttribute(),lv1)
+	local lv=c:GetLevel()
+	return lv>0 and c:IsFaceup() and Duel.IsExistingTarget(c26864586.filter2,tp,LOCATION_MZONE,0,1,c,c:GetRace(),c:GetAttribute(),lv)
 end
-function c26864586.filter2(c,rc,at,lv1)
-	local lv2=c:GetLevel()
-	return lv2>0 and lv2~=lv1 and c:IsFaceup() and c:IsRace(rc) and c:IsAttribute(at)
+function c26864586.filter2(c,rc,at,lv)
+	return not c:IsLevel(lv) and c:IsFaceup() and c:IsRace(rc) and c:IsAttribute(at)
 end
 function c26864586.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
@@ -32,14 +31,13 @@ function c26864586.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc1=e:GetLabelObject()
 	local tc2=g:GetFirst()
 	if tc1==tc2 then tc2=g:GetNext() end
-	local lv1=tc1:GetLevel()
-	local lv2=tc2:GetLevel()
-	if lv1==lv2 then return end
+	local lv=tc1:GetLevel()
+	if tc2:IsLevel(lv) then return end
 	if tc1:IsFaceup() and tc1:IsRelateToEffect(e) and tc2:IsFaceup() and tc2:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
-		e1:SetValue(lv1)
+		e1:SetValue(lv)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		tc2:RegisterEffect(e1)
 	end

--- a/c27103517.lua
+++ b/c27103517.lua
@@ -22,7 +22,7 @@ end
 function c27103517.sumcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)>=5
 end
 function c27103517.spcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c27217742.lua
+++ b/c27217742.lua
@@ -11,7 +11,7 @@ function c27217742.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c27217742.thfilter(c)
-	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4 and not c:IsCode(27217742) and c:IsAbleToHand()
+	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4) and not c:IsCode(27217742) and c:IsAbleToHand()
 end
 function c27217742.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c27217742.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c27407330.lua
+++ b/c27407330.lua
@@ -22,7 +22,7 @@ function c27407330.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c27407330.spfilter(c)
-	return c:GetLevel()>=5 and c:IsAttribute(ATTRIBUTE_LIGHT)
+	return c:IsLevelAbove(5) and c:IsAttribute(ATTRIBUTE_LIGHT)
 end
 function c27407330.spcon(e,c)
 	if c==nil then return true end

--- a/c27971137.lua
+++ b/c27971137.lua
@@ -31,7 +31,7 @@ function c27971137.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD) and e:GetHandler():IsReason(REASON_DESTROY)
 end
 function c27971137.filter(c,e,tp)
-	return c:GetLevel()==1 and (c:GetAttack()==0 and c:IsDefenseBelow(0)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(1) and (c:GetAttack()==0 and c:IsDefenseBelow(0)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c27971137.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c28118128.lua
+++ b/c28118128.lua
@@ -14,7 +14,7 @@ function c28118128.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c28118128.filter(c,e,tp)
-	return c:GetCode()~=28118128 and c:GetLevel()==2 and c:IsRace(RACE_BEAST)
+	return c:GetCode()~=28118128 and c:IsLevel(2) and c:IsRace(RACE_BEAST)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c28118128.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c28348537.lua
+++ b/c28348537.lua
@@ -24,7 +24,7 @@ function c28348537.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c28348537.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c28348537.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c28348537.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c28423537.lua
+++ b/c28423537.lua
@@ -33,7 +33,7 @@ function c28423537.initial_effect(c)
 end
 function c28423537.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c28423537.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c28529976.lua
+++ b/c28529976.lua
@@ -24,10 +24,9 @@ function c28529976.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c28529976.cfilter(c,e,tp,ft)
-	local lv=c:GetLevel()
-	return lv>0 and lv<=2 and c:IsRace(RACE_PLANT)
+	return c:IsLevelBelow(2) and c:IsRace(RACE_PLANT)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5)) and (c:IsControler(tp) or c:IsFaceup())
-		and Duel.IsExistingMatchingCard(c28529976.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,lv+3,e,tp)
+		and Duel.IsExistingMatchingCard(c28529976.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,c:GetLevel()+3,e,tp)
 end
 function c28529976.filter(c,lv,e,tp)
 	return c:IsLevelBelow(lv) and c:IsRace(RACE_PLANT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c28604635.lua
+++ b/c28604635.lua
@@ -15,7 +15,7 @@ function c28604635.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,500)
 end
 function c28604635.filter(c)
-	return c:IsPosition(POS_FACEUP_ATTACK) and c:GetLevel()==3
+	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsLevel(3)
 end
 function c28604635.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c28604635.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end

--- a/c28637168.lua
+++ b/c28637168.lua
@@ -13,7 +13,7 @@ function c28637168.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c28637168.spfilter(c,e,tp)
-	return c:GetLevel()==3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c28637168.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c28637168.spfilter(chkc,e,tp) end

--- a/c28654932.lua
+++ b/c28654932.lua
@@ -10,7 +10,7 @@ function c28654932.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c28654932.filter(c,e)
-	return c:IsFaceup() and c:IsType(TYPE_EFFECT) and c:GetLevel()>=5
+	return c:IsFaceup() and c:IsType(TYPE_EFFECT) and c:IsLevelAbove(5)
 		and (not e or c:IsRelateToEffect(e)) and c:IsAbleToRemove()
 end
 function c28654932.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c28929131.lua
+++ b/c28929131.lua
@@ -68,7 +68,7 @@ function c28929131.initial_effect(c)
 end
 function c28929131.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4
+	return minc==0 and c:IsLevelAbove(5)
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end

--- a/c28966434.lua
+++ b/c28966434.lua
@@ -13,7 +13,7 @@ function c28966434.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c28966434.filter1(c)
-	return c:IsFaceup() and c:IsSetCard(0x31) and c:GetLevel()>3
+	return c:IsFaceup() and c:IsSetCard(0x31) and c:IsLevelAbove(4)
 end
 function c28966434.filter2(c)
 	return c:IsFaceup()
@@ -34,7 +34,7 @@ function c28966434.desop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local tc=g:GetFirst()
 	if tc==c1 then tc=g:GetNext() end
-	if c1:GetLevel()<=3 or c1:IsFacedown() or not c1:IsRelateToEffect(e) then return end
+	if c1:IsLevelBelow(3) or c1:IsFacedown() or not c1:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_LEVEL)

--- a/c29021114.lua
+++ b/c29021114.lua
@@ -27,7 +27,7 @@ function c29021114.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c29021114.spfilter1(c,e,tp)
-	return c:IsRace(RACE_MACHINE) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_MACHINE) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c29021114.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -46,7 +46,7 @@ function c29021114.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0
 end
 function c29021114.spfilter2(c,e,tp)
-	return c:IsSetCard(0x51) and c:GetLevel()==4 and not c:IsCode(29021114) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x51) and c:IsLevel(4) and not c:IsCode(29021114) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c29021114.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c2903036.lua
+++ b/c2903036.lua
@@ -20,7 +20,7 @@ function c2903036.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c2903036.filter(c,e,tp)
-	return c:GetLevel()==7 and c:IsSummonableCard() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(7) and c:IsSummonableCard() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c2903036.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c2903036.filter,tp,LOCATION_HAND,0,1,nil,e,tp) end

--- a/c29904964.lua
+++ b/c29904964.lua
@@ -29,7 +29,7 @@ end
 function c29904964.ntcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)
 end
 function c29904964.spfilter(c,e,tp)

--- a/c29999161.lua
+++ b/c29999161.lua
@@ -23,7 +23,7 @@ function c29999161.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
 function c29999161.spfilter(c,lv,e,tp)
-	return c:IsSetCard(0x58) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x58) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c29999161.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c30086349.lua
+++ b/c30086349.lua
@@ -28,10 +28,10 @@ function c30086349.initial_effect(c)
 end
 c30086349.material_setcode=0x3b
 function c30086349.mfilter1(c)
-	return c:IsFusionSetCard(0x3b) and c:GetLevel()==7
+	return c:IsFusionSetCard(0x3b) and c:IsLevel(7)
 end
 function c30086349.mfilter2(c)
-	return c:IsRace(RACE_DRAGON) and c:GetLevel()==6
+	return c:IsRace(RACE_DRAGON) and c:IsLevel(6)
 end
 function c30086349.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_FUSION)

--- a/c30399511.lua
+++ b/c30399511.lua
@@ -12,7 +12,7 @@ function c30399511.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c30399511.filter(c)
-	return c:GetLevel()==3 and c:IsSetCard(0x2) and c:IsType(TYPE_EFFECT) and c:IsAbleToHand()
+	return c:IsLevel(3) and c:IsSetCard(0x2) and c:IsType(TYPE_EFFECT) and c:IsAbleToHand()
 end
 function c30399511.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c30399511.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c30435145.lua
+++ b/c30435145.lua
@@ -9,7 +9,7 @@ function c30435145.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c30435145.filter(c,g)
-	return c:GetLevel()>4 and c:IsSetCard(0x7) and g:CheckWithSumEqual(Card.GetLevel,c:GetLevel()*2,1,99)
+	return c:IsLevelAbove(5) and c:IsSetCard(0x7) and g:CheckWithSumEqual(Card.GetLevel,c:GetLevel()*2,1,99)
 end
 function c30435145.rfilter(c)
 	return c:GetLevel()>0 and c:IsSetCard(0x7) and c:IsAbleToRemove()
@@ -44,5 +44,5 @@ function c30435145.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c30435145.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end

--- a/c30907810.lua
+++ b/c30907810.lua
@@ -57,7 +57,7 @@ function c30907810.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c30907810.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c30907810.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c30907810.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c31320433.lua
+++ b/c31320433.lua
@@ -26,7 +26,7 @@ function c31320433.initial_effect(c)
 end
 c31320433.xyz_number=47
 function c31320433.matfilter(c)
-	return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and not c:IsType(TYPE_TOKEN) and c:GetLevel()==3 and c:IsAttribute(ATTRIBUTE_WATER)
+	return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and not c:IsType(TYPE_TOKEN) and c:IsLevel(3) and c:IsAttribute(ATTRIBUTE_WATER)
 end
 function c31320433.mattg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c31320433.matfilter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil) end

--- a/c3136426.lua
+++ b/c3136426.lua
@@ -16,5 +16,5 @@ function c3136426.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c3136426.target(e,c)
-	return c:GetLevel()>3 and c:IsFaceup()
+	return c:IsLevelAbove(4) and c:IsFaceup()
 end

--- a/c31571902.lua
+++ b/c31571902.lua
@@ -12,7 +12,7 @@ function c31571902.initial_effect(c)
 end
 function c31571902.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c31571902.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--to grave

--- a/c3160805.lua
+++ b/c3160805.lua
@@ -26,14 +26,14 @@ function c3160805.tgfilter1(c,tp)
 		and Duel.IsExistingMatchingCard(c3160805.thfilter1,tp,LOCATION_DECK,0,1,nil,c:GetLevel())
 end
 function c3160805.thfilter1(c,lv)
-	return c:GetLevel()==lv and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
+	return c:IsLevel(lv) and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
 end
 function c3160805.tgfilter2(c,tp)
 	return c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_DARK)
 		and Duel.IsExistingMatchingCard(c3160805.thfilter2,tp,LOCATION_DECK,0,1,nil,c:GetLevel())
 end
 function c3160805.thfilter2(c,lv)
-	return c:GetLevel()==lv and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToHand()
+	return c:IsLevel(lv) and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToHand()
 end
 function c3160805.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c31863912.lua
+++ b/c31863912.lua
@@ -39,7 +39,7 @@ function c31863912.target2(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)
 end
 function c31863912.filter(c,sp,e,lv)
-	return c:IsFaceup() and c:GetSummonPlayer()==sp and c:GetLevel()==lv and c:IsAbleToHand() and c:IsRelateToEffect(e)
+	return c:IsFaceup() and c:GetSummonPlayer()==sp and c:IsLevel(lv) and c:IsAbleToHand() and c:IsRelateToEffect(e)
 end
 function c31863912.operation(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetLabel()==0 or not e:GetHandler():IsRelateToEffect(e) then return end

--- a/c32015116.lua
+++ b/c32015116.lua
@@ -28,9 +28,9 @@ function c32015116.rdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c32015116.rdfilter(c,lv)
 	if lv<=5 then
-		return c:IsFaceup() and c:GetLevel()==lv
+		return c:IsFaceup() and c:IsLevel(lv)
 	elseif lv==6 then
-		return c:IsFaceup() and c:GetLevel()>=6
+		return c:IsFaceup() and c:IsLevelAbove(6)
 	else
 		return false
 	end

--- a/c32298781.lua
+++ b/c32298781.lua
@@ -11,7 +11,7 @@ function c32298781.initial_effect(c)
 end
 function c32298781.filter(c)
 	local tpe=c:GetType()
-	return c:IsFaceup() and bit.band(tpe,TYPE_NORMAL)~=0 and bit.band(tpe,TYPE_TOKEN)==0 and c:GetLevel()==1
+	return c:IsFaceup() and bit.band(tpe,TYPE_NORMAL)~=0 and bit.band(tpe,TYPE_TOKEN)==0 and c:IsLevel(1)
 end
 function c32298781.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c32298781.filter,tp,LOCATION_MZONE,0,1,nil) end
@@ -44,7 +44,7 @@ function c32298781.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(de,tp)
 end
 function c32298781.dfilter(c)
-	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:GetLevel()==1
+	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:IsLevel(1)
 end
 function c32298781.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c32298781.dfilter,tp,LOCATION_MZONE,0,1,nil)

--- a/c32393580.lua
+++ b/c32393580.lua
@@ -14,6 +14,6 @@ function c32393580.ntfilter(c)
 end
 function c32393580.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c32393580.ntfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end

--- a/c32465539.lua
+++ b/c32465539.lua
@@ -35,7 +35,7 @@ function c32465539.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPosition(POS_FACEUP_ATTACK)
 end
 function c32465539.spfil(c,e,tp)
-	return c:GetLevel()==3 and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsLevel(3) and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c32465539.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c32465539.spfil(chkc,e,tp) end

--- a/c32476434.lua
+++ b/c32476434.lua
@@ -12,7 +12,7 @@ function c32476434.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c32476434.filter(c)
-	return c:IsFaceup() and c:GetLevel()==3 and c:IsRace(RACE_BEASTWARRIOR)
+	return c:IsFaceup() and c:IsLevel(3) and c:IsRace(RACE_BEASTWARRIOR)
 end
 function c32476434.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c32476434.filter(chkc) and chkc~=e:GetHandler() end

--- a/c32566831.lua
+++ b/c32566831.lua
@@ -13,7 +13,7 @@ function c32566831.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c32566831.cfilter(c)
-	return c:IsSetCard(0x3b) and c:GetLevel()==7 and c:IsAbleToGraveAsCost()
+	return c:IsSetCard(0x3b) and c:IsLevel(7) and c:IsAbleToGraveAsCost()
 end
 function c32566831.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c32566831.cfilter,tp,LOCATION_HAND,0,1,nil) end
@@ -26,7 +26,7 @@ function c32566831.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)
 end
 function c32566831.tgfilter(c)
-	return c:IsSetCard(0x3b) and c:GetLevel()==7 and c:IsAbleToGrave()
+	return c:IsSetCard(0x3b) and c:IsLevel(7) and c:IsAbleToGrave()
 end
 function c32566831.activate(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)

--- a/c32646477.lua
+++ b/c32646477.lua
@@ -20,12 +20,9 @@ end
 function c32646477.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1
 end
-function c32646477.costfilter(c)
-	return c:GetLevel()>0
-end
 function c32646477.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(tp,c32646477.costfilter,1,nil) end
-	local g=Duel.SelectReleaseGroup(tp,c32646477.costfilter,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsLevelAbove,1,nil,1) end
+	local g=Duel.SelectReleaseGroup(tp,Card.IsLevelAbove,1,1,nil,1)
 	e:SetLabel(g:GetFirst():GetLevel()*200)
 	Duel.Release(g,REASON_COST)
 end

--- a/c32744558.lua
+++ b/c32744558.lua
@@ -16,7 +16,7 @@ function c32744558.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c32744558.filter(c,e,tp)
-	return c:IsSetCard(0x2) and c:GetLevel()<=3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x2) and c:IsLevelBelow(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c32744558.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c32872833.lua
+++ b/c32872833.lua
@@ -10,7 +10,7 @@ function c32872833.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c32872833.filter(c)
-	return c:IsFaceup() and c:GetLevel()==8
+	return c:IsFaceup() and c:IsLevel(8)
 end
 function c32872833.ntcon(e,c,minc)
 	if c==nil then return true end

--- a/c3298689.lua
+++ b/c3298689.lua
@@ -33,7 +33,7 @@ function c3298689.filter1(c,e,tp)
 end
 function c3298689.filter2(c,e,tp,mc,rk)
 	 if c:GetOriginalCode()==6165656 and mc:GetCode()~=48995978 then return false end
-	return c:GetRank()==rk and c:IsAttribute(ATTRIBUTE_DARK) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsAttribute(ATTRIBUTE_DARK) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c3298689.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c33034646.lua
+++ b/c33034646.lua
@@ -17,7 +17,7 @@ function c33034646.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c33034646.filter(c)
-	return c:IsFaceup() and c:GetLevel()~=0 and c:IsSetCard(0x2b)
+	return c:IsFaceup() and c:IsLevelAbove(1) and c:IsSetCard(0x2b)
 end
 function c33034646.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c33034646.filter(chkc) end

--- a/c33252803.lua
+++ b/c33252803.lua
@@ -18,7 +18,7 @@ function c33252803.filter1(c,e,tp)
 		and Duel.GetLocationCountFromEx(tp,tp,c)>0
 end
 function c33252803.filter2(c,e,tp,mc,rk,no)
-	return c:GetRank()==rk and c:IsSetCard(0x1048) and c.xyz_number==no and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0x1048) and c.xyz_number==no and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c33252803.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c33282498.lua
+++ b/c33282498.lua
@@ -64,7 +64,7 @@ function c33282498.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:GetTurnID()~=Duel.GetTurnCount() and c:GetFlagEffect(33282498)>0
 end
 function c33282498.spfilter(c,e,tp)
-	return (c:GetLevel()==7 or c:GetLevel()==8) and not c:IsCode(33282498) and c:IsRace(RACE_DRAGON)
+	return (c:IsLevel(7) or c:IsLevel(8)) and not c:IsCode(33282498) and c:IsRace(RACE_DRAGON)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c33282498.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c33460840.lua
+++ b/c33460840.lua
@@ -24,7 +24,7 @@ function c33460840.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c33460840.filter(c,ec)
-	return c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and not c:IsForbidden()
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and not c:IsForbidden()
 end
 function c33460840.eqtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
@@ -74,7 +74,7 @@ function c33460840.eqlimit(e,c)
 	return e:GetOwner()==c
 end
 function c33460840.spfilter(c,e,tp)
-	return c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c33460840.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c33846209.lua
+++ b/c33846209.lua
@@ -20,7 +20,7 @@ function c33846209.desfilter(c,tc,ec)
 	return c:GetEquipTarget()~=tc and c~=ec
 end
 function c33846209.costfilter(c,ec)
-	if c:IsFacedown() or c:GetLevel()~=4 or not c:IsType(TYPE_DUAL) then return false end
+	if c:IsFacedown() or not c:IsLevel(4) or not c:IsType(TYPE_DUAL) then return false end
 	return Duel.IsExistingTarget(c33846209.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c,c,ec)
 end
 function c33846209.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c340002.lua
+++ b/c340002.lua
@@ -28,7 +28,7 @@ function c340002.cfilter(c)
 end
 function c340002.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c340002.cfilter,c:GetControler(),LOCATION_ONFIELD,0,2,nil)
 end
 function c340002.atkcon(e)

--- a/c34124316.lua
+++ b/c34124316.lua
@@ -24,11 +24,10 @@ function c34124316.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ConfirmDecktop(tp,5)
 	local tc=g1:GetFirst()
 	while tc do
-		local lv=tc:GetLevel()
 		local pos=0
 		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then pos=pos+POS_FACEUP_ATTACK end
 		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then pos=pos+POS_FACEDOWN_DEFENSE end
-		if lv>0 and lv<=4 and pos~=0 then
+		if tc:IsLevelBelow(4) and pos~=0 then
 			Duel.DisableShuffleCheck()
 			Duel.SpecialSummonStep(tc,0,tp,tp,false,false,pos)
 		elseif tc:IsAbleToHand() then
@@ -39,11 +38,10 @@ function c34124316.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ConfirmDecktop(1-tp,5)
 	tc=g2:GetFirst()
 	while tc do
-		local lv=tc:GetLevel()
 		local pos=0
 		if tc:IsCanBeSpecialSummoned(e,0,1-tp,false,false,POS_FACEUP_ATTACK) then pos=pos+POS_FACEUP_ATTACK end
 		if tc:IsCanBeSpecialSummoned(e,0,1-tp,false,false,POS_FACEDOWN_DEFENSE) then pos=pos+POS_FACEDOWN_DEFENSE end
-		if lv>0 and lv<=4 and pos~=0 then
+		if tc:IsLevelBelow(4) and pos~=0 then
 			Duel.DisableShuffleCheck()
 			Duel.SpecialSummonStep(tc,0,1-tp,1-tp,false,false,pos)
 		elseif tc:IsAbleToHand() then

--- a/c34206604.lua
+++ b/c34206604.lua
@@ -12,7 +12,7 @@ function c34206604.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c34206604.filter(c,e,tp)
-	return c:IsType(TYPE_FUSION) and c:GetLevel()<=6 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_FUSION) and c:IsLevelBelow(6) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c34206604.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,1000) end

--- a/c34550857.lua
+++ b/c34550857.lua
@@ -20,7 +20,7 @@ function c34550857.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c34550857.thfilter(c)
-	return c:IsRace(RACE_WINDBEAST) and c:GetLevel()==1 and c:IsAbleToHand()
+	return c:IsRace(RACE_WINDBEAST) and c:IsLevel(1) and c:IsAbleToHand()
 end
 function c34550857.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c34550857.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c35014241.lua
+++ b/c35014241.lua
@@ -21,7 +21,7 @@ function c35014241.cfilter2(c,e,tp,tc)
 		and Duel.GetLocationCountFromEx(tp,tp,Group.FromCards(c,tc))>0
 end
 function c35014241.spfilter(c,e,tp,lv)
-	return c:IsType(TYPE_SYNCHRO) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsType(TYPE_SYNCHRO) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c35014241.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)

--- a/c35058857.lua
+++ b/c35058857.lua
@@ -41,7 +41,7 @@ function c35058857.spcon(e,c)
 		and Duel.IsExistingMatchingCard(c35058857.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end
 function c35058857.lvfilter(c,lv)
-	return (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE)) and c:GetLevel()>0 and c:GetLevel()~=lv
+	return (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE)) and not c:IsLevel(lv)
 end
 function c35058857.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local lv=e:GetHandler():GetLevel()

--- a/c35149085.lua
+++ b/c35149085.lua
@@ -23,7 +23,7 @@ function c35149085.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
 end
 function c35149085.spfilter(c,e,tp,lv)
-	return c:IsRace(RACE_BEAST) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_BEAST) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c35149085.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c35224440.lua
+++ b/c35224440.lua
@@ -10,8 +10,7 @@ function c35224440.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c35224440.filter(c)
-	local lv=c:GetLevel()
-	return c:IsSetCard(0x19) and lv>0 and lv<5 and c:IsAbleToHand()
+	return c:IsSetCard(0x19) and c:IsLevelBelow(4) and c:IsAbleToHand()
 end
 function c35224440.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c35224440.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c35307484.lua
+++ b/c35307484.lua
@@ -24,7 +24,7 @@ function c35307484.condition(e,tp,eg,ep,ev,re,r,rp)
 	return not eg:IsContains(e:GetHandler()) and eg:IsExists(c35307484.cfilter,1,nil,tp)
 end
 function c35307484.spfilter(c,e,tp)
-	return c:GetLevel()==2 and c:IsRace(RACE_FIEND) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(2) and c:IsRace(RACE_FIEND) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c35307484.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c35307484.spfilter(chkc,e,tp) end

--- a/c35329581.lua
+++ b/c35329581.lua
@@ -17,7 +17,7 @@ function c35329581.filter(c,e,tp)
 		and c:IsType(TYPE_SYNCHRO) and Duel.IsExistingMatchingCard(c35329581.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c)
 end
 function c35329581.spfilter(c,e,tp,tc)
-	return c:IsType(TYPE_SYNCHRO) and c:GetLevel()==tc:GetLevel()
+	return c:IsType(TYPE_SYNCHRO) and c:IsLevel(tc:GetLevel())
 		and c:GetRace()==tc:GetRace() and c:GetCode()~=tc:GetCode()
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end

--- a/c3534077.lua
+++ b/c3534077.lua
@@ -13,7 +13,7 @@ function c3534077.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c3534077.filter(c,e,tp)
-	return c:IsRace(RACE_BEASTWARRIOR) and c:IsAttribute(ATTRIBUTE_FIRE) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsRace(RACE_BEASTWARRIOR) and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c3534077.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c3534077.filter(chkc,e,tp) end

--- a/c35950025.lua
+++ b/c35950025.lua
@@ -26,7 +26,7 @@ function c35950025.cfilter(c)
 end
 function c35950025.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c35950025.cfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end
 function c35950025.spcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c3606728.lua
+++ b/c3606728.lua
@@ -19,7 +19,7 @@ function c3606728.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c3606728.lvfilter(c,lv)
-	return c:IsFaceup() and c:IsCode(26082117) and c:GetLevel()~=lv
+	return c:IsFaceup() and c:IsCode(26082117) and not c:IsLevel(lv)
 end
 function c3606728.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c3606728.lvfilter(chkc,e:GetHandler():GetLevel()) end

--- a/c36630403.lua
+++ b/c36630403.lua
@@ -18,7 +18,7 @@ function c36630403.filter1(c,e,tp,lv)
 		and Duel.IsExistingMatchingCard(c36630403.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,lv+clv)
 end
 function c36630403.filter2(c,e,tp,lv)
-	return c:GetLevel()==lv and c:IsRace(RACE_ZOMBIE) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsRace(RACE_ZOMBIE) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c36630403.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c36630403.filter1(chkc,e,tp,e:GetHandler():GetLevel()) end

--- a/c36737092.lua
+++ b/c36737092.lua
@@ -20,7 +20,7 @@ function c36737092.filter1(c,e,tp)
 		and Duel.GetLocationCountFromEx(tp,tp,c)>0
 end
 function c36737092.filter2(c,lv,e,tp)
-	return c:IsType(TYPE_SYNCHRO) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_SYNCHRO) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c36737092.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c36857073.lua
+++ b/c36857073.lua
@@ -64,7 +64,7 @@ function c36857073.spfilter2(c,e,tp)
 end
 function c36857073.spfilter3(c,e,tp,lv)
 	return c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
-		and c:GetLevel()==lv
+		and c:IsLevel(lv)
 end
 function c36857073.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)

--- a/c37168514.lua
+++ b/c37168514.lua
@@ -10,8 +10,7 @@ function c37168514.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37168514.filter(c)
-	local lv=c:GetLevel()
-	return c:IsFaceup() and c:IsRace(RACE_ROCK) and lv>0 and lv~=3
+	return c:IsFaceup() and c:IsRace(RACE_ROCK) and not c:IsLevel(3)
 end
 function c37168514.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c37168514.filter,tp,LOCATION_MZONE,0,1,nil) end

--- a/c37383714.lua
+++ b/c37383714.lua
@@ -23,7 +23,7 @@ function c37383714.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,1000)
 end
 function c37383714.spfilter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c37383714.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c37440988.lua
+++ b/c37440988.lua
@@ -43,7 +43,7 @@ function c37440988.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c37440988.hspfilter(c,tp,sc)
-	return c:IsSetCard(0x2034) and c:GetLevel()==10 and c:IsControler(tp) and Duel.GetLocationCountFromEx(tp,tp,sc,c)>0
+	return c:IsSetCard(0x2034) and c:IsLevel(10) and c:IsControler(tp) and Duel.GetLocationCountFromEx(tp,tp,sc,c)>0
 end
 function c37440988.hspcon(e,c)
 	if c==nil then return true end

--- a/c37507488.lua
+++ b/c37507488.lua
@@ -28,7 +28,7 @@ function c37507488.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
 function c37507488.spfilter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c37507488.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c37798171.lua
+++ b/c37798171.lua
@@ -22,7 +22,7 @@ function c37798171.initial_effect(c)
 end
 function c37798171.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 end
 function c37798171.atkcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c37991342.lua
+++ b/c37991342.lua
@@ -62,7 +62,7 @@ function c37991342.splimit(e,c)
 end
 function c37991342.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c37991342.lvcon(e)
 	return e:GetHandler():GetMaterialCount()==0

--- a/c38120068.lua
+++ b/c38120068.lua
@@ -12,7 +12,7 @@ function c38120068.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c38120068.filter(c)
-	return c:GetLevel()==8 and c:IsDiscardable()
+	return c:IsLevel(8) and c:IsDiscardable()
 end
 function c38120068.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c38120068.filter,tp,LOCATION_HAND,0,1,nil) end

--- a/c3825890.lua
+++ b/c3825890.lua
@@ -34,7 +34,7 @@ function c3825890.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c3825890.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c3825890.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c3825890.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c38525760.lua
+++ b/c38525760.lua
@@ -31,7 +31,7 @@ function c38525760.initial_effect(c)
 end
 function c38525760.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c38525760.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c38568567.lua
+++ b/c38568567.lua
@@ -15,7 +15,7 @@ function c38568567.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()
 end
 function c38568567.cfilter(c)
-	return c:GetLevel()==4 and c:IsRace(RACE_PLANT) and c:IsAbleToGraveAsCost()
+	return c:IsLevel(4) and c:IsRace(RACE_PLANT) and c:IsAbleToGraveAsCost()
 end
 function c38568567.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c38568567.cfilter,tp,LOCATION_HAND,0,1,nil) end

--- a/c38572779.lua
+++ b/c38572779.lua
@@ -95,7 +95,7 @@ function c38572779.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c38572779.sfilter(c,e,tp,lv)
-	return c:IsRace(RACE_DINOSAUR) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_DINOSAUR) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c38572779.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/c39024589.lua
+++ b/c39024589.lua
@@ -33,8 +33,7 @@ function c39024589.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c39024589.cfilter,1,nil,tp)
 end
 function c39024589.thfilter(c)
-	local lv=c:GetLevel()
-	return c:IsFaceup() and c:IsSetCard(0x10ec) and (lv==1 or lv==8) and c:IsType(TYPE_PENDULUM) and c:IsAbleToHand()
+	return c:IsFaceup() and c:IsSetCard(0x10ec) and (c:IsLevel(1) or c:IsLevel(8)) and c:IsType(TYPE_PENDULUM) and c:IsAbleToHand()
 end
 function c39024589.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c39024589.thfilter,tp,LOCATION_EXTRA,0,1,nil) end
@@ -57,9 +56,8 @@ function c39024589.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c39024589.filter(c,e,tp)
-	local lv=c:GetLevel()
 	return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsSetCard(0x10ec)
-		and (lv==1 or lv==8) and c:IsType(TYPE_PENDULUM) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and (c:IsLevel(1) or c:IsLevel(8)) and c:IsType(TYPE_PENDULUM) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c39024589.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local loc=0

--- a/c39041729.lua
+++ b/c39041729.lua
@@ -47,7 +47,7 @@ function c39041729.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE+LOCATION_HAND)
 end
 function c39041729.spfilter(c,e,tp,lv)
-	return c:GetLevel()==lv and c:IsRace(RACE_DINOSAUR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsRace(RACE_DINOSAUR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c39041729.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/c39091951.lua
+++ b/c39091951.lua
@@ -20,7 +20,7 @@ function c39091951.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,800)
 end
 function c39091951.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsRace(RACE_PSYCHO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsRace(RACE_PSYCHO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c39091951.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c39153655.lua
+++ b/c39153655.lua
@@ -25,7 +25,7 @@ function c39153655.initial_effect(c)
 end
 function c39153655.filter(c)
 	local lv=c:GetLevel()
-	return c:IsFaceup() and c:IsSetCard(0xaf) and lv>0 and lv~=4
+	return c:IsFaceup() and c:IsSetCard(0xaf) and not c:IsLevel(4)
 end
 function c39153655.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c39153655.filter(chkc) end
@@ -37,7 +37,7 @@ function c39153655.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:GetLevel()~=4 then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and not tc:IsLevel(4) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)

--- a/c3954901.lua
+++ b/c3954901.lua
@@ -25,14 +25,11 @@ end
 function c3954901.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_GRAVE)
 end
-function c3954901.filter(c)
-	return c:GetLevel()>0
-end
 function c3954901.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c3954901.filter(chkc) end
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and chkc:IsLevelAbove(1) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c3954901.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SelectTarget(tp,Card.IsLevelAbove,tp,LOCATION_GRAVE,0,1,1,nil,1)
 end
 function c3954901.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c40143123.lua
+++ b/c40143123.lua
@@ -11,7 +11,7 @@ function c40143123.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c40143123.filter(c,e,tp)
-	return c:IsSetCard(0x53) and c:GetLevel()==5 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsSetCard(0x53) and c:IsLevel(5) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c40143123.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c40160226.lua
+++ b/c40160226.lua
@@ -26,7 +26,7 @@ function c40160226.ntfilter(c)
 end
 function c40160226.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c40160226.ntfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end
 function c40160226.cost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c4022819.lua
+++ b/c4022819.lua
@@ -31,7 +31,7 @@ function c4022819.initial_effect(c)
 end
 function c4022819.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c4022819.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c40279770.lua
+++ b/c40279770.lua
@@ -14,7 +14,7 @@ function c40279770.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and bit.band(r,REASON_EFFECT)~=0
 end
 function c40279770.filter(c,e,tp)
-	return c:IsSetCard(0x33) and c:GetLevel()<=4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x33) and c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c40279770.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c40371092.lua
+++ b/c40371092.lua
@@ -30,7 +30,7 @@ function c40371092.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c40371092.filter(c)
-	return c:GetLevel()==4 and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
 end
 function c40371092.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c40371092.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c40450317.lua
+++ b/c40450317.lua
@@ -28,7 +28,7 @@ function c40450317.filter(c,e,tp)
 	return g:GetClassCount(Card.GetCode)>1
 end
 function c40450317.filter2(c,e,tp,tc)
-	return c:GetLevel()==tc:GetLevel() and c:IsRace(tc:GetRace()) and c:IsAttribute(tc:GetAttribute())
+	return c:IsLevel(tc:GetLevel()) and c:IsRace(tc:GetRace()) and c:IsAttribute(tc:GetAttribute())
 		and not c:IsCode(tc:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c40450317.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c40666140.lua
+++ b/c40666140.lua
@@ -16,7 +16,7 @@ function c40666140.filter(c,e,tp)
 	return c:IsFaceup() and lv>0 and Duel.IsExistingMatchingCard(c40666140.filter2,tp,LOCATION_HAND,0,1,nil,lv,e,tp)
 end
 function c40666140.filter2(c,lv,e,tp)
-	return c:IsSetCard(0x42) and c:GetLevel()<=lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x42) and c:IsLevelBelow(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c40666140.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c40666140.filter(chkc,e,tp) end

--- a/c40921744.lua
+++ b/c40921744.lua
@@ -40,7 +40,7 @@ function c40921744.sumcon(e,c,minc)
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c40921744.mfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
 	local ag=Duel.GetMatchingGroup(Card.IsAttribute,tp,LOCATION_GRAVE,0,nil,ATTRIBUTE_DARK)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 		and ag:GetClassCount(Card.GetCode)>=4
 end
 function c40921744.sumop(e,tp,eg,ep,ev,re,r,rp,c)

--- a/c41201386.lua
+++ b/c41201386.lua
@@ -30,7 +30,7 @@ function c41201386.filter1(c,e,tp)
 		and aux.MustMaterialCheck(c,tp,EFFECT_MUST_BE_XMATERIAL)
 end
 function c41201386.filter2(c,e,tp,mc,rk)
-	return c:GetRank()==rk and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c41201386.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c41269771.lua
+++ b/c41269771.lua
@@ -11,7 +11,7 @@ function c41269771.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c41269771.filter(c,e,tp)
-	return c:IsSetCard(0x53) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x53) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c41269771.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c41493640.lua
+++ b/c41493640.lua
@@ -41,7 +41,7 @@ function c41493640.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c41493640.spfilter(c,e,tp)
-	return c:GetLevel()==3 and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsLevel(3) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c41493640.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c41546.lua
+++ b/c41546.lua
@@ -44,7 +44,7 @@ function c41546.desfilter(c)
 	return c:IsSetCard(0xaf)
 end
 function c41546.spfilter(c,e,tp)
-	return c:IsSetCard(0x10af) and c:GetLevel()==8 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsSetCard(0x10af) and c:IsLevel(8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c41546.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_PZONE) and chkc:IsControler(tp) and c41546.desfilter(chkc) end

--- a/c41753322.lua
+++ b/c41753322.lua
@@ -51,7 +51,7 @@ function c41753322.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c41753322.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c41753322.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c41753322.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c41999284.lua
+++ b/c41999284.lua
@@ -1,7 +1,7 @@
 --リンクリボー
 function c41999284.initial_effect(c)
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,c41999284.matfilter,1)
+	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLevel,1),1)
 	--atk to 0
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
@@ -24,9 +24,6 @@ function c41999284.initial_effect(c)
 	e2:SetOperation(c41999284.spop)
 	c:RegisterEffect(e2)
 end
-function c41999284.matfilter(c)
-	return c:GetLevel()==1
-end
 function c41999284.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=Duel.GetTurnPlayer() and aux.nzatk(Duel.GetAttacker())
 end
@@ -46,7 +43,7 @@ function c41999284.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c41999284.cfilter(c,tp)
-	return c:GetLevel()==1 and Duel.GetMZoneCount(tp,c)>0
+	return c:IsLevel(1) and Duel.GetMZoneCount(tp,c)>0
 end
 function c41999284.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,c41999284.cfilter,1,nil,tp) end

--- a/c42023223.lua
+++ b/c42023223.lua
@@ -29,7 +29,7 @@ function c42023223.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c42023223.thfilter(c)
-	return c:IsSetCard(0xe9) and c:GetLevel()==8 and c:IsAbleToHand()
+	return c:IsSetCard(0xe9) and c:IsLevel(8) and c:IsAbleToHand()
 end
 function c42023223.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c42023223.thfilter,tp,LOCATION_DECK,0,1,nil) end
@@ -51,7 +51,7 @@ function c42023223.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c42023223.spfilter(c,e,tp)
-	return c:IsSetCard(0x2066) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x2066) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c42023223.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1

--- a/c42155488.lua
+++ b/c42155488.lua
@@ -21,7 +21,7 @@ function c42155488.initial_effect(c)
 end
 function c42155488.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c42155488.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c42237854.lua
+++ b/c42237854.lua
@@ -29,7 +29,7 @@ function c42237854.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c42237854.filter(c)
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:GetLevel()==4
+	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsLevel(4)
 end
 function c42237854.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c42237854.filter(chkc) end

--- a/c423585.lua
+++ b/c423585.lua
@@ -53,7 +53,7 @@ function c423585.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.DiscardHand(tp,c423585.costfilter,1,1,REASON_COST+REASON_DISCARD)
 end
 function c423585.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c423585.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c42548470.lua
+++ b/c42548470.lua
@@ -15,8 +15,7 @@ function c42548470.filter1(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0x58) and lv1~=0 and Duel.IsExistingTarget(c42548470.filter2,tp,LOCATION_MZONE,0,1,c,lv1)
 end
 function c42548470.filter2(c,lv)
-	local lv2=c:GetLevel()
-	return c:IsFaceup() and c:IsSetCard(0x58) and lv2~=0 and lv2~=lv
+	return c:IsFaceup() and c:IsSetCard(0x58) and not c:IsLevel(lv)
 end
 function c42548470.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/c42737833.lua
+++ b/c42737833.lua
@@ -15,7 +15,7 @@ function c42737833.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c42737833.filter(c,e,tp)
-	return c:GetLevel()<=4 and c:IsSetCard(0x100d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevelBelow(4) and c:IsSetCard(0x100d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c42737833.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c42880485.lua
+++ b/c42880485.lua
@@ -97,7 +97,7 @@ function c42880485.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c42880485.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c42880485.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c42880485.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c43138260.lua
+++ b/c43138260.lua
@@ -34,7 +34,7 @@ function c43138260.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL+1
 end
 function c43138260.spfilter(c,e,tp)
-	return c:IsRace(RACE_FISH) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsRace(RACE_FISH) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c43138260.sptg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c43138260.spfilter(chkc,e,tp) end

--- a/c43140791.lua
+++ b/c43140791.lua
@@ -14,7 +14,7 @@ function c43140791.initial_effect(c)
 	Duel.AddCustomActivityCounter(43140791,ACTIVITY_SPSUMMON,c43140791.counterfilter)
 end
 function c43140791.counterfilter(c)
-	return c:GetLevel()~=3 and c:GetLevel()~=4
+	return not (c:IsLevel(3) or c:IsLevel(4))
 end
 function c43140791.cfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_INSECT)
@@ -38,8 +38,7 @@ function c43140791.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e2,tp)
 end
 function c43140791.sumlimit(e,c,sump,sumtype,sumpos,targetp,se)
-	local lv=c:GetLevel()
-	return lv==3 or lv==4
+	return c:IsLevel(3) or c:IsLevel(4)
 end
 function c43140791.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)

--- a/c4334811.lua
+++ b/c4334811.lua
@@ -41,7 +41,7 @@ function c4334811.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c4334811.cfilter(c)
-	return c:IsAttribute(ATTRIBUTE_EARTH) and c:IsRace(RACE_MACHINE) and c:GetLevel()==4 and c:IsAbleToDeckAsCost()
+	return c:IsAttribute(ATTRIBUTE_EARTH) and c:IsRace(RACE_MACHINE) and c:IsLevel(4) and c:IsAbleToDeckAsCost()
 end
 function c4334811.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c4334811.cfilter,tp,LOCATION_GRAVE,0,2,nil) end

--- a/c43383478.lua
+++ b/c43383478.lua
@@ -42,7 +42,7 @@ function c43383478.filter1(c,e,tp)
 		and Duel.IsExistingMatchingCard(c43383478.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()+1)
 end
 function c43383478.filter2(c,e,tp,mc,rk)
-	return c:GetRank()==rk and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c43383478.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c43413875.lua
+++ b/c43413875.lua
@@ -31,7 +31,7 @@ function c43413875.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c43413875.hspfilter(c,ft,tp)
-	return c:IsSetCard(0xe6) and c:GetLevel()==8 and not c:IsCode(43413875)
+	return c:IsSetCard(0xe6) and c:IsLevel(8) and not c:IsCode(43413875)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5)) and (c:IsControler(tp) or c:IsFaceup())
 end
 function c43413875.hspcon(e,c)

--- a/c43464884.lua
+++ b/c43464884.lua
@@ -45,7 +45,7 @@ function c43464884.splimit(e,c)
 	return not c:IsRace(RACE_BEASTWARRIOR)
 end
 function c43464884.cgfilter(c,mc)
-	return c:IsRace(RACE_BEASTWARRIOR) and c:GetLevel()>0 and not (c:GetLevel()==mc:GetLevel() and c:IsAttribute(mc:GetAttribute()))
+	return c:IsRace(RACE_BEASTWARRIOR) and c:GetLevel()>0 and not (c:IsLevel(mc:GetLevel()) and c:IsAttribute(mc:GetAttribute()))
 end
 function c43464884.cgtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()

--- a/c43476205.lua
+++ b/c43476205.lua
@@ -24,7 +24,7 @@ function c43476205.filter2(c,e,tp)
 		and Duel.IsExistingMatchingCard(c43476205.filter3,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,rk+1)
 end
 function c43476205.filter3(c,e,tp,mc,rk)
-	return c:GetRank()==rk and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c43476205.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c4357063.lua
+++ b/c4357063.lua
@@ -22,7 +22,7 @@ function c4357063.costfilter(c,e,tp)
 		and Duel.IsExistingTarget(c4357063.spfilter,tp,LOCATION_GRAVE,0,1,c,e,tp,c:GetLevel())
 end
 function c4357063.spfilter(c,e,tp,lv)
-	return c:IsSetCard(0x70) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x70) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c4357063.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c4357063.spfilter(chkc,e,tp,e:GetLabel()) end

--- a/c43708640.lua
+++ b/c43708640.lua
@@ -22,7 +22,7 @@ function c43708640.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c43708640.filter(c,e,tp)
-	return c:IsType(TYPE_NORMAL) and c:GetLevel()==4 and c:IsRace(RACE_BEASTWARRIOR)
+	return c:IsType(TYPE_NORMAL) and c:IsLevel(4) and c:IsRace(RACE_BEASTWARRIOR)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c43708640.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c43889633.lua
+++ b/c43889633.lua
@@ -27,8 +27,7 @@ function c43889633.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c43889633.filter(c)
-	local lv=c:GetLevel()
-	return c:IsFaceup() and lv>0 and lv<=4 and c:IsRace(RACE_FISH+RACE_SEASERPENT+RACE_AQUA) and c:IsAbleToRemove()
+	return c:IsFaceup() and c:IsLevelBelow(4) and c:IsRace(RACE_FISH+RACE_SEASERPENT+RACE_AQUA) and c:IsAbleToRemove()
 end
 function c43889633.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43889633.filter(chkc) end

--- a/c4423206.lua
+++ b/c4423206.lua
@@ -21,7 +21,7 @@ function c4423206.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c4423206.spfilter(c,e,tp)
 	return c:IsRace(RACE_WARRIOR+RACE_BEASTWARRIOR) and c:IsAttribute(ATTRIBUTE_EARTH)
-		and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+		and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c4423206.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c44341034.lua
+++ b/c44341034.lua
@@ -12,7 +12,7 @@ function c44341034.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c44341034.filter(c,e,tp)
-	return c:GetLevel()==3 and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c44341034.sumtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c44341034.filter(chkc,e,tp) end

--- a/c44364207.lua
+++ b/c44364207.lua
@@ -31,7 +31,7 @@ function c44364207.condition(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsPreviousPosition(POS_FACEUP)
 end
 function c44364207.filter(c)
-	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4 and c:IsAbleToHand()
+	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4) and c:IsAbleToHand()
 end
 function c44364207.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingMatchingCard(c44364207.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c44635489.lua
+++ b/c44635489.lua
@@ -33,8 +33,7 @@ function c44635489.spcon(e,c)
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c44635489.filter(c,clv)
-	local lv=c:GetLevel()
-	return c:IsSetCard(0x53) and lv~=0 and lv~=clv
+	return c:IsSetCard(0x53) and not c:IsLevel(clv)
 		and ((c:IsLocation(LOCATION_MZONE) and c:IsFaceup()) or c:IsLocation(LOCATION_GRAVE))
 end
 function c44635489.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c44762290.lua
+++ b/c44762290.lua
@@ -23,10 +23,10 @@ function c44762290.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c44762290.eqlimit(e,c)
-	return c:GetLevel()==1
+	return c:IsLevel(1)
 end
 function c44762290.filter(c)
-	return c:IsFaceup() and c:GetLevel()==1
+	return c:IsFaceup() and c:IsLevel(1)
 end
 function c44762290.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c44762290.filter(chkc) end

--- a/c44790889.lua
+++ b/c44790889.lua
@@ -18,7 +18,7 @@ function c44790889.initial_effect(c)
 end
 function c44790889.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_ONFIELD,0,nil)==0
 		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_ONFIELD,nil)>0
 end

--- a/c45221020.lua
+++ b/c45221020.lua
@@ -40,7 +40,7 @@ function c45221020.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c45221020.sfilter(c,lv,e,tp)
-	return c:IsType(TYPE_NORMAL) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_NORMAL) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c45221020.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/c45282603.lua
+++ b/c45282603.lua
@@ -13,7 +13,7 @@ function c45282603.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c45282603.filter(c,lv,e,tp)
-	return c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c45282603.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c45349196.lua
+++ b/c45349196.lua
@@ -29,7 +29,7 @@ function c45349196.initial_effect(c)
 end
 c45349196.material_setcode=0x3b
 function c45349196.mfilter1(c)
-	return c:IsFusionSetCard(0x45) and c:IsFusionType(TYPE_NORMAL) and c:GetLevel()==6
+	return c:IsFusionSetCard(0x45) and c:IsFusionType(TYPE_NORMAL) and c:IsLevel(6)
 end
 function c45349196.mfilter2(c)
 	return c:IsFusionSetCard(0x3b) and c:IsFusionType(TYPE_NORMAL)

--- a/c45450218.lua
+++ b/c45450218.lua
@@ -39,7 +39,7 @@ function c45450218.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ct=Duel.Draw(tp,1,REASON_EFFECT)
 	if ct==0 or Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local tc=Duel.GetOperatedGroup():GetFirst()
-	if tc:GetLevel()<=4 and tc:IsAttribute(ATTRIBUTE_DARK) and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	if tc:IsLevelBelow(4) and tc:IsAttribute(ATTRIBUTE_DARK) and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.SelectYesNo(tp,aux.Stringid(45450218,1)) then
 		Duel.ConfirmCards(1-tp,tc)
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)

--- a/c45452224.lua
+++ b/c45452224.lua
@@ -32,7 +32,7 @@ function c45452224.initial_effect(c)
 	e5:SetLabelObject(e6)
 end
 function c45452224.filter(c,e,tp)
-	return c:GetLevel()==1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c45452224.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c45452224.filter(chkc,e,tp) end

--- a/c45496268.lua
+++ b/c45496268.lua
@@ -45,7 +45,7 @@ function c45496268.sumop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c45496268.lvfilter(c)
-	return c:IsFaceup() and (c:IsSetCard(0x85) or c:IsCode(71071546)) and c:GetLevel()~=8
+	return c:IsFaceup() and (c:IsSetCard(0x85) or c:IsCode(71071546)) and not c:IsLevel(8)
 end
 function c45496268.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c45496268.lvfilter(chkc) end

--- a/c45644898.lua
+++ b/c45644898.lua
@@ -24,7 +24,7 @@ function c45644898.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c45644898.thfilter(c)
-	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==1 and c:IsAbleToHand()
+	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(1) and c:IsAbleToHand()
 end
 function c45644898.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c45644898.thfilter(chkc) end

--- a/c45651298.lua
+++ b/c45651298.lua
@@ -11,7 +11,7 @@ function c45651298.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c45651298.filter(c)
-	return c:IsFaceup() and c:GetLevel()==3
+	return c:IsFaceup() and c:IsLevel(3)
 end
 function c45651298.spcon(e,c)
 	if c==nil then return true end

--- a/c45725480.lua
+++ b/c45725480.lua
@@ -13,7 +13,7 @@ function c45725480.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c45725480.filter(c)
-	return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:GetLevel()==7 and c:IsAbleToRemoveAsCost()
+	return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsLevel(7) and c:IsAbleToRemoveAsCost()
 end
 function c45725480.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c45725480.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil) end

--- a/c45948430.lua
+++ b/c45948430.lua
@@ -16,13 +16,12 @@ function c45948430.filter(c,e,tp)
 	return Duel.IsExistingMatchingCard(c45948430.matfilter1,tp,LOCATION_HAND,0,1,c,tp,c)
 end
 function c45948430.matfilter1(c,tp,rc)
-	local lv=c:GetLevel()
-	return lv>0 and lv<8 and c:IsAttribute(ATTRIBUTE_LIGHT+ATTRIBUTE_DARK) and c:IsAbleToGrave() and c:IsCanBeRitualMaterial(rc)
-		and Duel.IsExistingMatchingCard(c45948430.matfilter2,tp,LOCATION_DECK,0,1,c,lv,c:GetAttribute(),rc)
+	return c:IsLevelBelow(7) and c:IsAttribute(ATTRIBUTE_LIGHT+ATTRIBUTE_DARK) and c:IsAbleToGrave() and c:IsCanBeRitualMaterial(rc)
+		and Duel.IsExistingMatchingCard(c45948430.matfilter2,tp,LOCATION_DECK,0,1,c,c:GetLevel(),c:GetAttribute(),rc)
 end
 function c45948430.matfilter2(c,lv,att,rc)
 	return ((c:IsAttribute(ATTRIBUTE_LIGHT) and att==ATTRIBUTE_DARK) or (c:IsAttribute(ATTRIBUTE_DARK) and att==ATTRIBUTE_LIGHT))
-		and c:GetLevel()==8-lv and c:IsAbleToGrave() and c:IsCanBeRitualMaterial(rc)
+		and c:IsLevel(8-lv) and c:IsAbleToGrave() and c:IsCanBeRitualMaterial(rc)
 end
 function c45948430.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c45950291.lua
+++ b/c45950291.lua
@@ -35,7 +35,7 @@ function c45950291.filter1(c,e,tp)
 end
 function c45950291.filter2(c,e,tp,mc,rk,rc,att,code)
 	if c:GetOriginalCode()==6165656 and code~=48995978 then return false end
-	return c:GetRank()==rk and c:IsRace(rc) and c:IsAttribute(att) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsRace(rc) and c:IsAttribute(att) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c45950291.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c46181000.lua
+++ b/c46181000.lua
@@ -17,7 +17,7 @@ function c46181000.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c46181000.filter(c,e,sp)
-	return c:IsType(TYPE_UNION) and c:GetLevel()<=4 and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
+	return c:IsType(TYPE_UNION) and c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
 end
 function c46181000.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c46195773.lua
+++ b/c46195773.lua
@@ -30,7 +30,7 @@ function c46195773.efilter(e,re,rp)
 end
 function c46195773.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local d=Duel.GetAttackTarget()
-	if chk==0 then return d and d:IsFaceup() and d:GetLevel()>=6 and d:IsType(TYPE_SYNCHRO) end
+	if chk==0 then return d and d:IsFaceup() and d:IsLevelAbove(6) and d:IsType(TYPE_SYNCHRO) end
 	d:CreateEffectRelation(e)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,d,1,0,0)
 end

--- a/c46291010.lua
+++ b/c46291010.lua
@@ -11,7 +11,7 @@ function c46291010.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c46291010.filter(c,lv)
-	return c:IsRace(RACE_PSYCHO) and c:GetLevel()~=lv and c:IsAbleToRemove()
+	return c:IsRace(RACE_PSYCHO) and not c:IsLevel(lv) and c:IsAbleToRemove()
 end
 function c46291010.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c46291010.filter,tp,LOCATION_DECK,0,1,nil,e:GetHandler():GetLevel()) end

--- a/c46303688.lua
+++ b/c46303688.lua
@@ -16,7 +16,7 @@ function c46303688.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,2)
 end
 function c46303688.dfilter(c,lv)
-	return c:IsFaceup() and c:GetLevel()==lv
+	return c:IsFaceup() and c:IsLevel(lv)
 end
 function c46303688.activate(e,tp,eg,ep,ev,re,r,rp)
 	local d1,d2=Duel.TossDice(tp,2)

--- a/c46411259.lua
+++ b/c46411259.lua
@@ -21,7 +21,7 @@ function c46411259.filter1(c,e,tp)
 		and Duel.GetLocationCountFromEx(tp,tp,c)>0
 end
 function c46411259.filter2(c,lv,e,tp)
-	return c:IsType(TYPE_FUSION) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_FUSION) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c46411259.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c46871387.lua
+++ b/c46871387.lua
@@ -30,7 +30,7 @@ function c46871387.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c46871387.filter(c)
-	return c:IsRace(RACE_ROCK) and c:IsAttribute(ATTRIBUTE_EARTH) and c:GetLevel()==4 and c:IsAbleToHand()
+	return c:IsRace(RACE_ROCK) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsLevel(4) and c:IsAbleToHand()
 end
 function c46871387.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c46871387.filter(chkc) end

--- a/c47185546.lua
+++ b/c47185546.lua
@@ -19,7 +19,7 @@ function c47185546.filter1(c,e,tp)
 		and aux.MustMaterialCheck(c,tp,EFFECT_MUST_BE_XMATERIAL)
 end
 function c47185546.filter2(c,e,tp,mc,rk)
-	return (c:GetRank()==rk+2 or c:GetRank()==rk-2) and c:IsRace(RACE_INSECT) and mc:IsCanBeXyzMaterial(c)
+	return (c:IsRank(rk+2) or c:IsRank(rk-2) and c:IsRace(RACE_INSECT) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c47185546.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c47594939.lua
+++ b/c47594939.lua
@@ -28,10 +28,10 @@ function c47594939.initial_effect(c)
 	e3:SetLabelObject(g)
 end
 function c47594939.lvfilter(c,lv,tp)
-	return c:GetLevel()==lv and c:IsControler(tp)
+	return c:IsLevel(lv) and c:IsControler(tp)
 end
 function c47594939.rkfilter(c,rk,tp)
-	return c:GetRank()==rk and c:IsControler(tp)
+	return c:IsRank(rk) and c:IsControler(tp)
 end
 function c47594939.splimit(e,c,sump,sumtype,sumpos,targetp)
 	local lv=c:GetLevel()

--- a/c47660516.lua
+++ b/c47660516.lua
@@ -19,7 +19,7 @@ function c47660516.filter1(c,e,tp)
 end
 function c47660516.filter2(c,e,tp,mc,rk,rc,code)
 	if c:GetOriginalCode()==6165656 and code~=48995978 then return false end
-	return c:GetRank()==rk and c:IsRace(rc) and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073)) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsRace(rc) and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073)) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c47660516.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c47687766.lua
+++ b/c47687766.lua
@@ -11,7 +11,7 @@ function c47687766.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c47687766.filter(c)
-	return c:GetLevel()==4 and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH) and not c:IsCode(47687766) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH) and not c:IsCode(47687766) and c:IsAbleToHand()
 end
 function c47687766.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c47687766.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c47882565.lua
+++ b/c47882565.lua
@@ -22,7 +22,7 @@ function c47882565.filter1(c,e,tp)
 		and aux.MustMaterialCheck(c,tp,EFFECT_MUST_BE_XMATERIAL)
 end
 function c47882565.filter2(c,e,tp,mc,rk)
-	return c:GetRank()==rk and c:IsSetCard(0xe5) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0xe5) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c47882565.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c48049769.lua
+++ b/c48049769.lua
@@ -25,7 +25,7 @@ function c48049769.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c48049769.filter(c)
-	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4 and c:IsAttackBelow(1600) and c:IsAbleToHand()
+	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4) and c:IsAttackBelow(1600) and c:IsAbleToHand()
 end
 function c48049769.filter1(c,g)
 	return g:IsExists(Card.IsCode,1,c,c:GetCode())

--- a/c48333324.lua
+++ b/c48333324.lua
@@ -19,7 +19,7 @@ function c48333324.filter1(c,e,tp)
 end
 function c48333324.filter2(c,e,tp,mc,rk,rc,code)
 	if c:GetOriginalCode()==6165656 and code~=48995978 then return false end
-	return c:GetRank()==rk and c:IsRace(rc) and c:IsSetCard(0x1048) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsRace(rc) and c:IsSetCard(0x1048) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c48333324.disfilter(c)

--- a/c49121795.lua
+++ b/c49121795.lua
@@ -71,7 +71,7 @@ function c49121795.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:GetPreviousControler()==tp and rp==1-tp and c:IsReason(REASON_DESTROY)
 end
 function c49121795.thfilter(c)
-	return c:IsRace(RACE_MACHINE) and c:GetLevel()==4 and c:IsAbleToHand()
+	return c:IsRace(RACE_MACHINE) and c:IsLevel(4) and c:IsAbleToHand()
 end
 function c49121795.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c49121795.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c49633574.lua
+++ b/c49633574.lua
@@ -12,7 +12,7 @@ function c49633574.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c49633574.spfilter(c,e,tp)
-	return c:IsSetCard(0x35) and c:GetLevel()==3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x35) and c:IsLevel(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c49633574.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c49669730.lua
+++ b/c49669730.lua
@@ -21,7 +21,7 @@ function c49669730.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
 end
 function c49669730.filter(c,e,sp)
-	return c:IsAttribute(ATTRIBUTE_WATER) and c:GetLevel()<=4 and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
+	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
 end
 function c49669730.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c50457953.lua
+++ b/c50457953.lua
@@ -13,8 +13,7 @@ function c50457953.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c50457953.lvfilter(c,lv)
-	local clv=c:GetLevel()
-	return c:IsFaceup() and clv>0 and clv~=lv and c:IsAttribute(ATTRIBUTE_WATER) and c:IsRace(RACE_DRAGON)
+	return c:IsFaceup() and not c:IsLevel(lv) and c:IsAttribute(ATTRIBUTE_WATER) and c:IsRace(RACE_DRAGON)
 end
 function c50457953.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c50457953.lvfilter(chkc,e:GetHandler():GetLevel()) end

--- a/c50732780.lua
+++ b/c50732780.lua
@@ -15,7 +15,7 @@ function c50732780.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c50732780.filter(c,e,tp)
-	return c:IsRace(RACE_FIEND) and c:GetLevel()==1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_FIEND) and c:IsLevel(1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c50732780.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c50785356.lua
+++ b/c50785356.lua
@@ -14,8 +14,7 @@ function c50785356.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c50785356.filter(c)
-	local lv=c:GetLevel()
-	return c:IsFaceup() and lv>0 and lv~=3
+	return c:IsFaceup() and not c:IsLevel(3)
 end
 function c50785356.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c50785356.filter(chkc) end

--- a/c51020079.lua
+++ b/c51020079.lua
@@ -16,7 +16,7 @@ function c51020079.rfilter(c,e,tp)
 	return c:IsType(TYPE_TUNER) and Duel.IsExistingTarget(c51020079.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,c:GetLevel(),c:GetAttribute())
 end
 function c51020079.spfilter(c,e,tp,lv,att)
-	return c:GetLevel()==lv and c:IsAttribute(att) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsAttribute(att) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c51020079.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c51020079.spfilter(chkc,e,tp) end

--- a/c51043053.lua
+++ b/c51043053.lua
@@ -23,10 +23,10 @@ function c51043053.atcon(e)
 		and Duel.GetFieldGroupCount(e:GetHandlerPlayer(),0,LOCATION_HAND)<5
 end
 function c51043053.filter(c)
-	return c:IsFaceup() and c:GetLevel()==8 and c:IsRace(RACE_DRAGON)
+	return c:IsFaceup() and c:IsLevel(8) and c:IsRace(RACE_DRAGON)
 end
 function c51043053.condition(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetLevel()~=8
+	return not e:GetHandler():IsLevel(8)
 		and Duel.IsExistingMatchingCard(c51043053.filter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c51043053.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c51126152.lua
+++ b/c51126152.lua
@@ -19,7 +19,7 @@ function c51126152.initial_effect(c)
 end
 function c51126152.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c51126152.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c51192573.lua
+++ b/c51192573.lua
@@ -42,7 +42,7 @@ function c51192573.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c51192573.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,1-tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c51192573.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c51192573.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,1-tp)

--- a/c51405049.lua
+++ b/c51405049.lua
@@ -11,13 +11,13 @@ function c51405049.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c51405049.cfilter(c)
-	return c:IsFaceup() and c:GetLevel()==1
+	return c:IsFaceup() and c:IsLevel(1)
 end
 function c51405049.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c51405049.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c51405049.filter(c)
-	return c:GetLevel()==1 and c:IsAbleToHand()
+	return c:IsLevel(1) and c:IsAbleToHand()
 end
 function c51405049.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c51405049.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c51630558.lua
+++ b/c51630558.lua
@@ -12,7 +12,7 @@ function c51630558.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c51630558.filter(c)
-	return c:IsFaceup() and c:GetLevel()>=8
+	return c:IsFaceup() and c:IsLevelAbove(8)
 end
 function c51630558.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,c51630558.filter,1,nil) end

--- a/c51632798.lua
+++ b/c51632798.lua
@@ -15,7 +15,7 @@ function c51632798.initial_effect(c)
 end
 function c51632798.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c51632798.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c5186893.lua
+++ b/c5186893.lua
@@ -28,7 +28,7 @@ function c5186893.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c5186893.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c5186893.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c5186893.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c51912531.lua
+++ b/c51912531.lua
@@ -23,7 +23,7 @@ function c51912531.synlimit(e,c)
 	return not c:IsAttribute(ATTRIBUTE_EARTH)
 end
 function c51912531.filter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_EARTH) and c:GetLevel()>1
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsLevelAbove(2)
 end
 function c51912531.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c51912531.filter(chkc) end

--- a/c52068432.lua
+++ b/c52068432.lua
@@ -35,7 +35,7 @@ function c52068432.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c52068432.mat_filter(c)
-	return c:GetLevel()~=9
+	return not c:IsLevel(9)
 end
 function c52068432.tfilter(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0xb4) and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)

--- a/c52085072.lua
+++ b/c52085072.lua
@@ -37,7 +37,7 @@ function c52085072.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c52085072.spcfilter(c)
-	return c:IsFaceup() and c:GetLevel()==1 and c:IsAbleToGraveAsCost()
+	return c:IsFaceup() and c:IsLevel(1) and c:IsAbleToGraveAsCost()
 end
 function c52085072.mzfilter(c,tp)
 	return c:GetSequence()<5

--- a/c52176579.lua
+++ b/c52176579.lua
@@ -50,7 +50,7 @@ function c52176579.lvfilter(c,tp)
 	return lv>0 and c:IsFaceup() and c:IsSetCard(0xea) and Duel.IsExistingMatchingCard(c52176579.tgfilter,tp,LOCATION_DECK,0,1,nil,lv)
 end
 function c52176579.tgfilter(c,lv)
-	return c:IsSetCard(0xea) and c:GetLevel()~=lv and c:IsType(TYPE_MONSTER) and c:IsAbleToGrave()
+	return c:IsSetCard(0xea) and not c:IsLevel(lv) and c:IsType(TYPE_MONSTER) and c:IsAbleToGrave()
 end
 function c52176579.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c52176579.lvfilter(chkc,tp) end

--- a/c52346240.lua
+++ b/c52346240.lua
@@ -12,7 +12,7 @@ function c52346240.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c52346240.filter(c,e,tp)
-	return c:GetLevel()==1 and c:IsRace(RACE_BEAST) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsLevel(1) and c:IsRace(RACE_BEAST) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c52346240.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c52346240.filter(chkc,e,tp) end

--- a/c5288597.lua
+++ b/c5288597.lua
@@ -28,7 +28,7 @@ function c5288597.cfilter(c,e,tp)
 		and Duel.IsExistingMatchingCard(c5288597.spfilter,tp,LOCATION_DECK,0,1,nil,lv+1,rc,att,e,tp)
 end
 function c5288597.spfilter(c,lv,rc,att,e,tp)
-	return c:GetLevel()==lv and c:IsRace(rc) and c:IsAttribute(att) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsRace(rc) and c:IsAttribute(att) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c5288597.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c53090623.lua
+++ b/c53090623.lua
@@ -42,7 +42,7 @@ function c53090623.rdcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RemoveOverlayCard(tp,1,0,1,1,REASON_COST)
 end
 function c53090623.filter(c)
-	return c:IsFaceup() and c:GetRank()>1
+	return c:IsFaceup() and c:IsRankAbove(1)
 end
 function c53090623.rdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c53090623.filter(chkc) end

--- a/c53199020.lua
+++ b/c53199020.lua
@@ -35,7 +35,7 @@ function c53199020.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c53199020.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c53199020.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c53199020.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c53291093.lua
+++ b/c53291093.lua
@@ -23,7 +23,7 @@ function c53291093.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,0,tp,LOCATION_DECK)
 end
 function c53291093.spfilter(c,e,tp)
-	return c:IsSetCard(0xc) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0xc) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c53291093.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c53944920.lua
+++ b/c53944920.lua
@@ -14,6 +14,6 @@ function c53944920.ntfilter(c)
 end
 function c53944920.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c53944920.ntfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end

--- a/c54031490.lua
+++ b/c54031490.lua
@@ -10,8 +10,7 @@ function c54031490.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c54031490.filter(c)
-	local lv=c:GetLevel()
-	return c:IsSetCard(0x3d) and lv>0 and lv<4 and c:IsAbleToHand()
+	return c:IsSetCard(0x3d) and c:IsLevelBelow(3) and c:IsAbleToHand()
 end
 function c54031490.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c54031490.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c54359696.lua
+++ b/c54359696.lua
@@ -11,7 +11,7 @@ function c54359696.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c54359696.filter(c)
-	return c:IsSetCard(0x6e) and c:GetLevel()==3 and c:IsAbleToHand()
+	return c:IsSetCard(0x6e) and c:IsLevel(3) and c:IsAbleToHand()
 end
 function c54359696.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c54537489.lua
+++ b/c54537489.lua
@@ -22,7 +22,7 @@ function c54537489.splimit(e,se,sp,st)
 	return se:IsActiveType(TYPE_MONSTER) and se:GetHandler():IsRace(RACE_WYRM)
 end
 function c54537489.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetLevel()>1
+	if chk==0 then return e:GetHandler():IsLevelAbove(2)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,54537490,0,0x4011,300,200,1,RACE_WYRM,ATTRIBUTE_WATER) end
 	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
@@ -30,7 +30,7 @@ function c54537489.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c54537489.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) or c:GetLevel()<2 then return end
+	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) or c:IsLevel(1) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_LEVEL)

--- a/c55010259.lua
+++ b/c55010259.lua
@@ -27,7 +27,7 @@ function c55010259.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c55010259.spfilter1(c,e,tp)
-	return c:IsRace(RACE_MACHINE) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_MACHINE) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c55010259.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -46,7 +46,7 @@ function c55010259.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0
 end
 function c55010259.spfilter2(c,e,tp)
-	return c:IsSetCard(0x51) and c:GetLevel()==4 and not c:IsCode(55010259) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x51) and c:IsLevel(4) and not c:IsCode(55010259) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c55010259.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c55416843.lua
+++ b/c55416843.lua
@@ -10,7 +10,7 @@ function c55416843.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c55416843.filter(c,e,tp)
-	return c:GetLevel()==5 and c:IsRace(RACE_WARRIOR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(5) and c:IsRace(RACE_WARRIOR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c55416843.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c55690251.lua
+++ b/c55690251.lua
@@ -39,7 +39,7 @@ function c55690251.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c55690251.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c55690251.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c55690251.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c56427559.lua
+++ b/c56427559.lua
@@ -20,8 +20,7 @@ function c56427559.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c56427559.lvfilter(c,lv)
-	local clv=c:GetLevel()
-	return c:IsFaceup() and c:IsSetCard(0x83) and clv>0 and clv~=lv
+	return c:IsFaceup() and c:IsSetCard(0x83) and not c:IsLevel(lv)
 end
 function c56427559.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c56427559.lvfilter(chkc,e:GetHandler():GetLevel()) end

--- a/c56511382.lua
+++ b/c56511382.lua
@@ -22,14 +22,11 @@ function c56511382.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.SelectMatchingCard(tp,c56511382.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SendtoGrave(g,REASON_COST)
 end
-function c56511382.filter(c)
-	return c:IsFaceup()
-end
 function c56511382.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c56511382.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c56511382.filter,tp,0,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,c56511382.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,1,1-tp,g:GetFirst():GetLevel()*400)
 end

--- a/c56585883.lua
+++ b/c56585883.lua
@@ -70,7 +70,7 @@ function c56585883.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetFlagEffect(56585883)>0
 end
 function c56585883.thfilter(c)
-	return c:IsAttackBelow(1500) and c:IsRace(RACE_WINDBEAST) and c:GetLevel()==4 and c:IsAbleToHand()
+	return c:IsAttackBelow(1500) and c:IsRace(RACE_WINDBEAST) and c:IsLevel(4) and c:IsAbleToHand()
 end
 function c56585883.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c56585883.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c56611470.lua
+++ b/c56611470.lua
@@ -76,7 +76,7 @@ function c56611470.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return rp~=tp and e:GetHandler():GetPreviousControler()==tp
 end
 function c56611470.cffilter(c)
-	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==5 and not c:IsPublic()
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(5) and not c:IsPublic()
 end
 function c56611470.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c56611470.cffilter,tp,LOCATION_HAND,0,1,nil) end

--- a/c56827051.lua
+++ b/c56827051.lua
@@ -38,7 +38,7 @@ function c56827051.lvop(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
 	local ct=e:GetLabel()
 	local sel=nil
-	if c:GetLevel()==1 then
+	if c:IsLevel(1) then
 		sel=Duel.SelectOption(tp,aux.Stringid(56827051,2))
 	else
 		sel=Duel.SelectOption(tp,aux.Stringid(56827051,2),aux.Stringid(56827051,3))

--- a/c56832966.lua
+++ b/c56832966.lua
@@ -34,7 +34,7 @@ function c56832966.initial_effect(c)
 end
 c56832966.xyz_number=39
 function c56832966.ovfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x107f) and c:IsType(TYPE_XYZ) and c:GetRank()==4
+	return c:IsFaceup() and c:IsSetCard(0x107f) and c:IsType(TYPE_XYZ) and c:IsRank(4)
 end
 function c56832966.aclimit(e,re,tp)
 	return not re:GetHandler():IsImmuneToEffect(e)

--- a/c56931015.lua
+++ b/c56931015.lua
@@ -22,7 +22,7 @@ function c56931015.initial_effect(c)
 end
 function c56931015.ntcon(e,c,minc)
 	if c==nil then return Duel.GetTurnCount()~=1 end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_ONFIELD,LOCATION_ONFIELD)==0
 end
 function c56931015.descost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c57019473.lua
+++ b/c57019473.lua
@@ -12,7 +12,7 @@ function c57019473.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c57019473.filter(c)
-	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4
+	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4)
 		and c:GetCode()~=57019473 and c:IsAttackBelow(1600) and c:IsAbleToRemove()
 end
 function c57019473.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c5703682.lua
+++ b/c5703682.lua
@@ -11,7 +11,7 @@ function c5703682.initial_effect(c)
 end
 function c5703682.filter(c)
 	local tpe=c:GetType()
-	return c:IsFaceup() and bit.band(tpe,TYPE_NORMAL)~=0 and bit.band(tpe,TYPE_TOKEN)==0 and c:GetLevel()==2
+	return c:IsFaceup() and bit.band(tpe,TYPE_NORMAL)~=0 and bit.band(tpe,TYPE_TOKEN)==0 and c:IsLevel(2)
 end
 function c5703682.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c5703682.filter,tp,LOCATION_MZONE,0,1,nil) end
@@ -44,7 +44,7 @@ function c5703682.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(de,tp)
 end
 function c5703682.dfilter(c)
-	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:GetLevel()==2
+	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:IsLevel(2)
 end
 function c5703682.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c5703682.dfilter,tp,LOCATION_MZONE,0,1,nil)

--- a/c57108202.lua
+++ b/c57108202.lua
@@ -25,7 +25,7 @@ function c57108202.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c57108202.filter(c,lv)
-	return c:IsSetCard(0x26) and c:GetLevel()==lv and c:IsAbleToHand()
+	return c:IsSetCard(0x26) and c:IsLevel(lv) and c:IsAbleToHand()
 end
 function c57108202.cona(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsDisabled() and e:GetHandler():IsAttackPos()

--- a/c5728014.lua
+++ b/c5728014.lua
@@ -15,7 +15,7 @@ function c5728014.filter(c,e,tp)
 	return c:IsFaceup() and lv>0 and Duel.IsExistingMatchingCard(c5728014.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp,lv)
 end
 function c5728014.spfilter(c,e,tp,lv)
-	return c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c5728014.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/c57421866.lua
+++ b/c57421866.lua
@@ -20,7 +20,7 @@ function c57421866.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c57421866.filter(c)
-	return c:IsFaceup() and c:GetLevel()>=5
+	return c:IsFaceup() and c:IsLevelAbove(5)
 end
 function c57421866.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c57421866.filter(chkc) end

--- a/c57441100.lua
+++ b/c57441100.lua
@@ -22,7 +22,7 @@ function c57441100.condition(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)~=0
 end
 function c57441100.filter(c,e,sp)
-	return c:IsType(TYPE_DUAL) and c:GetLevel()<=4 and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
+	return c:IsType(TYPE_DUAL) and c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
 end
 function c57441100.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c57707471.lua
+++ b/c57707471.lua
@@ -24,7 +24,7 @@ function c57707471.initial_effect(c)
 end
 c57707471.xyz_number=21
 function c57707471.ovfilter(c)
-	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and c:GetRank()==5
+	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and c:IsRank(5)
 end
 function c57707471.xyzop(e,tp,chk,mc)
 	if chk==0 then return mc:CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/c58257569.lua
+++ b/c58257569.lua
@@ -70,7 +70,7 @@ function c58257569.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:GetPreviousLocation()==LOCATION_SZONE and not c:IsReason(REASON_LOST_TARGET)
 end
 function c58257569.thfilter(c)
-	return c:IsRace(RACE_DRAGON) and c:GetLevel()==1 and c:IsAbleToHand()
+	return c:IsRace(RACE_DRAGON) and c:IsLevel(1) and c:IsAbleToHand()
 end
 function c58257569.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c58257569.thfilter,tp,LOCATION_GRAVE+LOCATION_DECK,0,1,nil) end

--- a/c58441120.lua
+++ b/c58441120.lua
@@ -11,7 +11,7 @@ function c58441120.initial_effect(c)
 end
 function c58441120.filter(c)
 	local lv=c:GetLevel()
-	return c:IsFaceup() and lv>0 and lv~=4
+	return c:IsFaceup() and not c:IsLevel(4)
 end
 function c58441120.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c58441120.filter(chkc) end

--- a/c58471134.lua
+++ b/c58471134.lua
@@ -24,7 +24,7 @@ function c58471134.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.DiscardHand(tp,c58471134.cfilter,1,1,REASON_COST+REASON_DISCARD)
 end
 function c58471134.filter(c)
-	return c:GetLevel()==3 and c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToHand()
+	return c:IsLevel(3) and c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToHand()
 end
 function c58471134.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c58471134.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c58494728.lua
+++ b/c58494728.lua
@@ -36,7 +36,7 @@ function c58494728.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c58494728.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c58494728.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c58494728.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c58531587.lua
+++ b/c58531587.lua
@@ -28,7 +28,7 @@ function c58531587.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c58531587.atktarget(e,c)
-	return c:GetLevel()>=4
+	return c:IsLevelAbove(4)
 end
 function c58531587.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp

--- a/c58554959.lua
+++ b/c58554959.lua
@@ -19,7 +19,7 @@ end
 function c58554959.otcon(e,c,minc)
 	if c==nil then return true end
 	return Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)>0
-		and c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1)
+		and c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1)
 end
 function c58554959.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local sg=Duel.SelectTribute(tp,c,1,1)

--- a/c58577036.lua
+++ b/c58577036.lua
@@ -35,7 +35,7 @@ function c58577036.operation(e,tp,eg,ep,ev,re,r,rp)
 		return
 	end
 	Duel.ConfirmDecktop(tp,dcount-seq)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and lv~=spcard:GetLevel()
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and not spcard:IsLevel(lv)
 		and spcard:IsCanBeSpecialSummoned(e,0,tp,false,false) then
 		Duel.DisableShuffleCheck()
 		if dcount-seq==1 then Duel.SpecialSummon(spcard,0,tp,tp,false,false,POS_FACEUP)

--- a/c58600555.lua
+++ b/c58600555.lua
@@ -29,7 +29,7 @@ function c58600555.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c58600555.ovfilter(c)
-	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and (c:GetRank()==3 or c:GetRank()==4) and c:IsRace(RACE_INSECT)
+	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and (c:IsRank(3) or c:IsRank(4) and c:IsRace(RACE_INSECT)
 end
 function c58600555.mfilter(c)
 	return c:IsRace(RACE_INSECT) and c:IsAttribute(ATTRIBUTE_LIGHT)

--- a/c58616392.lua
+++ b/c58616392.lua
@@ -19,7 +19,7 @@ function c58616392.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c58616392.filter(c)
-	return c:IsRace(RACE_FIEND) and c:GetLevel()==8 and c:IsAbleToHand()
+	return c:IsRace(RACE_FIEND) and c:IsLevel(8) and c:IsAbleToHand()
 end
 function c58616392.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)

--- a/c58787301.lua
+++ b/c58787301.lua
@@ -19,7 +19,7 @@ function c58787301.cfilter(c,e,tp)
 		and Duel.IsExistingMatchingCard(c58787301.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,c:GetLevel())
 end
 function c58787301.spfilter(c,e,tp,lv)
-	return c:IsSetCard(0xef) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsSetCard(0xef) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c58787301.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c58988903.lua
+++ b/c58988903.lua
@@ -31,7 +31,7 @@ function c58988903.filter1(c,e,tp)
 		and aux.MustMaterialCheck(c,tp,EFFECT_MUST_BE_XMATERIAL)
 end
 function c58988903.filter2(c,e,tp,mc,rk)
-	return c:GetRank()==rk and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0xba) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c58988903.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c59123937.lua
+++ b/c59123937.lua
@@ -25,7 +25,7 @@ function c59123937.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c59123937.spfilter(c,e,tp)
-	return c:GetLevel()==7 and c:IsSetCard(0x10af) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(7) and c:IsSetCard(0x10af) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c59123937.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1

--- a/c59563768.lua
+++ b/c59563768.lua
@@ -10,7 +10,7 @@ function c59563768.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c59563768.filter(c)
-	return c:IsFaceup() and c:GetLevel()==2
+	return c:IsFaceup() and c:IsLevel(2)
 end
 function c59563768.atkval(e,c)
 	return Duel.GetMatchingGroupCount(c59563768.filter,e:GetHandlerPlayer(),LOCATION_MZONE,0,nil)*400

--- a/c5998840.lua
+++ b/c5998840.lua
@@ -22,7 +22,7 @@ function c5998840.synlimit(e,c)
 	return not c:IsSetCard(0x100d)
 end
 function c5998840.filter(c,e,tp)
-	return c:GetLevel()<=4 and c:IsSetCard(0x100d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevelBelow(4) and c:IsSetCard(0x100d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c5998840.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c60461077.lua
+++ b/c60461077.lua
@@ -28,7 +28,7 @@ end
 function c60461077.ntcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and (Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 or not Duel.IsExistingMatchingCard(c60461077.cfilter,tp,LOCATION_MZONE,0,1,nil))
 end
 function c60461077.thcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c6061630.lua
+++ b/c6061630.lua
@@ -59,7 +59,7 @@ function c6061630.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c6061630.sfilter(c,lv,e,tp)
 	return c:IsRace(RACE_SPELLCASTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and c:GetLevel()==lv
+		and c:IsLevel(lv)
 end
 function c6061630.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/c60681103.lua
+++ b/c60681103.lua
@@ -54,7 +54,7 @@ function c60681103.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c60681103.filter(c,e,tp)
-	return c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and not c:IsCode(60681103)
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and not c:IsCode(60681103)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c60681103.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c6075801.lua
+++ b/c6075801.lua
@@ -33,7 +33,7 @@ function c6075801.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c6075801.filter(c)
-	return c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and not c:IsForbidden()
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and not c:IsForbidden()
 end
 function c6075801.eqtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
@@ -69,7 +69,7 @@ function c6075801.efilter(e,te)
 	return te:IsActiveType(TYPE_MONSTER) and te:GetOwner()~=e:GetOwner()
 end
 function c6075801.spfilter(c,e,tp)
-	return c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c6075801.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c60954556.lua
+++ b/c60954556.lua
@@ -26,7 +26,7 @@ function c60954556.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c60954556.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c60954556.spfilter(c,e,tp)
-	return c:IsRace(RACE_WINDBEAST) and c:GetLevel()==1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_WINDBEAST) and c:IsLevel(1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c60954556.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c61231400.lua
+++ b/c61231400.lua
@@ -18,7 +18,7 @@ function c61231400.initial_effect(c)
 end
 function c61231400.otcon(e,c,minc)
 	if c==nil then return true end
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1)
 end
 function c61231400.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local g=Duel.SelectTribute(tp,c,1,1)

--- a/c61777313.lua
+++ b/c61777313.lua
@@ -21,8 +21,7 @@ function c61777313.synlimit(e,c)
 	return c:IsSetCard(0x42)
 end
 function c61777313.cfilter(c,lv)
-	local clv=c:GetLevel()
-	return c:IsSetCard(0x42) and clv>0 and clv~=lv and c:IsAbleToGraveAsCost()
+	return c:IsSetCard(0x42) and not c:IsLevel(lv) and c:IsAbleToGraveAsCost()
 end
 function c61777313.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c61777313.cfilter,tp,LOCATION_DECK,0,1,nil,e:GetHandler():GetLevel()) end

--- a/c62376646.lua
+++ b/c62376646.lua
@@ -15,9 +15,6 @@ function c62376646.spfilter(c,e,tp)
 	return c:IsSetCard(0xfc) and c:GetLevel()>0
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) and c:IsCanBeEffectTarget(e)
 end
-function c62376646.rfilter(c,lv)
-	return c:GetLevel()==lv
-end
 function c62376646.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local g=Duel.GetMatchingGroup(c62376646.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp)
@@ -26,7 +23,7 @@ function c62376646.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and g:GetClassCount(Card.GetLevel)>=2 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g1=g:Select(tp,1,1,nil)
-	g:Remove(c62376646.rfilter,nil,g1:GetFirst():GetLevel())
+	g:Remove(Card.IsLevel,nil,g1:GetFirst():GetLevel())
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g2=g:Select(tp,1,1,nil)
 	g1:Merge(g2)

--- a/c62541668.lua
+++ b/c62541668.lua
@@ -25,7 +25,6 @@ function c62541668.initial_effect(c)
 end
 c62541668.xyz_number=77
 function c62541668.ovfilter(c)
-	local rk=c:GetRank()
 	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_XYZ) and (c:IsRank(10) or c:IsRank(11))
 end
 function c62541668.xyzop(e,tp,chk)

--- a/c62541668.lua
+++ b/c62541668.lua
@@ -26,7 +26,7 @@ end
 c62541668.xyz_number=77
 function c62541668.ovfilter(c)
 	local rk=c:GetRank()
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_XYZ) and (rk==10 or rk==11)
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_XYZ) and (c:IsRank(10) or c:IsRank(11))
 end
 function c62541668.xyzop(e,tp,chk)
 	if chk==0 then return true end

--- a/c6256844.lua
+++ b/c6256844.lua
@@ -12,7 +12,7 @@ function c6256844.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c6256844.filter(c)
-	return c:GetLevel()==1 and c:IsSetCard(0x2) and c:IsAbleToHand()
+	return c:IsLevel(1) and c:IsSetCard(0x2) and c:IsAbleToHand()
 end
 function c6256844.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c6256844.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c62709239.lua
+++ b/c62709239.lua
@@ -58,7 +58,7 @@ function c62709239.spfilter1(c,e,tp)
 		and Duel.IsExistingTarget(c62709239.spfilter2,tp,LOCATION_GRAVE,0,1,c,c:GetLevel(),e,tp)
 end
 function c62709239.spfilter2(c,lv,e,tp)
-	return c:GetLevel()==lv and c:IsSetCard(0x10db) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsSetCard(0x10db) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c62709239.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/c62742651.lua
+++ b/c62742651.lua
@@ -24,7 +24,7 @@ function c62742651.ntfilter(c)
 end
 function c62742651.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c62742651.ntfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end
 function c62742651.damcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c62957424.lua
+++ b/c62957424.lua
@@ -54,7 +54,7 @@ function c62957424.ssop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 end
 function c62957424.spfilter(c,e,tp)
-	return c:GetLevel()==3 and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_FIEND) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(3) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_FIEND) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c62957424.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c63049052.lua
+++ b/c63049052.lua
@@ -40,7 +40,7 @@ function c63049052.tgop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetOwner():CancelToGrave(false)
 end
 function c63049052.filter(c)
-	return c:IsFaceup() and c:GetRank()==4
+	return c:IsFaceup() and c:IsRank(4)
 end
 function c63049052.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c63049052.filter(chkc) end

--- a/c63193879.lua
+++ b/c63193879.lua
@@ -46,7 +46,7 @@ function c63193879.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	local g=Duel.SelectTarget(tp,c63193879.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	local op=0
-	if g:GetFirst():GetLevel()==1 then op=Duel.SelectOption(tp,aux.Stringid(63193879,1))
+	if g:GetFirst():IsLevel(1) then op=Duel.SelectOption(tp,aux.Stringid(63193879,1))
 	else op=Duel.SelectOption(tp,aux.Stringid(63193879,1),aux.Stringid(63193879,2)) end
 	e:SetLabel(op)
 end

--- a/c63485233.lua
+++ b/c63485233.lua
@@ -19,7 +19,7 @@ function c63485233.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c63485233.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	local tc=g:GetFirst()
 	local op=0
-	if tc:GetLevel()==1 then op=Duel.SelectOption(tp,aux.Stringid(63485233,0))
+	if tc:IsLevel(1) then op=Duel.SelectOption(tp,aux.Stringid(63485233,0))
 	else op=Duel.SelectOption(tp,aux.Stringid(63485233,0),aux.Stringid(63485233,1)) end
 	e:SetLabel(op)
 end

--- a/c63730624.lua
+++ b/c63730624.lua
@@ -54,11 +54,11 @@ function c63730624.initial_effect(c)
 end
 function c63730624.eqlimit(e,c)
 	return c:GetControler()==e:GetHandler():GetControler()
-		and (c:IsCode(2403771) or (c:IsSetCard(0x26) and c:GetLevel()>=4 and c:IsRace(RACE_MACHINE)))
+		and (c:IsCode(2403771) or (c:IsSetCard(0x26) and c:IsLevelAbove(4) and c:IsRace(RACE_MACHINE)))
 end
 function c63730624.filter(c,tp)
 	return c:IsControler(tp) and c:IsFaceup()
-		and (c:IsCode(2403771) or (c:IsSetCard(0x26) and c:GetLevel()>=4 and c:IsRace(RACE_MACHINE)))
+		and (c:IsCode(2403771) or (c:IsSetCard(0x26) and c:IsLevelAbove(4) and c:IsRace(RACE_MACHINE)))
 end
 function c63730624.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c63730624.filter(chkc,tp) end

--- a/c63883999.lua
+++ b/c63883999.lua
@@ -36,7 +36,7 @@ function c63883999.rfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_FIEND) and c:IsAbleToRemove()
 end
 function c63883999.spfilter(c,lv,e,tp)
-	return c:IsSetCard(0x45) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x45) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c63883999.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c63883999.filter(chkc,e,tp) end

--- a/c64161630.lua
+++ b/c64161630.lua
@@ -18,7 +18,7 @@ function c64161630.cfilter(c,e,tp)
 end
 function c64161630.filter(c,rk,rc,e,tp)
 	return c:IsType(TYPE_XYZ) and c:IsSetCard(0x48)
-		and c:GetRank()==rk and c:IsRace(rc) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and c:IsRank(rk) and c:IsRace(rc) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c64161630.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(100)

--- a/c64319467.lua
+++ b/c64319467.lua
@@ -31,8 +31,7 @@ function c64319467.splimit(e,c)
 	return c:GetAttribute()~=ATTRIBUTE_WATER
 end
 function c64319467.filter(c,e,tp)
-	local lv=c:GetLevel()
-	return (lv==3 or lv==4) and c:IsRace(RACE_FISH) and c:IsAttribute(ATTRIBUTE_WATER)
+	return (c:IsLevel(3) or c:IsLevel(4)) and c:IsRace(RACE_FISH) and c:IsAttribute(ATTRIBUTE_WATER)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c64319467.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c6442944.lua
+++ b/c6442944.lua
@@ -37,7 +37,7 @@ function c6442944.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL+1
 end
 function c6442944.spfilter(c,e,tp)
-	return c:IsRace(RACE_SEASERPENT) and c:GetLevel()==8 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_SEASERPENT) and c:IsLevel(8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c6442944.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c64454614.lua
+++ b/c64454614.lua
@@ -63,11 +63,11 @@ function c64454614.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsSummonType(SUMMON_TYPE_LINK)
 end
 function c64454614.spfilter(c,e,tp)
-	return c:IsType(TYPE_NORMAL) and c:GetLevel()==4 and c:IsRace(RACE_WARRIOR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_NORMAL) and c:IsLevel(4) and c:IsRace(RACE_WARRIOR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsExistingMatchingCard(c64454614.thfilter,tp,LOCATION_DECK,0,1,c)
 end
 function c64454614.thfilter(c)
-	return c:GetLevel()==4 and c:IsRace(RACE_WARRIOR) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsRace(RACE_WARRIOR) and c:IsAbleToHand()
 end
 function c64454614.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c64496451.lua
+++ b/c64496451.lua
@@ -70,7 +70,7 @@ function c64496451.splimit(e,c)
 end
 function c64496451.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c64496451.lvcon(e)
 	return e:GetHandler():GetMaterialCount()==0

--- a/c65149697.lua
+++ b/c65149697.lua
@@ -12,7 +12,7 @@ function c65149697.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c65149697.filter(c)
-	return c:GetLevel()==4 and c:IsSetCard(0x1002) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsSetCard(0x1002) and c:IsAbleToHand()
 end
 function c65149697.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c65149697.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c652362.lua
+++ b/c652362.lua
@@ -12,8 +12,7 @@ function c652362.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c652362.filter(c,e,tp)
-	local lv=c:GetLevel()
-	return lv>0 and lv<=4 and c:IsSetCard(0xc) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevelBelow(4) and c:IsSetCard(0xc) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c652362.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c652362.filter(chkc,e,tp) end

--- a/c65314286.lua
+++ b/c65314286.lua
@@ -54,7 +54,7 @@ function c65314286.initial_effect(c)
 end
 function c65314286.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4
+	return minc==0 and c:IsLevelAbove(5)
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end

--- a/c65536818.lua
+++ b/c65536818.lua
@@ -57,8 +57,7 @@ function c65536818.thop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c65536818.costfilter(c,lv)
-	local clv=c:GetLevel()
-	return clv>0 and clv~=lv and c:IsRace(RACE_WYRM) and c:IsAbleToGraveAsCost()
+	return not c:IsLevel(lv) and c:IsRace(RACE_WYRM) and c:IsAbleToGraveAsCost()
 end
 function c65536818.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local lv=e:GetHandler():GetLevel()

--- a/c65591858.lua
+++ b/c65591858.lua
@@ -31,7 +31,7 @@ function c65591858.splimit(e,c,sump,sumtype,sumpos,targetp,se)
 	return not c:IsSetCard(0x70)
 end
 function c65591858.filter(c,e,tp)
-	return c:GetLevel()==5 and c:IsSetCard(0x70) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(5) and c:IsSetCard(0x70) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c65591858.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c65591858.filter(chkc,e,tp) end

--- a/c65737274.lua
+++ b/c65737274.lua
@@ -44,8 +44,7 @@ function c65737274.cfilter(c,tp)
 	return c:IsRace(RACE_DRAGON) and Duel.IsExistingTarget(c65737274.lvfilter,tp,LOCATION_MZONE,0,1,c)
 end
 function c65737274.lvfilter(c)
-	local lv=c:GetLevel()
-	return c:IsFaceup() and lv>0 and lv~=8
+	return c:IsFaceup() and not c:IsLevel(8)
 end
 function c65737274.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,c65737274.cfilter,1,nil,tp) end
@@ -60,7 +59,7 @@ function c65737274.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c65737274.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetLevel()~=8 then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and not tc:IsLevel(8) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)

--- a/c66141736.lua
+++ b/c66141736.lua
@@ -67,7 +67,7 @@ function c66141736.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c66141736.spfilter2(c,e,tp)
-	return c:IsSetCard(0x57) and c:GetLevel()==1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x57) and c:IsLevel(1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c66141736.sptg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c66141736.spfilter2(chkc,e,tp) end

--- a/c6614221.lua
+++ b/c6614221.lua
@@ -40,7 +40,7 @@ function c6614221.initial_effect(c)
 end
 function c6614221.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c6614221.ttcon(e,c,minc)
 	if c==nil then return true end

--- a/c66214679.lua
+++ b/c66214679.lua
@@ -28,7 +28,7 @@ function c66214679.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and e:GetHandler():GetFlagEffect(1)>0
 end
 function c66214679.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsAttribute(ATTRIBUTE_DARK) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c66214679.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c66214679.filter(chkc,e,tp) end

--- a/c66762372.lua
+++ b/c66762372.lua
@@ -33,7 +33,7 @@ function c66762372.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c66762372.spfilter(c,e,tp)
-	return c:IsSetCard(0x79) and c:GetLevel()==4 and c:GetCode()~=66762372 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x79) and c:IsLevel(4) and c:GetCode()~=66762372 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c66762372.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c67136033.lua
+++ b/c67136033.lua
@@ -28,7 +28,7 @@ function c67136033.initial_effect(c)
 end
 function c67136033.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c67136033.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack
@@ -42,7 +42,7 @@ function c67136033.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	c:RegisterEffect(e1)
 end
 function c67136033.filter(c)
-	return c:IsRace(RACE_BEASTWARRIOR) and c:GetLevel()==4
+	return c:IsRace(RACE_BEASTWARRIOR) and c:IsLevel(4)
 end
 function c67136033.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c67136033.filter,tp,LOCATION_MZONE,0,1,nil) end

--- a/c67196946.lua
+++ b/c67196946.lua
@@ -13,13 +13,10 @@ end
 function c67196946.con(e,tp,eg,ep,ev,re,r,rp)
 	return not Duel.IsPlayerAffectedByEffect(tp,EFFECT_LPCOST_CHANGE)
 end
-function c67196946.filter(c,lv)
-	return c:GetLevel()>lv
-end
 function c67196946.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,500) end
 	local lp=Duel.GetLP(tp)
-	local g=Duel.GetMatchingGroup(c67196946.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,1)
+	local g=Duel.GetMatchingGroup(Card.IsLevelAbove,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,2)
 	local tg=g:GetMaxGroup(Card.GetLevel)
 	local maxlv=tg:GetFirst():GetLevel()
 	local t={}
@@ -34,11 +31,11 @@ function c67196946.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(announce/500)
 end
 function c67196946.tg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c67196946.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil,1) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsLevelAbove,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil,2) end
 end
 function c67196946.op(e,tp,eg,ep,ev,re,r,rp)
 	local ct=e:GetLabel()
-	local g=Duel.GetMatchingGroup(c67196946.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,ct)
+	local g=Duel.GetMatchingGroup(Card.IsLevelAbove,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,ct+1)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(67196946,1))
 		local sg=g:Select(tp,1,1,nil)

--- a/c67218327.lua
+++ b/c67218327.lua
@@ -20,7 +20,7 @@ function c67218327.lkfilter(c)
 	return c:IsType(TYPE_LINK) and c:IsLinkState()
 end
 function c67218327.filter(c)
-	return c:IsRace(RACE_CYBERSE) and c:GetLevel()==4 and c:IsAbleToHand()
+	return c:IsRace(RACE_CYBERSE) and c:IsLevel(4) and c:IsAbleToHand()
 end
 function c67218327.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c67218327.filter(chkc) end

--- a/c67310848.lua
+++ b/c67310848.lua
@@ -25,7 +25,7 @@ function c67310848.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetFlagEffect(67310848)~=0
 end
 function c67310848.thfilter(c)
-	return c:GetLevel()==7 and c:IsAttribute(ATTRIBUTE_LIGHT+ATTRIBUTE_DARK) and c:IsAbleToHand()
+	return c:IsLevel(7) and c:IsAttribute(ATTRIBUTE_LIGHT+ATTRIBUTE_DARK) and c:IsAbleToHand()
 end
 function c67310848.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c67310848.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c6733059.lua
+++ b/c6733059.lua
@@ -83,7 +83,7 @@ function c6733059.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetTargetParam(lv)
 end
 function c6733059.dfilter(c,lv)
-	return c:IsFaceup() and c:GetLevel()==lv
+	return c:IsFaceup() and c:IsLevel(lv)
 end
 function c6733059.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end

--- a/c67464807.lua
+++ b/c67464807.lua
@@ -15,7 +15,7 @@ function c67464807.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp
 end
 function c67464807.filter(c)
-	return c:IsFaceup() and c:GetLevel()>1
+	return c:IsFaceup() and c:IsLevelAbove(2)
 end
 function c67464807.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c67464807.filter(chkc) end
@@ -41,7 +41,7 @@ function c67464807.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c67464807.damcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()==tp and ep==tp and eg:GetFirst():GetLevel()==e:GetLabel()-1
+	return Duel.GetTurnPlayer()==tp and ep==tp and eg:GetFirst():IsLevel(e:GetLabel()-1)
 end
 function c67464807.damop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Damage(1-tp,e:GetLabel()*500,REASON_EFFECT)

--- a/c67547370.lua
+++ b/c67547370.lua
@@ -70,7 +70,7 @@ function c67547370.countcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RegisterEffect(e1)
 end
 function c67547370.filter(c)
-	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:GetLevel()==1
+	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:IsLevel(1)
 end
 function c67547370.counttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c67547370.filter(chkc) end

--- a/c68371799.lua
+++ b/c68371799.lua
@@ -74,7 +74,7 @@ function c68371799.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_ADVANCE)
 end
 function c68371799.spfilter(c,e,tp)
-	return c:GetLevel()==6 and c:IsSetCard(0x45) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsLevel(6) and c:IsSetCard(0x45) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c68371799.sptg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c68371799.spfilter(chkc,e,tp) end

--- a/c6849042.lua
+++ b/c6849042.lua
@@ -29,7 +29,7 @@ function c6849042.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c6849042.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c6849042.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c6849042.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c6853254.lua
+++ b/c6853254.lua
@@ -20,7 +20,7 @@ function c6853254.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c6853254.filter(c,e,tp)
-	return c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c6853254.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c6853254.filter(chkc,e,tp) end

--- a/c68950538.lua
+++ b/c68950538.lua
@@ -35,7 +35,7 @@ function c68950538.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return not c:IsStatus(STATUS_CONTINUOUS_POS) and c:IsPosition(POS_FACEUP_DEFENSE) and c:IsPreviousPosition(POS_FACEUP_ATTACK)
 end
 function c68950538.spfilter(c,e,tp)
-	return c:GetLevel()==3 and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsLevel(3) and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c68950538.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c69042950.lua
+++ b/c69042950.lua
@@ -10,15 +10,14 @@ function c69042950.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c69042950.mfilter(c,clv)
-	return c:IsFaceup() and c:GetLevel()==clv
+	return c:IsFaceup() and c:IsLevel(clv)
 end
 function c69042950.mfilter2(c)
 	return c:IsFaceup() and c:IsLevelBelow(4)
 end
 function c69042950.spfilter(c,e,tp)
-	local lv=c:GetLevel()
-	return lv>0 and lv<=4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and Duel.IsExistingMatchingCard(c69042950.mfilter,tp,LOCATION_MZONE,0,1,nil,lv)
+	return c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(c69042950.mfilter,tp,LOCATION_MZONE,0,1,nil,c:GetLevel())
 end
 function c69042950.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c69105797.lua
+++ b/c69105797.lua
@@ -61,7 +61,7 @@ function c69105797.cop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:GetFirst()
 	while tc do
 		tc:AddCounter(0x1041,1)
-		if tc:GetLevel()>1 then
+		if tc:IsLevelAbove(2) then
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_CHANGE_LEVEL)

--- a/c69230391.lua
+++ b/c69230391.lua
@@ -36,7 +36,7 @@ end
 function c69230391.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c69230391.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c69230391.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c69230391.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c69257165.lua
+++ b/c69257165.lua
@@ -12,7 +12,7 @@ function c69257165.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c69257165.ctffilter(c,lv)
-	return c:IsFaceup() and c:IsControlerCanBeChanged() and c:GetLevel()==lv
+	return c:IsFaceup() and c:IsControlerCanBeChanged() and c:IsLevel(lv)
 end
 function c69257165.ctfilter(c,tp)
 	return c:IsType(TYPE_MONSTER) and c:IsDiscardable()
@@ -40,7 +40,7 @@ function c69257165.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c69257165.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetLevel()==e:GetLabel() then
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsLevel(e:GetLabel()) then
 		Duel.GetControl(tc,tp,PHASE_END,1)
 	end
 end

--- a/c69303178.lua
+++ b/c69303178.lua
@@ -12,7 +12,7 @@ function c69303178.initial_effect(c)
 end
 function c69303178.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c69303178.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--to grave

--- a/c69327790.lua
+++ b/c69327790.lua
@@ -37,7 +37,7 @@ end
 function c69327790.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c69327790.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c69327790.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c69327790.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c69865139.lua
+++ b/c69865139.lua
@@ -12,7 +12,7 @@ function c69865139.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c69865139.filter(c,e,tp)
-	return c:GetLevel()==1 and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(1) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c69865139.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c69865139.filter(chkc,e,tp) end

--- a/c69868555.lua
+++ b/c69868555.lua
@@ -42,7 +42,7 @@ function c69868555.cfilter(c)
 	return c:GetSummonLocation()~=LOCATION_GRAVE
 end
 function c69868555.dfilter(c,eg)
-	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and not eg:IsContains(c)
+	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and not eg:IsContains(c)
 end
 function c69868555.discon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c69868555.cfilter,1,nil) and Duel.IsExistingMatchingCard(c69868555.dfilter,tp,LOCATION_MZONE,0,1,nil,eg)
@@ -105,7 +105,7 @@ function c69868555.tkop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 end
 function c69868555.thcostfilter(c)
-	return c:IsRace(RACE_DRAGON) and (c:GetLevel()==7 or c:GetLevel()==8) and c:IsAbleToGraveAsCost()
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and c:IsAbleToGraveAsCost()
 		and (c:IsLocation(LOCATION_HAND) or c:IsFaceup())
 end
 function c69868555.thcost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c69946549.lua
+++ b/c69946549.lua
@@ -33,7 +33,7 @@ function c69946549.cttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c69946549.ctop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:AddCounter(0x1041,1) and tc:GetLevel()>1 then
+	if tc:IsRelateToEffect(e) and tc:AddCounter(0x1041,1) and tc:IsLevelAbove(2) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)

--- a/c70101178.lua
+++ b/c70101178.lua
@@ -20,7 +20,7 @@ function c70101178.initial_effect(c)
 end
 function c70101178.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)>1
 end
 function c70101178.filter(c)

--- a/c70238111.lua
+++ b/c70238111.lua
@@ -25,7 +25,7 @@ function c70238111.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c70238111.filter(c,tp)
-	return c:IsRace(RACE_CYBERSE) and c:GetLink()==3 and (c:IsFaceup() or not c:IsLocation(LOCATION_MZONE))
+	return c:IsRace(RACE_CYBERSE) and c:IsLink(3) and (c:IsFaceup() or not c:IsLocation(LOCATION_MZONE))
 		and c:IsAbleToRemove() and Duel.GetLocationCountFromEx(tp,tp,c)>0
 end
 function c70238111.spfilter(c,e,tp)

--- a/c70479321.lua
+++ b/c70479321.lua
@@ -63,7 +63,7 @@ function c70479321.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c70479321.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,LOCATION_MZONE)==0
 end
 function c70479321.lvcon(e)

--- a/c70546737.lua
+++ b/c70546737.lua
@@ -24,8 +24,7 @@ function c70546737.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c70546737.filter(c,clv)
-	local lv=c:GetLevel()
-	return c:IsSetCard(0x87) and lv~=0 and lv~=clv
+	return c:IsSetCard(0x87) and not c:IsLevel(clv)
 		and ((c:IsLocation(LOCATION_MZONE) and c:IsFaceup()) or c:IsLocation(LOCATION_GRAVE))
 end
 function c70546737.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c70655556.lua
+++ b/c70655556.lua
@@ -15,7 +15,7 @@ function c70655556.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c70655556.filter(c)
-	return c:IsFaceup() and c:GetLevel()==3 and c:IsRace(RACE_FISH)
+	return c:IsFaceup() and c:IsLevel(3) and c:IsRace(RACE_FISH)
 end
 function c70655556.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c70655556.filter,tp,LOCATION_MZONE,0,1,nil) end

--- a/c70676581.lua
+++ b/c70676581.lua
@@ -64,7 +64,7 @@ function c70676581.condition(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.GetDrawCount(tp)>0
 end
 function c70676581.filter(c)
-	return c:GetLevel()==4 and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
 end
 function c70676581.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c70676581.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c70908596.lua
+++ b/c70908596.lua
@@ -28,7 +28,7 @@ function c70908596.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c70908596.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	local tc=g:GetFirst()
 	local op=0
-	if tc:GetLevel()==1 then op=Duel.SelectOption(tp,aux.Stringid(70908596,1))
+	if tc:IsLevel(1) then op=Duel.SelectOption(tp,aux.Stringid(70908596,1))
 	else op=Duel.SelectOption(tp,aux.Stringid(70908596,1),aux.Stringid(70908596,2)) end
 	e:SetLabel(op)
 end

--- a/c70969517.lua
+++ b/c70969517.lua
@@ -39,7 +39,7 @@ function c70969517.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c70969517.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c70969517.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c70969517.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c71340250.lua
+++ b/c71340250.lua
@@ -97,7 +97,7 @@ function c71340250.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c71340250.sfilter(c,e,tp,lv)
-	return c:IsSetCard(0x16) and c:IsType(TYPE_FUSION) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsSetCard(0x16) and c:IsType(TYPE_FUSION) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c71340250.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCountFromEx(tp)<=0 then return end

--- a/c71386411.lua
+++ b/c71386411.lua
@@ -95,7 +95,7 @@ function c71386411.spop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsImmuneToEffect(e) or tc:GetLevel()<2 then return end
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsImmuneToEffect(e) or tc:IsLevel(1) then return end
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_UPDATE_LEVEL)

--- a/c71541986.lua
+++ b/c71541986.lua
@@ -17,7 +17,7 @@ function c71541986.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousPosition(POS_FACEDOWN)
 end
 function c71541986.spfilter(c,e,tp)
-	return c:IsAttribute(ATTRIBUTE_WATER) and c:GetLevel()==8 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsLevel(8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c71541986.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)

--- a/c71612253.lua
+++ b/c71612253.lua
@@ -37,7 +37,7 @@ function c71612253.initial_effect(c)
 	end
 end
 function c71612253.ovfilter(c)
-	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsSetCard(0x10af) and c:GetRank()==4
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsSetCard(0x10af) and c:IsRank(4)
 end
 function c71612253.checkop(e,tp,eg,ep,ev,re,r,rp)
 	if bit.band(r,REASON_EFFECT)~=0 then

--- a/c71786742.lua
+++ b/c71786742.lua
@@ -16,7 +16,7 @@ function c71786742.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c71786742.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsRace(RACE_MACHINE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsRace(RACE_MACHINE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c71786742.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c71786742.filter(chkc,e,tp) end

--- a/c72129804.lua
+++ b/c72129804.lua
@@ -38,7 +38,7 @@ function c72129804.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	local tc=tg:GetFirst()
 	while tc do
-		if tc:AddCounter(0x1041,1) and tc:GetLevel()>1 then
+		if tc:AddCounter(0x1041,1) and tc:IsLevelAbove(2) then
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_CHANGE_LEVEL)

--- a/c72258771.lua
+++ b/c72258771.lua
@@ -65,7 +65,7 @@ function c72258771.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c72258771.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c72258771.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c72258771.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c72549351.lua
+++ b/c72549351.lua
@@ -21,7 +21,7 @@ function c72549351.mzfilter(c,tp)
 	return c:IsControler(tp) and c:GetSequence()<5
 end
 function c72549351.spfilter(c,e,tp)
-	return c:IsRace(RACE_DRAGON) and c:GetLevel()==8 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_DRAGON) and c:IsLevel(8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c72549351.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local rg=Duel.GetReleaseGroup(tp):Filter(c72549351.rfilter,nil,tp)

--- a/c72563071.lua
+++ b/c72563071.lua
@@ -22,7 +22,7 @@ function c72563071.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.DiscardHand(tp,c72563071.cfilter,1,1,REASON_COST+REASON_DISCARD)
 end
 function c72563071.spfilter(c,e,tp)
-	return c:GetLevel()==6 and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_MACHINE)
+	return c:IsLevel(6) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_MACHINE)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c72563071.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c72714392.lua
+++ b/c72714392.lua
@@ -25,7 +25,7 @@ function c72714392.filter(c,e,tp)
 		and Duel.IsExistingMatchingCard(c72714392.exfilter,tp,LOCATION_EXTRA,0,1,nil,lv+1,e,tp)
 end
 function c72714392.exfilter(c,lv,e,tp)
-	return c:IsSetCard(0x33) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x33) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c72714392.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c72714392.filter(chkc,e,tp) end

--- a/c72855441.lua
+++ b/c72855441.lua
@@ -20,7 +20,7 @@ function c72855441.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c72855441.spfilter1(c,e,tp)
-	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c72855441.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c73289035.lua
+++ b/c73289035.lua
@@ -55,7 +55,7 @@ function c73289035.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and e:GetHandler():IsPreviousPosition(POS_FACEUP) and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c73289035.spfilter(c,e,tp)
-	return c:GetLevel()==4 and c:IsSetCard(0x88) and c:IsRace(RACE_BEASTWARRIOR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsSetCard(0x88) and c:IsRace(RACE_BEASTWARRIOR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c73289035.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c73289035.spfilter(chkc,e,tp) end

--- a/c73347079.lua
+++ b/c73347079.lua
@@ -36,7 +36,7 @@ function c73347079.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c73347079.thfilter(c)
-	return c:GetLevel()==4 and c:IsRace(RACE_WINDBEAST) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsRace(RACE_WINDBEAST) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
 end
 function c73347079.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c73347079.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c7405310.lua
+++ b/c7405310.lua
@@ -16,7 +16,7 @@ function c7405310.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(lv)
 end
 function c7405310.filter(c,lv)
-	return c:GetLevel()==lv
+	return c:IsLevel(lv)
 end
 function c7405310.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c7405310.filter,1-tp,LOCATION_EXTRA,0,nil,e:GetLabel())

--- a/c7409792.lua
+++ b/c7409792.lua
@@ -29,7 +29,7 @@ function c7409792.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SPECIAL+1
 end
 function c7409792.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c7409792.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c7409792.filter),1-tp,LOCATION_GRAVE,LOCATION_GRAVE,nil,e,1-tp)

--- a/c74122412.lua
+++ b/c74122412.lua
@@ -33,7 +33,7 @@ function c74122412.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c74122412.mat_filter(c)
-	return c:GetLevel()~=7
+	return not c:IsLevel(7)
 end
 function c74122412.indcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end

--- a/c74168099.lua
+++ b/c74168099.lua
@@ -25,7 +25,7 @@ function c74168099.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
 end
 function c74168099.spfilter(c,e,tp)
-	return c:IsAttribute(ATTRIBUTE_FIRE) and c:GetLevel()==3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsAttribute(ATTRIBUTE_FIRE) and c:IsLevel(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c74168099.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c74530899.lua
+++ b/c74530899.lua
@@ -57,7 +57,7 @@ function c74530899.initial_effect(c)
 end
 function c74530899.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4
+	return minc==0 and c:IsLevelAbove(5)
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end

--- a/c74611888.lua
+++ b/c74611888.lua
@@ -12,7 +12,7 @@ function c74611888.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c74611888.cfilter(c)
-	return c:IsFaceup() and c:GetLevel()~=c:GetOriginalLevel()
+	return c:IsFaceup() and not c:IsLevel(c:GetOriginalLevel())
 end
 function c74611888.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c74611888.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)

--- a/c74728028.lua
+++ b/c74728028.lua
@@ -15,7 +15,7 @@ function c74728028.filter1(c,e,tp)
 	return lv>0 and c:IsFaceup() and Duel.IsExistingMatchingCard(c74728028.filter2,tp,LOCATION_HAND,0,1,nil,lv,e,tp)
 end
 function c74728028.filter2(c,lv,e,tp)
-	return c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c74728028.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c74728028.filter1(chkc,e,tp) end

--- a/c74926274.lua
+++ b/c74926274.lua
@@ -21,7 +21,7 @@ function c74926274.filter(c,e,tp,ft)
 		and Duel.IsExistingMatchingCard(c74926274.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp,lv)
 end
 function c74926274.spfilter(c,e,tp,lv)
-	return c:IsType(TYPE_PENDULUM) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_PENDULUM) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c74926274.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c7500772.lua
+++ b/c7500772.lua
@@ -20,7 +20,7 @@ function c7500772.initial_effect(c)
 end
 function c7500772.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)>1
 end
 function c7500772.filter(c)

--- a/c75498415.lua
+++ b/c75498415.lua
@@ -26,7 +26,7 @@ function c75498415.initial_effect(c)
 end
 function c75498415.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 		and Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)>0
 end

--- a/c75937826.lua
+++ b/c75937826.lua
@@ -76,6 +76,6 @@ function c75937826.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c75937826.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 end

--- a/c76136345.lua
+++ b/c76136345.lua
@@ -34,13 +34,13 @@ function c76136345.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c76136345.cfilter(c,tp)
-	return c:IsFaceup() and c:GetLevel()==10 and c:IsControler(tp) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH)
+	return c:IsFaceup() and c:IsLevel(10) and c:IsControler(tp) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH)
 end
 function c76136345.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c76136345.cfilter,1,nil,tp)
 end
 function c76136345.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsAttackAbove(1800) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH)
+	return c:IsLevel(4) and c:IsAttackAbove(1800) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c76136345.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -78,7 +78,7 @@ function c76136345.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.DiscardHand(tp,Card.IsAbleToGraveAsCost,1,1,REASON_COST)
 end
 function c76136345.thfilter(c)
-	return c:GetLevel()==10 and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsAbleToHand()
+	return c:IsLevel(10) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsAbleToHand()
 end
 function c76136345.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c76136345.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c7634581.lua
+++ b/c7634581.lua
@@ -34,7 +34,7 @@ function c7634581.value(e,c)
 	return Duel.GetFieldGroupCount(c:GetControler(),0,LOCATION_MZONE)*1000
 end
 function c7634581.efilter(e,c)
-	return c:IsType(TYPE_NORMAL) and c:GetLevel()==4
+	return c:IsType(TYPE_NORMAL) and c:IsLevel(4)
 end
 function c7634581.cfilter(c,tp)
 	return bit.band(c:GetPreviousTypeOnField(),TYPE_NORMAL)~=0 and c:GetPreviousControler()==tp

--- a/c76891401.lua
+++ b/c76891401.lua
@@ -1,7 +1,7 @@
 --神海竜ギシルノドン
 function c76891401.initial_effect(c)
 	--synchro summon
-	aux.AddSynchroProcedure(c,nil,aux.NonTuner(c76891401.synfilter),1,1)
+	aux.AddSynchroProcedure(c,nil,aux.NonTuner(Card.IsLevel,3),1,1)
 	c:EnableReviveLimit()
 	--atk change
 	local e1=Effect.CreateEffect(c)
@@ -13,9 +13,6 @@ function c76891401.initial_effect(c)
 	e1:SetCondition(c76891401.atkcon)
 	e1:SetOperation(c76891401.atkop)
 	c:RegisterEffect(e1)
-end
-function c76891401.synfilter(c)
-	return c:GetLevel()==3
 end
 function c76891401.filter(c)
 	return c:IsLevelBelow(3) and c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousPosition(POS_FACEUP)

--- a/c76930964.lua
+++ b/c76930964.lua
@@ -32,7 +32,7 @@ function c76930964.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c76930964.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c76930964.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c76930964.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c77152542.lua
+++ b/c77152542.lua
@@ -30,7 +30,7 @@ function c77152542.spcon(e,c)
 		and Duel.IsExistingMatchingCard(c77152542.cfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end
 function c77152542.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x33) and c:GetLevel()>=1
+	return c:IsFaceup() and c:IsSetCard(0x33) and c:IsLevelAbove(1)
 end
 function c77152542.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c77152542.filter(chkc) and chkc~=e:GetHandler() end

--- a/c77363314.lua
+++ b/c77363314.lua
@@ -18,7 +18,7 @@ function c77363314.thcon(e,tp,eg,ep,ev,re,r,rp)
 		and e:GetHandler():GetBattledGroupCount()>0
 end
 function c77363314.thfilter(c)
-	return c:IsRace(RACE_DRAGON) and c:GetLevel()==8 and c:IsAbleToHand()
+	return c:IsRace(RACE_DRAGON) and c:IsLevel(8) and c:IsAbleToHand()
 end
 function c77363314.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c77363314.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c7817703.lua
+++ b/c7817703.lua
@@ -24,10 +24,10 @@ function c7817703.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c7817703.eqlimit(e,c)
-	return c:IsSetCard(0x26) and c:GetLevel()==3
+	return c:IsSetCard(0x26) and c:IsLevel(3)
 end
 function c7817703.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x26) and c:GetLevel()==3
+	return c:IsFaceup() and c:IsSetCard(0x26) and c:IsLevel(3)
 end
 function c7817703.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c7817703.filter(chkc) end

--- a/c78275321.lua
+++ b/c78275321.lua
@@ -16,7 +16,7 @@ function c78275321.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c78275321.filter(c,e,tp)
-	return c:GetLevel()==5 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(5) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c78275321.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c78275321.filter(chkc,e,tp) end

--- a/c7841921.lua
+++ b/c7841921.lua
@@ -27,7 +27,7 @@ function c7841921.initial_effect(c)
 end
 function c7841921.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c7841921.atkcon(e)
 	return e:GetHandler():GetMaterialCount()==0

--- a/c78651105.lua
+++ b/c78651105.lua
@@ -33,7 +33,7 @@ function c78651105.initial_effect(c)
 end
 function c78651105.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c78651105.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c78811937.lua
+++ b/c78811937.lua
@@ -20,7 +20,7 @@ function c78811937.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(rg,POS_FACEUP,REASON_COST)
 end
 function c78811937.filter(c)
-	return c:GetLevel()==4 and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToHand()
 end
 function c78811937.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c78811937.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c78845026.lua
+++ b/c78845026.lua
@@ -11,7 +11,7 @@ function c78845026.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c78845026.filter(c)
-	return c:IsFaceup() and c:GetLevel()==4 and c:IsAttribute(ATTRIBUTE_LIGHT) and not c:IsType(TYPE_TUNER)
+	return c:IsFaceup() and c:IsLevel(4) and c:IsAttribute(ATTRIBUTE_LIGHT) and not c:IsType(TYPE_TUNER)
 end
 function c78845026.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c78845026.filter(chkc) end

--- a/c79106360.lua
+++ b/c79106360.lua
@@ -41,8 +41,7 @@ function c79106360.operation(e,tp,eg,ep,ev,re,r,rp)
 	if g2 then Duel.ShuffleSetCard(g2) end
 end
 function c79106360.spfilter(c,e,tp)
-	local lv=c:GetLevel()
-	return lv>0 and lv<=4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+	return c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
 end
 function c79106360.sp(e,tp,ct)
 	local g=Duel.GetFieldGroup(tp,LOCATION_DECK,0)

--- a/c79418928.lua
+++ b/c79418928.lua
@@ -51,7 +51,7 @@ function c79418928.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function c79418928.spfilter(c,e,tp)
-	return c:IsSetCard(0x2066) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x2066) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c79418928.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1

--- a/c7953868.lua
+++ b/c7953868.lua
@@ -40,7 +40,7 @@ function c7953868.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RemoveOverlayCard(tp,1,0,1,1,REASON_COST)
 end
 function c7953868.filter(c,e,tp)
-	return c:IsRace(RACE_ZOMBIE) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_ZOMBIE) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c7953868.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c7953868.filter(chkc,e,tp) end

--- a/c79816536.lua
+++ b/c79816536.lua
@@ -10,7 +10,7 @@ function c79816536.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c79816536.filter(c)
-	return c:GetLevel()>=5 and c:IsType(TYPE_NORMAL) and c:IsAbleToHand()
+	return c:IsLevelAbove(5) and c:IsType(TYPE_NORMAL) and c:IsAbleToHand()
 end
 function c79816536.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c79816536.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c80250319.lua
+++ b/c80250319.lua
@@ -33,7 +33,7 @@ function c80250319.sptg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function c80250319.spfilter2(c,e,tp,lv)
-	return c:IsRace(RACE_AQUA) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_AQUA) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c80250319.spop1(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c80402389.lua
+++ b/c80402389.lua
@@ -28,14 +28,14 @@ function c80402389.check(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
 	while tc do
 		if tc:IsPreviousLocation(LOCATION_MZONE) and tc:IsReason(REASON_DESTROY)
-			and tc:IsRace(RACE_INSECT) and tc:GetLevel()~=0 and tc:IsPreviousPosition(POS_FACEUP) then
+			and tc:IsRace(RACE_INSECT) and tc:IsLevelAbove(1) and tc:IsPreviousPosition(POS_FACEUP) then
 			Duel.RaiseSingleEvent(c,EVENT_CUSTOM+80402389,e,r,rp,tc:GetControler(),tc:GetLevel())
 		end
 		tc=eg:GetNext()
 	end
 end
 function c80402389.filter(c,lv)
-	return c:IsRace(RACE_INSECT) and c:GetLevel()==lv and c:IsAbleToHand()
+	return c:IsRace(RACE_INSECT) and c:IsLevel(lv) and c:IsAbleToHand()
 end
 function c80402389.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsRelateToEffect(e)

--- a/c80532587.lua
+++ b/c80532587.lua
@@ -69,7 +69,7 @@ function c80532587.sprop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.SendtoGrave(g1,REASON_COST)
 end
 function c80532587.spfilter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c80532587.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c80773359.lua
+++ b/c80773359.lua
@@ -68,7 +68,7 @@ function c80773359.tnop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e1)
 end
 function c80773359.lvfilter(c,lv)
-	return c:IsSetCard(0x33) and c:GetLevel()>0 and c:GetLevel()~=lv
+	return c:IsSetCard(0x33) and not c:IsLevel(lv)
 end
 function c80773359.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c80773359.lvfilter(chkc,e:GetHandler():GetLevel()) end

--- a/c81254059.lua
+++ b/c81254059.lua
@@ -29,7 +29,7 @@ function c81254059.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c81254059.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c81254059.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c81254059.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c8240199.lua
+++ b/c8240199.lua
@@ -21,7 +21,7 @@ function c8240199.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c8240199.thfilter(c)
-	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==1 and not c:IsCode(8240199) and c:IsAbleToHand()
+	return c:IsType(TYPE_TUNER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(1) and not c:IsCode(8240199) and c:IsAbleToHand()
 end
 function c8240199.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c8240199.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c82693042.lua
+++ b/c82693042.lua
@@ -35,7 +35,7 @@ function c82693042.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_ADVANCE)
 end
 function c82693042.filter(c)
-	return c:GetLevel()==3 and c:IsAbleToHand()
+	return c:IsLevel(3) and c:IsAbleToHand()
 end
 function c82693042.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c82693042.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c82768499.lua
+++ b/c82768499.lua
@@ -12,7 +12,7 @@ function c82768499.desfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x99)
 end
 function c82768499.thfilter(c)
-	return c:IsSetCard(0x99) and c:GetLevel()==7 and (c:IsFaceup() or not c:IsLocation(LOCATION_EXTRA)) and c:IsAbleToHand()
+	return c:IsSetCard(0x99) and c:IsLevel(7) and (c:IsFaceup() or not c:IsLocation(LOCATION_EXTRA)) and c:IsAbleToHand()
 end
 function c82768499.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() end

--- a/c83048208.lua
+++ b/c83048208.lua
@@ -35,7 +35,7 @@ function c83048208.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return not c:IsStatus(STATUS_CONTINUOUS_POS) and c:IsPosition(POS_FACEUP_DEFENSE) and c:IsPreviousPosition(POS_FACEUP_ATTACK)
 end
 function c83048208.thfilter(c)
-	return c:IsRace(RACE_INSECT) and c:GetLevel()==3 and c:IsAbleToHand()
+	return c:IsRace(RACE_INSECT) and c:IsLevel(3) and c:IsAbleToHand()
 end
 function c83048208.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c83048208.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c83266092.lua
+++ b/c83266092.lua
@@ -24,5 +24,5 @@ function c83266092.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c83266092.target(e,c)
-	return c:GetLevel()>=6 and c:IsSummonType(SUMMON_TYPE_SPECIAL)
+	return c:IsLevelAbove(6) and c:IsSummonType(SUMMON_TYPE_SPECIAL)
 end

--- a/c83274244.lua
+++ b/c83274244.lua
@@ -18,7 +18,7 @@ function c83274244.initial_effect(c)
 end
 function c83274244.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c83274244.ntop(e,tp,eg,ep,ev,re,r,rp,c)
 	--change base attack

--- a/c83319610.lua
+++ b/c83319610.lua
@@ -59,7 +59,7 @@ function c83319610.spfilter1(c,e,tp)
 		and aux.MustMaterialCheck(c,tp,EFFECT_MUST_BE_XMATERIAL)
 end
 function c83319610.spfilter2(c,e,tp,mc,rk)
-	return c:GetRank()==rk and c:IsSetCard(0x58) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0x58) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c83319610.spcost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c8339504.lua
+++ b/c8339504.lua
@@ -21,11 +21,11 @@ function c8339504.cfilter(c,e,tp)
 	return rk>0 and Duel.IsExistingMatchingCard(c8339504.spfilter1,tp,LOCATION_EXTRA,0,1,nil,c,e,tp)
 end
 function c8339504.spfilter1(c,tc,e,tp)
-	return c:GetRank()==tc:GetRank() and c:IsRace(tc:GetRace()) and c:IsAttribute(tc:GetAttribute())
+	return c:IsRank(tc:GetRank()) and c:IsRace(tc:GetRace()) and c:IsAttribute(tc:GetAttribute())
 		and not c:IsCode(tc:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c8339504.spfilter2(c,tc,e,tp)
-	return c:GetRank()==tc:GetPreviousRankOnField() and c:IsRace(tc:GetPreviousRaceOnField()) and c:IsAttribute(tc:GetPreviousAttributeOnField())
+	return c:IsRank(tc:GetPreviousRankOnField()) and c:IsRace(tc:GetPreviousRaceOnField()) and c:IsAttribute(tc:GetPreviousAttributeOnField())
 		and not c:IsCode(tc:GetPreviousCodeOnField()) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c8339504.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c83546647.lua
+++ b/c83546647.lua
@@ -16,7 +16,7 @@ function c83546647.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:GetFirst():IsControler(1-tp) and ep==tp and Duel.GetAttackTarget()==nil
 end
 function c83546647.spfilter(c,e,tp)
-	return c:GetLevel()==1 and not c:IsPublic() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(1) and not c:IsPublic() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsExistingMatchingCard(c83546647.spfilter2,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetCode())
 end
 function c83546647.spfilter2(c,e,tp,code)

--- a/c83810690.lua
+++ b/c83810690.lua
@@ -18,7 +18,7 @@ function c83810690.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
 end
 function c83810690.filter(c,e,tp)
-	return c:IsRace(RACE_WARRIOR) and c:GetLevel()<=4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_WARRIOR) and c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c83810690.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c83994646.lua
+++ b/c83994646.lua
@@ -10,7 +10,7 @@ function c83994646.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c83994646.filter(c)
-	return c:IsFaceup() and c:GetLevel()==4
+	return c:IsFaceup() and c:IsLevel(4)
 end
 function c83994646.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end

--- a/c84530620.lua
+++ b/c84530620.lua
@@ -12,7 +12,7 @@ function c84530620.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c84530620.filter(c)
-	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:GetLevel()==4
+	return c:IsRace(RACE_THUNDER) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4)
 		and c:GetCode()~=84530620 and c:IsSummonable(true,nil)
 end
 function c84530620.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c84536654.lua
+++ b/c84536654.lua
@@ -11,7 +11,7 @@ function c84536654.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c84536654.spfilter(c,code,lv,e,tp)
-	return c:GetLevel()==lv and c:IsSetCard(0xa008) and not c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsLevel(lv) and c:IsSetCard(0xa008) and not c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c84536654.filter(c,e,tp)
 	return c:IsFaceup() and c:IsSetCard(0x8) and c:IsType(TYPE_FUSION) and c:IsAbleToExtra()

--- a/c84764038.lua
+++ b/c84764038.lua
@@ -66,7 +66,7 @@ function c84764038.regop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterFlagEffect(84764038,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 end
 function c84764038.thfilter(c)
-	return c:GetLevel()==3 and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_FIEND)
+	return c:IsLevel(3) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_FIEND)
 		and not c:IsCode(84764038) and c:IsAbleToHand()
 end
 function c84764038.thcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c8491961.lua
+++ b/c8491961.lua
@@ -73,7 +73,7 @@ function c8491961.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c8491961.thfilter(c)
-	return c:GetLevel()==1 and c:IsRace(RACE_WINDBEAST) and c:IsAbleToHand()
+	return c:IsLevel(1) and c:IsRace(RACE_WINDBEAST) and c:IsAbleToHand()
 end
 function c8491961.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c8491961.thfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c85004150.lua
+++ b/c85004150.lua
@@ -22,7 +22,7 @@ function c85004150.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c85004150.ovfilter(c)
-	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and (c:GetRank()==5 or c:GetRank()==6) and c:IsRace(RACE_INSECT)
+	return c:IsFaceup() and c:IsXyzType(TYPE_XYZ) and (c:IsRank(5) or c:IsRank(6)) and c:IsRace(RACE_INSECT)
 end
 function c85004150.mfilter(c)
 	return c:IsRace(RACE_INSECT) and c:IsAttribute(ATTRIBUTE_LIGHT)

--- a/c85101228.lua
+++ b/c85101228.lua
@@ -26,5 +26,5 @@ function c85101228.con(e)
 	return Duel.IsExistingMatchingCard(c85101228.filter,e:GetHandler():GetControler(),LOCATION_MZONE,0,1,nil)
 end
 function c85101228.tg(e,c)
-	return c:GetLevel()>=4
+	return c:IsLevelAbove(4)
 end

--- a/c85239662.lua
+++ b/c85239662.lua
@@ -34,5 +34,5 @@ function c85239662.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c85239662.target(e,c)
-	return c:GetLevel()~=e:GetLabel()
+	return not c:IsLevel(e:GetLabel())
 end

--- a/c85310252.lua
+++ b/c85310252.lua
@@ -38,7 +38,7 @@ function c85310252.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c85310252.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	local tc=g:GetFirst()
 	local op=0
-	if tc:GetLevel()==1 then op=Duel.SelectOption(tp,aux.Stringid(85310252,1))
+	if tc:IsLevel(1) then op=Duel.SelectOption(tp,aux.Stringid(85310252,1))
 	else op=Duel.SelectOption(tp,aux.Stringid(85310252,1),aux.Stringid(85310252,2)) end
 	e:SetLabel(op)
 end

--- a/c85352446.lua
+++ b/c85352446.lua
@@ -12,12 +12,10 @@ function c85352446.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c85352446.filter(c)
-	local lv=c:GetLevel()
-	return lv>0 and lv<=5 and c:IsFaceup() and Duel.IsExistingMatchingCard(c85352446.filter2,0,LOCATION_MZONE,LOCATION_MZONE,1,c,lv)
+	return c:IsLevelBelow(5) and c:IsFaceup() and Duel.IsExistingMatchingCard(c85352446.filter2,0,LOCATION_MZONE,LOCATION_MZONE,1,c,c:GetLevel())
 end
 function c85352446.filter2(c,lv)
-	local clv=c:GetLevel()
-	return c:IsFaceup() and clv>0 and lv~=clv
+	return c:IsFaceup() and not c:IsLevel(lv)
 end
 function c85352446.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c85352446.filter(chkc) end

--- a/c85742772.lua
+++ b/c85742772.lua
@@ -15,5 +15,5 @@ function c85742772.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c85742772.atktarget(e,c)
-	return c:GetLevel()>=4
+	return c:IsLevelAbove(4)
 end

--- a/c85821180.lua
+++ b/c85821180.lua
@@ -13,10 +13,10 @@ function c85821180.initial_effect(c)
 end
 function c85821180.cfilter(c,e,tp)
 	return c:IsType(TYPE_MONSTER) and c:IsDiscardable()
-		and Duel.IsExistingMatchingCard(c85821180.filter,tp,LOCATION_DECK,0,1,nil,c:GetRace(),c:GetAttribute(),c:GetLevel(),e,tp)
+		and Duel.IsExistingMatchingCard(c85821180.filter,tp,LOCATION_DECK,0,1,nil,c:GetRace(),c:GetAttribute(),c:GetLevel()+1,e,tp)
 end
 function c85821180.filter(c,race,att,lv,e,tp)
-	return c:IsType(TYPE_TUNER) and c:IsRace(race) and c:IsAttribute(att) and c:GetLevel()==lv+1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsType(TYPE_TUNER) and c:IsRace(race) and c:IsAttribute(att) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c85821180.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(100)
@@ -42,7 +42,7 @@ function c85821180.activate(e,tp,eg,ep,ev,re,r,rp)
 	local att=e:GetValue()
 	local lv=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c85821180.filter,tp,LOCATION_DECK,0,1,1,nil,race,att,lv,e,tp)
+	local g=Duel.SelectMatchingCard(tp,c85821180.filter,tp,LOCATION_DECK,0,1,1,nil,race,att,lv+1,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c86174055.lua
+++ b/c86174055.lua
@@ -16,7 +16,7 @@ function c86174055.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c86174055.filter(c,e,tp)
-	return c:GetLevel()==2 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(2) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c86174055.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c86174055.filter(chkc,e,tp) end

--- a/c86196216.lua
+++ b/c86196216.lua
@@ -33,7 +33,7 @@ function c86196216.filter1(c,e,tp)
 		and Duel.IsExistingMatchingCard(c86196216.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()*2)
 end
 function c86196216.filter2(c,e,tp,mc,rk)
-	return c:GetRank()==rk and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c86196216.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c86474024.lua
+++ b/c86474024.lua
@@ -15,7 +15,7 @@ function c86474024.filter1(c,tp)
 	return lv1>0 and c:IsFaceup() and Duel.IsExistingMatchingCard(c86474024.filter2,tp,LOCATION_MZONE,0,1,c,lv1)
 end
 function c86474024.filter2(c,lv1)
-	return c:IsFaceup() and c:GetLevel()==lv1
+	return c:IsFaceup() and c:IsLevel(lv1)
 end
 function c86474024.condition(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_TRAP) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)

--- a/c86676862.lua
+++ b/c86676862.lua
@@ -42,7 +42,7 @@ function c86676862.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 end
 function c86676862.ffilter(c)
-	return c:IsRace(RACE_FIEND) and c:GetLevel()>=6
+	return c:IsRace(RACE_FIEND) and c:IsLevelAbove(6)
 end
 function c86676862.poscon(e)
 	local ph=Duel.GetCurrentPhase()

--- a/c87047161.lua
+++ b/c87047161.lua
@@ -11,8 +11,7 @@ function c87047161.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c87047161.filter(c)
-	local lv=c:GetLevel()
-	return (lv==3 or lv==4 or lv==5) and c:IsRace(RACE_FISH) and c:IsAbleToHand()
+	return (c:IsLevel(3) or c:IsLevel(4) or c:IsLevel(5)) and c:IsRace(RACE_FISH) and c:IsAbleToHand()
 end
 function c87047161.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c87047161.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c87288189.lua
+++ b/c87288189.lua
@@ -37,7 +37,7 @@ end
 function c87288189.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c87288189.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c87288189.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c87288189.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c87588741.lua
+++ b/c87588741.lua
@@ -70,7 +70,7 @@ function c87588741.splimit(e,c)
 end
 function c87588741.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c87588741.lvcon(e)
 	return e:GetHandler():GetMaterialCount()==0

--- a/c87602890.lua
+++ b/c87602890.lua
@@ -37,7 +37,7 @@ end
 function c87602890.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c87602890.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c87602890.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c87602890.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c87835759.lua
+++ b/c87835759.lua
@@ -36,8 +36,7 @@ function c87835759.lvcon(e)
 	return Duel.GetTurnPlayer()~=e:GetHandlerPlayer()
 end
 function c87835759.tgfilter(c)
-	local lv=c:GetLevel()
-	return c:IsRace(RACE_DRAGON) and (lv==7 or lv==8) and c:IsAbleToGrave()
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and c:IsAbleToGrave()
 end
 function c87835759.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c87835759.tgfilter,tp,LOCATION_DECK,0,1,nil) end
@@ -55,8 +54,7 @@ function c87835759.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.DiscardHand(tp,Card.IsAbleToGraveAsCost,1,1,REASON_COST)
 end
 function c87835759.spfilter(c,e,tp)
-	local lv=c:GetLevel()
-	return c:IsRace(RACE_DRAGON) and (lv==7 or lv==8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_DRAGON) and (c:IsLevel(7) or c:IsLevel(8)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c87835759.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c87835759.spfilter(chkc,e,tp) end

--- a/c8785161.lua
+++ b/c8785161.lua
@@ -34,11 +34,11 @@ function c8785161.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c8785161.spfilter1(c,e,tp)
 	local lv=c:GetLevel()
-	return lv>0 and lv<6 and c:IsSetCard(0xba) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevelBelow(5) and c:IsSetCard(0xba) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsExistingMatchingCard(c8785161.spfilter2,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,c,e,tp,6-lv)
 end
 function c8785161.spfilter2(c,e,tp,lv)
-	return c:IsSetCard(0xba) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0xba) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c8785161.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c88071625.lua
+++ b/c88071625.lua
@@ -46,7 +46,7 @@ function c88071625.initial_effect(c)
 end
 function c88071625.otcon(e,c,minc)
 	if c==nil then return true end
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1)
 end
 function c88071625.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local sg=Duel.SelectTribute(tp,c,1,1)

--- a/c88197162.lua
+++ b/c88197162.lua
@@ -20,7 +20,7 @@ function c88197162.condition(e,tp,eg,ep,ev,re,r,rp)
 	return not Duel.IsExistingMatchingCard(c88197162.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c88197162.filter(c)
-	return c:IsFaceup() and c:GetLevel()==4 and c:IsSummonType(SUMMON_TYPE_NORMAL)
+	return c:IsFaceup() and c:IsLevel(4) and c:IsSummonType(SUMMON_TYPE_NORMAL)
 end
 function c88197162.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetActivityCount(tp,ACTIVITY_SPSUMMON)==0

--- a/c88240999.lua
+++ b/c88240999.lua
@@ -36,7 +36,7 @@ function c88240999.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c88240999.mat_filter(c)
-	return c:GetLevel()~=10
+	return not c:IsLevel(10)
 end
 function c88240999.adcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()

--- a/c88283496.lua
+++ b/c88283496.lua
@@ -16,8 +16,7 @@ function c88283496.retcon(e,tp,eg,ep,ev,re,r,rp)
 	if tc==e:GetHandler() then tc=Duel.GetAttackTarget() end
 	if not tc then return false end
 	e:SetLabelObject(tc)
-	local lv=tc:GetLevel()
-	return lv>0 and lv<=4 and not tc:IsStatus(STATUS_BATTLE_DESTROYED)
+	return IsLevelBelow(4) and not tc:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c88283496.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk ==0 then	return e:GetLabelObject():IsAbleToHand() end

--- a/c88482761.lua
+++ b/c88482761.lua
@@ -35,7 +35,7 @@ function c88482761.rmfilter2(c,e,tp,lv)
 		and Duel.IsExistingMatchingCard(c88482761.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c:GetOriginalLevel()+lv)
 end
 function c88482761.spfilter(c,e,tp,lv)
-	return c:GetLevel()==lv and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c88482761.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c88482761.rmfilter1(chkc,e,tp) end

--- a/c88671720.lua
+++ b/c88671720.lua
@@ -12,7 +12,7 @@ function c88671720.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c88671720.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_DARK)
+	return c:IsLevel(4) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_DARK)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c88671720.sumtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c88935103.lua
+++ b/c88935103.lua
@@ -65,7 +65,7 @@ function c88935103.valcheck(e,c)
 	end
 end
 function c88935103.cfilter(c)
-	return c:IsFaceup() and c:GetLevel()>=7 and c:IsSetCard(0x99)
+	return c:IsFaceup() and c:IsLevelAbove(7) and c:IsSetCard(0x99)
 end
 function c88935103.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c88935103.cfilter(chkc) end
@@ -78,7 +78,7 @@ function c88935103.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c88935103.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsImmuneToEffect(e) or tc:GetLevel()<4 then return end
+	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsImmuneToEffect(e) or tc:IsLevelBelow(3) then return end
 	local c=e:GetHandler()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c89235196.lua
+++ b/c89235196.lua
@@ -12,7 +12,7 @@ function c89235196.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c89235196.cfilter(c)
-	return c:GetLevel()==1 and c:IsAbleToGraveAsCost()
+	return c:IsLevel(1) and c:IsAbleToGraveAsCost()
 end
 function c89235196.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c89235196.cfilter,tp,LOCATION_HAND,0,1,e:GetHandler()) end

--- a/c8967776.lua
+++ b/c8967776.lua
@@ -33,7 +33,7 @@ function c8967776.spcon(e,c)
 		Duel.IsExistingMatchingCard(Card.IsType,c:GetControler(),LOCATION_GRAVE,0,10,nil,TYPE_MONSTER)
 end
 function c8967776.filter(c,e,tp)
-	return c:IsRace(RACE_FAIRY) and c:GetLevel()>=8
+	return c:IsRace(RACE_FAIRY) and c:IsLevelAbove(8)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c8967776.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c89731911.lua
+++ b/c89731911.lua
@@ -15,7 +15,7 @@ function c89731911.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c89731911.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c89731911.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c89818984.lua
+++ b/c89818984.lua
@@ -35,7 +35,7 @@ function c89818984.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c89818984.hspfilter(c,ft,tp)
-	return c:IsSetCard(0xe6) and c:GetLevel()==11 and not c:IsCode(89818984)
+	return c:IsSetCard(0xe6) and c:IsLevel(11) and not c:IsCode(89818984)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5)) and (c:IsControler(tp) or c:IsFaceup())
 end
 function c89818984.hspcon(e,c)

--- a/c90036274.lua
+++ b/c90036274.lua
@@ -46,7 +46,7 @@ function c90036274.cfilter1(c,tp)
 		and Duel.IsExistingMatchingCard(c90036274.cfilter2,tp,LOCATION_MZONE,0,1,c,c:GetLevel())
 end
 function c90036274.cfilter2(c,lv)
-	return c:IsFaceup() and c:IsNotTuner() and c:GetLevel()==7-lv and c:IsAbleToGraveAsCost()
+	return c:IsFaceup() and c:IsNotTuner() and c:IsLevel(7-lv) and c:IsAbleToGraveAsCost()
 end
 function c90036274.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c90036274.cfilter1,tp,LOCATION_MZONE,0,1,nil,tp) end

--- a/c90075978.lua
+++ b/c90075978.lua
@@ -33,7 +33,7 @@ function c90075978.sfilter(c)
 	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_REPTILE) and c:IsCanTurnSet()
 end
 function c90075978.spfilter(c,e,tp)
-	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_REPTILE) and c:GetLevel()>=7
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_REPTILE) and c:IsLevelAbove(7)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c90075978.setcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c9074847.lua
+++ b/c9074847.lua
@@ -20,7 +20,7 @@ function c9074847.thfilter(c,tp)
 	return c:IsLocation(LOCATION_HAND) and c:IsControler(tp)
 end
 function c9074847.spfilter(c,e,tp)
-	return c:GetLevel()<=4 and c:IsSummonableCard() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevelBelow(4) and c:IsSummonableCard() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c9074847.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end

--- a/c90884403.lua
+++ b/c90884403.lua
@@ -47,7 +47,7 @@ function c90884403.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c90884403.sprfilter(c)
-	return c:IsFaceup() and c:GetLevel()>7 and c:IsAbleToGraveAsCost()
+	return c:IsFaceup() and c:IsLevelAbove(8) and c:IsAbleToGraveAsCost()
 end
 function c90884403.sprfilter1(c,tp,g,sc)
 	local lv=c:GetLevel()
@@ -55,7 +55,7 @@ function c90884403.sprfilter1(c,tp,g,sc)
 end
 function c90884403.sprfilter2(c,tp,mc,sc,lv)
 	local sg=Group.FromCards(c,mc)
-	return c:GetLevel()==lv and not c:IsType(TYPE_TUNER)
+	return c:IsLevel(lv) and not c:IsType(TYPE_TUNER)
 		and Duel.GetLocationCountFromEx(tp,tp,sg,sc)>0
 end
 function c90884403.sprcon(e,c)

--- a/c90885155.lua
+++ b/c90885155.lua
@@ -68,7 +68,7 @@ function c90885155.splimit(e,c)
 end
 function c90885155.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c90885155.lvcon(e)
 	return e:GetHandler():GetMaterialCount()==0

--- a/c90887783.lua
+++ b/c90887783.lua
@@ -14,7 +14,7 @@ function c90887783.filter1(c,tp)
 		and Duel.IsExistingMatchingCard(c90887783.filter2,tp,LOCATION_DECK,0,1,nil,c:GetLevel())
 end
 function c90887783.filter2(c,lv)
-	return c:IsRace(RACE_DRAGON) and c:GetLevel()==lv and c:IsAbleToHand()
+	return c:IsRace(RACE_DRAGON) and c:IsLevel(lv) and c:IsAbleToHand()
 end
 function c90887783.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c90887783.filter1,tp,LOCATION_HAND,0,1,nil,tp) end

--- a/c91712985.lua
+++ b/c91712985.lua
@@ -56,7 +56,7 @@ function c91712985.initial_effect(c)
 end
 function c91712985.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4
+	return minc==0 and c:IsLevelAbove(5)
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end

--- a/c91907707.lua
+++ b/c91907707.lua
@@ -63,7 +63,7 @@ function c91907707.splimit(e,c)
 end
 function c91907707.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c91907707.lvcon(e)
 	return e:GetHandler():GetMaterialCount()==0

--- a/c91949988.lua
+++ b/c91949988.lua
@@ -10,6 +10,5 @@ function c91949988.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c91949988.ovfilter(c)
-	local rk=c:GetRank()
-	return c:IsFaceup() and (rk==5 or rk==6)
+	return c:IsFaceup() and (c:IsRank(5) or c:IsRank(6))
 end

--- a/c92365601.lua
+++ b/c92365601.lua
@@ -11,15 +11,14 @@ function c92365601.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c92365601.filter1(c,e,tp)
-	local rk=c:GetRank()
-	return c:IsFaceup() and c:IsType(TYPE_XYZ) and rk==4
-		and Duel.IsExistingMatchingCard(c92365601.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,rk+1)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsRank(4)
+		and Duel.IsExistingMatchingCard(c92365601.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()+1)
 		and Duel.GetLocationCountFromEx(tp,tp,c)>0
 		and aux.MustMaterialCheck(c,tp,EFFECT_MUST_BE_XMATERIAL)
 end
 function c92365601.filter2(c,e,tp,mc,rk)
 	if c:GetOriginalCode()==6165656 and not mc:IsCode(48995978) then return false end
-	return c:GetRank()==rk and c:IsSetCard(0x1048) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and c:IsSetCard(0x1048) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c92365601.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c92435533.lua
+++ b/c92435533.lua
@@ -69,7 +69,7 @@ function c92435533.initial_effect(c)
 end
 function c92435533.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and c:GetLevel()>4
+	return minc==0 and c:IsLevelAbove(5)
 		and Duel.GetFieldGroupCount(c:GetControler(),LOCATION_MZONE,0)==0
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end

--- a/c92609670.lua
+++ b/c92609670.lua
@@ -54,7 +54,7 @@ function c92609670.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
 function c92609670.lvfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x106f) and c:GetLevel()>1
+	return c:IsFaceup() and c:IsSetCard(0x106f) and c:IsLevelAbove(2)
 end
 function c92609670.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c92609670.lvfilter,tp,LOCATION_MZONE,0,1,nil) end

--- a/c92729410.lua
+++ b/c92729410.lua
@@ -30,7 +30,7 @@ function c92729410.splimit(e,c)
 	return c:GetRace()~=RACE_BEAST
 end
 function c92729410.filter(c,e,tp)
-	return c:GetCode()~=92729410 and c:GetLevel()==2 and c:IsRace(RACE_BEAST)
+	return c:GetCode()~=92729410 and c:IsLevel(2) and c:IsRace(RACE_BEAST)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
 end
 function c92729410.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c9348522.lua
+++ b/c9348522.lua
@@ -45,7 +45,7 @@ function c9348522.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
 end
 function c9348522.spfilter(c,e,tp)
-	return c:GetLevel()==9 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(9) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c9348522.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c9348522.spfilter(chkc,e,tp) end

--- a/c93543806.lua
+++ b/c93543806.lua
@@ -31,7 +31,7 @@ function c93543806.splimit(e,c)
 	return not c:IsSetCard(0x70)
 end
 function c93543806.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x70) and c:GetLevel()~=6
+	return c:IsFaceup() and c:IsSetCard(0x70) and not c:IsLevel(6)
 end
 function c93543806.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c93543806.filter(chkc) end

--- a/c93751476.lua
+++ b/c93751476.lua
@@ -35,7 +35,7 @@ function c93751476.regop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c93751476.spfilter(c,e,tp)
-	return c:IsSetCard(0x79) and c:GetLevel()==4 and c:GetCode()~=93751476 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x79) and c:IsLevel(4) and c:GetCode()~=93751476 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c93751476.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c9402966.lua
+++ b/c9402966.lua
@@ -24,7 +24,7 @@ function c9402966.filter(c,e,tp,lv)
 		and Duel.IsExistingMatchingCard(c9402966.scfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,lv+c:GetOriginalLevel())
 end
 function c9402966.scfilter(c,e,tp,lv)
-	return c:IsSetCard(0x9a) and c:GetLevel()==lv and c:IsType(TYPE_SYNCHRO)
+	return c:IsSetCard(0x9a) and c:IsLevel(lv) and c:IsType(TYPE_SYNCHRO)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_SYNCHRO,tp,false,false)
 end
 function c9402966.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c94145683.lua
+++ b/c94145683.lua
@@ -22,7 +22,7 @@ function c94145683.filter1(c,e,tp,ft)
 		and Duel.IsExistingMatchingCard(c94145683.filter2,tp,LOCATION_DECK,0,1,nil,lv,e,tp)
 end
 function c94145683.filter2(c,lv,e,tp)
-	return c:IsRace(RACE_WINDBEAST) and c:GetLevel()==lv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_WINDBEAST) and c:IsLevel(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c94145683.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c94203886.lua
+++ b/c94203886.lua
@@ -43,8 +43,7 @@ function c94203886.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c94203886.lvfilter(c,lv)
-	local clv=c:GetLevel()
-	return c:IsFaceup() and c:IsSetCard(0x54) and clv>0 and clv~=lv
+	return c:IsFaceup() and c:IsSetCard(0x54) and not c:IsLevel(lv)
 end
 function c94203886.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c94203886.lvfilter(chkc,e:GetHandler():GetLevel()) end

--- a/c94220427.lua
+++ b/c94220427.lua
@@ -31,7 +31,7 @@ function c94220427.filter1(c,e,tp)
 end
 function c94220427.filter2(c,e,tp,mc,rk,code)
 	if c:GetOriginalCode()==6165656 and code~=48995978 then return false end
-	return c:GetRank()==rk and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073)) and mc:IsCanBeXyzMaterial(c)
+	return c:IsRank(rk) and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073)) and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c94220427.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c94344242.lua
+++ b/c94344242.lua
@@ -31,7 +31,7 @@ function c94344242.xyzlimit(e,c)
 	return not c:IsRace(RACE_INSECT)
 end
 function c94344242.spfilter(c,e,tp)
-	return c:GetLevel()==3 and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsLevel(3) and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c94344242.filter(c)
 	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsCanChangePosition()

--- a/c94599451.lua
+++ b/c94599451.lua
@@ -72,7 +72,7 @@ function c94599451.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c94599451.thfilter2(c,lv)
 	return (c:IsLocation(LOCATION_DECK) or (c:IsFaceup() and c:IsType(TYPE_PENDULUM))) and c:IsCanAddCounter(0x1,1,false,LOCATION_MZONE)
-		and c:GetLevel()==lv and c:IsAbleToHand()
+		and c:IsLevel(lv) and c:IsAbleToHand()
 end
 function c94599451.thop(e,tp,eg,ep,ev,re,r,rp)
 	local lv=e:GetLabel()

--- a/c94656263.lua
+++ b/c94656263.lua
@@ -22,7 +22,7 @@ function c94656263.initial_effect(c)
 end
 function c94656263.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=eg:GetFirst()
-	return ep==tp and ec:GetLevel()==4
+	return ep==tp and ec:IsLevel(4)
 end
 function c94656263.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c94878265.lua
+++ b/c94878265.lua
@@ -16,7 +16,7 @@ function c94878265.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c94878265.filter(c)
-	return c:GetLevel()==4 and c:IsRace(RACE_BEAST) and c:IsAbleToHand()
+	return c:IsLevel(4) and c:IsRace(RACE_BEAST) and c:IsAbleToHand()
 end
 function c94878265.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c94878265.filter(chkc) end

--- a/c95352218.lua
+++ b/c95352218.lua
@@ -22,7 +22,7 @@ function c95352218.checklv(g)
 	local lv=tc:GetLevel()
 	tc=g:GetNext()
 	while tc do
-		if tc:GetLevel()~=lv then return false end
+		if not tc:IsLevel(lv) then return false end
 		tc=g:GetNext()
 	end
 	return true
@@ -31,7 +31,7 @@ function c95352218.filter1(c)
 	return c:IsFaceup() and c:IsLevelAbove(1)
 end
 function c95352218.filter2(c,lv)
-	return c:IsFaceup() and c:GetLevel()~=lv
+	return c:IsFaceup() and not c:IsLevel(lv)
 end
 function c95352218.adjustop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end

--- a/c95658967.lua
+++ b/c95658967.lua
@@ -66,7 +66,7 @@ function c95658967.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 end
 function c95658967.spfilter2(c,e,tp,lv)
-	return c:GetLevel()==lv and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c95658967.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c95658967.spfilter2(chkc,e,tp,e:GetLabel()) end

--- a/c95701283.lua
+++ b/c95701283.lua
@@ -18,7 +18,7 @@ function c95701283.initial_effect(c)
 end
 function c95701283.otcon(e,c,minc)
 	if c==nil then return true end
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1)
 end
 function c95701283.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local g=Duel.SelectTribute(tp,c,1,1)

--- a/c9576193.lua
+++ b/c9576193.lua
@@ -15,7 +15,7 @@ function c9576193.filter1(c,tp)
 	return lv>0 and c:IsFaceup() and Duel.IsExistingTarget(c9576193.filter2,tp,LOCATION_GRAVE,0,1,nil,lv)
 end
 function c9576193.filter2(c,lv)
-	return c:GetLevel()==lv and c:IsAbleToRemove()
+	return c:IsLevel(lv) and c:IsAbleToRemove()
 end
 function c9576193.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
@@ -34,13 +34,13 @@ function c9576193.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc2=g:GetFirst()
 	if tc2==tc1 then tc2=g:GetNext() end
 	if tc1:IsFacedown() or not tc1:IsRelateToEffect(e) then return end
-	if not tc2:IsRelateToEffect(e) or tc2:GetLevel()~=tc1:GetLevel() or Duel.Remove(tc2,POS_FACEUP,REASON_EFFECT)==0 then return end
+	if not tc2:IsRelateToEffect(e) or not tc2:IsLevel(tc1:GetLevel()) or Duel.Remove(tc2,POS_FACEUP,REASON_EFFECT)==0 then return end
 	Duel.BreakEffect()
 	if Duel.Draw(tp,1,REASON_EFFECT)==0 then return end
 	local dr=Duel.GetOperatedGroup():GetFirst()
 	Duel.ConfirmCards(1-tp,dr)
 	Duel.BreakEffect()
-	if dr:GetLevel()==tc1:GetLevel() then
+	if dr:IsLevel(tc1:GetLevel()) then
 		if Duel.SpecialSummon(dr,0,tp,tp,false,false,POS_FACEUP)==0 then
 			Duel.ShuffleHand(tp)
 		end

--- a/c95816395.lua
+++ b/c95816395.lua
@@ -24,12 +24,9 @@ function c95816395.regop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 	end
 end
-function c95816395.cfilter(c,lv)
-	return c:GetLevel()==lv
-end
 function c95816395.filter(c,tp)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
-		and not Duel.IsExistingMatchingCard(c95816395.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil,c:GetLevel())
+		and not Duel.IsExistingMatchingCard(Card.IsLevel,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil,c:GetLevel())
 end
 function c95816395.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c95816395.filter,tp,LOCATION_DECK,0,1,nil,tp) end

--- a/c9583383.lua
+++ b/c9583383.lua
@@ -35,8 +35,7 @@ function c9583383.rfilter(c,tp)
 		and Duel.IsExistingMatchingCard(c9583383.tfilter,tp,LOCATION_MZONE,0,1,nil,lv)
 end
 function c9583383.tfilter(c,clv)
-	local lv=c:GetLevel()
-	return lv>0 and lv~=clv and c:IsFaceup() and c:IsSetCard(0x54)
+	return not c:IsLevel(clv) and c:IsFaceup() and c:IsSetCard(0x54)
 end
 function c9583383.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c9583383.rfilter,tp,LOCATION_GRAVE,0,1,nil,tp) end

--- a/c96142517.lua
+++ b/c96142517.lua
@@ -32,10 +32,10 @@ function c96142517.filter1(c,e,tp)
 		and Duel.IsExistingMatchingCard(c96142517.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,rk+1)
 end
 function c96142517.filter2(c,e,rk)
-	return c:IsType(TYPE_XYZ) and c:GetRank()==rk and c:IsCanBeEffectTarget(e)
+	return c:IsType(TYPE_XYZ) and c:IsRank(rk) and c:IsCanBeEffectTarget(e)
 end
 function c96142517.filter3(c)
-	return c:IsType(TYPE_XYZ) and c:GetRank()==8 and c:IsCode(48995978)
+	return c:IsType(TYPE_XYZ) and c:IsRank(8) and c:IsCode(48995978)
 end
 function c96142517.spfilter(c,e,tp,rk)
 	if c:GetOriginalCode()==6165656 then
@@ -44,14 +44,14 @@ function c96142517.spfilter(c,e,tp,rk)
 		return c:IsCanBeSpecialSummoned(e,0,tp,false,false) and g1:GetCount()>0 and g2:GetCount()>0 
 			and (g1:IsExists(Card.IsCode,1,nil,48995978) or g2:IsExists(Card.IsCode,1,nil,48995978))
 	else
-		return c:GetRank()==rk and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073))	and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		return c:IsRank(rk) and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073))	and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 	end
 end
 function c96142517.spfilter2(c,e,tp,rk,g)
 	if c:GetOriginalCode()==6165656 then
 		return c:IsCanBeSpecialSummoned(e,0,tp,false,false) and g:IsExists(Card.IsCode,1,nil,48995978)
 	else
-		return c:GetRank()==rk and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073))	and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		return c:IsRank(rk) and (c:IsSetCard(0x1048) or c:IsSetCard(0x1073))	and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 	end
 end
 function c96142517.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c96157835.lua
+++ b/c96157835.lua
@@ -38,7 +38,7 @@ function c96157835.spcost1(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c96157835.spfilter1(c,e,tp)
-	return c:IsRace(RACE_WINDBEAST) and c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsRace(RACE_WINDBEAST) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c96157835.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c96470883.lua
+++ b/c96470883.lua
@@ -30,7 +30,7 @@ function c96470883.otcon(e,c,minc)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local mg=Duel.GetMatchingGroup(c96470883.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c96470883.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c96470883.otfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)

--- a/c96471335.lua
+++ b/c96471335.lua
@@ -29,7 +29,7 @@ function c96471335.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c96471335.ovfilter(c)
-	return c:IsFaceup() and c:GetRank()==6 and c:IsRace(RACE_SPELLCASTER)
+	return c:IsFaceup() and c:IsRank(6) and c:IsRace(RACE_SPELLCASTER)
 end
 function c96471335.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/c96570609.lua
+++ b/c96570609.lua
@@ -44,7 +44,7 @@ end
 function c96570609.otcon(e,c,minc)
 	if c==nil then return true end
 	local mg=Duel.GetMatchingGroup(c96570609.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return c:GetLevel()>6 and minc<=1 and Duel.CheckTribute(c,1,1,mg)
+	return c:IsLevelAbove(7) and minc<=1 and Duel.CheckTribute(c,1,1,mg)
 end
 function c96570609.otop(e,tp,eg,ep,ev,re,r,rp,c)
 	local mg=Duel.GetMatchingGroup(c96570609.otfilter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c96622984.lua
+++ b/c96622984.lua
@@ -29,7 +29,7 @@ function c96622984.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c96622984.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:AddCounter(0x1041,1) and tc:GetLevel()>1 then
+	if tc:IsRelateToEffect(e) and tc:AddCounter(0x1041,1) and tc:IsLevelAbove(2) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)

--- a/c96729612.lua
+++ b/c96729612.lua
@@ -10,7 +10,7 @@ function c96729612.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c96729612.filter(c)
-	return bit.band(c:GetType(),0x81)==0x81 and c:GetLevel()<=7 and c:IsAbleToHand()
+	return bit.band(c:GetType(),0x81)==0x81 and c:IsLevelBelow(7) and c:IsAbleToHand()
 end
 function c96729612.filter2(c)
 	return bit.band(c:GetType(),0x82)==0x82 and c:IsAbleToHand()

--- a/c96965364.lua
+++ b/c96965364.lua
@@ -21,7 +21,7 @@ function c96965364.cfilter(c,e,tp,ft)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5)) and (c:IsControler(tp) or c:IsFaceup())
 end
 function c96965364.spfilter(c,lv,e,tp)
-	return c:GetLevel()==lv and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(lv) and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c96965364.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c97173708.lua
+++ b/c97173708.lua
@@ -22,11 +22,10 @@ function c97173708.rfilter1(c,e,tp)
 		and Duel.IsExistingTarget(c97173708.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,lv)
 end
 function c97173708.rfilter2(c,clv)
-	local lv=c:GetLevel()
-	return lv==clv and c:IsType(TYPE_TOKEN)
+	return c:IsLevel(clv) and c:IsType(TYPE_TOKEN)
 end
 function c97173708.spfilter(c,e,tp,clv)
-	return c:GetLevel()==clv and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(clv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c97173708.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c97173708.spfilter(chkc,e,tp,e:GetLabel()) end

--- a/c97433739.lua
+++ b/c97433739.lua
@@ -33,9 +33,6 @@ end
 function c97433739.spfilter(c,e,tp)
 	return c:IsLevelAbove(1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and c:IsCanBeEffectTarget(e)
 end
-function c97433739.rfilter(c,lv)
-	return c:GetLevel()==lv
-end
 function c97433739.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local g=Duel.GetMatchingGroup(c97433739.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp)
@@ -44,10 +41,10 @@ function c97433739.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and g:GetClassCount(Card.GetLevel)>=3 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g1=g:Select(tp,1,1,nil)
-	g:Remove(c97433739.rfilter,nil,g1:GetFirst():GetLevel())
+	g:Remove(Card.IsLevel,nil,g1:GetFirst():GetLevel())
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g2=g:Select(tp,1,1,nil)
-	g:Remove(c97433739.rfilter,nil,g2:GetFirst():GetLevel())
+	g:Remove(Card.IsLevel,nil,g2:GetFirst():GetLevel())
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g3=g:Select(tp,1,1,nil)
 	g1:Merge(g2)

--- a/c97520701.lua
+++ b/c97520701.lua
@@ -43,7 +43,7 @@ function c97520701.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD) and e:GetHandler():IsPreviousPosition(POS_FACEDOWN)
 end
 function c97520701.thfilter(c)
-	return c:GetLevel()==10 and c:IsRace(RACE_MACHINE) and c:IsAbleToHand()
+	return c:IsLevel(10) and c:IsRace(RACE_MACHINE) and c:IsAbleToHand()
 end
 function c97520701.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c97520701.thfilter(chkc) end

--- a/c98777036.lua
+++ b/c98777036.lua
@@ -67,7 +67,7 @@ function c98777036.sumop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 end
 function c98777036.ctffilter(c,lv)
-	return c:IsControlerCanBeChanged() and c:IsFaceup() and c:GetLevel()==lv
+	return c:IsControlerCanBeChanged() and c:IsFaceup() and c:IsLevel(lv)
 end
 function c98777036.ctfilter(c,tp)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()

--- a/c98931003.lua
+++ b/c98931003.lua
@@ -10,7 +10,7 @@ function c98931003.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c98931003.filter(c)
-	return c:IsFaceup() and (c:GetLevel()==7 or c:GetRank()==7)
+	return c:IsFaceup() and (c:IsLevel(7) or c:IsRank(7))
 end
 function c98931003.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c98931003.filter(chkc) end

--- a/c99075257.lua
+++ b/c99075257.lua
@@ -12,7 +12,6 @@ function c99075257.initial_effect(c)
 end
 function c99075257.condition(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
-	local lv=tc:GetLevel()
 	return eg:GetCount()==1 and tc:IsSetCard(0x3008) and tc:IsPreviousPosition(POS_FACEUP) and tc:GetPreviousControler()==tp
 end
 function c99075257.filter(c,lv)

--- a/c99150062.lua
+++ b/c99150062.lua
@@ -19,7 +19,7 @@ function c99150062.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c99150062.cfilter,1,nil,tp)
 end
 function c99150062.filter(c,e,tp)
-	return c:IsSetCard(0x2a) and c:GetLevel()<=3 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x2a) and c:IsLevelBelow(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c99150062.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c99214782.lua
+++ b/c99214782.lua
@@ -14,5 +14,5 @@ function c99214782.condition(e)
 	return e:GetHandler():IsAttackPos()
 end
 function c99214782.target(e,c)
-	return c:GetLevel()>=5 and c:IsSummonType(SUMMON_TYPE_SPECIAL)
+	return c:IsLevelAbove(5) and c:IsSummonType(SUMMON_TYPE_SPECIAL)
 end

--- a/c99469936.lua
+++ b/c99469936.lua
@@ -32,7 +32,7 @@ function c99469936.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c99469936.ovfilter(c)
-	return c:IsFaceup() and c:GetRank()==5 and c:IsAttribute(ATTRIBUTE_WATER)
+	return c:IsFaceup() and c:IsRank(5) and c:IsAttribute(ATTRIBUTE_WATER)
 end
 function c99469936.atkval(e,c)
 	return c:GetOverlayCount()*500

--- a/c99594764.lua
+++ b/c99594764.lua
@@ -16,7 +16,7 @@ function c99594764.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:GetCount()==1 and eg:GetFirst()==e:GetHandler():GetEquipTarget()
 end
 function c99594764.filter(c,race,att)
-	return c:IsRace(race) and c:IsAttribute(att) and c:GetLevel()<=4 and c:IsAbleToHand()
+	return c:IsRace(race) and c:IsAttribute(att) and c:IsLevelBelow(4) and c:IsAbleToHand()
 end
 function c99594764.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local eqc=e:GetHandler():GetEquipTarget()


### PR DESCRIPTION
adress the issue https://github.com/Fluorohydride/ygopro-scripts/issues/947
this commit updates all those GetLevel/Rank/Link==xx to IsLevel/Rank/Link
also, updated some GetLevel>=xx or <=xx functions to use IsLevelAbove/Below instead
I counldn't find any files that would need Duel.AnnounceLevel updates, all those seem to have been done already?