### PR TITLE
add aux.AddCodeList

### DIFF
--- a/c111280.lua
+++ b/c111280.lua
@@ -1,5 +1,6 @@
 --黒魔導強化
 function c111280.initial_effect(c)
+	aux.AddCodeList(c,46986414,38033121)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
@@ -12,7 +13,6 @@ function c111280.initial_effect(c)
 	e1:SetOperation(c111280.activate)
 	c:RegisterEffect(e1)
 end
-c111280.card_code_list={46986414,38033121}
 function c111280.cfilter(c)
 	return c:IsFaceup() and c:IsCode(46986414,38033121)
 end

--- a/c11502550.lua
+++ b/c11502550.lua
@@ -38,7 +38,6 @@ function c11502550.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c11502550.material_setcode=0x8
-c11502550.card_code_list={89943723}
 c11502550.neos_fusion=true
 function c11502550.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)

--- a/c11646785.lua
+++ b/c11646785.lua
@@ -1,5 +1,6 @@
 --超量機獣エアロボロス
 function c11646785.initial_effect(c)
+	aux.AddCodeList(c,85374678)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,4,2)
 	c:EnableReviveLimit()
@@ -38,7 +39,6 @@ function c11646785.initial_effect(c)
 	e4:SetOperation(c11646785.mtop)
 	c:RegisterEffect(e4)
 end
-c11646785.card_code_list={85374678}
 function c11646785.atcon(e)
 	return e:GetHandler():GetOverlayCount()==0
 end

--- a/c11913700.lua
+++ b/c11913700.lua
@@ -1,5 +1,6 @@
 --インスタント・ネオスペース
 function c11913700.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_EQUIP)
@@ -33,7 +34,6 @@ function c11913700.initial_effect(c)
 	e4:SetOperation(c11913700.spop)
 	c:RegisterEffect(e4)
 end
-c11913700.card_code_list={89943723}
 function c11913700.eqlimit(e,c)
 	return aux.IsMaterialListCode(c,89943723)
 end

--- a/c12071500.lua
+++ b/c12071500.lua
@@ -1,5 +1,6 @@
 --ダーク・コーリング
 function c12071500.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
@@ -9,7 +10,6 @@ function c12071500.initial_effect(c)
 	e1:SetOperation(c12071500.activate)
 	c:RegisterEffect(e1)
 end
-c12071500.card_code_list={94820406}
 function c12071500.filter0(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsAbleToRemove()
 end

--- a/c12171659.lua
+++ b/c12171659.lua
@@ -1,5 +1,6 @@
 --天空の使者 ゼラディアス
 function c12171659.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(12171659,0))
@@ -19,7 +20,6 @@ function c12171659.initial_effect(c)
 	e2:SetCondition(c12171659.descon)
 	c:RegisterEffect(e2)
 end
-c12171659.card_code_list={56433456}
 function c12171659.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return c:IsAbleToGraveAsCost() and c:IsDiscardable() end

--- a/c12181376.lua
+++ b/c12181376.lua
@@ -1,5 +1,6 @@
 --トライアングル・X・スパーク
 function c12181376.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
@@ -9,7 +10,6 @@ function c12181376.initial_effect(c)
 	e1:SetOperation(c12181376.activate)
 	c:RegisterEffect(e1)
 end
-c12181376.card_code_list={12206212}
 function c12181376.filter(c)
 	return c:IsFaceup() and c:IsCode(12206212)
 end

--- a/c12510878.lua
+++ b/c12510878.lua
@@ -1,5 +1,6 @@
 --天空勇士ネオパーシアス
 function c12510878.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -37,7 +38,6 @@ function c12510878.initial_effect(c)
 	e5:SetCode(EFFECT_UPDATE_DEFENSE)
 	c:RegisterEffect(e5)
 end
-c12510878.card_code_list={56433456}
 function c12510878.spcon(e,c)
 	if c==nil then return true end
 	return Duel.CheckReleaseGroup(c:GetControler(),Card.IsCode,1,nil,18036057)

--- a/c13048472.lua
+++ b/c13048472.lua
@@ -15,10 +15,7 @@ function c13048472.filter(c,tp)
 		and Duel.IsExistingMatchingCard(c13048472.filter2,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil,c)
 end
 function c13048472.filter2(c,mc)
-	return bit.band(c:GetType(),0x81)==0x81 and c:IsAbleToHand() and c13048472.isfit(c,mc)
-end
-function c13048472.isfit(c,mc)
-	return (mc.fit_monster and c:IsCode(table.unpack(mc.fit_monster))) or aux.IsCodeListed(mc,c:GetCode())
+	return bit.band(c:GetType(),0x81)==0x81 and c:IsAbleToHand() and aux.IsCodeListed(mc,c:GetCode())
 end
 function c13048472.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c13048472.filter,tp,LOCATION_DECK,0,1,nil,tp) end

--- a/c13293158.lua
+++ b/c13293158.lua
@@ -1,5 +1,6 @@
 --E－HERO ワイルド・サイクロン
 function c13293158.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcCode2(c,21844576,86188410,true,true)
@@ -33,7 +34,6 @@ function c13293158.initial_effect(c)
 end
 c13293158.material_setcode=0x8
 c13293158.dark_calling=true
-c13293158.card_code_list={94820406}
 function c13293158.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 		or Duel.IsPlayerAffectedByEffect(sp,72043279) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION

--- a/c13604200.lua
+++ b/c13604200.lua
@@ -1,5 +1,6 @@
 --賢者の宝石
 function c13604200.initial_effect(c)
+	aux.AddCodeList(c,46986414,38033121)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -10,7 +11,6 @@ function c13604200.initial_effect(c)
 	e1:SetOperation(c13604200.activate)
 	c:RegisterEffect(e1)
 end
-c13604200.card_code_list={46986414,38033121}
 function c13604200.cfilter(c)
 	return c:IsFaceup() and c:IsCode(38033121)
 end

--- a/c13650422.lua
+++ b/c13650422.lua
@@ -1,5 +1,6 @@
 --E－HERO アダスター・ゴールド
 function c13650422.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -17,7 +18,6 @@ function c13650422.initial_effect(c)
 	e2:SetCondition(c13650422.atkcon)
 	c:RegisterEffect(e2)
 end
-c13650422.card_code_list={94820406}
 function c13650422.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return c:IsDiscardable() end

--- a/c14088859.lua
+++ b/c14088859.lua
@@ -1,5 +1,6 @@
 --ネオス・フュージョン
 function c14088859.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(14088859,0))
@@ -28,7 +29,6 @@ function c14088859.initial_effect(c)
 	e3:SetValue(c14088859.repval2)
 	c:RegisterEffect(e3)
 end
-c14088859.card_code_list={89943723}
 function c14088859.filter1(c,e)
 	return c:IsAbleToGrave() and not c:IsImmuneToEffect(e)
 end

--- a/c14512825.lua
+++ b/c14512825.lua
@@ -1,5 +1,7 @@
 --カボチャの馬車
 function c14512825.initial_effect(c)
+	aux.AddCodeList(c,72283691)
+	--direct attack
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_DIRECT_ATTACK)
@@ -21,7 +23,6 @@ function c14512825.initial_effect(c)
 	e3:SetValue(1)
 	c:RegisterEffect(e3)
 end
-c14512825.card_code_list={72283691}
 function c14512825.indtg(e,c)
 	return c:IsFaceup() and c:IsCode(72283691)
 end

--- a/c14553285.lua
+++ b/c14553285.lua
@@ -1,5 +1,6 @@
 --アーカナイト・マジシャン／バスター
 function c14553285.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	c:EnableReviveLimit()
 	c:EnableCounterPermit(0x1)
 	--Cannot special summon
@@ -48,7 +49,6 @@ function c14553285.initial_effect(c)
 	e5:SetOperation(c14553285.spop)
 	c:RegisterEffect(e5)
 end
-c14553285.card_code_list={80280737}
 c14553285.assault_name=31924889
 function c14553285.addct(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c15449853.lua
+++ b/c15449853.lua
@@ -1,5 +1,6 @@
 --パーシアスの神域
 function c15449853.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -50,7 +51,6 @@ function c15449853.initial_effect(c)
 	e7:SetOperation(c15449853.tdop)
 	c:RegisterEffect(e7)
 end
-c15449853.card_code_list={56433456}
 function c15449853.tdfilter(c,e)
 	return (c:IsRace(RACE_FAIRY) or c:IsType(TYPE_COUNTER)) and c:IsAbleToDeck() and (not e or c:IsCanBeEffectTarget(e))
 end

--- a/c16241441.lua
+++ b/c16241441.lua
@@ -1,5 +1,6 @@
 --C・ラーバ
 function c16241441.initial_effect(c)
+	aux.AddCodeList(c,89621922)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(16241441,0))
@@ -12,7 +13,6 @@ function c16241441.initial_effect(c)
 	e1:SetOperation(c16241441.spop)
 	c:RegisterEffect(e1)
 end
-c16241441.card_code_list={89621922}
 function c16241441.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c17032740.lua
+++ b/c17032740.lua
@@ -42,7 +42,6 @@ function c17032740.initial_effect(c)
 end
 c17032740.material_setcode=0x8
 c17032740.toss_coin=true
-c17032740.card_code_list={89943723}
 function c17032740.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end

--- a/c17363041.lua
+++ b/c17363041.lua
@@ -1,5 +1,6 @@
 --C・チッキー
 function c17363041.initial_effect(c)
+	aux.AddCodeList(c,54959865)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(17363041,0))
@@ -12,7 +13,6 @@ function c17363041.initial_effect(c)
 	e1:SetOperation(c17363041.spop)
 	c:RegisterEffect(e1)
 end
-c17363041.card_code_list={54959865}
 function c17363041.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c1764972.lua
+++ b/c1764972.lua
@@ -1,5 +1,6 @@
 --デスカイザー・ドラゴン／バスター
 function c1764972.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	c:EnableReviveLimit()
 	--Cannot special summon
 	local e1=Effect.CreateEffect(c)
