### PR TITLE
Update c7153114.lua

### DIFF
--- a/c7153114.lua
+++ b/c7153114.lua
@@ -11,7 +11,8 @@ function c7153114.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
 	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
 	e2:SetRange(LOCATION_SZONE)
-	e2:SetProperty(EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_SET_AVAILABLE)
+	e2:SetTargetRange(LOCATION_FZONE,LOCATION_FZONE)
+	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
 	e2:SetTarget(c7153114.infilter)
 	e2:SetValue(1)
 	c:RegisterEffect(e2)
@@ -24,22 +25,10 @@ function c7153114.initial_effect(c)
 	e3:SetTargetRange(1,1)
 	e3:SetValue(c7153114.filter)
 	c:RegisterEffect(e3)
-	--cannot set
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_FIELD)
-	e4:SetCode(EFFECT_CANNOT_SSET)
-	e4:SetRange(LOCATION_SZONE)
-	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-	e4:SetTargetRange(1,1)
-	e4:SetTarget(c7153114.sfilter)
-	c:RegisterEffect(e4)
 end
 function c7153114.infilter(e,c)
 	return c:IsType(TYPE_FIELD)
 end
 function c7153114.filter(e,re,tp)
 	return re:GetHandler():IsType(TYPE_FIELD) and re:IsHasType(EFFECT_TYPE_ACTIVATE)
-end
-function c7153114.sfilter(e,c,tp)
-	return c:IsType(TYPE_FIELD) and Duel.GetFieldCard(tp,LOCATION_SZONE,5)~=nil
 end

--- a/c7153114.lua
+++ b/c7153114.lua
@@ -13,7 +13,6 @@ function c7153114.initial_effect(c)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetTargetRange(LOCATION_FZONE,LOCATION_FZONE)
 	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
-	e2:SetTarget(c7153114.infilter)
 	e2:SetValue(1)
 	c:RegisterEffect(e2)
 	--cannot activate
@@ -25,9 +24,6 @@ function c7153114.initial_effect(c)
 	e3:SetTargetRange(1,1)
 	e3:SetValue(c7153114.filter)
 	c:RegisterEffect(e3)
-end
-function c7153114.infilter(e,c)
-	return c:IsType(TYPE_FIELD)
 end
 function c7153114.filter(e,re,tp)
 	return re:GetHandler():IsType(TYPE_FIELD) and re:IsHasType(EFFECT_TYPE_ACTIVATE)


### PR DESCRIPTION
Removed set limitation because of New Master Rule.
Field Barrier will only protect field spells on Field instead of all areas.
Ｑ：このカードが存在する時に、《闇のデッキ破壊ウイルス》などの効果で《歯車街》が破壊されれば、破壊された《歯車街》の効果を使うことができますか？
Ａ：このカードの効果が適用されている時に、《闇のデッキ破壊ウイルス》を相手が発動した場合、フィールド上に存在する《歯車街》は破壊されません。
　　手札の《歯車街》の場合は破壊されその効果を使うことができます。(13/11/14)