### PR TITLE
fix 幻創龍ファンタズメイ

### DIFF
--- a/c78661338.lua
+++ b/c78661338.lua
@@ -49,7 +49,10 @@ function c78661338.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ShuffleHand(tp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 		local g=Duel.SelectMatchingCard(tp,Card.IsAbleToDeck,tp,LOCATION_HAND,0,ct,ct,nil)
-		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
+		if g:GetCount()>0 then
+			Duel.BreakEffect()
+			Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
+		end
 	end
 end
 function c78661338.tfilter(c,tp)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14097
■『このカードを手札から特殊召喚する』処理と、『その後、自分は相手フィールドのリンクモンスターの数＋１枚をデッキからドローし、相手フィールドのリンクモンスターの数だけ自分の手札を選んでデッキに戻す』処理は同時に行われる扱いではありません。また、『自分は相手フィールドのリンクモンスターの数＋１枚をデッキからドローし』の処理と、『相手フィールドのリンクモンスターの数だけ自分の手札を選んでデッキに戻す』処理も同時に行われる扱いではありません。