### PR TITLE
fix Magical Musketeer monsers

### DIFF
--- a/c31629407.lua
+++ b/c31629407.lua
@@ -17,7 +17,8 @@ function c31629407.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
-	e0:SetOperation(aux.chainreg)
+	e0:SetCondition(aux.mskregcon)
+	e0:SetOperation(aux.mskreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(31629407,0))
@@ -33,9 +34,7 @@ function c31629407.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c31629407.spcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(re:GetHandler())
+	return e:GetHandler():GetFlagEffect(ev)>0
 end
 function c31629407.spfilter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsSetCard(0x108) and not c:IsCode(31629407) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)

--- a/c32841045.lua
+++ b/c32841045.lua
@@ -17,7 +17,8 @@ function c32841045.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
-	e0:SetOperation(aux.chainreg)
+	e0:SetCondition(aux.mskregcon)
+	e0:SetOperation(aux.mskreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(32841045,0))
@@ -33,9 +34,7 @@ function c32841045.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c32841045.thcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(re:GetHandler())
+	return e:GetHandler():GetFlagEffect(ev)>0
 end
 function c32841045.thfilter(c,rc)
 	return c:IsSetCard(0x108) and not c:IsCode(rc:GetCode()) and c:IsAbleToHand()

--- a/c5230799.lua
+++ b/c5230799.lua
@@ -17,7 +17,8 @@ function c5230799.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
-	e0:SetOperation(aux.chainreg)
+	e0:SetCondition(aux.mskregcon)
+	e0:SetOperation(aux.mskreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(5230799,0))
@@ -34,9 +35,7 @@ function c5230799.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c5230799.drcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(re:GetHandler())
+	return e:GetHandler():GetFlagEffect(ev)>0
 end
 function c5230799.cfilter(c)
 	return c:IsSetCard(0x108) and c:IsDiscardable()

--- a/c68024506.lua
+++ b/c68024506.lua
@@ -17,7 +17,8 @@ function c68024506.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
-	e0:SetOperation(aux.chainreg)
+	e0:SetCondition(aux.mskregcon)
+	e0:SetOperation(aux.mskreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(68024506,0))
@@ -33,9 +34,7 @@ function c68024506.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c68024506.spcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(re:GetHandler())
+	return e:GetHandler():GetFlagEffect(ev)>0
 end
 function c68024506.filter(c,e,tp)
 	return c:IsSetCard(0x108) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)

--- a/c68246154.lua
+++ b/c68246154.lua
@@ -17,7 +17,8 @@ function c68246154.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
-	e0:SetOperation(aux.chainreg)
+	e0:SetCondition(aux.mskregcon)
+	e0:SetOperation(aux.mskreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(68246154,0))
@@ -33,9 +34,7 @@ function c68246154.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c68246154.thcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(re:GetHandler())
+	return e:GetHandler():GetFlagEffect(ev)>0
 end
 function c68246154.thfilter(c,rc)
 	return c:IsSetCard(0x108) and not c:IsCode(rc:GetCode()) and c:IsAbleToHand()

--- a/c94418111.lua
+++ b/c94418111.lua
@@ -17,7 +17,8 @@ function c94418111.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
-	e0:SetOperation(aux.chainreg)
+	e0:SetCondition(aux.mskregcon)
+	e0:SetOperation(aux.mskreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(94418111,0))
@@ -33,9 +34,7 @@ function c94418111.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c94418111.tdcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(re:GetHandler())
+	return e:GetHandler():GetFlagEffect(ev)>0
 end
 function c94418111.filter(c)
 	return c:IsSetCard(0x108) and c:IsAbleToDeck()

--- a/utility.lua
+++ b/utility.lua
@@ -2064,6 +2064,14 @@ function Auxiliary.evospcon(e,tp,eg,ep,ev,re,r,rp)
 	local st=e:GetHandler():GetSummonType()
 	return st>=(SUMMON_TYPE_SPECIAL+150) and st<(SUMMON_TYPE_SPECIAL+180)
 end
+--chain reg condition for magical musketeer monsters
+function Auxiliary.mskregcon(e,tp,eg,ep,ev,re,r,rp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and e:GetHandler():GetColumnGroup():IsContains(re:GetHandler())
+end
+--chain reg for magical musketeer monsters
+function Auxiliary.mskreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(ev,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 --filter for necro_valley test
 function Auxiliary.NecroValleyFilter(f)
 	return	function(target,...)


### PR DESCRIPTION
Fix1: The effect won't trigger if the S&T in same column is destroyed in chain.
Fix2: The effect may chain against wrong chain, making _Caspar_ can search wrong card.