### PR TITLE
fix Type Zero Magic Crusher

### DIFF
--- a/c21237481.lua
+++ b/c21237481.lua
@@ -25,16 +25,14 @@ end
 function c21237481.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c21237481.costfilter,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
-	local cg=Duel.SelectMatchingCard(tp,c21237481.costfilter,tp,LOCATION_HAND,0,1,60,nil)
+	local cg=Duel.SelectMatchingCard(tp,c21237481.costfilter,tp,LOCATION_HAND,0,1,1,nil)
 	Duel.SendtoGrave(cg,REASON_COST+REASON_DISCARD)
-	e:SetLabel(cg:GetCount())
 end
 function c21237481.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local dam=e:GetLabel()*500
 	Duel.SetTargetPlayer(1-tp)
-	Duel.SetTargetParam(dam)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+	Duel.SetTargetParam(500)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
 end
 function c21237481.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end


### PR DESCRIPTION
Fix this: mistake cost.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5153
■『手札の魔法カード１枚を捨てる事で、相手ライフに５００ポイントダメージを与える』効果はチェーンブロックの作られる効果です。（対象を取る効果ではありません。この効果を発動する際に、コストとして、**手札の魔法カード1枚を捨てます**。また、この効果をダメージステップに発動する事はできません。）