### PR TITLE
fix UniqueOnField

### DIFF
--- a/c10817524.lua
+++ b/c10817524.lua
@@ -1,6 +1,6 @@
 --始祖竜ワイアーム
 function c10817524.initial_effect(c)
-	c:SetUniqueOnField(1,0,10817524)
+	c:SetUniqueOnField(1,0,10817524,LOCATION_MZONE)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcFunRep(c,aux.FilterBoolFunction(Card.IsFusionType,TYPE_NORMAL),2,false)

--- a/c13903402.lua
+++ b/c13903402.lua
@@ -1,6 +1,6 @@
 --光の王 マルデル
 function c13903402.initial_effect(c)
-	c:SetUniqueOnField(1,0,13903402)
+	c:SetUniqueOnField(1,0,13903402,LOCATION_MZONE)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(13903402,0))

--- a/c14365823.lua
+++ b/c14365823.lua
@@ -1,7 +1,7 @@
 --トリックスター・ディーヴァリディス
 function c14365823.initial_effect(c)
 	c:EnableReviveLimit()
-	c:SetUniqueOnField(1,0,14365823)
+	c:SetUniqueOnField(1,0,14365823,LOCATION_MZONE)
 	aux.AddLinkProcedure(c,c14365823.mfilter,2,2)
 	--damage
 	local e1=Effect.CreateEffect(c)

--- a/c16366810.lua
+++ b/c16366810.lua
@@ -1,6 +1,6 @@
 --イエロー・ダストン
 function c16366810.initial_effect(c)
-	c:SetUniqueOnField(1,0,16366810)
+	c:SetUniqueOnField(1,0,16366810,LOCATION_MZONE)
 	--cannot release
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c1855932.lua
+++ b/c1855932.lua
@@ -1,6 +1,6 @@
 --武神帝－カグツチ
 function c1855932.initial_effect(c)
-	c:SetUniqueOnField(1,0,1855932)
+	c:SetUniqueOnField(1,0,1855932,LOCATION_MZONE)
 	--xyz summon
 	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_BEASTWARRIOR),4,2)
 	c:EnableReviveLimit()

--- a/c2220237.lua
+++ b/c2220237.lua
@@ -1,6 +1,6 @@
 --セキュア・ガードナー
 function c2220237.initial_effect(c)
-	c:SetUniqueOnField(1,0,2220237)
+	c:SetUniqueOnField(1,0,2220237,LOCATION_MZONE)
 	--link summon
 	c:EnableReviveLimit()
 	aux.AddLinkProcedure(c,c2220237.matfilter,1,1)

--- a/c23979249.lua
+++ b/c23979249.lua
@@ -1,6 +1,6 @@
 --武神－アラスダ
 function c23979249.initial_effect(c)
-	c:SetUniqueOnField(1,0,23979249)
+	c:SetUniqueOnField(1,0,23979249,LOCATION_MZONE)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(23979249,0))

--- a/c26082117.lua
+++ b/c26082117.lua
@@ -1,6 +1,6 @@
 --ガガガマジシャン
 function c26082117.initial_effect(c)
-	c:SetUniqueOnField(1,0,26082117)
+	c:SetUniqueOnField(1,0,26082117,LOCATION_MZONE)
 	--lv change
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(26082117,0))

--- a/c2665273.lua
+++ b/c2665273.lua
@@ -1,6 +1,6 @@
 --永の王 オルムガンド
 function c2665273.initial_effect(c)
-	c:SetUniqueOnField(1,0,2665273)
+	c:SetUniqueOnField(1,0,2665273,LOCATION_MZONE)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,9,2,nil,nil,99)
 	c:EnableReviveLimit()

--- a/c2881864.lua
+++ b/c2881864.lua
@@ -1,6 +1,6 @@
 --炎の王 ナグルファー
 function c2881864.initial_effect(c)
-	c:SetUniqueOnField(1,0,2881864)
+	c:SetUniqueOnField(1,0,2881864,LOCATION_MZONE)
 	--destroy replace
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)

--- a/c30607616.lua
+++ b/c30607616.lua
@@ -1,6 +1,6 @@
 --轍の魔妖－朧車
 function c30607616.initial_effect(c)
