### PR TITLE
fix Wrath of Neos

### DIFF
--- a/c52098461.lua
+++ b/c52098461.lua
@@ -29,7 +29,6 @@ function c52098461.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and c52098461.filter(tc)
 		and Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_DECK) then
-		Duel.BreakEffect()
 		local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,aux.ExceptThisCard(e))
 		Duel.Destroy(g,REASON_EFFECT)
 	end


### PR DESCRIPTION
Fix this: The "Return it to the Deck" and the "destroy all cards on the field" are not the same.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7553
■『その「E・HERO ネオス」を持ち主のデッキに戻し』の処理と、『フィールドのカードを全て破壊する』処理は**同時に行われる扱いとなります**。