### PR TITLE
fix 半魔導帯域 vs ポップルアップ

### DIFF
--- a/c15248873.lua
+++ b/c15248873.lua
@@ -18,10 +18,13 @@ function c15248873.filter(c,tp)
 end
 function c15248873.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c15248873.filter,tp,LOCATION_DECK,0,1,nil,tp) end
+	if not Duel.CheckPhaseActivity() then e:SetLabel(1) else e:SetLabel(0) end
 end
 function c15248873.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(15248873,0))
+	if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
 	local tc=Duel.SelectMatchingCard(tp,c15248873.filter,tp,LOCATION_DECK,0,1,1,nil,tp):GetFirst()
+	if c71650854 then c71650854.popup_check=false end
 	if tc then
 		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 		if fc then

--- a/c15248873.lua
+++ b/c15248873.lua
@@ -22,9 +22,9 @@ function c15248873.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c15248873.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(15248873,0))
-	if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
+	if e:GetLabel()==1 then Duel.RegisterFlagEffect(tp,15248873,RESET_CHAIN,0,1) end
 	local tc=Duel.SelectMatchingCard(tp,c15248873.filter,tp,LOCATION_DECK,0,1,1,nil,tp):GetFirst()
-	if c71650854 then c71650854.popup_check=false end
+	Duel.ResetFlagEffect(tp,15248873)
 	if tc then
 		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 		if fc then

--- a/c61818176.lua
+++ b/c61818176.lua
@@ -27,6 +27,7 @@ function c61818176.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 	if chkc then return false end
 	if chk==0 then return tc and tc:IsFaceup() and tc:IsSetCard(0x8d) and tc:IsAbleToHand() and tc:IsCanBeEffectTarget(e) end
+	if not Duel.CheckPhaseActivity() then e:SetLabel(1) else e:SetLabel(0) end
 	Duel.SetTargetCard(tc)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,tc,1,0,0)
 end
@@ -36,7 +37,9 @@ end
 function c61818176.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
+		if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
 		local g=Duel.GetMatchingGroup(c61818176.actfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil,tp)
+		if c71650854 then c71650854.popup_check=false end
 		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(61818176,1)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)

--- a/c61818176.lua
+++ b/c61818176.lua
@@ -37,9 +37,9 @@ end
 function c61818176.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
-		if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
+		if e:GetLabel()==1 then Duel.RegisterFlagEffect(tp,15248873,RESET_CHAIN,0,1) end
 		local g=Duel.GetMatchingGroup(c61818176.actfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil,tp)
-		if c71650854 then c71650854.popup_check=false end
+		Duel.ResetFlagEffect(tp,15248873)
 		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(61818176,1)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)

--- a/c71650854.lua
+++ b/c71650854.lua
@@ -50,7 +50,7 @@ function c71650854.initial_effect(c)
 end
 function c71650854.condition(e,tp,eg,ep,ev,re,r,rp)
 	return (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
-		and not Duel.CheckPhaseActivity()
+		and (not Duel.CheckPhaseActivity() or c71650854.popup_check)
 end
 function c71650854.indcon(e)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1

--- a/c71650854.lua
+++ b/c71650854.lua
@@ -49,7 +49,8 @@ function c71650854.initial_effect(c)
 	c:RegisterEffect(e7)
 end
 function c71650854.condition(e,tp,eg,ep,ev,re,r,rp)
-	return (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
+	return Duel.GetTurnPlayer()==tp
+		and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
 		and (not Duel.CheckPhaseActivity() or Duel.GetFlagEffect(tp,15248873)>0)
 end
 function c71650854.indcon(e)

--- a/c71650854.lua
+++ b/c71650854.lua
@@ -50,7 +50,7 @@ function c71650854.initial_effect(c)
 end
 function c71650854.condition(e,tp,eg,ep,ev,re,r,rp)
 	return (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
-		and (not Duel.CheckPhaseActivity() or c71650854.popup_check)
+		and (not Duel.CheckPhaseActivity() or Duel.GetFlagEffect(tp,15248873)>0)
 end
 function c71650854.indcon(e)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1

--- a/c89208725.lua
+++ b/c89208725.lua
@@ -14,16 +14,21 @@ function c89208725.filter(c,tp)
 end
 function c89208725.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c89208725.filter,tp,LOCATION_DECK,0,1,nil,tp) end
+	if not Duel.CheckPhaseActivity() then e:SetLabel(1) else e:SetLabel(0) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c89208725.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(89208725,0))
+	if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
 	local g=Duel.SelectMatchingCard(tp,c89208725.filter,tp,LOCATION_DECK,0,1,1,nil,tp)
+	if c71650854 then c71650854.popup_check=false end
 	local tc=g:GetFirst()
 	if tc then
 		local te=tc:GetActivateEffect()
 		local b1=tc:IsAbleToHand()
-		local b2=te:IsActivatable(tp)
+		if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
+		local b2=te:IsActivatable(tp,true,true)
+		if c71650854 then c71650854.popup_check=false end
 		if b1 and (not b2 or Duel.SelectOption(tp,1190,1150)==0) then
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,tc)

--- a/c89208725.lua
+++ b/c89208725.lua
@@ -19,16 +19,16 @@ function c89208725.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c89208725.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(89208725,0))
-	if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
+	if e:GetLabel()==1 then Duel.RegisterFlagEffect(tp,15248873,RESET_CHAIN,0,1) end
 	local g=Duel.SelectMatchingCard(tp,c89208725.filter,tp,LOCATION_DECK,0,1,1,nil,tp)
-	if c71650854 then c71650854.popup_check=false end
+	Duel.ResetFlagEffect(tp,15248873)
 	local tc=g:GetFirst()
 	if tc then
 		local te=tc:GetActivateEffect()
 		local b1=tc:IsAbleToHand()
-		if c71650854 and e:GetLabel()==1 then c71650854.popup_check=true end
+		if e:GetLabel()==1 then Duel.RegisterFlagEffect(tp,15248873,RESET_CHAIN,0,1) end
 		local b2=te:IsActivatable(tp,true,true)
-		if c71650854 then c71650854.popup_check=false end
+		Duel.ResetFlagEffect(tp,15248873)
 		if b1 and (not b2 or Duel.SelectOption(tp,1190,1150)==0) then
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,tc)


### PR DESCRIPTION
>その「ポップルアップ」が自分のターンのメインフェイズ１の開始時、または、自分のターンのメインフェイズ２の開始時に発動されているのであれば、「ポップルアップ」の効果処理によって、デッキから「半魔導帯域」を発動する事ができます。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18734&keyword=&tag=-1

>Mail: 
Q. 
「王宮の勅命」の適用中、自分のターンのメインフェイズ１の開始時、自分が2枚の「メタバース」をチェーンして発動した場合、チェーン2の「メタバース」でデッキから「半魔導帯域」を発動できますか？ チェーン1の「メタバース」でデッキから「半魔導帯域」を発動できますか？ 
A. 
チェーン1で発動した「メタバース」のみ、「半魔導帯域」を発動できます。