-	c:SetUniqueOnField(1,0,30607616)
+	c:SetUniqueOnField(1,0,30607616,LOCATION_MZONE)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()

--- a/c32339440.lua
+++ b/c32339440.lua
@@ -1,6 +1,6 @@
 --武神－ヤマト
 function c32339440.initial_effect(c)
-	c:SetUniqueOnField(1,0,32339440)
+	c:SetUniqueOnField(1,0,32339440,LOCATION_MZONE)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(32339440,0))

--- a/c33015627.lua
+++ b/c33015627.lua
@@ -1,6 +1,6 @@
 --時械神サンダイオン
 function c33015627.initial_effect(c)
-	c:SetUniqueOnField(1,0,33015627)
+	c:SetUniqueOnField(1,0,33015627,LOCATION_MZONE)
 	--cannot special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)

--- a/c3486020.lua
+++ b/c3486020.lua
@@ -1,6 +1,6 @@
 --麗の魔妖－妖狐
 function c3486020.initial_effect(c)
-	c:SetUniqueOnField(1,0,3486020)
+	c:SetUniqueOnField(1,0,3486020,LOCATION_MZONE)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()

--- a/c39475024.lua
+++ b/c39475024.lua
@@ -1,6 +1,6 @@
 --骸の魔妖－餓者髑髏
 function c39475024.initial_effect(c)
-	c:SetUniqueOnField(1,0,39475024)
+	c:SetUniqueOnField(1,0,39475024,LOCATION_MZONE)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()

--- a/c40217358.lua
+++ b/c40217358.lua
@@ -1,6 +1,6 @@
 --ブルー・ダストン
 function c40217358.initial_effect(c)
-	c:SetUniqueOnField(1,0,40217358)
+	c:SetUniqueOnField(1,0,40217358,LOCATION_MZONE)
 	--cannot release
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c40894584.lua
+++ b/c40894584.lua
@@ -1,6 +1,6 @@
 --ジゴバイト
 function c40894584.initial_effect(c)
-	c:SetUniqueOnField(1,0,40894584)
+	c:SetUniqueOnField(1,0,40894584,LOCATION_MZONE)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c40998517.lua
+++ b/c40998517.lua
@@ -1,6 +1,6 @@
 --剣の王 フローディ
 function c40998517.initial_effect(c)
-	c:SetUniqueOnField(1,0,40998517)
+	c:SetUniqueOnField(1,0,40998517,LOCATION_MZONE)
 	--destroy
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(40998517,0))

--- a/c4103668.lua
+++ b/c4103668.lua
@@ -1,6 +1,6 @@
 --翼の魔妖－天狗
 function c4103668.initial_effect(c)
-	c:SetUniqueOnField(1,0,4103668)
+	c:SetUniqueOnField(1,0,4103668,LOCATION_MZONE)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()

--- a/c42542842.lua
+++ b/c42542842.lua
@@ -1,6 +1,6 @@
 --麗の魔妖－妲姫
 function c42542842.initial_effect(c)
-	c:SetUniqueOnField(1,0,42542842)
+	c:SetUniqueOnField(1,0,42542842,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(42542842,0))

--- a/c4280258.lua
+++ b/c4280258.lua
@@ -1,6 +1,6 @@
 --召命の神弓－アポロウーサ
 function c4280258.initial_effect(c)
-	c:SetUniqueOnField(1,0,4280258)
+	c:SetUniqueOnField(1,0,4280258,LOCATION_MZONE)
 	--link summon
 	aux.AddLinkProcedure(c,aux.NOT(aux.FilterBoolFunction(Card.IsLinkType,TYPE_TOKEN)),2,99,c4280258.lcheck)
 	c:EnableReviveLimit()

--- a/c44680819.lua
+++ b/c44680819.lua
@@ -1,6 +1,6 @@
 --ランリュウ
 function c44680819.initial_effect(c)
