### PR TITLE
fix

### DIFF
--- a/c20374520.lua
+++ b/c20374520.lua
@@ -13,9 +13,13 @@ function c20374520.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCode(EVENT_BATTLE_DAMAGE)
+	e2:SetCondition(c20374520.condition)
 	e2:SetTarget(c20374520.target)
 	e2:SetOperation(c20374520.operation)
 	c:RegisterEffect(e2)
+end
+function c20374520.condition(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsStatus(STATUS_EFFECT_ENABLED)
 end
 function c20374520.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
> ■「門前払い」のカードの発動は、ダメージステップ以外であればいつでも行う事ができます。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5918

It is said this card can't be activated in damage step, but I think it actually means the effect of this card can only applied when this card is face-up.