### PR TITLE
fix 起爆獣ヴァルカノン

### DIFF
--- a/c10365322.lua
+++ b/c10365322.lua
@@ -30,17 +30,13 @@ end
 function c10365322.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local c=e:GetHandler()
-	if not tc:IsRelateToEffect(e) and not c:IsRelateToEffect(e) then return end
-	if not tc:IsRelateToEffect(e) then
-		Duel.Destroy(c,REASON_EFFECT)
-	elseif not c:IsRelateToEffect(e) then
-		Duel.Destroy(tc,REASON_EFFECT)
-	else
-		local dg=Group.FromCards(c,tc)
-		if Duel.Destroy(dg,REASON_EFFECT)==2 and tc:IsLocation(LOCATION_GRAVE) and c:IsLocation(LOCATION_GRAVE) then
+	if not tc:IsRelateToEffect(e) or not c:IsRelateToEffect(e) then return end
+	if not tc:IsControler(1-tp) then return end
+	local dg=Group.FromCards(c,tc)
+	if Duel.Destroy(dg,REASON_EFFECT)==2 and tc:IsLocation(LOCATION_GRAVE) and c:IsLocation(LOCATION_GRAVE) then
+		local d=tc:GetTextAttack()
+		if d>0 then
 			Duel.BreakEffect()
-			local d=tc:GetAttack()
-			if d<0 then d=0 end
 			Duel.Damage(1-tp,d,REASON_EFFECT)
 		end
 	end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10309&keyword=&tag=-1&request_locale=ja

Question
「起爆獣ヴァルカノン」のモンスター効果の発動にチェーンして「強制脱出装置」が発動し、効果処理時に、「起爆獣ヴァルカノン」自身、または対象とした相手のモンスターゾーンのモンスターがフィールドに存在しなくなっている場合、処理はどうなりますか？
Answer
「起爆獣ヴァルカノン」のモンスター効果の処理時に、効果の対象に選択したモンスター、または、効果を発動した「起爆獣ヴァルカノン」自身がフィールドに存在しなくなっている場合には、効果処理は適用されません。
（どちらのモンスターも破壊されず、ダメージを与える処理が適用される事もありません。）