### PR TITLE
fix change controller

### DIFF
--- a/c29834183.lua
+++ b/c29834183.lua
@@ -17,7 +17,7 @@ function c29834183.eqcon(e,tp,eg,ep,ev,re,r,rp)
 		and c:IsReason(REASON_DESTROY) and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE)
 end
 function c29834183.eqfilter(c,tp)
-	if not c:IsFaceup() or not c:IsControlerCanBeChanged() then return false end
+	if not c:IsFaceup() then return false end
 	if c:IsType(TYPE_TRAPMONSTER) then return Duel.GetLocationCount(tp,LOCATION_SZONE,tp,LOCATION_REASON_CONTROL)>0 and Duel.GetLocationCount(tp,LOCATION_SZONE,tp,0)>=2 end
 	return true
 end

--- a/c66451379.lua
+++ b/c66451379.lua
@@ -17,7 +17,7 @@ function c66451379.eqcon(e,tp,eg,ep,ev,re,r,rp)
 		and c:IsReason(REASON_DESTROY) and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE)
 end
 function c66451379.eqfilter(c,tp)
-	if not c:IsFaceup() or not c:IsControlerCanBeChanged() then return false end
+	if not c:IsFaceup() then return false end
 	if c:IsType(TYPE_TRAPMONSTER) then return Duel.GetLocationCount(tp,LOCATION_SZONE,tp,LOCATION_REASON_CONTROL)>0 and Duel.GetLocationCount(tp,LOCATION_SZONE,tp,0)>=2 end
 	return true
 end

--- a/c93445074.lua
+++ b/c93445074.lua
@@ -17,7 +17,7 @@ function c93445074.eqcon(e,tp,eg,ep,ev,re,r,rp)
 		and c:IsReason(REASON_DESTROY) and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE)
 end
 function c93445074.eqfilter(c,tp)
-	if not c:IsFaceup() or not c:IsControlerCanBeChanged() then return false end
+	if not c:IsFaceup() then return false end
 	if c:IsType(TYPE_TRAPMONSTER) then return Duel.GetLocationCount(tp,LOCATION_SZONE,tp,LOCATION_REASON_CONTROL)>0 and Duel.GetLocationCount(tp,LOCATION_SZONE,tp,0)>=2 end
 	return true
 end


### PR DESCRIPTION
These effects can target and the cards can equip the monster which is can not be changed controller.
The effect that equips to a monster and the effect that changes controller are not the same effect.
According to：
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10018
Question
「グレイドル・アリゲーター」、「グレイドル・コブラ」、「グレイドル・イーグル」が破壊され、『このカードを装備カード扱いとしてその相手モンスターに装備する』効果が発動した際に、『このカードはフィールド上に表側表示で存在する限り、コントロールを変更する事はできない』効果が適用されている相手の「ボタニカル・ライオ」を対象として選択する事はできますか？
Answer
相手の「ボタニカル・ライオ」を対象として、「グレイドル・アリゲーター」等の効果を発動し、装備させる事はできます。

その場合、相手の「ボタニカル・ライオ」のコントロールを得る事はできませんが、『このカードがフィールドから離れた時に装備モンスターは破壊される』効果は適用される事になります。

なお、「グレイドル・アリゲーター」等が装備された後、「ボタニカル・ライオ」の効果が「スキルドレイン」で無効になった場合には、「グレイドル・アリゲーター」等の効果が適用されている状態ですので、コントロールを得る事になります。