### PR TITLE
fix 六花絢爛

### DIFF
--- a/c69164989.lua
+++ b/c69164989.lua
@@ -57,6 +57,9 @@ end
 function c69164989.activate2(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,c69164989.thfilter,tp,LOCATION_DECK,0,1,1,nil,tp)
+	if g:GetCount()==0 then
+		g=Duel.SelectMatchingCard(tp,c69164989.thfilter,tp,LOCATION_DECK,0,1,1,nil,tp,true)
+	end
 	local tc=g:GetFirst()
 	if tc and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 then
 		Duel.ConfirmCards(1-tp,tc)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22995

Question
自分フィールドの植物族モンスターをリリースして、「六花絢爛」を発動しました。

その発動にチェーンして、自分が「針虫の巣窟」を発動し、デッキのカードが墓地へ送られた事によって、自分のデッキに存在する植物族モンスターが自分のデッキに存在する植物族モンスターが「六花」と名のついたモンスター１体のみとなった場合、処理はどうなりますか？
Answer
質問の状況のように、植物族モンスターをリリースして発動した「六花絢爛」の処理時に、自分のデッキに植物族モンスターが１体のみになった場合、『デッキから「六花」モンスター１体を手札に加える』処理を行う事はできますが、『さらに手札に加えたモンスターとはカード名が異なり、元々のレベルが同じ植物族モンスター１体をデッキから手札に加える』処理を行う事はできません。