### PR TITLE
fix: 幻影霧剣, デモンズ・チェーン

### DIFF
--- a/c25542642.lua
+++ b/c25542642.lua
@@ -66,11 +66,12 @@ function c25542642.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)
+		--workaround
+		Duel.AdjustInstantly(c)
 	end
 end
 function c25542642.descon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsStatus(STATUS_DESTROY_CONFIRMED) then return false end
 	local tc=c:GetFirstCardTarget()
 	return tc and eg:IsContains(tc)
 end

--- a/c50078509.lua
+++ b/c50078509.lua
@@ -46,11 +46,12 @@ function c50078509.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)
+		--workaround
+		Duel.AdjustInstantly(c)
 	end
 end
 function c50078509.descon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsStatus(STATUS_DESTROY_CONFIRMED) then return false end
 	local tc=c:GetFirstCardTarget()
 	return tc and eg:IsContains(tc) and tc:IsReason(REASON_DESTROY)
 end


### PR DESCRIPTION
幻影霧剣, デモンズ・チェーン
1. Add Duel.AdjustInstantly() to avoid Fluorohydride/ygopro#2200.
2. The self-destroy conditions match similar effects.

大捕り物
~~Now "cannot attack or activate" applies to face-down monsters.~~
moved to another pull request

@DailyShana 
Add  Duel.AdjustInstantly() as workaround. Thank you for your advice.

Test replays:
https://www.sendspace.com/file/5ar638