@@ -30,7 +31,6 @@ function c1764972.initial_effect(c)
 	e3:SetOperation(c1764972.spop2)
 	c:RegisterEffect(e3)
 end
-c1764972.card_code_list={80280737}
 c1764972.assault_name=6021033
 function c1764972.filter1(c,e,tp)
 	return c:IsRace(RACE_ZOMBIE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c17655904.lua
+++ b/c17655904.lua
@@ -1,5 +1,6 @@
 --滅びの爆裂疾風弾
 function c17655904.initial_effect(c)
+	aux.AddCodeList(c,89631139)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY)
@@ -12,7 +13,6 @@ function c17655904.initial_effect(c)
 	c:RegisterEffect(e1)
 	Duel.AddCustomActivityCounter(17655904,ACTIVITY_ATTACK,c17655904.counterfilter)
 end
-c17655904.card_code_list={89631139}
 function c17655904.counterfilter(c)
 	return not c:IsCode(89631139)
 end

--- a/c18302224.lua
+++ b/c18302224.lua
@@ -1,5 +1,6 @@
 --リバース・オブ・ネオス
 function c18302224.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -10,7 +11,6 @@ function c18302224.initial_effect(c)
 	e1:SetOperation(c18302224.activate)
 	c:RegisterEffect(e1)
 end
-c18302224.card_code_list={89943723}
 function c18302224.cfilter(c,tp)
 	return c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousControler()==tp
 		and c:IsPreviousPosition(POS_FACEUP) and c:IsSetCard(0x9) and c:IsType(TYPE_FUSION)

--- a/c18378582.lua
+++ b/c18378582.lua
@@ -1,5 +1,6 @@
 --大天使ゼラート
 function c18378582.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	c:EnableReviveLimit()
 	--cannot special summon
 	local e1=Effect.CreateEffect(c)
@@ -27,7 +28,6 @@ function c18378582.initial_effect(c)
 	e3:SetOperation(c18378582.desop)
 	c:RegisterEffect(e3)
 end
-c18378582.card_code_list={56433456}
 function c18378582.rfilter(c,code)
 	return c:IsFaceup() and c:IsCode(code)
 end

--- a/c18438874.lua
+++ b/c18438874.lua
@@ -1,5 +1,6 @@
 --イービル・マインド
 function c18438874.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--draw
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(18438874,0))
@@ -35,7 +36,6 @@ function c18438874.initial_effect(c)
 	e3:SetOperation(c18438874.thop2)
 	c:RegisterEffect(e3)
 end
-c18438874.card_code_list={94820406}
 function c18438874.cfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_FIEND)
 end

--- a/c21082832.lua
+++ b/c21082832.lua
@@ -1,8 +1,8 @@
 --カオス・フォーム
 function c21082832.initial_effect(c)
+	aux.AddCodeList(c,46986414,89631139)
 	aux.AddRitualProcEqual2(c,c21082832.filter,nil,c21082832.mfilter)
 end
-c21082832.card_code_list={46986414,89631139}
 function c21082832.filter(c,e,tp,m1,m2,ft)
 	return c:IsSetCard(0xcf)
 end

--- a/c21947653.lua
+++ b/c21947653.lua
@@ -1,5 +1,6 @@
 --E－HERO ライトニング・ゴーレム
 function c21947653.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcCode2(c,20721928,84327329,true,true)
@@ -24,7 +25,6 @@ function c21947653.initial_effect(c)
 end
 c21947653.material_setcode=0x8
 c21947653.dark_calling=true
-c21947653.card_code_list={94820406}
 function c21947653.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 		or Duel.IsPlayerAffectedByEffect(sp,72043279) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION

--- a/c22160245.lua
+++ b/c22160245.lua
@@ -1,5 +1,6 @@
 --E－HERO インフェルノ・ウィング
 function c22160245.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcCode2(c,58932615,21844576,true,true)
@@ -29,7 +30,6 @@ function c22160245.initial_effect(c)
 end
 c22160245.material_setcode=0x8
 c22160245.dark_calling=true
-c22160245.card_code_list={94820406}
 function c22160245.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 		or Duel.IsPlayerAffectedByEffect(sp,72043279) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION

--- a/c2314238.lua
+++ b/c2314238.lua
@@ -1,5 +1,6 @@
 --黒・魔・導
 function c2314238.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY)
@@ -10,7 +11,6 @@ function c2314238.initial_effect(c)
 	e1:SetOperation(c2314238.activate)
 	c:RegisterEffect(e1)
 end
-c2314238.card_code_list={46986414}
 function c2314238.cfilter(c)
 	return c:IsFaceup() and c:IsCode(46986414)
 end

--- a/c23459650.lua
+++ b/c23459650.lua
@@ -1,5 +1,6 @@
 --ネフティスの輪廻
 function c23459650.initial_effect(c)
+	aux.AddCodeList(c,88176533,24175232)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -9,7 +10,6 @@ function c23459650.initial_effect(c)
 	e1:SetOperation(c23459650.activate)
 	c:RegisterEffect(e1)
 end
-c23459650.fit_monster={88176533,24175232}
 function c23459650.filter(c,e,tp)
 	return c:IsSetCard(0x11f)
 end

--- a/c27383110.lua
+++ b/c27383110.lua
@@ -1,5 +1,6 @@
 --宣告者の預言
 function c27383110.initial_effect(c)
+	aux.AddCodeList(c,44665365)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -31,7 +32,6 @@ function c27383110.initial_effect(c)
 	c:RegisterEffect(e3)
 	e1:SetLabelObject(e3)
 end
-c27383110.fit_monster={44665365}
 function c27383110.filter(c,e,tp)
 	return c:IsCode(44665365)
 end

--- a/c28573958.lua
+++ b/c28573958.lua
@@ -1,5 +1,6 @@
 --奇跡の代行者 ジュピター
 function c28573958.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--atkup
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(28573958,0))
@@ -26,7 +27,6 @@ function c28573958.initial_effect(c)
 	e2:SetOperation(c28573958.spop)
 	c:RegisterEffect(e2)
 end
-c28573958.card_code_list={56433456}
 function c28573958.cfilter1(c)
 	return c:IsSetCard(0x44) and c:IsAbleToRemoveAsCost()
 end

--- a/c28677304.lua
+++ b/c28677304.lua
@@ -41,7 +41,6 @@ function c28677304.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c28677304.material_setcode=0x8
-c28677304.card_code_list={89943723}
 c28677304.neos_fusion=true
 function c28677304.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)

--- a/c29246354.lua
+++ b/c29246354.lua
@@ -1,5 +1,6 @@
 --C・ピニー
 function c29246354.initial_effect(c)
+	aux.AddCodeList(c,17732278)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(29246354,0))
@@ -12,7 +13,6 @@ function c29246354.initial_effect(c)
 	e1:SetOperation(c29246354.spop)
 	c:RegisterEffect(e1)
 end
-c29246354.card_code_list={17732278}
 function c29246354.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c29432790.lua
+++ b/c29432790.lua
@@ -1,5 +1,6 @@
 --青き眼の激臨
 function c29432790.initial_effect(c)
+	aux.AddCodeList(c,89631139)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_REMOVE)
@@ -13,7 +14,6 @@ function c29432790.initial_effect(c)
 	Duel.AddCustomActivityCounter(29432790,ACTIVITY_SUMMON,c29432790.counterfilter)
 	Duel.AddCustomActivityCounter(29432790,ACTIVITY_SPSUMMON,c29432790.counterfilter)
 end
-c29432790.card_code_list={89631139}
 function c29432790.counterfilter(c)
 	return c:IsCode(89631139)
 end

--- a/c29436665.lua
+++ b/c29436665.lua
@@ -1,5 +1,6 @@
 --黒魔導の執行官
 function c29436665.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	c:EnableReviveLimit()
 	--cannot special summon
 	local e1=Effect.CreateEffect(c)

--- a/c30603688.lua
+++ b/c30603688.lua
@@ -1,5 +1,6 @@
 --幻想の見習い魔導師
 function c30603688.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c313513.lua
+++ b/c313513.lua
@@ -1,5 +1,6 @@
 --魔法の歯車
 function c313513.initial_effect(c)
+	aux.AddCodeList(c,83104731)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -10,7 +11,6 @@ function c313513.initial_effect(c)
 	e1:SetOperation(c313513.activate)
 	c:RegisterEffect(e1)
 end
-c313513.card_code_list={83104731}
 function c313513.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x7) and c:IsAbleToGraveAsCost()
 end

--- a/c3431737.lua
+++ b/c3431737.lua
@@ -1,5 +1,6 @@
 --バスター・ビースト
 function c3431737.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(3431737,0))
@@ -11,7 +12,6 @@ function c3431737.initial_effect(c)
 	e1:SetOperation(c3431737.operation)
 	c:RegisterEffect(e1)
 end
-c3431737.card_code_list={80280737}
 function c3431737.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return c:IsAbleToGraveAsCost() and c:IsDiscardable() end

--- a/c35191415.lua
+++ b/c35191415.lua
@@ -1,5 +1,6 @@
 --マジシャン・オブ・ブラック・イリュージョン
 function c35191415.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--change name
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c35255456.lua
+++ b/c35255456.lua
@@ -1,5 +1,6 @@
 --ミラクル・コンタクト
 function c35255456.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -9,7 +10,6 @@ function c35255456.initial_effect(c)
 	e1:SetOperation(c35255456.activate)
 	c:RegisterEffect(e1)
 end
-c35255456.card_code_list={89943723}
 function c35255456.filter1(c,e)
 	return c:IsAbleToDeck() and not c:IsImmuneToEffect(e)
 end

--- a/c37169670.lua
+++ b/c37169670.lua
@@ -1,5 +1,6 @@
 --ハイパーサイコガンナー／バスター
 function c37169670.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	c:EnableReviveLimit()
 	--Cannot special summon
 	local e1=Effect.CreateEffect(c)
