### PR TITLE
fix Naturia Pineapple

### DIFF
--- a/c7304544.lua
+++ b/c7304544.lua
@@ -22,13 +22,14 @@ function c7304544.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c7304544.filter(c)
-	return c:IsType(TYPE_SPELL+TYPE_TRAP) or (c:IsCode(7304544) and c:IsFaceup())
+	return c:IsCode(7304544) and c:IsFaceup()
 end
 function c7304544.filter2(c)
 	return c:IsType(TYPE_MONSTER) and not c:IsRace(RACE_PLANT+RACE_BEAST)
 end
 function c7304544.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp==Duel.GetTurnPlayer() and not Duel.IsExistingMatchingCard(c7304544.filter,tp,LOCATION_ONFIELD,0,1,nil) 
+	return tp==Duel.GetTurnPlayer() and not Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_ONFIELD,0,1,nil,TYPE_SPELL+TYPE_TRAP)
+		and not Duel.IsExistingMatchingCard(c7304544.filter,tp,LOCATION_ONFIELD,0,1,nil)
 		and not Duel.IsExistingMatchingCard(c7304544.filter2,tp,LOCATION_GRAVE,0,1,nil)
 end
 function c7304544.target(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -38,8 +39,7 @@ function c7304544.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c7304544.operation(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e)
-		and not Duel.IsExistingMatchingCard(c7304544.filter,tp,LOCATION_ONFIELD,0,1,nil)
-		and not Duel.IsExistingMatchingCard(c7304544.filter2,tp,LOCATION_GRAVE,0,1,nil) then
+		and not Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_ONFIELD,0,1,nil,TYPE_SPELL+TYPE_TRAP) then
 		Duel.SpecialSummon(e:GetHandler(),0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
Fix this: If player don't control a _Naturia Pineapple_ or monsters in player's Graveyard except Plant or Beast-Type, _Naturia Pineapple_ don't Special Summon.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13821
Q.「ナチュル・パイナポー」の『自分のスタンバイフェイズ時にこのカードが墓地に存在し、自分フィールド上に魔法・罠カードが存在しない場合、このカードを墓地から特殊召喚する事ができる。この効果は自分フィールド上に「ナチュル・パイナポー」が表側表示で存在する場合、または自分の墓地に植物族・獣族以外のモンスターが存在する場合には発動できない』効果の処理時に、自分フィールドに、他の「ナチュル・パイナポー」が存在する場合、特殊召喚する処理は適用されますか？
A.墓地にて発動した「ナチュル・パイナポー」の効果処理時に、自分フィールドに他の「ナチュル・パイナポー」が表側表示で存在している場合でも、既に効果を発動している状態ですので、**効果処理は通常通り行われます**。 

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13822
Q.「ナチュル・パイナポー」の『自分のスタンバイフェイズ時にこのカードが墓地に存在し、自分フィールド上に魔法・罠カードが存在しない場合、このカードを墓地から特殊召喚する事ができる。この効果は自分フィールド上に「ナチュル・パイナポー」が表側表示で存在する場合、または自分の墓地に植物族・獣族以外のモンスターが存在する場合には発動できない』効果の処理時に、自分の墓地に植物族・獣族以外のモンスターが存在する場合、特殊召喚する処理は適用されますか？
A.墓地にて発動した「ナチュル・パイナポー」の効果処理時に、自分の墓地に植物族・獣族以外のモンスターが存在している場合でも、既に効果を発動している状態ですので、**効果処理は通常通り行われます**。 