### PR TITLE
The field id in group key should begin with 1

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -2007,7 +2007,7 @@ end
 function Auxiliary.GetGroupKey(g)
 	local v=0
 	for c in Auxiliary.Next(g) do
-		math.randomseed(c:GetFieldID())
+		math.randomseed(c:GetFieldID()+1)
 		v=v+math.random()
 	end
 	return v


### PR DESCRIPTION
In `math.randomseed`, giving 0 or 1 has the same result. So the card with field id 0 and the card with field id 1 may encounter a conflict in subgroup check.