### PR TITLE
fix Equip Spell Card

### DIFF
--- a/c33453260.lua
+++ b/c33453260.lua
@@ -51,7 +51,7 @@ function c33453260.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c33453260.cfilter,tp,LOCATION_ONFIELD,0,1,nil)
 end
 function c33453260.filter(c)
-	return c:IsFaceup() and c:IsControlerCanBeChanged()
+	return c:IsFaceup()
 end
 function c33453260.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c33453260.filter(chkc) end

--- a/c45247637.lua
+++ b/c45247637.lua
@@ -44,7 +44,7 @@ function c45247637.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c45247637.filter(c)
-	return c:IsFaceup() and c:IsControlerCanBeChanged()
+	return c:IsFaceup()
 end
 function c45247637.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:GetLocation()==LOCATION_MZONE and chkc:GetControler()~=tp and c45247637.filter(chkc) end


### PR DESCRIPTION
Equip Spell Card can equip to every monster that satisfies its equip condition.
For example，<i>Demotion</i> can equip to a XYZ Monster or a LINK Monster.