-	c:SetUniqueOnField(1,0,44680819)
+	c:SetUniqueOnField(1,0,44680819,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c464362.lua
+++ b/c464362.lua
@@ -1,6 +1,6 @@
 --デストーイ・シザー・タイガー
 function c464362.initial_effect(c)
-	c:SetUniqueOnField(1,0,464362)
+	c:SetUniqueOnField(1,0,464362,LOCATION_MZONE)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcCodeFunRep(c,30068120,aux.FilterBoolFunction(Card.IsFusionSetCard,0xa9),1,63,true,true)

--- a/c49275969.lua
+++ b/c49275969.lua
@@ -1,6 +1,6 @@
 --氷の王 ニードヘッグ
 function c49275969.initial_effect(c)
-	c:SetUniqueOnField(1,0,49275969)
+	c:SetUniqueOnField(1,0,49275969,LOCATION_MZONE)
 	--disable special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(49275969,0))

--- a/c49847524.lua
+++ b/c49847524.lua
@@ -1,7 +1,7 @@
 --フレイム・アドミニスター
 function c49847524.initial_effect(c)
 	c:EnableReviveLimit()
-	c:SetUniqueOnField(1,0,49847524)
+	c:SetUniqueOnField(1,0,49847524,LOCATION_MZONE)
 	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkRace,RACE_CYBERSE),2,2)
 	--atk up
 	local e1=Effect.CreateEffect(c)

--- a/c52182715.lua
+++ b/c52182715.lua
@@ -1,6 +1,6 @@
 --グリーン・ダストン
 function c52182715.initial_effect(c)
-	c:SetUniqueOnField(1,0,52182715)
+	c:SetUniqueOnField(1,0,52182715,LOCATION_MZONE)
 	--cannot release
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c5291803.lua
+++ b/c5291803.lua
@@ -1,6 +1,6 @@
 --先史遺産トゥーラ・ガーディアン
 function c5291803.initial_effect(c)
-	c:SetUniqueOnField(1,0,5291803)
+	c:SetUniqueOnField(1,0,5291803,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c5325155.lua
+++ b/c5325155.lua
@@ -1,6 +1,6 @@
 --毒の魔妖－束脛
 function c5325155.initial_effect(c)
-	c:SetUniqueOnField(1,0,5325155)
+	c:SetUniqueOnField(1,0,5325155,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(5325155,0))

--- a/c53678698.lua
+++ b/c53678698.lua
@@ -1,6 +1,6 @@
 --武神－ミカヅチ
 function c53678698.initial_effect(c)
-	c:SetUniqueOnField(1,0,53678698)
+	c:SetUniqueOnField(1,0,53678698,LOCATION_MZONE)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(53678698,0))

--- a/c601193.lua
+++ b/c601193.lua
@@ -1,6 +1,6 @@
 --彼岸の詩人 ウェルギリウス
 function c601193.initial_effect(c)
-	c:SetUniqueOnField(1,0,601193)
+	c:SetUniqueOnField(1,0,601193,LOCATION_MZONE)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()

--- a/c60666820.lua
+++ b/c60666820.lua
@@ -1,6 +1,6 @@
 --デーモン・イーター
 function c60666820.initial_effect(c)
-	c:SetUniqueOnField(1,0,60666820)
+	c:SetUniqueOnField(1,0,60666820,LOCATION_MZONE)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c61019812.lua
+++ b/c61019812.lua
@@ -1,6 +1,6 @@
 --レッド・ダストン
 function c61019812.initial_effect(c)
-	c:SetUniqueOnField(1,0,61019812)
+	c:SetUniqueOnField(1,0,61019812,LOCATION_MZONE)
 	--cannot release
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c62953041.lua
+++ b/c62953041.lua
@@ -1,6 +1,6 @@
 --稲荷火
 function c62953041.initial_effect(c)
-	c:SetUniqueOnField(1,0,62953041)
+	c:SetUniqueOnField(1,0,62953041,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c63253763.lua
+++ b/c63253763.lua
@@ -1,6 +1,6 @@
 --エーリアン・リベンジャー
 function c63253763.initial_effect(c)
-	c:SetUniqueOnField(1,0,63253763)
+	c:SetUniqueOnField(1,0,63253763,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c66870733.lua
+++ b/c66870733.lua
@@ -1,6 +1,6 @@
 --氷の魔妖－雪女
 function c66870733.initial_effect(c)
-	c:SetUniqueOnField(1,0,66870733)
+	c:SetUniqueOnField(1,0,66870733,LOCATION_MZONE)
 	--link summon
 	c:EnableReviveLimit()
 	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkSetCard,0x121),2,2)

