### PR TITLE
fix Abyss Actors Curtain Call

### DIFF
--- a/c4682617.lua
+++ b/c4682617.lua
@@ -52,7 +52,7 @@ function c4682617.activate(e,tp,eg,ep,ev,re,r,rp)
 	if hg:GetCount()>0 and Duel.SendtoHand(hg,nil,REASON_EFFECT)~=0 then
 		local sct=Duel.GetOperatedGroup():FilterCount(Card.IsControler,nil,tp)
 		local sg=Duel.GetMatchingGroup(c4682617.spfilter,tp,LOCATION_HAND,0,nil,e,tp)
-		local ft=math.min((Duel.GetLocationCount(tp,LOCATION_MZONE)),sg:GetCount())
+		local ft=math.min((Duel.GetLocationCount(tp,LOCATION_MZONE)),sg:GetClassCount(Card.GetCode))
 		if sct>0 and ft>0 and Duel.SelectYesNo(tp,aux.Stringid(4682617,0)) then
 			Duel.BreakEffect()
 			if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end


### PR DESCRIPTION
fixed a bug that sometimes gets an error message if you have 2 or more monsters of the same name in the hand