### PR TITLE
fix エクシーズ・オーバーディレイ

### DIFF
--- a/c78610936.lua
+++ b/c78610936.lua
@@ -32,6 +32,7 @@ function c78610936.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not tc:IsRelateToEffect(e) then return end
 	local mg=tc:GetOverlayGroup()
 	Duel.SendtoGrave(mg,REASON_EFFECT)
+	Duel.AdjustInstantly(tc)
 	if Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)>0 then
 		local g=mg:Filter(aux.NecroValleyFilter(c78610936.spfilter),nil,e,tp)
 		local ft=Duel.GetLocationCount(1-tp,LOCATION_MZONE)


### PR DESCRIPTION
@DailyShana  @mercury233 
Problem
[86.zip](https://github.com/Fluorohydride/ygopro-core/files/4776515/86.zip)
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6890&keyword=&tag=-1
エクシーズ・オーバーディレイ(taeget: No.86 H－C ロンゴミアント with 3+ materials)
Now: No. 86 will not return to Extra Deck.
Correst: No. 86 will return to Extra Deck.

Reason
The status of No.86 is not refreshed after losing its materials.

Require
Fluorohydride/ygopro-core#319