### PR TITLE
fix 破滅竜ガンドラX

### DIFF
--- a/c71525232.lua
+++ b/c71525232.lua
@@ -27,11 +27,16 @@ end
 function c71525232.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_HAND)
 end
+function c71525232.damfilter(c)
+	if c:IsFaceup() then
+		return c:GetAttack()
+	else return 0 end
+end
 function c71525232.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler()) end
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,e:GetHandler())
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
-	local mg,atk=g:GetMaxGroup(Card.GetAttack)
+	local mg,atk=g:GetMaxGroup(c71525232.damfilter)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,atk)
 end
 function c71525232.filter(c)
@@ -46,7 +51,7 @@ function c71525232.operation(e,tp,eg,ep,ev,re,r,rp)
 		local og=Duel.GetOperatedGroup()
 		local mg,atk=og:GetMaxGroup(c71525232.filter)
 		local dam=Duel.Damage(1-tp,atk,REASON_EFFECT)
-		if dam>0 and c:IsFaceup() and c:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_SET_ATTACK_FINAL)


### PR DESCRIPTION
fix:
1. the wrong damage value in operation info.
2. its attack won't change if the damage is 0.