### PR TITLE
Fix "Cloudian - Poison Cloud"

### DIFF
--- a/c83982270.lua
+++ b/c83982270.lua
@@ -13,7 +13,7 @@ function c83982270.initial_effect(c)
 end
 function c83982270.condition(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsPreviousPosition(POS_FACEUP)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE)
 end
 function c83982270.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
`if it was face-up at the start of the Damage Step` is absent from the OCG version when compared to the TCG version, but the script reflects the latter version: https://yugipedia.com/wiki/Cloudian_-_Poison_Cloud#Other_languages

I fixed the script of "Cloudian - Poison Cloud" to work like in the OCG.