### PR TITLE
fix ディープアイズ・ホワイト・ドラゴン

### DIFF
--- a/c22804410.lua
+++ b/c22804410.lua
@@ -71,7 +71,7 @@ function c22804410.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc or not tc:IsRelateToEffect(e) then return end
 	local atk=tc:GetAttack()
-	if atk>0 and c:IsRelateToEffect(e) and c:IsFaceup() then
+	if c:IsRelateToEffect(e) and c:IsFaceup() then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_ATTACK_FINAL)


### PR DESCRIPTION
It's attack can change to 0.
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19177&keyword=ディープアイズ・ホワイト・ドラゴン&tag=-1

Question
「ディープアイズ・ホワイト・ドラゴン」の『②：このカードが召喚・特殊召喚に成功した場合、自分の墓地のドラゴン族モンスター１体を対象として発動する。このカードの攻撃力はそのモンスターの攻撃力と同じになる』モンスター効果の対象として、自分の墓地に存在する、攻撃力が0の「破壊竜ガンドラ」や、攻撃力が？の「モンタージュ・ドラゴン」を選択する事はできますか？
Answer
「ディープアイズ・ホワイト・ドラゴン」の『このカードの攻撃力はそのモンスターの攻撃力と同じになる』モンスター効果は、自身が召喚・特殊召喚に成功した場合に必ず発動する効果となります。

自分の墓地に存在する攻撃力が0の「破壊竜ガンドラ」や、攻撃力が？の「モンタージュ・ドラゴン」をその対象として選択する事もできます。（その場合、「ディープアイズ・ホワイト・ドラゴン」の攻撃力は0になります。）