@@ -29,7 +30,6 @@ function c37169670.initial_effect(c)
 	e3:SetOperation(c37169670.spop)
 	c:RegisterEffect(e3)
 end
-c37169670.card_code_list={80280737}
 c37169670.assault_name=95526884
 function c37169670.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetAttackTarget()~=nil end

--- a/c38033121.lua
+++ b/c38033121.lua
@@ -1,5 +1,6 @@
 --ブラック・マジシャン・ガール
 function c38033121.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--atkup
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c38784726.lua
+++ b/c38784726.lua
@@ -1,5 +1,6 @@
 --転生炎獣の降臨
 function c38784726.initial_effect(c)
+	aux.AddCodeList(c,16313112)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -19,7 +20,6 @@ function c38784726.initial_effect(c)
 	e2:SetOperation(c38784726.spop)
 	c:RegisterEffect(e2)
 end
-c38784726.fit_monster={16313112}
 function c38784726.filter(c,e,tp)
 	return c:IsSetCard(0x119)
 end

--- a/c38898779.lua
+++ b/c38898779.lua
@@ -1,5 +1,6 @@
 --ギガンテック・ファイター/バスター
 function c38898779.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	c:EnableReviveLimit()
 	--Cannot special summon
 	local e1=Effect.CreateEffect(c)
@@ -37,7 +38,6 @@ function c38898779.initial_effect(c)
 	e4:SetOperation(c38898779.spop)
 	c:RegisterEffect(e4)
 end
-c38898779.card_code_list={80280737}
 c38898779.assault_name=23693634
 function c38898779.tgfilter(c)
 	return c:IsRace(RACE_WARRIOR) and c:IsAbleToGrave()

--- a/c39015.lua
+++ b/c39015.lua
@@ -1,5 +1,6 @@
 --バスター・スナイパー
 function c39015.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(39015,0))
@@ -22,7 +23,6 @@ function c39015.initial_effect(c)
 	e2:SetOperation(c39015.chop)
 	c:RegisterEffect(e2)
 end
-c39015.card_code_list={80280737}
 function c39015.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsReleasable() end
 	Duel.Release(e:GetHandler(),REASON_COST)

--- a/c39275698.lua
+++ b/c39275698.lua
@@ -1,5 +1,6 @@
 --ハーピィの羽根休め
 function c39275698.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -11,7 +12,6 @@ function c39275698.initial_effect(c)
 	e1:SetCountLimit(1,39275698+EFFECT_COUNT_CODE_OATH)
 	c:RegisterEffect(e1)
 end
-c39275698.card_code_list={12206212}
 function c39275698.drfilter(c)
 	return c:IsCode(76812113,12206212) and c:IsAbleToDeck()
 end

--- a/c39392286.lua
+++ b/c39392286.lua
@@ -1,5 +1,6 @@
 --ハーピィ・パフューマー
 function c39392286.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(39392286,0))
@@ -23,7 +24,6 @@ function c39392286.initial_effect(c)
 	e3:SetValue(76812113)
 	c:RegisterEffect(e3)
 end
-c39392286.card_code_list={12206212}
 function c39392286.thfilter(c)
 	return aux.IsCodeListed(c,12206212) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToHand()
 end

--- a/c40048324.lua
+++ b/c40048324.lua
@@ -1,5 +1,6 @@
 --アーケイン・ファイロ
 function c40048324.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(40048324,0))
@@ -12,7 +13,6 @@ function c40048324.initial_effect(c)
 	e1:SetOperation(c40048324.operation)
 	c:RegisterEffect(e1)
 end
-c40048324.card_code_list={80280737}
 function c40048324.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and r==REASON_SYNCHRO
 end

--- a/c40080312.lua
+++ b/c40080312.lua
@@ -40,7 +40,6 @@ function c40080312.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c40080312.material_setcode=0x8
-c40080312.card_code_list={89943723}
 function c40080312.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end

--- a/c41735184.lua
+++ b/c41735184.lua
@@ -1,5 +1,6 @@
 --黒魔術の継承
 function c41735184.initial_effect(c)
+	aux.AddCodeList(c,46986414,38033121)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -11,7 +12,6 @@ function c41735184.initial_effect(c)
 	e1:SetOperation(c41735184.activate)
 	c:RegisterEffect(e1)
 end
-c41735184.card_code_list={46986414,38033121}
 function c41735184.cfilter(c)
 	return c:IsType(TYPE_SPELL) and c:IsAbleToRemoveAsCost()
 end

--- a/c41916534.lua
+++ b/c41916534.lua
@@ -1,5 +1,6 @@
 --鉄のハンス
 function c41916534.initial_effect(c)
+	aux.AddCodeList(c,72283691)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(41916534,0))
@@ -27,7 +28,6 @@ function c41916534.initial_effect(c)
 	e4:SetValue(c41916534.value)
 	c:RegisterEffect(e4)
 end
-c41916534.card_code_list={72283691}
 function c41916534.filter(c,e,tp)
 	return c:IsCode(73405179) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end

--- a/c41933425.lua
+++ b/c41933425.lua
@@ -1,5 +1,6 @@
 --コンタクト・ゲート
 function c41933425.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -24,7 +25,6 @@ function c41933425.initial_effect(c)
 	e2:SetOperation(c41933425.spop)
 	c:RegisterEffect(e2)
 end
-c41933425.card_code_list={89943723}
 function c41933425.cfilter1(c,e,tp)
 	return c:IsSetCard(0x1f) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
 		and Duel.IsExistingMatchingCard(c41933425.cfilter2,tp,LOCATION_GRAVE,0,1,c,e,tp,c)

--- a/c42006475.lua
+++ b/c42006475.lua
@@ -1,5 +1,6 @@
 --守護神官マナ
 function c42006475.initial_effect(c)
+	aux.AddCodeList(c,38033121)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(42006475,0))
@@ -32,7 +33,6 @@ function c42006475.initial_effect(c)
 	e3:SetOperation(c42006475.spop2)
 	c:RegisterEffect(e3)
 end
-c42006475.card_code_list={38033121}
 function c42006475.tfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_SPELLCASTER)
 end

--- a/c42015635.lua
+++ b/c42015635.lua
@@ -1,5 +1,6 @@
 --ネオスペース
 function c42015635.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -22,7 +23,6 @@ function c42015635.initial_effect(c)
 	e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
 	c:RegisterEffect(e3)
 end
-c42015635.card_code_list={89943723}
 function c42015635.atktg(e,c)
 	return c:IsCode(89943723) or aux.IsMaterialListCode(c,89943723)
 end

--- a/c42239546.lua
+++ b/c42239546.lua
@@ -1,5 +1,6 @@
 --C・モーグ
 function c42239546.initial_effect(c)
+	aux.AddCodeList(c,80344569)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(42239546,0))
@@ -12,7 +13,6 @@ function c42239546.initial_effect(c)
 	e1:SetOperation(c42239546.spop)
 	c:RegisterEffect(e1)
 end
-c42239546.card_code_list={80344569}
 function c42239546.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c42682609.lua
+++ b/c42682609.lua
@@ -1,5 +1,6 @@
 --C・ドルフィーナ
 function c42682609.initial_effect(c)
+	aux.AddCodeList(c,17955766)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(42682609,0))
@@ -12,7 +13,6 @@ function c42682609.initial_effect(c)
 	e1:SetOperation(c42682609.spop)
 	c:RegisterEffect(e1)
 end
-c42682609.card_code_list={17955766}
 function c42682609.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c43751755.lua
+++ b/c43751755.lua
@@ -1,5 +1,6 @@
 --C・パンテール
 function c43751755.initial_effect(c)
+	aux.AddCodeList(c,43237273)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(43751755,0))
@@ -12,7 +13,6 @@ function c43751755.initial_effect(c)
 	e1:SetOperation(c43751755.spop)
 	c:RegisterEffect(e1)
 end
-c43751755.card_code_list={43237273}
 function c43751755.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(42015635)
 end

--- a/c43845801.lua
+++ b/c43845801.lua
@@ -1,5 +1,6 @@
 --アルティメット・バースト
 function c43845801.initial_effect(c)
+	aux.AddCodeList(c,23995346)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -10,7 +11,6 @@ function c43845801.initial_effect(c)
 	e1:SetOperation(c43845801.activate)
 	c:RegisterEffect(e1)
 end
-c43845801.card_code_list={23995346}
 function c43845801.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()
 end

--- a/c44595286.lua
+++ b/c44595286.lua
@@ -1,5 +1,6 @@
 --裁きの光
 function c44595286.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOGRAVE)
@@ -12,7 +13,6 @@ function c44595286.initial_effect(c)
 	e1:SetOperation(c44595286.activate)
 	c:RegisterEffect(e1)
 end
-c44595286.card_code_list={56433456}
 function c44595286.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(56433456)
 end

--- a/c46294982.lua
+++ b/c46294982.lua
@@ -1,5 +1,6 @@
 --ヘクサ・トルーデ
 function c46294982.initial_effect(c)
+	aux.AddCodeList(c,72283691)
 	--summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(46294982,0))
@@ -32,7 +33,6 @@ function c46294982.initial_effect(c)
 	e3:SetOperation(c46294982.atkop)
 	c:RegisterEffect(e3)
 end
-c46294982.card_code_list={72283691}
 function c46294982.ntcon(e,c,minc)
 	if c==nil then return true end
 	return minc==0 and c:IsLevelAbove(5) and Duel.IsEnvironment(72283691)

--- a/c47027714.lua
+++ b/c47027714.lua
@@ -1,5 +1,6 @@
 --TG ハルバード・キャノン／バスター
 function c47027714.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	c:EnableReviveLimit()
 	--Cannot special summon
 	local e0=Effect.CreateEffect(c)
@@ -37,7 +38,6 @@ function c47027714.initial_effect(c)
 	e4:SetOperation(c47027714.spop)
 	c:RegisterEffect(e4)
 end
