### PR TITLE
fix 二重召喚 and サモンチェーン

### DIFF
--- a/c43422537.lua
+++ b/c43422537.lua
@@ -10,8 +10,8 @@ function c43422537.initial_effect(c)
 end
 function c43422537.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local ct=Duel.GetFlagEffectLabel(tp,43422537)
-		return ct==nil or ct<2
+		local te=Duel.IsPlayerAffectedByEffect(tp,EFFECT_SET_SUMMON_COUNT_LIMIT)
+		return te==nil or te:GetValue()<2
 	end
 end
 function c43422537.activate(e,tp,eg,ep,ev,re,r,rp)
@@ -23,5 +23,4 @@ function c43422537.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(2)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
-	Duel.RegisterFlagEffect(tp,43422537,RESET_PHASE+PHASE_END,0,1,2)
 end

--- a/c43422537.lua
+++ b/c43422537.lua
@@ -10,8 +10,12 @@ function c43422537.initial_effect(c)
 end
 function c43422537.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local te=Duel.IsPlayerAffectedByEffect(tp,EFFECT_SET_SUMMON_COUNT_LIMIT)
-		return te==nil or te:GetValue()<2
+		local ct=0
+		local ce={Duel.IsPlayerAffectedByEffect(tp,EFFECT_SET_SUMMON_COUNT_LIMIT)}
+		for _,te in ipairs(ce) do
+			ct=math.max(ct,te:GetValue())
+		end
+		return ct<2
 	end
 end
 function c43422537.activate(e,tp,eg,ep,ev,re,r,rp)

--- a/c43422537.lua
+++ b/c43422537.lua
@@ -4,8 +4,15 @@ function c43422537.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c43422537.target)
 	e1:SetOperation(c43422537.activate)
 	c:RegisterEffect(e1)
+end
+function c43422537.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local ct=Duel.GetFlagEffectLabel(tp,43422537)
+		return ct==nil or ct<2
+	end
 end
 function c43422537.activate(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
@@ -16,4 +23,5 @@ function c43422537.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(2)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+	Duel.RegisterFlagEffect(tp,43422537,RESET_PHASE+PHASE_END,0,1,2)
 end

--- a/c9952083.lua
+++ b/c9952083.lua
@@ -14,8 +14,8 @@ function c9952083.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c9952083.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local ct=Duel.GetFlagEffectLabel(tp,43422537)
-		return ct==nil or ct<3
+		local te=Duel.IsPlayerAffectedByEffect(tp,EFFECT_SET_SUMMON_COUNT_LIMIT)
+		return te==nil or te:GetValue()<3
 	end
 end
 function c9952083.activate(e,tp,eg,ep,ev,re,r,rp)
@@ -27,5 +27,4 @@ function c9952083.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(3)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
-	Duel.RegisterFlagEffect(tp,43422537,RESET_PHASE+PHASE_END,0,1,3)
 end

--- a/c9952083.lua
+++ b/c9952083.lua
@@ -14,8 +14,12 @@ function c9952083.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c9952083.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local te=Duel.IsPlayerAffectedByEffect(tp,EFFECT_SET_SUMMON_COUNT_LIMIT)
-		return te==nil or te:GetValue()<3
+		local ct=0
+		local ce={Duel.IsPlayerAffectedByEffect(tp,EFFECT_SET_SUMMON_COUNT_LIMIT)}
+		for _,te in ipairs(ce) do
+			ct=math.max(ct,te:GetValue())
+		end
+		return ct<3
 	end
 end
 function c9952083.activate(e,tp,eg,ep,ev,re,r,rp)

--- a/c9952083.lua
+++ b/c9952083.lua
@@ -5,11 +5,18 @@ function c9952083.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCondition(c9952083.condition)
+	e1:SetTarget(c9952083.target)
 	e1:SetOperation(c9952083.activate)
 	c:RegisterEffect(e1)
 end
 function c9952083.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentChain()>1 and Duel.CheckChainUniqueness() and Duel.GetTurnPlayer()==tp
+end
+function c9952083.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local ct=Duel.GetFlagEffectLabel(tp,43422537)
+		return ct==nil or ct<3
+	end
 end
 function c9952083.activate(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
@@ -20,4 +27,5 @@ function c9952083.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(3)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+	Duel.RegisterFlagEffect(tp,43422537,RESET_PHASE+PHASE_END,0,1,3)
 end


### PR DESCRIPTION
> Ｑ：同じターンに２枚目の《二重召喚》を発動することはできますか？
Ａ：《二重召喚》を同一ターン中に複数枚発動する事はできません。(15/09/22)
Ｑ：同じターンに《サモンチェーン》を発動することはできますか？
Ａ：同じターンに《サモンチェーン》を発動することはできます。
　　なお、《サモンチェーン》と《二重召喚》を両方発動した場合、通常召喚できる回数は最大３回です。(15/09/23)
Ｑ：《サモンチェーン》を発動したターン、このカードを発動できますか？（空撃ちに該当するか？）
Ａ：いいえ、できません。(17/05/21)