### PR TITLE
fix Number C15: Gimmick Puppet Giant Hunter

### DIFF
--- a/c33776843.lua
+++ b/c33776843.lua
@@ -33,6 +33,7 @@ function c33776843.operation(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 and tc:IsPreviousLocation(LOCATION_MZONE) then
 		local atk=tc:GetTextAttack()
 		if atk<0 then atk=0 end
+		Duel.BreakEffect()
 		Duel.Damage(1-tp,atk,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Fix this: The "destroy it" and the "inflict damage to your opponent equal to its original ATK" are the same.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11014
■対象としたカードがモンスターである場合、『選択したカードを破壊する』処理と、『さらにそのモンスターの元々の攻撃力分のダメージを相手ライフに与える』処理が適用されます。（破壊する処理と、ダメージを与える処理は**同時に行われる扱いではありません**。）