### PR TITLE
Added LOCATION_PZONE

### DIFF
--- a/c18716735.lua
+++ b/c18716735.lua
@@ -58,6 +58,7 @@ function c18716735.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c18716735.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+		or e:GetHandler():IsPreviousLocation(LOCATION_PZONE)
 end
 function c18716735.thfilter(c)
 	return c:IsSetCard(0xe1) and c:IsType(TYPE_MONSTER)

--- a/c7563579.lua
+++ b/c7563579.lua
@@ -48,6 +48,7 @@ function c7563579.spop1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c7563579.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+		or e:GetHandler():IsPreviousLocation(LOCATION_PZONE)
 end
 function c7563579.spfilter(c,e,tp)
 	return c:IsSetCard(0xc6) and not c:IsCode(7563579) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c83190280.lua
+++ b/c83190280.lua
@@ -88,6 +88,7 @@ function c83190280.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c83190280.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+		or e:GetHandler():IsPreviousLocation(LOCATION_PZONE)
 end
 function c83190280.sptg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c83190280.filter(chkc,e,tp) end


### PR DESCRIPTION
The location constant was added, because it seems LOCATION_ONFIELD does not include PZONE for whatever reason. For example, Lunalight Tiger will not trigger when destroyed in the PZONE. This is a temporary fix to the 3 cards: Lunalight Tiger, Performage Plushfire and Raremetalfoes Bismugear, until the constant is changed.