### PR TITLE
temp fix Sin パラドクス・ドラゴン

### DIFF
--- a/c8310162.lua
+++ b/c8310162.lua
@@ -28,7 +28,7 @@ function c8310162.descon(e)
 	return not Duel.IsEnvironment(27564031)
 end
 function c8310162.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO) and e:GetHandler():IsLocation(LOCATION_MZONE)
 end
 function c8310162.spfilter(c,e,tp)
 	return c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)


### PR DESCRIPTION
@DailyShana @mercury233 
Problem
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10978&keyword=&tag=-1
[bug_paradox.zip](https://github.com/Fluorohydride/ygopro-scripts/files/4847177/bug_paradox.zip)
Now: 2nd effect of Sin パラドクス・ドラゴン can be activated if Sin World is not on the field.
Correct: 2nd effect of Sin パラドクス・ドラゴン cannot be activated if Sin World is not on the field.
