### PR TITLE
fix

### DIFF
--- a/c49514333.lua
+++ b/c49514333.lua
@@ -37,7 +37,7 @@ function c49514333.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummonComplete()
 end
 function c49514333.repfilter(c,tp)
-	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:GetDestination()==LOCATION_GRAVE and c:IsReason(REASON_DESTROY)
+	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:GetDestination()==LOCATION_GRAVE and c:GetLeaveFieldDest()==0 and c:IsReason(REASON_DESTROY)
 		and c:GetReasonPlayer()==1-tp and c:GetOwner()==tp and bit.band(c:GetOriginalType(),TYPE_TRAP)~=0 and c:IsCanTurnSet()
 end
 function c49514333.reptg(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
> 自身の効果によって発動後、モンスターカード扱いとなっている「バージェストマ・オレノイデス」は、『フィールドから離れた場合に除外される』効果が適用されていますので、破壊された場合でも墓地へ送られる事はありません。
したがって、「ソウル・オブ・スタチュー」の『このカード以外のモンスター扱いとした罠カードが相手によって破壊され自分の墓地へ送られる場合、墓地へ送らず魔法＆罠カードゾーンにセットする事ができる』効果を適用する事はできません。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19870&keyword=&tag=-1