### PR TITLE
fix Superheavy Samurai Gigagloves

### DIFF
--- a/c62017867.lua
+++ b/c62017867.lua
@@ -43,8 +43,7 @@ function c62017867.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()
 	Duel.DisableShuffleCheck()
-	if tc:IsSetCard(0x9a) then
-		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+	if tc:IsSetCard(0x9a) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 then
 		Duel.ShuffleHand(tp)
 		local at=Duel.GetAttacker()
 		if at:IsFaceup() and at:IsRelateToBattle() then


### PR DESCRIPTION
fix: if something is on the field to prevent the card from being added to the hand (e.g. Mistake/Thunder King) the atk should not be reduced and the revealed card should be sent to the grave
ruling for that:
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14883&keyword=&tag=-1
 Question
「ライオウ」の効果適用中に、相手モンスターが直接攻撃を宣言した時、自分の墓地の「超重武者グロウ－V」の『②：相手モンスターの直接攻撃宣言時、墓地のこのカードを除外して発動できる。自分のデッキの一番上のカードをめくり、そのカードが「超重武者」モンスターだった場合は手札に加え、その攻撃モンスターの攻撃力を０にする。違った場合はめくったカードを墓地へ送る』効果を発動する事はできますか？
Answer
質問の状況の場合でも、「超重武者グロウ－V」の効果を発動する事はできます。

めくったカードが「超重武者」と名のついたモンスターだった場合は、めくったカードは手札に加える事はできず、墓地へ送られます。この時、攻撃モンスターの攻撃力を０にする処理も適用されません。

また、めくったカードが「超重武者」と名のついたモンスターではなかった場合は、通常通りめくったカードを墓地へ送り、処理を完了します。 