### PR TITLE
Add Auxiliary.GetMultiLinkedZone(tp)

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -2114,3 +2114,17 @@ function Auxiliary.ExceptThisCard(e)
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) then return c else return nil end
 end
+--used for multi-linked zone(zone linked by two or more link monsters)
+function Auxiliary.GetMultiLinkedZone(tp)
+	local function f(c) return c:IsFaceup() and c:IsType(TYPE_LINK) end
+	local lg=Duel.GetMatchingGroup(f,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local a=0
+	local b=0
+	local c=0
+	for tc in aux.Next(lg) do
+		a=tc:GetLinkedZone(tp) & 0x1f
+		c=b & a | c
+		b=b ~ a
+	end
+	return c
+end

--- a/utility.lua
+++ b/utility.lua
@@ -2122,7 +2122,7 @@ function Auxiliary.GetMultiLinkedZone(tp)
 	local b=0
 	local c=0
 	for tc in aux.Next(lg) do
-		a=tc:GetLinkedZone(tp) & 0x1f
+		a=tc:GetLinkedZone(tp) & 0x7f
 		c=b & a | c
 		b=b ~ a
 	end


### PR DESCRIPTION
Added Auxiliary.GetMultiLinkedZone(tp) for multi-linked zone(zone linked by two or more link monsters).
Special thanks to Bilibili user "我才不会写代码呢(I won't write code any more)".