### PR TITLE
Fix "Ghost Sister & Spooky Dogwood" & "Blazing Mirror Force"

### DIFF
--- a/c60643553.lua
+++ b/c60643553.lua
@@ -68,7 +68,9 @@ end
 function c60643553.lpop1(e,tp,eg,ep,ev,re,r,rp)
 	local lg=eg:Filter(c60643553.cfilter,nil,1-tp)
 	local rnum=lg:GetSum(Card.GetAttack)
-	if Duel.Recover(tp,rnum,REASON_EFFECT)<1 then return end
+	local lp=Duel.GetLP(tp)
+	Duel.Recover(tp,rnum,REASON_EFFECT)
+	if Duel.GetLP(tp)<=lp then return end
 	Duel.RegisterFlagEffect(tp,60643553,RESET_PHASE+PHASE_END,0,1)
 end
 function c60643553.regcon(e,tp,eg,ep,ev,re,r,rp)
@@ -99,7 +101,9 @@ function c60643553.lpop2(e,tp,eg,ep,ev,re,r,rp)
 	g:KeepAlive()
 	e:GetLabelObject():SetLabelObject(g)
 	lg:DeleteGroup()
-	if Duel.Recover(tp,rnum,REASON_EFFECT)<1 then return end
+	local lp=Duel.GetLP(tp)
+	Duel.Recover(tp,rnum,REASON_EFFECT)
+	if Duel.GetLP(tp)<=lp then return end
 	Duel.RegisterFlagEffect(tp,60643553,RESET_PHASE+PHASE_END,0,1)
 end
 function c60643553.damcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c75249652.lua
+++ b/c75249652.lua
@@ -34,10 +34,12 @@ function c75249652.activate(e,tp,eg,ep,ev,re,r,rp)
 			if tatk>0 then atk=atk+tatk end
 			tc=dg:GetNext()
 		end
-		local dam=Duel.Damage(tp,math.floor(atk/2),REASON_EFFECT)
-		if Duel.GetLP(tp)>0 and dam>0 then
+		local dam=Duel.GetLP(tp)
+		Duel.Damage(tp,atk/2,REASON_EFFECT)
+		local dam2=dam-Duel.GetLP(tp)
+		if Duel.GetLP(tp)>0 and dam2>0 then
 			Duel.BreakEffect()
-			Duel.Damage(1-tp,dam,REASON_EFFECT)
+			Duel.Damage(1-tp,dam2,REASON_EFFECT)
 		end
 	end
 end


### PR DESCRIPTION
Cards which depend on amount of LP lost (by damage) or gained got glitched up because `Duel.Damage` and `Duel.Recover` are returning nil.
- "Ghost Sister" halved her user's LP at the end of the turn, even if they gained LP with her effect that turn
- "Blazing Mirror Force" did not damage the opponent after damaging its user