### PR TITLE
Why is CATEGORY_DESTROY needed here?

### DIFF
--- a/c6511113.lua
+++ b/c6511113.lua
@@ -94,7 +94,6 @@ function c6511113.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if tg then tg(e,tp,ceg,cep,cev,cre,cr,crp,1) end
 	te:SetLabelObject(e:GetLabelObject())
 	e:SetLabelObject(te)
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,nil,0,0,0)
 end
 function c6511113.operation(e,tp,eg,ep,ev,re,r,rp)
 	local te=e:GetLabelObject()


### PR DESCRIPTION
The category should come with the copied trap cards, rather than this effect.