### PR TITLE
fix Gishki Emilia

### DIFF
--- a/c73551138.lua
+++ b/c73551138.lua
@@ -15,6 +15,7 @@ function c73551138.initial_effect(c)
 	e4:SetCategory(CATEGORY_DISABLE)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	e4:SetCondition(c73551138.negcon)
 	e4:SetOperation(c73551138.negop)
 	c:RegisterEffect(e4)
 	local e5=e4:Clone()
@@ -23,6 +24,9 @@ function c73551138.initial_effect(c)
 end
 function c73551138.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0x3a)
+end
+function c73551138.negcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c73551138.filter,tp,LOCATION_MZONE,0,1,e:GetHandler())
 end
 function c73551138.negop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix this: If player control _Gishki Emilia_ only, _Gishki Emilia_'s effect activate.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9592
■『自分フィールド上にこのカード以外の「リチュア」と名のついたモンスターが存在する場合、エンドフェイズ時までフィールド上の罠カードの効果を無効にする』モンスター効果は、**「リチュア・エミリア」自身以外に「リチュア」と名のついたモンスターが1体以上、自分のモンスターゾーンに表側表示で存在する場合にのみ発動する効果です**。また、その効果処理時に、「リチュア・エミリア」自身以外に「リチュア」と名のついたモンスターが1体以上、自分のモンスターゾーンに表側表示で存在する状態でなければその効果処理は適用されません。