-c47027714.card_code_list={80280737}
 c47027714.assault_name=97836203
 function c47027714.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=ep and Duel.GetCurrentChain()==0

--- a/c47222536.lua
+++ b/c47222536.lua
@@ -1,5 +1,6 @@
 --黒の魔導陣
 function c47222536.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -26,7 +27,6 @@ function c47222536.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e3)
 end
-c47222536.card_code_list={46986414}
 function c47222536.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>2 end
 end

--- a/c47274077.lua
+++ b/c47274077.lua
@@ -1,5 +1,6 @@
 --ネオス・フォース
 function c47274077.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_EQUIP)
@@ -46,7 +47,6 @@ function c47274077.initial_effect(c)
 	e5:SetOperation(c47274077.retop)
 	c:RegisterEffect(e5)
 end
-c47274077.card_code_list={89943723}
 function c47274077.eqlimit(e,c)
 	return c:IsCode(89943723)
 end

--- a/c47963370.lua
+++ b/c47963370.lua
@@ -1,5 +1,6 @@
 --マジシャン・オブ・カオス
 function c47963370.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	c:EnableReviveLimit()
 	--change name
 	local e1=Effect.CreateEffect(c)
@@ -33,7 +34,6 @@ function c47963370.initial_effect(c)
 	e3:SetOperation(c47963370.spop)
 	c:RegisterEffect(e3)
 end
-c47963370.card_code_list={46986414}
 function c47963370.descon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP)
 end

--- a/c48589580.lua
+++ b/c48589580.lua
@@ -1,5 +1,6 @@
 --天空神騎士ロードパーシアス
 function c48589580.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--link summon
 	c:EnableReviveLimit()
 	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkRace,RACE_FAIRY),2)
@@ -29,7 +30,6 @@ function c48589580.initial_effect(c)
 	e2:SetOperation(c48589580.spop)
 	c:RegisterEffect(e2)
 end
-c48589580.card_code_list={56433456}
 function c48589580.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)

--- a/c48680970.lua
+++ b/c48680970.lua
@@ -1,5 +1,6 @@
 --永遠の魂
 function c48680970.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -37,7 +38,6 @@ function c48680970.initial_effect(c)
 	e4:SetOperation(c48680970.desop)
 	c:RegisterEffect(e4)
 end
-c48680970.card_code_list={46986414}
 function c48680970.filter1(c,e,tp)
 	return c:IsCode(46986414) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end

--- a/c48783998.lua
+++ b/c48783998.lua
@@ -1,5 +1,6 @@
 --コーリング・ノヴァ
 function c48783998.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(48783998,0))
@@ -11,7 +12,6 @@ function c48783998.initial_effect(c)
 	e1:SetOperation(c48783998.operation)
 	c:RegisterEffect(e1)
 end
-c48783998.card_code_list={56433456}
 function c48783998.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end

--- a/c48996569.lua
+++ b/c48996569.lua
@@ -41,7 +41,6 @@ function c48996569.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c48996569.material_setcode=0x8
-c48996569.card_code_list={89943723}
 c48996569.neos_fusion=true
 function c48996569.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)

--- a/c49352945.lua
+++ b/c49352945.lua
@@ -49,7 +49,6 @@ function c49352945.initial_effect(c)
 	c:RegisterEffect(e6)
 end
 c49352945.material_setcode=0x8
-c49352945.card_code_list={89943723}
 function c49352945.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end

--- a/c49826746.lua
+++ b/c49826746.lua
@@ -1,5 +1,6 @@
 --黒翼の魔術師
 function c49826746.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--Trap activate in set turn
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -10,4 +11,3 @@ function c49826746.initial_effect(c)
 	e1:SetTarget(aux.TargetBoolFunction(Card.IsCode,80280737))
 	c:RegisterEffect(e1)
 end
-c49826746.card_code_list={80280737}

--- a/c49905576.lua
+++ b/c49905576.lua
@@ -1,5 +1,6 @@
 --天空聖者メルティウス
 function c49905576.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--recover&destroy
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -8,7 +9,6 @@ function c49905576.initial_effect(c)
 	e1:SetOperation(c49905576.drop)
 	c:RegisterEffect(e1)
 end
-c49905576.card_code_list={56433456}
 function c49905576.drop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not re:IsActiveType(TYPE_COUNTER) or not c:IsLocation(LOCATION_MZONE) or not c:IsFaceup() then return end

--- a/c50282757.lua
+++ b/c50282757.lua
@@ -1,5 +1,6 @@
 --E－HERO ヘル・スナイパー
 function c50282757.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcCode2(c,84327329,58932615,true,true)
@@ -34,7 +35,6 @@ function c50282757.initial_effect(c)
 end
 c50282757.material_setcode=0x8
 c50282757.dark_calling=true
-c50282757.card_code_list={94820406}
 function c50282757.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 		or Duel.IsPlayerAffectedByEffect(sp,72043279) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION

--- a/c5126490.lua
+++ b/c5126490.lua
@@ -1,5 +1,6 @@
 --ネオス・ワイズマン
 function c5126490.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	c:EnableReviveLimit()
 	--spsummon condition
 	local e1=Effect.CreateEffect(c)
@@ -34,7 +35,6 @@ function c5126490.initial_effect(c)
 	e4:SetValue(1)
 	c:RegisterEffect(e4)
 end
-c5126490.card_code_list={89943723}
 function c5126490.spfilter1(c,tp)
 	return c:IsFaceup() and c:IsCode(89943723) and c:IsAbleToGraveAsCost()
 		and Duel.IsExistingMatchingCard(c5126490.spfilter2,tp,LOCATION_MZONE,0,1,c)
@@ -43,7 +43,7 @@ function c5126490.spfilter2(c)
 	return c:IsFaceup() and c:IsCode(78371393) and c:IsAbleToGraveAsCost()
 end
 function c5126490.spcon(e,c)
-	if c==nil then return true end 
+	if c==nil then return true end
 	local tp=c:GetControler()
 	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-2
 		and Duel.IsExistingMatchingCard(c5126490.spfilter1,tp,LOCATION_MZONE,0,1,nil,tp)

--- a/c5128859.lua
+++ b/c5128859.lua
@@ -23,7 +23,6 @@ function c5128859.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 c5128859.material_setcode=0x8
-c5128859.card_code_list={89943723}
 c5128859.neos_fusion=true
 function c5128859.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)

--- a/c52098461.lua
+++ b/c52098461.lua
@@ -1,5 +1,6 @@
 --ラス・オブ・ネオス
 function c52098461.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TODECK+CATEGORY_DESTROY)
@@ -10,7 +11,6 @@ function c52098461.initial_effect(c)
 	e1:SetOperation(c52098461.activate)
 	c:RegisterEffect(e1)
 end
-c52098461.card_code_list={89943723}
 function c52098461.filter(c)
 	return c:IsFaceup() and c:IsCode(89943723) and c:IsAbleToDeck()
 end

--- a/c53666449.lua
+++ b/c53666449.lua
@@ -1,5 +1,6 @@
 --天空賢者ミネルヴァ
 function c53666449.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--atk
 	local e0=Effect.CreateEffect(c)
 	e0:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -17,7 +18,6 @@ function c53666449.initial_effect(c)
 	e1:SetOperation(c53666449.atkop)
 	c:RegisterEffect(e1)
 end
-c53666449.card_code_list={56433456}
 function c53666449.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_COUNTER) and e:GetHandler():GetFlagEffect(1)>0
 end

--- a/c55171412.lua
+++ b/c55171412.lua
@@ -41,7 +41,6 @@ function c55171412.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c55171412.material_setcode=0x8
-c55171412.card_code_list={89943723}
 c55171412.neos_fusion=true
 function c55171412.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)

--- a/c55794644.lua
+++ b/c55794644.lua
@@ -1,5 +1,6 @@
 --マスター・ヒュペリオン
 function c55794644.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--spsummon proc
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -22,7 +23,6 @@ function c55794644.initial_effect(c)
 	e2:SetOperation(c55794644.operation)
 	c:RegisterEffect(e2)
 end
-c55794644.card_code_list={56433456}
 function c55794644.spfilter(c)
 	return c:IsSetCard(0x44) and c:IsAbleToRemoveAsCost() and (not c:IsLocation(LOCATION_MZONE) or c:IsFaceup())
 end

--- a/c56252810.lua
+++ b/c56252810.lua
@@ -1,5 +1,6 @@
 --Re－BUSTER
 function c56252810.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
@@ -11,7 +12,6 @@ function c56252810.initial_effect(c)
 	e1:SetOperation(c56252810.activate)
 	c:RegisterEffect(e1)
 end
-c56252810.card_code_list={80280737}
 function c56252810.cfilter(c)
 	return c:IsCode(80280737) and c:IsAbleToRemoveAsCost()
 end

--- a/c56889.lua
+++ b/c56889.lua
@@ -1,5 +1,6 @@
 --競闘－クロス・ディメンション
 function c56889.initial_effect(c)
+	aux.AddCodeList(c,83104731)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_REMOVE)
@@ -20,7 +21,6 @@ function c56889.initial_effect(c)
 	e2:SetOperation(c56889.repop)
 	c:RegisterEffect(e2)
 end
-c56889.card_code_list={83104731}
 function c56889.rmfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x7) and c:IsAbleToRemove()
 end

--- a/c56920308.lua
+++ b/c56920308.lua
@@ -1,5 +1,6 @@
 --強靭！無敵！最強！
 function c56920308.initial_effect(c)
+	aux.AddCodeList(c,89631139)
 	--effect gain
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -24,7 +25,6 @@ function c56920308.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e3)
 end
-c56920308.card_code_list={89631139}
 function c56920308.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0xdd)
 end

--- a/c57031794.lua
+++ b/c57031794.lua
@@ -1,5 +1,6 @@
 --超量機獣マグナライガー
 function c57031794.initial_effect(c)
