### PR TITLE
fix Ten Thousand Dragon

### DIFF
--- a/c10000.lua
+++ b/c10000.lua
@@ -38,7 +38,7 @@ function c10000.spcon(e,c)
 	return rg:CheckSubGroup(c10000.fselect,1,rg:GetCount(),tp)
 end
 function c10000.sptg(e,tp,eg,ep,ev,re,r,rp,chk,c)
-	local rg=Duel.GetReleaseGroup(tp)
+	local rg=Duel.GetReleaseGroup(tp):Filter(c10000.rfilter,nil,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
 	local sg=rg:SelectSubGroup(tp,c10000.fselect,true,1,rg:GetCount(),tp)
 	if sg then

--- a/c10000.lua
+++ b/c10000.lua
@@ -18,6 +18,9 @@ function c10000.initial_effect(c)
 	e2:SetOperation(c10000.spop)
 	c:RegisterEffect(e2)
 end
+function c10000.rfilter(c,tp)
+	return c:IsControler(tp) or c:IsFaceup()
+end
 function c10000.sumfilter(c)
 	return c:GetAttack()+c:GetDefense()
 end
@@ -31,7 +34,7 @@ end
 function c10000.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	local rg=Duel.GetReleaseGroup(tp)
+	local rg=Duel.GetReleaseGroup(tp):Filter(c10000.rfilter,nil,tp)
 	return rg:CheckSubGroup(c10000.fselect,1,rg:GetCount(),tp)
 end
 function c10000.sptg(e,tp,eg,ep,ev,re,r,rp,chk,c)


### PR DESCRIPTION
fix for Soul Exchange,and there are maybe more cards which use `Duel.GetReleaseGroup()` but not `Duel.CheckReleaseGroup()` and `Duel.SelectReleaseGroup()` need to be fixed because `Duel.GetReleaseGroup()` will get the opponent's face-down cards and don't filter these cards.
