### PR TITLE
fix Offering to the Immortals

### DIFF
--- a/c82340056.lua
+++ b/c82340056.lua
@@ -32,7 +32,6 @@ function c82340056.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,c82340056.filter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()==0 then return end
-	Duel.BreakEffect()
 	Duel.SendtoHand(g,nil,REASON_EFFECT)
 	Duel.ConfirmCards(1-tp,g)
 	Duel.ShuffleHand(tp)


### PR DESCRIPTION
Fix this: The "Negate the attack" and the "Special Summon 2 "Ceremonial Tokens" are not the same.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8679
■『そのモンスターの攻撃を無効にし』の処理と、『自分フィールド上に「贄の石碑トークン」（岩石族・地・星１・攻／守０）２体を特殊召喚し』の処理、『自分のデッキから「地縛神」と名のついたカード１枚を手札に加える』処理はそれぞれ**同時に行われる扱いとなります**。