### PR TITLE
fix マドルチェ・プロムナード

### DIFF
--- a/c68159562.lua
+++ b/c68159562.lua
@@ -40,7 +40,7 @@ function c68159562.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	e:SetLabelObject(g1:GetFirst())
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 	local g2=Duel.SelectTarget(tp,c68159562.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g2,1,tp,LOCATION_MZONE+LOCATION_GRAVE)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g2,1,0,0)
 end
 function c68159562.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
fix: the effect can be chained by `Ghost Belle & Haunted Mansion` even the target isn't in grave.