### PR TITLE
Fix Metamorphortress in Master Rule 2020

### DIFF
--- a/c43959432.lua
+++ b/c43959432.lua
@@ -36,7 +36,6 @@ end
 function c43959432.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43959432.filter(chkc) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
 		and Duel.IsExistingTarget(c43959432.filter,tp,LOCATION_MZONE,0,1,nil)
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,43959432,0,0x21,1000,1000,4,RACE_ROCK,ATTRIBUTE_EARTH) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)


### PR DESCRIPTION
> Q.
自分の魔法＆罠ゾーンに「メタモル・クレイ・フォートレス」を含む5枚の魔法・罠カードがセットされています。
自分のモンスターゾーンに「幻創龍ファンタズメイ」が表側表示で存在しています。
この状況で、「幻創龍ファンタズメイ」を対象として、セットされている「メタモル・クレイ・フォートレス」を発動できますか？
A.
ご質問の状況の場合、「メタモル・クレイ・フォートレス」を発動でき、「幻創龍ファンタズメイ」は装備カード扱いとなります。
Q.
自分の魔法＆罠ゾーンに「メタモル・クレイ・フォートレス」を含む5枚の魔法・罠カードがセットされています。
「メタモル・クレイ・フォートレス」と同じ縦列の自分のモンスターゾーンに「鉄騎龍ティアマトン」が表側表示で存在しています。
この状況で、「鉄騎龍ティアマトン」を対象として、セットされている「メタモル・クレイ・フォートレス」を発動できますか？
Ａ．
ご質問の状況の場合、「メタモル・クレイ・フォートレス」を発動し特殊召喚することはできますが、「鉄騎龍ティアマトン」は墓地に送られることになります。
Q.
自分の魔法＆罠ゾーンに「メタモル・クレイ・フォートレス」を含む5枚の魔法・罠カードがセットされています。
「メタモル・クレイ・フォートレス」と同じ縦列の自分のモンスターゾーンに「鉄騎龍ティアマトン」が表側表示で存在し、それ以外のモンスターゾーンに「幻創龍ファンタズメイ」が表側表示で存在しています。
この状況で、「幻創龍ファンタズメイ」を対象として、セットされている「メタモル・クレイ・フォートレス」を発動できますか？
A.
ご質問の状況の場合、「メタモル・クレイ・フォートレス」を発動し特殊召喚することはできますが、「幻創龍ファンタズメイ」は墓地に送られることになります。

Fix it temporary according to https://github.com/Fluorohydride/ygopro-scripts/issues/1424