--- a/c68618157.lua
+++ b/c68618157.lua
@@ -1,6 +1,6 @@
 --武神姫－アマテラス
 function c68618157.initial_effect(c)
-	c:SetUniqueOnField(1,0,68618157)
+	c:SetUniqueOnField(1,0,68618157,LOCATION_MZONE)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,4,3)
 	c:EnableReviveLimit()

--- a/c70101178.lua
+++ b/c70101178.lua
@@ -1,6 +1,6 @@
 --パンサー・シャーク
 function c70101178.initial_effect(c)
-	c:SetUniqueOnField(1,0,70101178)
+	c:SetUniqueOnField(1,0,70101178,LOCATION_MZONE)
 	--summon with no tribute
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(70101178,0))

--- a/c71799173.lua
+++ b/c71799173.lua
@@ -1,6 +1,6 @@
 --ガーディアン・オブ・オーダー
 function c71799173.initial_effect(c)
-	c:SetUniqueOnField(1,0,71799173)
+	c:SetUniqueOnField(1,0,71799173,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c7194917.lua
+++ b/c7194917.lua
@@ -1,6 +1,6 @@
 --No.52 ダイヤモンド・クラブ・キング
 function c7194917.initial_effect(c)
-	c:SetUniqueOnField(1,0,7194917)
+	c:SetUniqueOnField(1,0,7194917,LOCATION_MZONE)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,4,2)
 	c:EnableReviveLimit()

--- a/c73289035.lua
+++ b/c73289035.lua
@@ -1,6 +1,6 @@
 --武神帝－ツクヨミ
 function c73289035.initial_effect(c)
-	c:SetUniqueOnField(1,0,73289035)
+	c:SetUniqueOnField(1,0,73289035,LOCATION_MZONE)
 	--xyz summon
 	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_LIGHT),4,2)
 	c:EnableReviveLimit()

--- a/c7500772.lua
+++ b/c7500772.lua
@@ -1,6 +1,6 @@
 --イーグル・シャーク
 function c7500772.initial_effect(c)
-	c:SetUniqueOnField(1,0,7500772)
+	c:SetUniqueOnField(1,0,7500772,LOCATION_MZONE)
 	--summon with no tribute
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(7500772,0))

--- a/c75660578.lua
+++ b/c75660578.lua
@@ -1,6 +1,6 @@
 --死の王 ヘル
 function c75660578.initial_effect(c)
-	c:SetUniqueOnField(1,0,75660578)
+	c:SetUniqueOnField(1,0,75660578,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(75660578,0))

--- a/c75840616.lua
+++ b/c75840616.lua
@@ -1,6 +1,6 @@
 --武神帝－スサノヲ
 function c75840616.initial_effect(c)
-	c:SetUniqueOnField(1,0,75840616)
+	c:SetUniqueOnField(1,0,75840616,LOCATION_MZONE)
 	--xyz summon
 	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x88),4,2)
 	c:EnableReviveLimit()

--- a/c76382116.lua
+++ b/c76382116.lua
@@ -1,6 +1,6 @@
 --鉄の王 ドヴェルグス
 function c76382116.initial_effect(c)
-	c:SetUniqueOnField(1,0,76382116)
+	c:SetUniqueOnField(1,0,76382116,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(76382116,0))

--- a/c77092311.lua
+++ b/c77092311.lua
@@ -1,6 +1,6 @@
 --毒の魔妖－土蜘蛛
 function c77092311.initial_effect(c)
-	c:SetUniqueOnField(1,0,77092311)
+	c:SetUniqueOnField(1,0,77092311,LOCATION_MZONE)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(nil),1)
 	c:EnableReviveLimit()

--- a/c80208158.lua
+++ b/c80208158.lua
@@ -1,6 +1,6 @@
 --異次元エスパー・スター・ロビン
 function c80208158.initial_effect(c)
