### PR TITLE
update Number S0: Utopic ZEXAL

### DIFF
--- a/c52653092.lua
+++ b/c52653092.lua
@@ -86,10 +86,7 @@ function c52653092.actop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
 	e1:SetTargetRange(0,1)
-	e1:SetValue(c52653092.actlimit)
+	e1:SetValue(aux.TRUE)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
-end
-function c52653092.actlimit(e,re,tp)
-	return not re:GetHandler():IsImmuneToEffect(e)
 end


### PR DESCRIPTION
Update This: revert https://github.com/Fluorohydride/ygopro-scripts/pull/395.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11069
Q.エクストラモンスターゾーンに相手の「SNo.0 ホープ・ゼアル」と、自分の「バージェストマ・オパビニア」が表側表示で存在し、相手の「SNo.0 ホープ・ゼアル」の『④：相手ターンに１度、このカードのX素材を１つ取り除いて発動できる。このターン相手は効果を発動できない』モンスター効果が適用されている自分のターンのメインフェイズです。
この状況で、自分は『①：このカードは他のモンスターの効果を受けない』モンスター効果を持つ「バージェストマ・オパビニア」のモンスター効果の発動を行えますか？
A.「SNo.0 ホープ・ゼアル」の『このターン相手は効果を発動できない』モンスター効果は、**モンスターが受ける効果ではありません**。
質問の状況の場合、「バージェストマ・オパビニア」もモンスター効果を発動する事はできません。 