### PR TITLE
Fix "Abyss Actor - Extras"

### DIFF
--- a/c88412339.lua
+++ b/c88412339.lua
@@ -78,5 +78,5 @@ function c88412339.splimit(e,c)
 end
 function c88412339.aclimit(e,re,tp)
 	local rc=re:GetHandler()
-	return rc:IsCode(88412339) and re:GetActiveType()==TYPE_PENDULUM+TYPE_SPELL
+	return rc:IsOnField() and rc:IsCode(88412339) and re:GetActiveType()==TYPE_PENDULUM+TYPE_SPELL
 end


### PR DESCRIPTION
It was unable to be activated as a scale after using its monster effect.