### PR TITLE
Update 原始生命態ニビル

### DIFF
--- a/c27204311.lua
+++ b/c27204311.lua
@@ -40,7 +40,7 @@ function c27204311.relfilter(c)
 end
 function c27204311.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c27204311.relfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	if chk==0 then return g:GetCount()>0 and Duel.GetMZoneCount(tp,g)>0 and Duel.GetMZoneCount(1-tp,g,tp)>0
+	if chk==0 then return g:GetCount()>0
 		and Duel.IsPlayerCanSpecialSummonCount(tp,2)
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,27204312,0,0x4011,g:GetSum(Card.GetBaseAttack),g:GetSum(Card.GetBaseDefense),11,RACE_ROCK,ATTRIBUTE_LIGHT) end


### PR DESCRIPTION
> Q.
相手が5体以上のモンスターの召喚・特殊召喚に成功しているターンに、
エクストラモンスターゾーンに「I：Pマスカレーナ」が表側表示で存在し、自分のメインモンスターゾーンに「プリン隊」3体と「召喚僧サモンプリースト」2体が表側表示で存在しています。
この状況で、自分は手札の「原始生命態ニビル」のモンスター効果を発動することはできますか？
発動できる場合、効果処理はどうなりますか？特殊召喚されなかった「原始生命態ニビル」は墓地へ送られますか？
A.
ご質問の状況においても「原始生命態ニビル」の効果は発動できます。
ただし、リリースできるのはエクストラモンスターゾーンに存在する「I：Pマスカレーナ」だけですので、「原始生命態ニビル」は特殊召喚できず手札に残ったままとなり、「原始生命態トークン」も特殊召喚されません。