### PR TITLE
fix オルターガイスト・プロトコル

### DIFF
--- a/c27541563.lua
+++ b/c27541563.lua
@@ -5,6 +5,7 @@ function c27541563.initial_effect(c)
 	e1:SetDescription(aux.Stringid(27541563,0))
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c27541563.condition)
 	c:RegisterEffect(e1)
 	--negate
 	local e2=Effect.CreateEffect(c)
@@ -36,6 +37,9 @@ function c27541563.initial_effect(c)
 	e5:SetRange(LOCATION_SZONE)
 	e5:SetValue(c27541563.effectfilter)
 	c:RegisterEffect(e5)
+end
+function c27541563.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE and Duel.GetCurrentPhase()~=PHASE_DAMAGE_CAL
 end
 function c27541563.discon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c27541563.lua
+++ b/c27541563.lua
@@ -39,7 +39,7 @@ function c27541563.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c27541563.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()~=PHASE_DAMAGE and Duel.GetCurrentPhase()~=PHASE_DAMAGE_CAL
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
 end
 function c27541563.discon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix this:If your opponent activates a monster's effect in damage step，this card can activate without using its second effect.（In fact，if you want to activate this card in damage step，you must use its effect when you activate it）.