+	aux.AddCodeList(c,59975920)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,5,2)
 	c:EnableReviveLimit()
@@ -38,7 +39,6 @@ function c57031794.initial_effect(c)
 	e4:SetOperation(c57031794.mtop)
 	c:RegisterEffect(e4)
 end
-c57031794.card_code_list={59975920}
 function c57031794.atcon(e)
 	return e:GetHandler():GetOverlayCount()==0
 end

--- a/c57450198.lua
+++ b/c57450198.lua
@@ -1,5 +1,6 @@
 --超量機獣ラスターレックス
 function c57450198.initial_effect(c)
+	aux.AddCodeList(c,73422829)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,7,2)
 	c:EnableReviveLimit()
@@ -38,7 +39,6 @@ function c57450198.initial_effect(c)
 	e4:SetOperation(c57450198.mtop)
 	c:RegisterEffect(e4)
 end
-c57450198.card_code_list={73422829}
 function c57450198.atcon(e)
 	return e:GetHandler():GetOverlayCount()==0
 end

--- a/c58332301.lua
+++ b/c58332301.lua
@@ -1,5 +1,6 @@
 --E－HERO ダーク・ガイア
 function c58332301.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsRace,RACE_FIEND),aux.FilterBoolFunction(Card.IsRace,RACE_ROCK),true)
@@ -28,7 +29,6 @@ function c58332301.initial_effect(c)
 end
 c58332301.material_setcode=0x8
 c58332301.dark_calling=true
-c58332301.card_code_list={94820406}
 function c58332301.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 		or Duel.IsPlayerAffectedByEffect(sp,72043279) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION

--- a/c60709218.lua
+++ b/c60709218.lua
@@ -1,5 +1,6 @@
 --師弟の絆
 function c60709218.initial_effect(c)
+	aux.AddCodeList(c,46986414,38033121)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -11,7 +12,6 @@ function c60709218.initial_effect(c)
 	e1:SetOperation(c60709218.activate)
 	c:RegisterEffect(e1)
 end
-c60709218.card_code_list={46986414,38033121}
 function c60709218.cfilter(c)
 	return c:IsCode(46986414) and c:IsFaceup()
 end

--- a/c61257789.lua
+++ b/c61257789.lua
@@ -1,5 +1,6 @@
 --スターダスト・ドラゴン／バスター
 function c61257789.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	c:EnableReviveLimit()
 	--Cannot special summon
 	local e1=Effect.CreateEffect(c)
@@ -44,7 +45,6 @@ function c61257789.initial_effect(c)
 	e4:SetOperation(c61257789.spop)
 	c:RegisterEffect(e4)
 end
-c61257789.card_code_list={80280737}
 c61257789.assault_name=44508094
 function c61257789.negcon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)

--- a/c63224564.lua
+++ b/c63224564.lua
@@ -1,5 +1,6 @@
 --サイバー・ボンテージ
 function c63224564.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_EQUIP)
@@ -23,7 +24,6 @@ function c63224564.initial_effect(c)
 	e4:SetValue(c63224564.eqlimit)
 	c:RegisterEffect(e4)
 end
-c63224564.card_code_list={12206212}
 function c63224564.eqlimit(e,c)
 	return c:IsCode(76812113,12206212)
 end

--- a/c63391643.lua
+++ b/c63391643.lua
@@ -1,5 +1,6 @@
 --千本ナイフ
 function c63391643.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY)
@@ -11,7 +12,6 @@ function c63391643.initial_effect(c)
 	e1:SetOperation(c63391643.activate)
 	c:RegisterEffect(e1)
 end
-c63391643.card_code_list={46986414}
 function c63391643.cfilter(c)
 	return c:IsFaceup() and c:IsCode(46986414)
 end

--- a/c64061284.lua
+++ b/c64061284.lua
@@ -1,5 +1,6 @@
 --古代の機械融合
 function c64061284.initial_effect(c)
+	aux.AddCodeList(c,83104731)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON+CATEGORY_DECKDES)
@@ -9,7 +10,6 @@ function c64061284.initial_effect(c)
 	e1:SetOperation(c64061284.activate)
 	c:RegisterEffect(e1)
 end
-c64061284.card_code_list={83104731}
 function c64061284.fcheck(tp,sg,fc,mg)
 	if sg:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then
 		return sg:IsExists(c64061284.filterchk,1,nil) end

--- a/c64655485.lua
+++ b/c64655485.lua
@@ -30,7 +30,6 @@ function c64655485.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 c64655485.material_setcode=0x8
-c64655485.card_code_list={89943723}
 c64655485.neos_fusion=true
 function c64655485.ffilter(c)
 	return c:IsLevelBelow(4) and c:IsFusionType(TYPE_EFFECT)

--- a/c65664792.lua
+++ b/c65664792.lua
@@ -1,5 +1,6 @@
 --華麗なるハーピィ・レディ
 function c65664792.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TODECK)
@@ -21,7 +22,6 @@ function c65664792.initial_effect(c)
 	e2:SetOperation(c65664792.thop)
 	c:RegisterEffect(e2)
 end
-c65664792.card_code_list={12206212}
 function c65664792.tdfilter(c,e,tp)
 	return c:IsCode(12206212) and c:IsAbleToDeck()
 end

--- a/c66386380.lua
+++ b/c66386380.lua
@@ -1,5 +1,6 @@
 --ハーピィ・オラクル
 function c66386380.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(66386380,0))
@@ -33,7 +34,6 @@ function c66386380.initial_effect(c)
 	e4:SetOperation(c66386380.ssop)
 	c:RegisterEffect(e4)
 end
-c66386380.card_code_list={12206212}
 function c66386380.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c67227834.lua
+++ b/c67227834.lua
@@ -1,5 +1,6 @@
 --魔術の呪文書
 function c67227834.initial_effect(c)
+	aux.AddCodeList(c,46986414,38033121)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_EQUIP)
@@ -34,7 +35,6 @@ function c67227834.initial_effect(c)
 	e4:SetOperation(c67227834.recop)
 	c:RegisterEffect(e4)
 end
-c67227834.card_code_list={46986414,38033121}
 function c67227834.eqlimit(e,c)
 	return c:IsCode(46986414,38033121)
 end

--- a/c68334074.lua
+++ b/c68334074.lua
@@ -1,5 +1,6 @@
 --奇跡の復活
 function c68334074.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -12,7 +13,6 @@ function c68334074.initial_effect(c)
 	e1:SetOperation(c68334074.activate)
 	c:RegisterEffect(e1)
 end
-c68334074.card_code_list={46986414}
 function c68334074.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsCanRemoveCounter(tp,1,0,0x1,2,REASON_COST) end
 	Duel.RemoveCounter(tp,1,0,0x1,2,REASON_COST)

--- a/c69542930.lua
+++ b/c69542930.lua
@@ -1,5 +1,6 @@
 --光と闇の洗礼
 function c69542930.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -10,7 +11,6 @@ function c69542930.initial_effect(c)
 	e1:SetOperation(c69542930.activate)
 	c:RegisterEffect(e1)
 end
-c69542930.card_code_list={46986414}
 function c69542930.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsCode,1,nil,46986414) end
 	local g=Duel.SelectReleaseGroup(tp,Card.IsCode,1,1,nil,46986414)

--- a/c69884162.lua
+++ b/c69884162.lua
@@ -1,5 +1,6 @@
 --E・HERO アナザー・ネオス
 function c69884162.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	aux.EnableDualAttribute(c)
 	--code
 	local e1=Effect.CreateEffect(c)
@@ -11,4 +12,3 @@ function c69884162.initial_effect(c)
 	e1:SetValue(89943723)
 	c:RegisterEffect(e1)
 end
-c69884162.card_code_list={89943723}

--- a/c70168345.lua
+++ b/c70168345.lua
@@ -1,5 +1,6 @@
 --黒・魔・導・連・弾
 function c70168345.initial_effect(c)
+	aux.AddCodeList(c,46986414,38033121)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
@@ -11,7 +12,6 @@ function c70168345.initial_effect(c)
 	e1:SetOperation(c70168345.operation)
 	c:RegisterEffect(e1)
 end
-c70168345.card_code_list={46986414,38033121}
 function c70168345.filter(c)
 	return c:IsCode(38033121) and (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE))
 end

--- a/c7084129.lua
+++ b/c7084129.lua
@@ -1,5 +1,6 @@
 --マジシャンズ・ロッド
 function c7084129.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(7084129,0))

--- a/c71696014.lua
+++ b/c71696014.lua
@@ -1,5 +1,6 @@
 --マジシャンズ・ローブ
 function c71696014.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--spsummon (DM)
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(71696014,0))

--- a/c71703785.lua
+++ b/c71703785.lua
@@ -1,5 +1,6 @@
 --守護神官マハード
 function c71703785.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(71703785,0))

--- a/c72043279.lua
+++ b/c72043279.lua
@@ -1,5 +1,6 @@
 --覇王城
 function c72043279.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -26,7 +27,6 @@ function c72043279.initial_effect(c)
 	e3:SetOperation(c72043279.atkop)
 	c:RegisterEffect(e3)
 end
-c72043279.card_code_list={94820406}
 function c72043279.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetAttacker()
 	local bc=Duel.GetAttackTarget()

--- a/c72926163.lua
+++ b/c72926163.lua
@@ -36,7 +36,6 @@ function c72926163.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c72926163.material_setcode=0x8
-c72926163.card_code_list={89943723}
 c72926163.neos_fusion=true
 function c72926163.valcheck(e,c)
 	local g=c:GetMaterial()

--- a/c73239437.lua
+++ b/c73239437.lua
@@ -1,5 +1,6 @@
 --ダブルヒーローアタック
 function c73239437.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -12,7 +13,6 @@ function c73239437.initial_effect(c)
 	e1:SetOperation(c73239437.activate)
 	c:RegisterEffect(e1)
 end
-c73239437.card_code_list={89943723}
 function c73239437.cfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_FUSION) and aux.IsMaterialListCode(c,89943723)
 end

