### PR TITLE
fix & update Chrysalis, Contact and so on

### DIFF
--- a/c16241441.lua
+++ b/c16241441.lua
@@ -12,6 +12,7 @@ function c16241441.initial_effect(c)
 	e1:SetOperation(c16241441.spop)
 	c:RegisterEffect(e1)
 end
+c16241441.card_code_list={89621922}
 function c16241441.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c16616620.lua
+++ b/c16616620.lua
@@ -13,7 +13,7 @@ function c16616620.filter1(c,e,tp)
 	return c:IsFaceup() and c:IsSetCard(0x1e) and Duel.IsExistingMatchingCard(c16616620.filter2,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,c,e,tp)
 end
 function c16616620.filter2(c,mc,e,tp)
-	return aux.IsCodeListed(mc,c:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsSetCard(0x1f) and aux.IsCodeListed(mc,c:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c16616620.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1

--- a/c16616620.lua
+++ b/c16616620.lua
@@ -9,31 +9,28 @@ function c16616620.initial_effect(c)
 	e1:SetOperation(c16616620.activate)
 	c:RegisterEffect(e1)
 end
-c16616620.list={[42682609]=17955766,[43751755]=43237273,[17363041]=54959865,
-				[29246354]=17732278,[16241441]=89621922,[42239546]=80344569}
 function c16616620.filter1(c,e,tp)
-	local code=c:GetCode()
-	local tcode=c16616620.list[code]
-	return tcode and Duel.IsExistingMatchingCard(c16616620.filter2,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,tcode,e,tp)
+	return c:IsFaceup() and c:IsSetCard(0x1e) and Duel.IsExistingMatchingCard(c16616620.filter2,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,c,e,tp)
 end
-function c16616620.filter2(c,tcode,e,tp)
-	return c:IsCode(tcode) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+function c16616620.filter2(c,mc,e,tp)
+	return aux.IsCodeListed(mc,c:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c16616620.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
 		and Duel.IsExistingMatchingCard(c16616620.filter1,tp,LOCATION_MZONE,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK)
 end
+function c16616620.filter3(c)
+	return c:IsFaceup() and c:IsSetCard(0x1e)
+end
 function c16616620.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_MZONE,0,nil,0x1e)
+	local g=Duel.GetMatchingGroup(c16616620.filter3,tp,LOCATION_MZONE,0,nil)
 	if g:GetCount()==0 then return end
 	Duel.SendtoGrave(g,REASON_EFFECT)
 	local sg=Group.CreateGroup()
 	local tc=g:GetFirst()
 	while tc do
-		local code=tc:GetCode()
-		local tcode=c16616620.list[code]
-		local tg=Duel.GetMatchingGroup(c16616620.filter2,tp,LOCATION_HAND+LOCATION_DECK,0,nil,tcode,e,tp)
+		local tg=Duel.GetMatchingGroup(c16616620.filter2,tp,LOCATION_HAND+LOCATION_DECK,0,nil,tc,e,tp)
 		sg:Merge(tg)
 		tc=g:GetNext()
 	end

--- a/c17363041.lua
+++ b/c17363041.lua
@@ -12,6 +12,7 @@ function c17363041.initial_effect(c)
 	e1:SetOperation(c17363041.spop)
 	c:RegisterEffect(e1)
 end
+c17363041.card_code_list={54959865}
 function c17363041.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c29246354.lua
+++ b/c29246354.lua
@@ -12,6 +12,7 @@ function c29246354.initial_effect(c)
 	e1:SetOperation(c29246354.spop)
 	c:RegisterEffect(e1)
 end
+c29246354.card_code_list={17732278}
 function c29246354.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c42239546.lua
+++ b/c42239546.lua
@@ -12,6 +12,7 @@ function c42239546.initial_effect(c)
 	e1:SetOperation(c42239546.spop)
 	c:RegisterEffect(e1)
 end
+c42239546.card_code_list={80344569}
 function c42239546.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c42682609.lua
+++ b/c42682609.lua
@@ -12,6 +12,7 @@ function c42682609.initial_effect(c)
 	e1:SetOperation(c42682609.spop)
 	c:RegisterEffect(e1)
 end
+c42682609.card_code_list={17955766}
 function c42682609.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c43644025.lua
+++ b/c43644025.lua
@@ -17,16 +17,11 @@ function c43644025.initial_effect(c)
 	e2:SetOperation(c43644025.activate)
 	c:RegisterEffect(e2)
 end
-c43644025.list={[42682609]=17955766,[43751755]=43237273,[17363041]=54959865,
-				[29246354]=17732278,[16241441]=89621922,[42239546]=80344569}
 function c43644025.filter1(c,e,tp)
-	if c:IsFacedown() then return false end
-	local code=c:GetCode()
-	local tcode=c43644025.list[code]
-	return tcode and Duel.IsExistingTarget(c43644025.filter2,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,tcode,e,tp)
+	return c:IsFaceup() and c:IsSetCard(0x1e) and Duel.IsExistingTarget(c43644025.filter2,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,c,e,tp)
 end
-function c43644025.filter2(c,tcode,e,tp)
-	return c:IsCode(tcode) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+function c43644025.filter2(c,mc,e,tp)
+	return c:IsSetCard(0x1f) and aux.IsCodeListed(mc,c:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c43644025.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
@@ -41,11 +36,9 @@ function c43644025.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 			and Duel.CheckReleaseGroup(tp,c43644025.filter1,1,nil,e,tp) end
 	e:SetLabel(0)
 	local rg=Duel.SelectReleaseGroup(tp,c43644025.filter1,1,1,nil,e,tp)
-	local code=rg:GetFirst():GetCode()
-	local tcode=c43644025.list[code]
 	Duel.Release(rg,REASON_COST)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectTarget(tp,c43644025.filter2,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,tcode,e,tp)
+	local g=Duel.SelectTarget(tp,c43644025.filter2,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,rg:GetFirst(),e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function c43644025.activate(e,tp,eg,ep,ev,re,r,rp)

--- a/c43751755.lua
+++ b/c43751755.lua
@@ -12,6 +12,7 @@ function c43751755.initial_effect(c)
 	e1:SetOperation(c43751755.spop)
 	c:RegisterEffect(e1)
 end
+c43751755.card_code_list={43237273}
 function c43751755.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c56641453.lua
+++ b/c56641453.lua
@@ -10,16 +10,11 @@ function c56641453.initial_effect(c)
 	e1:SetOperation(c56641453.activate)
 	c:RegisterEffect(e1)
 end
-c56641453.list={[42682609]=17955766,[43751755]=43237273,[17363041]=54959865,
-				[29246354]=17732278,[16241441]=89621922,[42239546]=80344569}
 function c56641453.filter1(c,e,tp)
-	if c:IsFacedown() then return false end
-	local code=c:GetCode()
-	local tcode=c56641453.list[code]
-	return tcode and Duel.IsExistingTarget(c56641453.filter2,tp,0x13,0,1,nil,tcode,e,tp)
+	return c:IsFaceup() and c:IsSetCard(0x1e) and Duel.IsExistingMatchingCard(c56641453.filter2,tp,0x13,0,1,nil,c,e,tp)
 end
-function c56641453.filter2(c,tcode,e,tp)
-	return c:IsCode(tcode) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+function c56641453.filter2(c,mc,e,tp)
+	return c:IsSetCard(0x1f) and aux.IsCodeListed(mc,c:GetCode()) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c56641453.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
@@ -33,10 +28,8 @@ function c56641453.target(e,tp,eg,ep,ev,re,r,rp,chk)
 			and Duel.CheckReleaseGroup(tp,c56641453.filter1,1,nil,e,tp) end
 	e:SetLabel(0)
 	local rg=Duel.SelectReleaseGroup(tp,c56641453.filter1,1,1,nil,e,tp)
-	local code=rg:GetFirst():GetCode()
-	local tcode=c56641453.list[code]
 	Duel.Release(rg,REASON_COST)
-	Duel.SetTargetParam(tcode)
+	Duel.SetTargetCard(rg)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,0x13)
 end
 function c56641453.activate(e,tp,eg,ep,ev,re,r,rp)
@@ -53,9 +46,9 @@ function c56641453.activate(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e2,tp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
-	local tcode=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	local tc=Duel.GetFirstTarget()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c56641453.filter2),tp,0x13,0,1,1,nil,tcode,e,tp)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c56641453.filter2),tp,0x13,0,1,1,nil,tc,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end


### PR DESCRIPTION
Fix this: Face-down Chrysalis send to grave by _Contact_.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6774
■効果処理時に、自分のモンスターゾーンに**表側表示で存在する**「C」と名のついたモンスターを全て墓地に送ります。

Update this: use `aux.IsCodeListed`