### PR TITLE
Issues about Lair of Darkness

### DIFF
--- a/c12766474.lua
+++ b/c12766474.lua
@@ -61,9 +61,12 @@ function c12766474.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 	while true do
 		local mg=rg:Filter(c12766474.fselect,g,tp,rg,g)
-		if mg:GetCount()==0 or (c12766474.fgoal(tp,g) and not Duel.SelectYesNo(tp,210)) then break end
+		if #mg==0 then break end
+		local min=1
+		if c12766474.fgoal(tp,g) then min=0 end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-		local sg=Duel.SelectReleaseGroup(tp,c12766474.relfilter,1,1,nil,mg)
+		local sg=Duel.SelectReleaseGroup(tp,c12766474.relfilter,min,1,nil,mg)
+		if #sg==0 then break end
 		g:Merge(sg)
 	end
 	e:SetLabel(g:GetCount())


### PR DESCRIPTION
1. The Hex-Sealed Fusion monsters can use more than 1 monsters from opponent field to fusion.
 This PR try to fix this but it make _Cyberse Clock Dragon_ cant be summoned
2. The count is not used when release opponent's monster using _Nine-Tailed Fox_
3. This [ruling](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12112&keyword=&tag=-1&request_locale=ja) of _Voltanis the Adjudicator_ is not implemented.
4. We may find a better way to avoid `Duel.SelectYesNo(tp,210)`. Maybe after https://github.com/Fluorohydride/ygopro-scripts/pull/968 is merged.