--- a/c73405179.lua
+++ b/c73405179.lua
@@ -1,5 +1,6 @@
 --鉄の騎士
 function c73405179.initial_effect(c)
+	aux.AddCodeList(c,72283691)
 	--atk down
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -25,7 +26,6 @@ function c73405179.initial_effect(c)
 	e3:SetCondition(c73405179.thcon)
 	c:RegisterEffect(e3)
 end
-c73405179.card_code_list={72283691}
 function c73405179.filter(c)
 	return c:IsFaceup() and c:IsCode(41916534)
 end

--- a/c73616671.lua
+++ b/c73616671.lua
@@ -1,5 +1,6 @@
 --イリュージョン・マジック
 function c73616671.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -11,7 +12,6 @@ function c73616671.initial_effect(c)
 	e1:SetOperation(c73616671.activate)
 	c:RegisterEffect(e1)
 end
-c73616671.card_code_list={46986414}
 function c73616671.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsRace,1,nil,RACE_SPELLCASTER) end
 	local g=Duel.SelectReleaseGroup(tp,Card.IsRace,1,1,nil,RACE_SPELLCASTER)

--- a/c73752131.lua
+++ b/c73752131.lua
@@ -1,5 +1,6 @@
 --熟練の黒魔術師
 function c73752131.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	c:EnableCounterPermit(0x1)
 	c:SetCounterLimit(0x1,3)
 	--add counter

--- a/c74414885.lua
+++ b/c74414885.lua
@@ -1,5 +1,6 @@
 --NEXT
 function c74414885.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -16,7 +17,6 @@ function c74414885.initial_effect(c)
 	e2:SetCondition(c74414885.handcon)
 	c:RegisterEffect(e2)
 end
-c74414885.card_code_list={89943723}
 function c74414885.filter(c,e,tp)
 	return (c:IsCode(89943723) or c:IsSetCard(0x1f)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end

--- a/c74431740.lua
+++ b/c74431740.lua
@@ -1,5 +1,6 @@
 --バスター・リブート
 function c74431740.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -25,7 +26,6 @@ function c74431740.initial_effect(c)
 	e2:SetOperation(c74431740.tdop)
 	c:RegisterEffect(e2)
 end
-c74431740.card_code_list={80280737}
 function c74431740.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(100)
 	return true

--- a/c74644400.lua
+++ b/c74644400.lua
@@ -1,5 +1,6 @@
 --サイキック・リフレクター
 function c74644400.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(74644400,0))
@@ -27,7 +28,6 @@ function c74644400.initial_effect(c)
 	e3:SetOperation(c74644400.spop)
 	c:RegisterEffect(e3)
 end
-c74644400.card_code_list={80280737}
 function c74644400.thfilter(c)
 	return aux.IsCodeListed(c,80280737) and not c:IsCode(74644400) or c:IsCode(80280737)
 		and c:IsAbleToHand()

--- a/c75190122.lua
+++ b/c75190122.lua
@@ -1,5 +1,6 @@
 --黒・爆・裂・破・魔・導
 function c75190122.initial_effect(c)
+	aux.AddCodeList(c,46986414,38033121)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY)
@@ -10,7 +11,6 @@ function c75190122.initial_effect(c)
 	e1:SetOperation(c75190122.activate)
 	c:RegisterEffect(e1)
 end
-c75190122.card_code_list={46986414,38033121}
 function c75190122.cfilter(c,code)
 	return c:IsFaceup() and c:IsOriginalCodeRule(code)
 end

--- a/c75782277.lua
+++ b/c75782277.lua
@@ -1,5 +1,6 @@
 --ハーピィの狩場
 function c75782277.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -40,7 +41,6 @@ function c75782277.initial_effect(c)
 		Duel.RegisterEffect(ge2,0)
 	end
 end
-c75782277.card_code_list={12206212}
 function c75782277.check(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=eg:GetFirst()

--- a/c77036039.lua
+++ b/c77036039.lua
@@ -1,5 +1,6 @@
 --バスター・マーセナリ
 function c77036039.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--destroy
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(77036039,0))
@@ -13,7 +14,6 @@ function c77036039.initial_effect(c)
 	e1:SetOperation(c77036039.operation)
 	c:RegisterEffect(e1)
 end
-c77036039.card_code_list={80280737}
 function c77036039.cfilter(c)
 	return c:IsCode(80280737) and c:IsAbleToDeckAsCost()
 end

--- a/c77336644.lua
+++ b/c77336644.lua
@@ -1,5 +1,6 @@
 --レッド・デーモンズ・ドラゴン／バスター
 function c77336644.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	c:EnableReviveLimit()
 	--Cannot special summon
 	local e1=Effect.CreateEffect(c)
@@ -30,7 +31,6 @@ function c77336644.initial_effect(c)
 	e3:SetOperation(c77336644.spop)
 	c:RegisterEffect(e3)
 end
-c77336644.card_code_list={80280737}
 c77336644.assault_name=70902743
 function c77336644.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetAttacker()==e:GetHandler()

--- a/c78512663.lua
+++ b/c78512663.lua
@@ -47,7 +47,6 @@ function c78512663.initial_effect(c)
 	c:RegisterEffect(e6)
 end
 c78512663.material_setcode=0x8
-c78512663.card_code_list={89943723}
 function c78512663.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end

--- a/c78527720.lua
+++ b/c78527720.lua
@@ -1,5 +1,6 @@
 --シンデレラ
 function c78527720.initial_effect(c)
+	aux.AddCodeList(c,72283691)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(78527720,0))
@@ -26,7 +27,6 @@ function c78527720.initial_effect(c)
 	e3:SetOperation(c78527720.eqop)
 	c:RegisterEffect(e3)
 end
-c78527720.card_code_list={72283691}
 function c78527720.filter(c,e,tp)
 	return c:IsCode(14512825) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end

--- a/c7922915.lua
+++ b/c7922915.lua
@@ -1,5 +1,6 @@
 --マジシャンズ・ナビゲート
 function c7922915.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -23,7 +24,6 @@ function c7922915.initial_effect(c)
 	e2:SetOperation(c7922915.negop)
 	c:RegisterEffect(e2)
 end
-c7922915.card_code_list={46986414}
 function c7922915.filter(c,e,tp)
 	return c:IsCode(46986414) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
@@ -32,8 +32,8 @@ function c7922915.filter2(c,e,tp)
 end
 function c7922915.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanSpecialSummonCount(tp,2)
-		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1 
-		and Duel.IsExistingMatchingCard(c7922915.filter,tp,LOCATION_HAND,0,1,nil,e,tp) 
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
+		and Duel.IsExistingMatchingCard(c7922915.filter,tp,LOCATION_HAND,0,1,nil,e,tp)
 		and Duel.IsExistingMatchingCard(c7922915.filter2,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_HAND+LOCATION_DECK)
 end
@@ -46,7 +46,7 @@ function c7922915.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g2=Duel.SelectMatchingCard(tp,c7922915.filter2,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 		if g2:GetCount()>0 then
-			Duel.BreakEffect() 
+			Duel.BreakEffect()
 			Duel.SpecialSummon(g2,0,tp,tp,false,false,POS_FACEUP)
 		end
 	end

--- a/c79306385.lua
+++ b/c79306385.lua
@@ -1,5 +1,6 @@
 --宣告者の神託
 function c79306385.initial_effect(c)
+	aux.AddCodeList(c,48546368)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -9,7 +10,6 @@ function c79306385.initial_effect(c)
 	e1:SetOperation(c79306385.activate)
 	c:RegisterEffect(e1)
 end
-c79306385.fit_monster={48546368}
 function c79306385.filter(c,e,tp)
 	return c:IsCode(48546368)
 end

--- a/c81066751.lua
+++ b/c81066751.lua
@@ -1,5 +1,6 @@
 --神罰
 function c81066751.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--Activate(effect)
 	local e4=Effect.CreateEffect(c)
 	e4:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
@@ -10,7 +11,6 @@ function c81066751.initial_effect(c)
 	e4:SetOperation(c81066751.activate)
 	c:RegisterEffect(e4)
 end
-c81066751.card_code_list={56433456}
 function c81066751.cfilter(c)
 	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/c81566151.lua
+++ b/c81566151.lua
@@ -38,7 +38,6 @@ function c81566151.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c81566151.material_setcode=0x8
-c81566151.card_code_list={89943723}
 c81566151.neos_fusion=true
 function c81566151.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)

--- a/c84177693.lua
+++ b/c84177693.lua
@@ -1,5 +1,6 @@
 --ホーリー・ジェラル
 function c84177693.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--recover
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(84177693,0))
@@ -12,7 +13,6 @@ function c84177693.initial_effect(c)
 	e1:SetOperation(c84177693.recop)
 	c:RegisterEffect(e1)
 end
-c84177693.card_code_list={56433456}
 function c84177693.reccon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsReason(REASON_BATTLE) and Duel.IsEnvironment(56433456)
 end

--- a/c85252081.lua
+++ b/c85252081.lua
@@ -1,5 +1,6 @@
 --超量機獣グランパルス
 function c85252081.initial_effect(c)
+	aux.AddCodeList(c,12369277)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,3,2)
 	c:EnableReviveLimit()
@@ -38,7 +39,6 @@ function c85252081.initial_effect(c)
 	e4:SetOperation(c85252081.mtop)
 	c:RegisterEffect(e4)
 end
-c85252081.card_code_list={12369277}
 function c85252081.atcon(e)
 	return e:GetHandler():GetOverlayCount()==0
 end

--- a/c85507811.lua
+++ b/c85507811.lua
@@ -42,7 +42,6 @@ function c85507811.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c85507811.material_setcode=0x8
-c85507811.card_code_list={89943723}
 c85507811.neos_fusion=true
 function c85507811.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)

--- a/c85840608.lua
+++ b/c85840608.lua
@@ -1,5 +1,6 @@
 --ネオスペース・コネクター
 function c85840608.initial_effect(c)
