### PR TITLE
fix 霊獣の騎襲

### DIFF
--- a/c57815601.lua
+++ b/c57815601.lua
@@ -35,15 +35,16 @@ function c57815601.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	if g:GetCount()>0 then
-		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
-		if g:GetCount()<=ft then
-			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
-		else
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-			local sg=g:Select(tp,ft,ft,nil)
-			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
-			g:Sub(sg)
-			Duel.SendtoGrave(g,REASON_RULE)
+		if g:GetCount()==1 or not Duel.IsPlayerAffectedByEffect(tp,59822133) then
+			if g:GetCount()<=ft then
+				Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+			else
+				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+				local sg=g:Select(tp,ft,ft,nil)
+				Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+				g:Sub(sg)
+				Duel.SendtoGrave(g,REASON_RULE)
+			end
 		end
 	end
 	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18179

Question
2体以上のモンスターを対象とした「ソウル・チャージ」の発動にチェーンして「リビングデッドの呼び声」が発動し、「青眼の精霊龍」が特殊召喚された場合、「ソウル・チャージ」の効果処理はどうなりますか？
Answer
質問の状況の場合、チェーン2で発動した「リビングデッドの呼び声」の効果によって特殊召喚された「青眼の精霊龍」の『①：このカードがモンスターゾーンに存在する限り、お互いに２体以上のモンスターを同時に特殊召喚できない』モンスター効果が適用される事になりますので、2体以上のモンスターを対象として発動した「ソウル・チャージ」の効果処理は適用されません。
（モンスターは1体も特殊召喚されません。）