### PR TITLE
fix Marshmallon Glasses

### DIFF
--- a/c66865880.lua
+++ b/c66865880.lua
@@ -8,7 +8,7 @@ function c66865880.initial_effect(c)
 	--
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_CANNOT_SELECT_BATTLE_TARGET)
+	e2:SetCode(EFFECT_ONLY_ATTACK_MONSTER)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetTargetRange(0,LOCATION_MZONE)
 	e2:SetCondition(c66865880.con)
@@ -22,5 +22,5 @@ function c66865880.con(e)
 	return Duel.IsExistingMatchingCard(c66865880.cfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
 end
 function c66865880.atlimit(e,c)
-	return c:IsFacedown() or c:GetCode()~=31305911
+	return c:IsFaceup() and c:IsCode(31305911)
 end


### PR DESCRIPTION
Fix this: If _Marshmallon Glasses_ and _Marshmallon_ have on the field, monsetrs can direct attack.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6007
■「マシュマロンのメガネ」の効果が適用されている場合、相手のモンスターの攻撃対象は、自分のモンスターゾーンに表側表示で存在する「マシュマロン」を選択しなければなりません。（「ペアサイクロイド」等の**直接攻撃を行えるモンスターであっても、「マシュマロン」を攻撃対象として選択する事になります**。）