### PR TITLE
fix Revendread Evolution

### DIFF
--- a/c7986397.lua
+++ b/c7986397.lua
@@ -31,8 +31,9 @@ end
 function c7986397.mfilterf(c,tp,mg,dg,rc)
 	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
-		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
-			or dg:IsExists(c7986397.dlvfilter,1,nil,tp,mg,rc,rc:GetLevel()-c:GetRitualLevel(rc))
+		local lv=rc:GetLevel()-c:GetRitualLevel(rc)
+		return mg:CheckWithSumEqual(Card.GetRitualLevel,lv,0,99,rc)
+			or dg:IsExists(c7986397.dlvfilter,1,nil,tp,mg,rc,lv)
 	else return false end
 end
 function c7986397.dlvfilter(c,tp,mg,rc,lv)

--- a/c7986397.lua
+++ b/c7986397.lua
@@ -28,12 +28,13 @@ function c7986397.filter(c,e,tp,m,ft)
 		return ft>-1 and mg:IsExists(c7986397.mfilterf,1,nil,tp,mg,dg,c)
 	end
 end
-function c7986397.mfilterf(c,tp,mg,dg,rc)
+function c7986397.mfilterf(c,tp,mg1,dg,rc)
 	if c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 then
 		Duel.SetSelectedCard(c)
-		local lv=rc:GetLevel()-c:GetRitualLevel(rc)
-		return mg:CheckWithSumEqual(Card.GetRitualLevel,lv,0,99,rc)
-			or dg:IsExists(c7986397.dlvfilter,1,nil,tp,mg,rc,lv)
+		local mg=mg1:Clone()
+		mg:Sub(dg)
+		return mg:CheckWithSumEqual(Card.GetRitualLevel,rc:GetLevel(),0,99,rc)
+			or dg:IsExists(c7986397.dlvfilter,1,nil,tp,mg,rc,rc:GetLevel()-c:GetRitualLevel(rc))
 	else return false end
 end
 function c7986397.dlvfilter(c,tp,mg,rc,lv)


### PR DESCRIPTION
missing substraction from the rc level in mfilterf, which (rarely) can possibly lead to an error in the operation if the selected card on the field leaves no (or not enough) levels for any other possible materials