### PR TITLE
fix skystriker cannot attack when spsummoned in opponent's turn

### DIFF
--- a/c12421694.lua
+++ b/c12421694.lua
@@ -44,7 +44,7 @@ function c12421694.atkop(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CANNOT_ATTACK)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,2)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,Duel.GetTurnPlayer()==tp and 2 or 1)
 		tc:RegisterEffect(e1)
 	end
 end


### PR DESCRIPTION
When spsummoned this card at opponent's turn, and get control of the target monster at your next turn, it still can't attack.