### PR TITLE
fix Spell Power Grasp

### DIFF
--- a/c75014062.lua
+++ b/c75014062.lua
@@ -29,6 +29,7 @@ function c75014062.activate(e,tp,eg,ep,ev,re,r,rp)
 	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:AddCounter(0x1,1) then
 		local th=Duel.GetFirstMatchingCard(c75014062.tfilter,tp,LOCATION_DECK,0,nil)
 		if th and Duel.SelectYesNo(tp,aux.Stringid(75014062,0)) then
+			Duel.BreakEffect()
 			Duel.SendtoHand(th,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,th)
 		end


### PR DESCRIPTION
Fix this: The "place 1 Spell Counter on that target" and the "you can add 1 "Spell Power Grasp" from your Deck to your hand" are the same.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8136
■『そのカードに魔力カウンターを１つ置く』処理と、『その後、デッキから「魔力掌握」１枚を手札に加える事ができる』処理は**同時に行われる扱いではありません**。