### PR TITLE
fix for Timelord Progenitor Vulgate

### DIFF
--- a/c67508932.lua
+++ b/c67508932.lua
@@ -87,7 +87,7 @@ function c67508932.val(e,re,dam,r,rp,rc)
 end
 function c67508932.spfilter(c,e,tp)
 	return c:GetFlagEffectLabel(67508932)==e:GetHandler():GetFieldID()
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,1-tp)
 end
 function c67508932.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetFlagEffect(67508933)>0
@@ -98,7 +98,7 @@ function c67508932.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,#g,tp,LOCATION_REMOVED)
 end
 function c67508932.spop(e,tp,eg,ep,ev,re,r,rp)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local ft=Duel.GetLocationCount(1-tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c67508932.spfilter,tp,LOCATION_REMOVED,LOCATION_REMOVED,nil,e,tp)
 	if ft<=0 or #tg==0 then return end
 	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end


### PR DESCRIPTION
fixed following issues:
1. IsCanBeSpecialSummoned was missing one critic argument, wich leaved potentialy rivality/match bugs.
2. ft was geting location from the wrong player field, wich not reflected the real state of field it was about to be special summoned in.