### PR TITLE
update fusion spells

### DIFF
--- a/c36484016.lua
+++ b/c36484016.lua
@@ -28,13 +28,13 @@ function c36484016.filter1(c,e)
 end
 function c36484016.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and aux.IsMaterialListType(c,TYPE_SYNCHRO) and (not f or f(c))
-		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and m:IsExists(c36484016.filter3,1,nil,c,m,chkf)
-end
-function c36484016.filter3(c,fusc,m,chkf)
-	return c:IsType(TYPE_SYNCHRO) and fusc:CheckFusionMaterial(m,c,chkf)
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
 function c36484016.filter4(c)
 	return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
+function c36484016.fcheck(tp,sg,fc)
+	return sg:IsExists(Card.IsFusionType,1,nil,TYPE_SYNCHRO)
 end
 function c36484016.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
@@ -42,6 +42,7 @@ function c36484016.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		local mg1=Duel.GetFusionMaterial(tp):Filter(c36484016.filter0,nil)
 		local mg2=Duel.GetMatchingGroup(c36484016.filter4,tp,LOCATION_GRAVE,0,nil)
 		mg1:Merge(mg2)
+		aux.FCheckAdditional=c36484016.fcheck
 		local res=Duel.IsExistingMatchingCard(c36484016.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -52,6 +53,7 @@ function c36484016.target(e,tp,eg,ep,ev,re,r,rp,chk)
 				res=Duel.IsExistingMatchingCard(c36484016.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
 			end
 		end
+		aux.FCheckAdditional=nil
 		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
@@ -62,6 +64,7 @@ function c36484016.activate(e,tp,eg,ep,ev,re,r,rp)
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c36484016.filter1,nil,e)
 	local mg2=Duel.GetMatchingGroup(c36484016.filter4,tp,LOCATION_GRAVE,0,nil)
 	mg1:Merge(mg2)
+	aux.FCheckAdditional=c36484016.fcheck
 	local sg1=Duel.GetMatchingGroup(c36484016.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
 	local mg3=nil
 	local sg2=nil
@@ -79,24 +82,19 @@ function c36484016.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-			local gc=mg1:FilterSelect(tp,c36484016.filter3,1,1,nil,tc,mg1,chkf):GetFirst()
-			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,gc,chkf)
-			mat1:AddCard(gc)
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
 			tc:SetMaterial(mat1)
 			Duel.Remove(mat1,POS_FACEUP,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-			local gc=mg3:FilterSelect(tp,c36484016.filter3,1,1,nil,tc,mg3,chkf):GetFirst()
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,gc,chkf)
-			mat2:AddCard(gc)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end
 		tc:CompleteProcedure()
 	end
+	aux.FCheckAdditional=nil
 end
 function c36484016.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c41940225.lua
+++ b/c41940225.lua
@@ -46,18 +46,16 @@ function c41940225.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		mg1:Merge(mg2)
 		aux.FCheckAdditional=c41940225.fcheck
 		local res=Duel.IsExistingMatchingCard(c41940225.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
-		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				aux.FCheckAdditional=c41940225.fcheck
 				res=Duel.IsExistingMatchingCard(c41940225.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
-				aux.FCheckAdditional=nil
 			end
 		end
+		aux.FCheckAdditional=nil
 		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
@@ -69,7 +67,6 @@ function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 	mg1:Merge(mg2)
 	aux.FCheckAdditional=c41940225.fcheck
 	local sg1=Duel.GetMatchingGroup(c41940225.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -77,9 +74,7 @@ function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		aux.FCheckAdditional=c41940225.fcheck
 		sg2=Duel.GetMatchingGroup(c41940225.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
-		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -88,22 +83,19 @@ function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-			aux.FCheckAdditional=c41940225.fcheck
 			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
-			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			aux.FCheckAdditional=c41940225.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
-			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end
 		tc:CompleteProcedure()
 	end
+	aux.FCheckAdditional=nil
 end
 function c41940225.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_HAND,0,1,nil) end

--- a/c41940225.lua
+++ b/c41940225.lua
@@ -29,14 +29,14 @@ function c41940225.filter1(c,e)
 	return c:IsFaceup() and c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)
 end
 function c41940225.filter2(c,e,tp,m,f,chkf)
-	return c41940225.spfilter(c) and (not f or f(c))
+	return c:IsType(TYPE_FUSION) and aux.IsMaterialListCode(c,78193831) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
 function c41940225.filter3(c,e)
 	return not c:IsImmuneToEffect(e)
 end
-function c41940225.spfilter(c)
-	return aux.IsMaterialListCode(c,78193831)
+function c41940225.fcheck(tp,sg,fc)
+	return sg:IsExists(Card.IsFusionCode,1,nil,78193831)
 end
 function c41940225.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
@@ -44,14 +44,18 @@ function c41940225.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		local mg1=Duel.GetFusionMaterial(tp)
 		local mg2=Duel.GetMatchingGroup(c41940225.filter0,tp,0,LOCATION_MZONE,nil)
 		mg1:Merge(mg2)
+		aux.FCheckAdditional=c41940225.fcheck
 		local res=Duel.IsExistingMatchingCard(c41940225.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
+				aux.FCheckAdditional=c41940225.fcheck
 				res=Duel.IsExistingMatchingCard(c41940225.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
+				aux.FCheckAdditional=nil
 			end
 		end
 		return res
@@ -63,7 +67,9 @@ function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c41940225.filter3,nil,e)
 	local mg2=Duel.GetMatchingGroup(c41940225.filter1,tp,0,LOCATION_MZONE,nil,e)
 	mg1:Merge(mg2)
+	aux.FCheckAdditional=c41940225.fcheck
 	local sg1=Duel.GetMatchingGroup(c41940225.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -71,7 +77,9 @@ function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
+		aux.FCheckAdditional=c41940225.fcheck
 		sg2=Duel.GetMatchingGroup(c41940225.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -80,13 +88,17 @@ function c41940225.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			aux.FCheckAdditional=c41940225.fcheck
 			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
+			aux.FCheckAdditional=c41940225.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
+			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c52947044.lua
+++ b/c52947044.lua
@@ -17,8 +17,11 @@ function c52947044.filter1(c,e)
 	return not c:IsImmuneToEffect(e) and c:IsLocation(LOCATION_HAND)
 end
 function c52947044.filter2(c,e,tp,m,f,chkf)
-	return c:IsType(TYPE_FUSION) and (aux.IsMaterialListSetCard(c,0xc008) or c:IsCode(30757127,76263644,90579153,93657021)) and (not f or f(c))
+	return c:IsType(TYPE_FUSION) and aux.IsMaterialListSetCard(c,0xc008) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function c52947044.fcheck(tp,sg,fc)
+	return sg:IsExists(Card.IsFusionSetCard,1,nil,0xc008)
 end
 function c52947044.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
@@ -26,14 +29,18 @@ function c52947044.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsLocation,nil,LOCATION_HAND)
 		local mg2=Duel.GetMatchingGroup(c52947044.filter0,tp,LOCATION_DECK,0,nil)
 		mg1:Merge(mg2)
+		aux.FCheckAdditional=c52947044.fcheck
 		local res=Duel.IsExistingMatchingCard(c52947044.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg2=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
+				aux.FCheckAdditional=c52947044.fcheck
 				res=Duel.IsExistingMatchingCard(c52947044.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				aux.FCheckAdditional=nil
 			end
 		end
 		return res
@@ -46,7 +53,9 @@ function c52947044.activate(e,tp,eg,ep,ev,re,r,rp)
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c52947044.filter1,nil,e)
 	local mg2=Duel.GetMatchingGroup(c52947044.filter0,tp,LOCATION_DECK,0,nil)
 	mg1:Merge(mg2)
+	aux.FCheckAdditional=c52947044.fcheck
 	local sg1=Duel.GetMatchingGroup(c52947044.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -54,7 +63,9 @@ function c52947044.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
+		aux.FCheckAdditional=c52947044.fcheck
 		sg2=Duel.GetMatchingGroup(c52947044.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -63,13 +74,17 @@ function c52947044.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			aux.FCheckAdditional=c52947044.fcheck
 			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
+			aux.FCheckAdditional=c52947044.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
+			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c52947044.lua
+++ b/c52947044.lua
@@ -31,18 +31,16 @@ function c52947044.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		mg1:Merge(mg2)
 		aux.FCheckAdditional=c52947044.fcheck
 		local res=Duel.IsExistingMatchingCard(c52947044.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
-		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg2=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				aux.FCheckAdditional=c52947044.fcheck
 				res=Duel.IsExistingMatchingCard(c52947044.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
-				aux.FCheckAdditional=nil
 			end
 		end
+		aux.FCheckAdditional=nil
 		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
@@ -55,7 +53,6 @@ function c52947044.activate(e,tp,eg,ep,ev,re,r,rp)
 	mg1:Merge(mg2)
 	aux.FCheckAdditional=c52947044.fcheck
 	local sg1=Duel.GetMatchingGroup(c52947044.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -63,9 +60,7 @@ function c52947044.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		aux.FCheckAdditional=c52947044.fcheck
 		sg2=Duel.GetMatchingGroup(c52947044.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
-		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -74,17 +69,13 @@ function c52947044.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-			aux.FCheckAdditional=c52947044.fcheck
 			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
-			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			aux.FCheckAdditional=c52947044.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
-			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end
@@ -102,6 +93,7 @@ function c52947044.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetLabelObject(tc)
 		Duel.RegisterEffect(e1,tp)
 	end
+	aux.FCheckAdditional=nil
 	if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)

--- a/c55704856.lua
+++ b/c55704856.lua
@@ -23,18 +23,25 @@ end
 function c55704856.filter3(c)
 	return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToDeck()
 end
+function c55704856.fcheck(tp,sg,fc)
+	return sg:IsExists(Card.IsFusionSetCard,1,nil,0x1093)
+end
 function c55704856.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=tp
 		local mg=Duel.GetMatchingGroup(c55704856.filter0,tp,LOCATION_MZONE+LOCATION_REMOVED,0,nil)
+		aux.FCheckAdditional=c55704856.fcheck
 		local res=Duel.IsExistingMatchingCard(c55704856.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,nil,chkf)
+		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
+				aux.FCheckAdditional=c55704856.fcheck
 				res=Duel.IsExistingMatchingCard(c55704856.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
+				aux.FCheckAdditional=nil
 			end
 		end
 		return res
@@ -44,7 +51,9 @@ end
 function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=tp
 	local mg=Duel.GetMatchingGroup(c55704856.filter1,tp,LOCATION_MZONE+LOCATION_REMOVED,0,nil,e)
+	aux.FCheckAdditional=c55704856.fcheck
 	local sg1=Duel.GetMatchingGroup(c55704856.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
+	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -52,7 +61,9 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
+		aux.FCheckAdditional=c55704856.fcheck
 		sg2=Duel.GetMatchingGroup(c55704856.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -61,7 +72,9 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			aux.FCheckAdditional=c55704856.fcheck
 			local mat=Duel.SelectFusionMaterial(tp,tc,mg,nil,chkf)
+			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat)
 			if mat:IsExists(Card.IsFacedown,1,nil) then
 				local cg=mat:Filter(Card.IsFacedown,nil)
@@ -71,7 +84,9 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
+			aux.FCheckAdditional=c55704856.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
+			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c55704856.lua
+++ b/c55704856.lua
@@ -32,18 +32,16 @@ function c55704856.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		local mg=Duel.GetMatchingGroup(c55704856.filter0,tp,LOCATION_MZONE+LOCATION_REMOVED,0,nil)
 		aux.FCheckAdditional=c55704856.fcheck
 		local res=Duel.IsExistingMatchingCard(c55704856.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,nil,chkf)
-		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg3=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				aux.FCheckAdditional=c55704856.fcheck
 				res=Duel.IsExistingMatchingCard(c55704856.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
-				aux.FCheckAdditional=nil
 			end
 		end
+		aux.FCheckAdditional=nil
 		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
@@ -53,7 +51,6 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 	local mg=Duel.GetMatchingGroup(c55704856.filter1,tp,LOCATION_MZONE+LOCATION_REMOVED,0,nil,e)
 	aux.FCheckAdditional=c55704856.fcheck
 	local sg1=Duel.GetMatchingGroup(c55704856.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
-	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -61,9 +58,7 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		aux.FCheckAdditional=c55704856.fcheck
 		sg2=Duel.GetMatchingGroup(c55704856.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
-		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -72,9 +67,7 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-			aux.FCheckAdditional=c55704856.fcheck
 			local mat=Duel.SelectFusionMaterial(tp,tc,mg,nil,chkf)
-			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat)
 			if mat:IsExists(Card.IsFacedown,1,nil) then
 				local cg=mat:Filter(Card.IsFacedown,nil)
@@ -84,9 +77,7 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			aux.FCheckAdditional=c55704856.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
-			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end
@@ -101,6 +92,7 @@ function c55704856.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_PHASE+PHASE_END)
 		Duel.RegisterEffect(e1,tp)
 	end
+	aux.FCheckAdditional=nil
 end
 function c55704856.ftarget(e,c)
 	return e:GetLabel()~=c:GetFieldID()

--- a/c6172122.lua
+++ b/c6172122.lua
@@ -39,20 +39,27 @@ function c6172122.filter2(c,e,tp,m,f,chkf)
 	return c:IsType(TYPE_FUSION) and aux.IsMaterialListSetCard(c,0x3b) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
 end
+function c6172122.fcheck(tp,sg,fc)
+	return sg:IsExists(Card.IsFusionSetCard,1,nil,0x3b)
+end
 function c6172122.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=tp
 		local mg1=Duel.GetFusionMaterial(tp)
 		local mg2=Duel.GetMatchingGroup(c6172122.filter0,tp,LOCATION_DECK,0,nil)
 		mg1:Merge(mg2)
+		aux.FCheckAdditional=c6172122.fcheck
 		local res=Duel.IsExistingMatchingCard(c6172122.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg2=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
+				aux.FCheckAdditional=c6172122.fcheck
 				res=Duel.IsExistingMatchingCard(c6172122.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+				aux.FCheckAdditional=nil
 			end
 		end
 		return res
@@ -64,7 +71,9 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c6172122.filter1,nil,e)
 	local mg2=Duel.GetMatchingGroup(c6172122.filter0,tp,LOCATION_DECK,0,nil)
 	mg1:Merge(mg2)
+	aux.FCheckAdditional=c6172122.fcheck
 	local sg1=Duel.GetMatchingGroup(c6172122.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -72,7 +81,9 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
+		aux.FCheckAdditional=c6172122.fcheck
 		sg2=Duel.GetMatchingGroup(c6172122.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -81,13 +92,17 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			aux.FCheckAdditional=c6172122.fcheck
 			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
+			aux.FCheckAdditional=c6172122.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
+			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/c6172122.lua
+++ b/c6172122.lua
@@ -50,18 +50,16 @@ function c6172122.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		mg1:Merge(mg2)
 		aux.FCheckAdditional=c6172122.fcheck
 		local res=Duel.IsExistingMatchingCard(c6172122.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
-		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
 				local fgroup=ce:GetTarget()
 				local mg2=fgroup(ce,e,tp)
 				local mf=ce:GetValue()
-				aux.FCheckAdditional=c6172122.fcheck
 				res=Duel.IsExistingMatchingCard(c6172122.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
-				aux.FCheckAdditional=nil
 			end
 		end
+		aux.FCheckAdditional=nil
 		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
@@ -73,7 +71,6 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 	mg1:Merge(mg2)
 	aux.FCheckAdditional=c6172122.fcheck
 	local sg1=Duel.GetMatchingGroup(c6172122.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-	aux.FCheckAdditional=nil
 	local mg3=nil
 	local sg2=nil
 	local ce=Duel.GetChainMaterial(tp)
@@ -81,9 +78,7 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 		local fgroup=ce:GetTarget()
 		mg3=fgroup(ce,e,tp)
 		local mf=ce:GetValue()
-		aux.FCheckAdditional=c6172122.fcheck
 		sg2=Duel.GetMatchingGroup(c6172122.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
-		aux.FCheckAdditional=nil
 	end
 	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
 		local sg=sg1:Clone()
@@ -92,17 +87,13 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-			aux.FCheckAdditional=c6172122.fcheck
 			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
-			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			aux.FCheckAdditional=c6172122.fcheck
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
-			aux.FCheckAdditional=nil
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end
@@ -115,4 +106,5 @@ function c6172122.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1)
 	end
+	aux.FCheckAdditional=nil
 end

--- a/c64061284.lua
+++ b/c64061284.lua
@@ -10,7 +10,7 @@ function c64061284.initial_effect(c)
 	e1:SetOperation(c64061284.activate)
 	c:RegisterEffect(e1)
 end
-function c64061284.fcheck(tp,sg,fc,mg)
+function c64061284.fcheck(tp,sg,fc)
 	if sg:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then
 		return sg:IsExists(c64061284.filterchk,1,nil) end
 	return true


### PR DESCRIPTION
> 「破壊剣士融合」の効果によって、融合召喚を行う場合、「バスター・ブレイダー」を融合素材として含める必要があります。
「竜破壊の剣士－バスター・ブレイダー」の場合、融合素材として、『「バスター・ブレイダー」＋ドラゴン族モンスター』が必要となりますので、この場合、ドラゴン族モンスターと、『①：このカードは、融合モンスターカードにカード名が記された融合素材モンスター１体の代わりにできる。その際、他の融合素材モンスターは正規のものでなければならない』モンスター効果を適用した「沼地の魔神王」の組み合わせで、「竜破壊の剣士－バスター・ブレイダー」を融合召喚する事はできません。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22885&keyword=&tag=-1

> mail:
Q.
「真紅眼融合」の効果によって「真紅眼の黒刃竜」を融合召喚する際に、フィールドの「沼地の魔神王」と戦士族の「閃刀姫－ロゼ」を融合素材とする事はできますか？
また、フィールドの「沼地の魔神王」と戦士族の「真紅眼の鉄騎士－ギア・フリード」を融合素材とする事はできますか？
A.
「真紅眼融合」によって、フィールドの「沼地の魔神王」と「閃刀姫－ロゼ」を融合素材として、「真紅眼の黒刃竜」を融合召喚することはできません。
フィールドの「沼地の魔神王」と「真紅眼の鉄騎士－ギア・フリード」を融合素材として、「真紅眼の黒刃竜」を融合召喚することはできます。