### PR TITLE
fix Spell Calling

### DIFF
--- a/c41160595.lua
+++ b/c41160595.lua
@@ -3,11 +3,9 @@ function c41160595.initial_effect(c)
 	--set
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(41160595,0))
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e1:SetCode(EVENT_TO_GRAVE)
 	e1:SetCondition(c41160595.setcon)
-	e1:SetTarget(c41160595.settg)
 	e1:SetOperation(c41160595.setop)
 	c:RegisterEffect(e1)
 end
@@ -18,10 +16,6 @@ function c41160595.setcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c41160595.filter(c)
 	return c:GetType()==TYPE_SPELL+TYPE_QUICKPLAY and c:IsSSetable()
-end
-function c41160595.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingMatchingCard(c41160595.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function c41160595.setop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end


### PR DESCRIPTION
Fix this: If player has no Quick-Play Spell Card in player's Deck, _Spell Calling_ don't activate.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6781
■「コーリング・マジック」の効果が発動する際に、自分のデッキに速攻魔法カードが存在しない場合でも、**効果は発動し、チェーンブロックは作られます**。（セットできる速攻魔法カードが存在せず、効果処理は適用されません。）