### PR TITLE
fix Digvorzhak, King of Heavy Industry

### DIFF
--- a/c29515122.lua
+++ b/c29515122.lua
@@ -33,6 +33,8 @@ function c29515122.operation(e,tp,eg,ep,ev,re,r,rp)
 	if ct==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local dg=Duel.SelectMatchingCard(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,ct,nil)
+	if dg:GetCount()==0 then return end
+	Duel.BreakEffect()
 	Duel.HintSelection(dg)
 	Duel.Destroy(dg,REASON_EFFECT)
 end


### PR DESCRIPTION
Fix this: The "send the top 3 cards of your opponent's Deck to the Graveyard" and the "destroy cards your opponent controls, up to the number of monsters sent" are the same.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9962
■『相手のデッキの上からカードを３枚墓地へ送る』処理と、『この効果で墓地へ送ったカードの中にモンスターカードがあった場合、その数まで相手フィールド上のカードを破壊する』処理は**同時に行われる扱いではありません**。