### PR TITLE
fix Mermail Abyssleed

### DIFF
--- a/c37781520.lua
+++ b/c37781520.lua
@@ -13,7 +13,7 @@ function c37781520.initial_effect(c)
 	--search
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(37781520,1))
-	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetCategory(CATEGORY_TOHAND)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)


### PR DESCRIPTION
Fix this: _Mermail Abyssleed_'s effect is Search Effect.

https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=10393
この効果で特殊召喚に成功した時、**自分の墓地から**「アビス」と名のついた魔法・罠カード１枚を選択して手札に加える事ができる。