### PR TITLE
fix バブル・クラッシュ

### DIFF
--- a/c61622107.lua
+++ b/c61622107.lua
@@ -4,7 +4,6 @@ function c61622107.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 	e1:SetCondition(c61622107.condition)
 	e1:SetOperation(c61622107.activate)
 	c:RegisterEffect(e1)
@@ -14,17 +13,17 @@ function c61622107.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c61622107.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ct=Duel.GetFieldGroupCount(tp,0xe,0)
-	local g=Group.CreateGroup()
+	local exc=nil
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then exc=e:GetHandler() end
 	if ct>=6 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		local sg=Duel.SelectMatchingCard(tp,nil,tp,0xe,0,ct-5,ct-5,nil)
-		g:Merge(sg)
+		local sg=Duel.SelectMatchingCard(tp,nil,tp,0xe,0,ct-5,ct-5,exc)
+		Duel.SendtoGrave(sg,REASON_RULE)
 	end
 	ct=Duel.GetFieldGroupCount(1-tp,0xe,0)
 	if ct>=6 then
 		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_TOGRAVE)
 		local sg=Duel.SelectMatchingCard(1-tp,nil,1-tp,0xe,0,ct-5,ct-5,nil)
-		g:Merge(sg)
+		Duel.SendtoGrave(sg,REASON_RULE)
 	end
-	Duel.SendtoGrave(g,REASON_EFFECT)
 end

--- a/c61622107.lua
+++ b/c61622107.lua
@@ -12,18 +12,28 @@ function c61622107.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,0xe,0)>=6 or Duel.GetFieldGroupCount(tp,0,0xe)>=6
 end
 function c61622107.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ct=Duel.GetFieldGroupCount(tp,0xe,0)
+	local p=Duel.GetTurnPlayer()
+	local ct=Duel.GetFieldGroupCount(p,0xe,0)
 	local exc=nil
-	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then exc=e:GetHandler() end
 	if ct>=6 then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		local sg=Duel.SelectMatchingCard(tp,nil,tp,0xe,0,ct-5,ct-5,exc)
+		if p==tp and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+			exc=e:GetHandler()
+		else
+			exc=nil
+		end
+		Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TOGRAVE)
+		local sg=Duel.SelectMatchingCard(p,nil,p,0xe,0,ct-5,ct-5,exc)
 		Duel.SendtoGrave(sg,REASON_RULE)
 	end
-	ct=Duel.GetFieldGroupCount(1-tp,0xe,0)
+	ct=Duel.GetFieldGroupCount(1-p,0xe,0)
 	if ct>=6 then
-		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_TOGRAVE)
-		local sg=Duel.SelectMatchingCard(1-tp,nil,1-tp,0xe,0,ct-5,ct-5,nil)
+		if 1-p==tp and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+			exc=e:GetHandler()
+		else
+			exc=nil
+		end
+		Duel.Hint(HINT_SELECTMSG,1-p,HINTMSG_TOGRAVE)
+		local sg=Duel.SelectMatchingCard(1-p,nil,1-p,0xe,0,ct-5,ct-5,exc)
 		Duel.SendtoGrave(sg,REASON_RULE)
 	end
 end


### PR DESCRIPTION
1.the turn player's cards will be send to grave first:
Ｑ：お互いのプレイヤーが手札とフィールド上のカードを合計６枚以上持っているときにこのカードを発動しました。
　　このときお互いのプレイヤーが墓地へ送るカードはどのタイミングで公開されますか？
Ａ：カードを墓地へ送る処理はターンプレイヤーから先に行います。
　　ターンプレイヤーが選択したカードを墓地に送ったことを確認してから、非ターンプレイヤーが墓地へ送るカードを選択します。(16/03/12)

2.the `ACTIVATE` card can't be send to grave by its effect:
発動したこのカードも枚数にカウントされるため、実質発動者は合計４枚しか残せない。
発動したこのカード自身を墓地へ送るカードには選べないためである。(09/03/20)
《ジャンク・コレクター》で発動した場合はこの限りではないが。