### PR TITLE
update Onomatopaira

### DIFF
--- a/c6595475.lua
+++ b/c6595475.lua
@@ -22,20 +22,20 @@ function c6595475.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c6595475.filter,tp,LOCATION_DECK,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
+function c6595475.check(g)
+	if #g==1 then return true end
+	local res=0x0
+	if g:IsExists(Card.IsSetCard,1,nil,0x54) then res=res+0x1 end
+	if g:IsExists(Card.IsSetCard,1,nil,0x59) then res=res+0x2 end
+	if g:IsExists(Card.IsSetCard,1,nil,0x82) then res=res+0x4 end
+	if g:IsExists(Card.IsSetCard,1,nil,0x8f) then res=res+0x8 end
+	return res~=0x1 and res~=0x2 and res~=0x4 and res~=0x8
+end
 function c6595475.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c6595475.filter,tp,LOCATION_DECK,0,nil)
 	if g:GetCount()==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g1=g:Select(tp,1,1,nil)
-	local t={0x54,0x59,0x82,0x8f}
-	for i=1,4 do
-		if g1:GetFirst():IsSetCard(t[i]) then g:Remove(Card.IsSetCard,nil,t[i]) end
-	end
-	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(6595475,0)) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-		local g2=g:Select(tp,1,1,nil)
-		g1:Merge(g2)
-	end
+	local g1=g:SelectSubGroup(tp,c6595475.check,false,1,2)
 	Duel.SendtoHand(g1,nil,REASON_EFFECT)
 	Duel.ConfirmCards(1-tp,g1)
 end


### PR DESCRIPTION
> 「希望皇オノマトピア」は『このカード名はルール上「ズババ」、「ガガガ」、「ゴゴゴ」、「ドドド」カードとしても扱う』モンスターとなり、それぞれいずれかの名がついたモンスターの1体として扱いますので、「オノマト連携」の効果処理によって、2枚の「希望皇オノマトピア」を手札に加える事もできます。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22335&keyword=&tag=-1&request_locale=ja