+	aux.AddCodeList(c,89943723)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(85840608,0))
@@ -23,7 +24,6 @@ function c85840608.initial_effect(c)
 	e2:SetOperation(c85840608.spop2)
 	c:RegisterEffect(e2)
 end
-c85840608.card_code_list={89943723}
 function c85840608.spfilter(c,e,tp)
 	return (c:IsSetCard(0x1f) or c:IsCode(89943723)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end

--- a/c86165817.lua
+++ b/c86165817.lua
@@ -1,5 +1,6 @@
 --E－HERO マリシャス・ベイン
 function c86165817.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcFun2(c,c86165817.matfilter,aux.FilterBoolFunction(Card.IsFusionSetCard,0x6008),true)
@@ -33,7 +34,6 @@ function c86165817.initial_effect(c)
 end
 c86165817.material_setcode=0x8
 c86165817.dark_calling=true
-c86165817.card_code_list={94820406}
 function c86165817.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 		or Duel.IsPlayerAffectedByEffect(sp,72043279) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION

--- a/c86308219.lua
+++ b/c86308219.lua
@@ -1,5 +1,6 @@
 --ハーピィ・レディ －鳳凰の陣－
 function c86308219.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
@@ -13,7 +14,6 @@ function c86308219.initial_effect(c)
 	c:RegisterEffect(e1)
 	Duel.AddCustomActivityCounter(86308219,ACTIVITY_SPSUMMON,c86308219.counterfilter)
 end
-c86308219.card_code_list={12206212}
 function c86308219.counterfilter(c)
 	return bit.band(c:GetSummonLocation(),LOCATION_DECK+LOCATION_EXTRA)==0
 end

--- a/c86346643.lua
+++ b/c86346643.lua
@@ -43,7 +43,6 @@ function c86346643.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 c86346643.material_setcode=0x8
-c86346643.card_code_list={89943723}
 c86346643.neos_fusion=true
 function c86346643.cfilter1(c)
 	return c:IsAbleToGraveAsCost()

--- a/c86676862.lua
+++ b/c86676862.lua
@@ -1,5 +1,6 @@
 --E－HERO マリシャス・デビル
 function c86676862.initial_effect(c)
+	aux.AddCodeList(c,94820406)
 	--fusion material
 	c:EnableReviveLimit()
 	aux.AddFusionProcCodeFun(c,58554959,c86676862.ffilter,1,true,true)
@@ -34,7 +35,6 @@ function c86676862.initial_effect(c)
 end
 c86676862.material_setcode=0x8
 c86676862.dark_calling=true
-c86676862.card_code_list={94820406}
 function c86676862.splimit(e,se,sp,st)
 	return st==SUMMON_TYPE_FUSION+0x10
 		or Duel.IsPlayerAffectedByEffect(sp,72043279) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION

--- a/c87210505.lua
+++ b/c87210505.lua
@@ -1,5 +1,6 @@
 --騎士の称号
 function c87210505.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -10,7 +11,6 @@ function c87210505.initial_effect(c)
 	e1:SetOperation(c87210505.activate)
 	c:RegisterEffect(e1)
 end
-c87210505.card_code_list={46986414}
 function c87210505.costfilter(c,tp)
 	return c:IsFaceup() and c:IsCode(46986414) and Duel.GetMZoneCount(tp,c)>0
 end

--- a/c88332693.lua
+++ b/c88332693.lua
@@ -1,5 +1,6 @@
 --バスター・モード・ゼロ
 function c88332693.initial_effect(c)
+	aux.AddCodeList(c,80280737)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(88332693,0))
@@ -23,7 +24,6 @@ function c88332693.initial_effect(c)
 	e2:SetOperation(c88332693.setop)
 	c:RegisterEffect(e2)
 end
-c88332693.card_code_list={80280737}
 function c88332693.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
 	return true

--- a/c899287.lua
+++ b/c899287.lua
@@ -1,5 +1,6 @@
 --怪鳥グライフ
 function c899287.initial_effect(c)
+	aux.AddCodeList(c,72283691)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(899287,0))
@@ -25,7 +26,6 @@ function c899287.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e3)
 end
-c899287.card_code_list={72283691}
 function c899287.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return c:IsDiscardable() end

--- a/c90050480.lua
+++ b/c90050480.lua
@@ -39,7 +39,6 @@ function c90050480.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c90050480.material_setcode=0x8
-c90050480.card_code_list={89943723}
 function c90050480.ffilter(c,fc,sub,mg,sg)
 	return c:IsFusionSetCard(0x1f) and (not sg or not sg:Filter(Card.IsFusionSetCard,nil,0x1f):IsExists(Card.IsFusionAttribute,1,c,c:GetFusionAttribute()))
 end

--- a/c90219263.lua
+++ b/c90219263.lua
@@ -1,5 +1,6 @@
 --万華鏡－華麗なる分身－
 function c90219263.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -10,7 +11,6 @@ function c90219263.initial_effect(c)
 	e1:SetOperation(c90219263.activate)
 	c:RegisterEffect(e1)
 end
-c90219263.card_code_list={12206212}
 function c90219263.cfilter(c)
 	return c:IsFaceup() and c:IsCode(76812113)
 end

--- a/c90960358.lua
+++ b/c90960358.lua
@@ -1,5 +1,6 @@
 --トゥーン・ブラック・マジシャン・ガール
 function c90960358.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	c:EnableReviveLimit()
 	--special summon
 	local e2=Effect.CreateEffect(c)
@@ -60,7 +61,7 @@ function c90960358.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	return Duel.IsExistingMatchingCard(c90960358.cfilter,tp,LOCATION_ONFIELD,0,1,nil) 
+	return Duel.IsExistingMatchingCard(c90960358.cfilter,tp,LOCATION_ONFIELD,0,1,nil)
 		and ft>-1 and Duel.CheckReleaseGroup(tp,c90960358.spcfilter,1,nil,ft,tp)
 end
 function c90960358.spop(e,tp,eg,ep,ev,re,r,rp,c)

--- a/c91123920.lua
+++ b/c91123920.lua
@@ -1,5 +1,6 @@
 --力の代行者 マーズ
 function c91123920.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--immune spell
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -20,7 +21,6 @@ function c91123920.initial_effect(c)
 	e3:SetCode(EFFECT_UPDATE_DEFENSE)
 	c:RegisterEffect(e3)
 end
-c91123920.card_code_list={56433456}
 function c91123920.efilter(e,te)
 	return te:IsActiveType(TYPE_SPELL)
 end

--- a/c91188343.lua
+++ b/c91188343.lua
@@ -1,5 +1,6 @@
 --神秘の代行者 アース
 function c91188343.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(91188343,0))
@@ -10,7 +11,6 @@ function c91188343.initial_effect(c)
 	e1:SetOperation(c91188343.op)
 	c:RegisterEffect(e1)
 end
-c91188343.card_code_list={56433456}
 function c91188343.filter1(c)
 	return c:IsSetCard(0x44) and c:GetCode()~=91188343 and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end

--- a/c91345518.lua
+++ b/c91345518.lua
@@ -1,5 +1,6 @@
 --裁きの代行者 サターン
 function c91345518.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--damage
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(91345518,0))
@@ -12,7 +13,6 @@ function c91345518.initial_effect(c)
 	e1:SetOperation(c91345518.damop)
 	c:RegisterEffect(e1)
 end
-c91345518.card_code_list={56433456}
 function c91345518.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCurrentPhase()~=PHASE_MAIN2 and e:GetHandler():IsReleasable() end
 	Duel.Release(e:GetHandler(),REASON_COST)

--- a/c92377303.lua
+++ b/c92377303.lua
@@ -1,5 +1,6 @@
 --黒衣の大賢者
 function c92377303.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	c:EnableReviveLimit()
 	--special summon
 	local e1=Effect.CreateEffect(c)

--- a/c92881099.lua
+++ b/c92881099.lua
@@ -1,5 +1,6 @@
 --魅惑の合わせ鏡
 function c92881099.initial_effect(c)
+	aux.AddCodeList(c,12206212)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -29,7 +30,6 @@ function c92881099.initial_effect(c)
 	e3:SetOperation(c92881099.spop2)
 	c:RegisterEffect(e3)
 end
-c92881099.card_code_list={12206212}
 function c92881099.cfilter(c,tp)
 	return (c:GetPreviousCodeOnField()==76812113 or c:GetPreviousCodeOnField()==12206212)
 		and c:GetPreviousControler()==tp and c:IsPreviousLocation(LOCATION_MZONE)

--- a/c93437091.lua
+++ b/c93437091.lua
@@ -1,5 +1,6 @@
 --ビンゴマシーンGO!GO!
 function c93437091.initial_effect(c)
+	aux.AddCodeList(c,89631139,23995346)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -10,7 +11,6 @@ function c93437091.initial_effect(c)
 	e1:SetOperation(c93437091.thop)
 	c:RegisterEffect(e1)
 end
-c93437091.card_code_list={89631139,23995346}
 function c93437091.thfilter(c)
 	return (((aux.IsCodeListed(c,89631139) or aux.IsCodeListed(c,23995346)) and not c:IsCode(93437091) and c:IsType(TYPE_SPELL+TYPE_TRAP))
 		or (c:IsSetCard(0xdd) and c:IsType(TYPE_MONSTER))) and c:IsAbleToHand()

--- a/c94666032.lua
+++ b/c94666032.lua
@@ -1,5 +1,6 @@
 --リヴェンデット・ボーン
 function c94666032.initial_effect(c)
+	aux.AddCodeList(c,4388680)
 	aux.AddRitualProcGreater2(c,c94666032.filter,LOCATION_HAND+LOCATION_GRAVE,c94666032.mfilter)
 	--destroy replace
 	local e2=Effect.CreateEffect(c)
@@ -11,7 +12,6 @@ function c94666032.initial_effect(c)
 	e2:SetOperation(c94666032.repop)
 	c:RegisterEffect(e2)
 end
