### PR TITLE
fix Kycoo the Ghost Destroyer

### DIFF
--- a/c88240808.lua
+++ b/c88240808.lua
@@ -1,4 +1,4 @@
---霊滅術師 カイク
+--霊滅術師 カイクウ
 function c88240808.initial_effect(c)
 	--remove
 	local e1=Effect.CreateEffect(c)


### PR DESCRIPTION
Fix this: Japanese name comment mistake.