-	c:SetUniqueOnField(1,1,80208158)
+	c:SetUniqueOnField(1,1,80208158,LOCATION_MZONE)
 	--target
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c8198620.lua
+++ b/c8198620.lua
@@ -1,6 +1,6 @@
 --冥界龍 ドラゴネクロ
 function c8198620.initial_effect(c)
-	c:SetUniqueOnField(1,0,8198620)
+	c:SetUniqueOnField(1,0,8198620,LOCATION_MZONE)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcFunRep(c,aux.FilterBoolFunction(Card.IsRace,RACE_ZOMBIE),2,false)

--- a/c83039729.lua
+++ b/c83039729.lua
@@ -1,6 +1,6 @@
 --六武衆の師範
 function c83039729.initial_effect(c)
-	c:SetUniqueOnField(1,0,83039729)
+	c:SetUniqueOnField(1,0,83039729,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c8310162.lua
+++ b/c8310162.lua
@@ -3,7 +3,7 @@ function c8310162.initial_effect(c)
 	--synchro summon
 	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsCode,74509280),aux.NonTuner(Card.IsSetCard,0x23),1,1)
 	c:EnableReviveLimit()
-	c:SetUniqueOnField(1,1,8310162)
+	c:SetUniqueOnField(1,1,8310162,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(8310162,0))

--- a/c83519853.lua
+++ b/c83519853.lua
@@ -1,6 +1,6 @@
 --魔聖騎士皇ランスロット
 function c83519853.initial_effect(c)
-	c:SetUniqueOnField(1,0,83519853)
+	c:SetUniqueOnField(1,0,83519853,LOCATION_MZONE)
 	--synchro summon
 	aux.AddSynchroProcedure(c,nil,aux.NonTuner(Card.IsSetCard,0x107a),1)
 	c:EnableReviveLimit()

--- a/c83705073.lua
+++ b/c83705073.lua
@@ -1,6 +1,6 @@
 --ワルキューレ・エルダ
 function c83705073.initial_effect(c)
-	c:SetUniqueOnField(1,0,83705073)
+	c:SetUniqueOnField(1,0,83705073,LOCATION_MZONE)
 	--atk up
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)

--- a/c84268896.lua
+++ b/c84268896.lua
@@ -1,6 +1,6 @@
 --アーティファクト－カドケウス
 function c84268896.initial_effect(c)
-	c:SetUniqueOnField(1,0,84268896)
+	c:SetUniqueOnField(1,0,84268896,LOCATION_MZONE)
 	--set
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c8487449.lua
+++ b/c8487449.lua
@@ -1,6 +1,6 @@
 --ジェスター・コンフィ
 function c8487449.initial_effect(c)
-	c:SetUniqueOnField(1,0,8487449)
+	c:SetUniqueOnField(1,0,8487449,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c9418365.lua
+++ b/c9418365.lua
@@ -1,6 +1,6 @@
 --武神－ヒルメ
 function c9418365.initial_effect(c)
-	c:SetUniqueOnField(1,0,9418365)
+	c:SetUniqueOnField(1,0,9418365,LOCATION_MZONE)
 	c:EnableReviveLimit()
 	--special summon
 	local e1=Effect.CreateEffect(c)

--- a/c94766498.lua
+++ b/c94766498.lua
@@ -1,6 +1,6 @@
 --先史遺産アステカ・マスク・ゴーレム
 function c94766498.initial_effect(c)
-	c:SetUniqueOnField(1,0,94766498)
+	c:SetUniqueOnField(1,0,94766498,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c95772051.lua
+++ b/c95772051.lua
@@ -1,6 +1,6 @@
 --魔聖騎士ランスロット
 function c95772051.initial_effect(c)
-	c:SetUniqueOnField(1,0,95772051)
+	c:SetUniqueOnField(1,0,95772051,LOCATION_MZONE)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(95772051,0))


### PR DESCRIPTION
Unlike Spell&Trap Card,these monsters' uniqueness only applies in the Monster Zone.
These monsters use the description "1体",some other monsters use the description "1枚" whose uniqueness also applies in the Spell&Trap Zone,such as 「ZW」monster and 「Winged Kuriboh LV9」.