-c94666032.card_code_list={4388680}
 function c94666032.filter(c)
 	return c:IsSetCard(0x106)
 end

--- a/c97750534.lua
+++ b/c97750534.lua
@@ -1,5 +1,6 @@
 --死の代行者 ウラヌス
 function c97750534.initial_effect(c)
+	aux.AddCodeList(c,56433456)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -19,7 +20,6 @@ function c97750534.initial_effect(c)
 	e2:SetOperation(c97750534.tgop)
 	c:RegisterEffect(e2)
 end
-c97750534.card_code_list={56433456}
 function c97750534.spcon(e,c)
 	if c==nil then return Duel.IsEnvironment(56433456) end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0

--- a/c99789342.lua
+++ b/c99789342.lua
@@ -1,5 +1,6 @@
 --黒魔術のカーテン
 function c99789342.initial_effect(c)
+	aux.AddCodeList(c,46986414)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -10,7 +11,6 @@ function c99789342.initial_effect(c)
 	e1:SetOperation(c99789342.activate)
 	c:RegisterEffect(e1)
 end
-c99789342.card_code_list={46986414}
 function c99789342.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetActivityCount(tp,ACTIVITY_SUMMON)==0
 		and Duel.GetActivityCount(tp,ACTIVITY_FLIPSUMMON)==0 and Duel.GetActivityCount(tp,ACTIVITY_SPSUMMON)==0 end

--- a/utility.lua
+++ b/utility.lua
@@ -1639,10 +1639,6 @@ function Auxiliary.AddRitualProcGreater(c,filter,summon_location,grave_filter,ma
 	return Auxiliary.AddRitualProcUltimate(c,filter,Card.GetOriginalLevel,"Greater",summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcGreaterCode(c,code1,summon_location,grave_filter,mat_filter)
-	if not c:IsStatus(STATUS_COPYING_EFFECT) and c.fit_monster==nil then
-		local mt=getmetatable(c)
-		mt.fit_monster={code1}
-	end
 	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcGreater(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
@@ -1651,10 +1647,6 @@ function Auxiliary.AddRitualProcEqual(c,filter,summon_location,grave_filter,mat_
 	return Auxiliary.AddRitualProcUltimate(c,filter,Card.GetOriginalLevel,"Equal",summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcEqualCode(c,code1,summon_location,grave_filter,mat_filter)
-	if not c:IsStatus(STATUS_COPYING_EFFECT) and c.fit_monster==nil then
-		local mt=getmetatable(c)
-		mt.fit_monster={code1}
-	end
 	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcEqual(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
@@ -1663,18 +1655,10 @@ function Auxiliary.AddRitualProcEqual2(c,filter,summon_location,grave_filter,mat
 	return Auxiliary.AddRitualProcUltimate(c,filter,Card.GetLevel,"Equal",summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcEqual2Code(c,code1,summon_location,grave_filter,mat_filter)
-	if not c:IsStatus(STATUS_COPYING_EFFECT) and c.fit_monster==nil then
-		local mt=getmetatable(c)
-		mt.fit_monster={code1}
-	end
 	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcEqual2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcEqual2Code2(c,code1,code2,summon_location,grave_filter,mat_filter)
-	if not c:IsStatus(STATUS_COPYING_EFFECT) and c.fit_monster==nil then
-		local mt=getmetatable(c)
-		mt.fit_monster={code1,code2}
-	end
 	Auxiliary.AddCodeList(c,code1,code2)
 	return Auxiliary.AddRitualProcEqual2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1,code2),summon_location,grave_filter,mat_filter)
 end
@@ -1683,18 +1667,10 @@ function Auxiliary.AddRitualProcGreater2(c,filter,summon_location,grave_filter,m
 	return Auxiliary.AddRitualProcUltimate(c,filter,Card.GetLevel,"Greater",summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcGreater2Code(c,code1,summon_location,grave_filter,mat_filter)
-	if not c:IsStatus(STATUS_COPYING_EFFECT) and c.fit_monster==nil then
-		local mt=getmetatable(c)
-		mt.fit_monster={code1}
-	end
 	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcGreater2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcGreater2Code2(c,code1,code2,summon_location,grave_filter,mat_filter)
-	if not c:IsStatus(STATUS_COPYING_EFFECT) and c.fit_monster==nil then
-		local mt=getmetatable(c)
-		mt.fit_monster={code1,code2}
-	end
 	Auxiliary.AddCodeList(c,code1,code2)
 	return Auxiliary.AddRitualProcGreater2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1,code2),summon_location,grave_filter,mat_filter)
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1022,10 +1022,13 @@ function Auxiliary.AddFusionProcMix(c,sub,insf,...)
 			table.insert(mat,val[i])
 		end
 	end
-	if #mat>0 and c.material_count==nil then
-		local mt=getmetatable(c)
-		mt.material_count=#mat
-		mt.material=mat
+	if #mat>0 then
+		if c.material_count==nil then
+			local mt=getmetatable(c)
+			mt.material_count=#mat
+			mt.material=mat
+		end
+		Auxiliary.AddCodeList(c,table.unpack(mat))
 	end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -1134,10 +1137,13 @@ function Auxiliary.AddFusionProcMixRep(c,sub,insf,fun1,minc,maxc,...)
 			table.insert(mat,val[i])
 		end
 	end
-	if #mat>0 and c.material_count==nil then
-		local mt=getmetatable(c)
-		mt.material_count=#mat
-		mt.material=mat
+	if #mat>0 then
+		if c.material_count==nil then
+			local mt=getmetatable(c)
+			mt.material_count=#mat
+			mt.material=mat
+		end
+		Auxiliary.AddCodeList(c,table.unpack(mat))
 	end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -1333,9 +1339,11 @@ function Auxiliary.AddFusionProcCodeRep(c,code1,cc,sub,insf)
 					table.insert(mt.material,fcode)
 				end
 			end
+			Auxiliary.AddCodeList(c,table.unpack(code1))
 		else
 			mt.material_count=1
 			mt.material={code1}
+			Auxiliary.AddCodeList(c,code1)
 		end
 	end
 	Auxiliary.AddFusionProcMix(c,sub,insf,table.unpack(code))
@@ -1635,6 +1643,7 @@ function Auxiliary.AddRitualProcGreaterCode(c,code1,summon_location,grave_filter
 		local mt=getmetatable(c)
 		mt.fit_monster={code1}
 	end
+	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcGreater(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
 --Ritual Summon, equal to fixed lv
@@ -1646,6 +1655,7 @@ function Auxiliary.AddRitualProcEqualCode(c,code1,summon_location,grave_filter,m
 		local mt=getmetatable(c)
 		mt.fit_monster={code1}
 	end
+	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcEqual(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
 --Ritual Summon, equal to monster lv
@@ -1657,6 +1667,7 @@ function Auxiliary.AddRitualProcEqual2Code(c,code1,summon_location,grave_filter,
 		local mt=getmetatable(c)
 		mt.fit_monster={code1}
 	end
+	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcEqual2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcEqual2Code2(c,code1,code2,summon_location,grave_filter,mat_filter)
@@ -1664,6 +1675,7 @@ function Auxiliary.AddRitualProcEqual2Code2(c,code1,code2,summon_location,grave_
 		local mt=getmetatable(c)
 		mt.fit_monster={code1,code2}
 	end
+	Auxiliary.AddCodeList(c,code1,code2)
 	return Auxiliary.AddRitualProcEqual2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1,code2),summon_location,grave_filter,mat_filter)
 end
 --Ritual Summon, geq monster lv
@@ -1675,6 +1687,7 @@ function Auxiliary.AddRitualProcGreater2Code(c,code1,summon_location,grave_filte
 		local mt=getmetatable(c)
 		mt.fit_monster={code1}
 	end
+	Auxiliary.AddCodeList(c,code1)
 	return Auxiliary.AddRitualProcGreater2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1),summon_location,grave_filter,mat_filter)
 end
 function Auxiliary.AddRitualProcGreater2Code2(c,code1,code2,summon_location,grave_filter,mat_filter)
@@ -1682,6 +1695,7 @@ function Auxiliary.AddRitualProcGreater2Code2(c,code1,code2,summon_location,grav
 		local mt=getmetatable(c)
 		mt.fit_monster={code1,code2}
 	end
+	Auxiliary.AddCodeList(c,code1,code2)
 	return Auxiliary.AddRitualProcGreater2(c,Auxiliary.FilterBoolFunction(Card.IsCode,code1,code2),summon_location,grave_filter,mat_filter)
 end
 --add procedure to Pendulum monster, also allows registeration of activation effect
@@ -2024,6 +2038,20 @@ function Auxiliary.IsMaterialListSetCard(c,setcode)
 		return setcode&0xfff==c.material_setcode&0xfff and setcode&c.material_setcode==setcode
 	end
 	return false
+end
+function Auxiliary.AddCodeList(c,...)
+	if c:IsStatus(STATUS_COPYING_EFFECT) then return end
+	if c.card_code_list==nil then
+		local mt=getmetatable(c)
+		mt.card_code_list={}
+		for _,code in ipairs{...} do
+			table.insert(mt.card_code_list,code)
+		end
+	else
+		for _,code in ipairs{...} do
+			table.insert(c.card_code_list,code)
+		end
+	end
 end
 function Auxiliary.IsCodeListed(c,code)
 	if not c.card_code_list then return false end


### PR DESCRIPTION
> http://yugioh-wiki.net/index.php?%A1%D4%BA%B2%A4%CE%A4%B7%A4%E2%A4%D9%A1%D5#faq1
> Ｑ：融合素材にのみ《ブラック・マジシャン》または《ブラック・マジシャン・ガール》のカード名が記された融合モンスターをエクストラデッキに戻せますか？
> Ａ：はい、エクストラデッキに戻す事ができます。(19/11/09)

So, code list sets by default in fusion materials.