### PR TITLE
update プランキッズ・ウェザー for プランキッズ・ミュー

### DIFF
--- a/c44509529.lua
+++ b/c44509529.lua
@@ -24,10 +24,10 @@ function c44509529.initial_effect(c)
 	e2:SetCountLimit(1,44509529)
 	e2:SetHintTiming(0,TIMING_BATTLE_START+TIMING_END_PHASE)
 	e2:SetCondition(c44509529.spcon)
-	e2:SetCost(c44509529.spcost)
 	e2:SetTarget(c44509529.sptg)
 	e2:SetOperation(c44509529.spop)
 	c:RegisterEffect(e2)
+	c44509529.prankrep_effect=e2
 end
 function c44509529.actcon(e)
 	local a=Duel.GetAttacker()
@@ -36,23 +36,69 @@ end
 function c44509529.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp
 end
-function c44509529.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsReleasable() end
-	Duel.Release(e:GetHandler(),REASON_COST)
-end
 function c44509529.spfilter(c,e,tp)
 	return c:IsSetCard(0x120) and not c:IsType(TYPE_FUSION)
 		and c:IsCanBeEffectTarget(e) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
+function c44509529.costfilter(c)
+	return c:IsHasEffect(101102049) and c:IsAbleToRemoveAsCost()
+end
+function c44509529.repfilter1(c,tp)
+	return Duel.GetMZoneCount(tp,c)>1
+end
+function c44509529.repfilter2(c,g)
+	local cg=g:Clone()
+	cg:RemoveCard(c)
+	return cg:GetClassCount(Card.GetCode)>=2
+end
 function c44509529.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
 	if chkc then return false end
 	local g=Duel.GetMatchingGroup(c44509529.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp)
-	if chk==0 then return Duel.GetMZoneCount(tp,e:GetHandler())>1 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
-		and g:GetClassCount(Card.GetCode)>=2 end
+	local g1=Duel.GetMatchingGroup(c44509529.costfilter,tp,LOCATION_MZONE,0,nil)
+	local g2=Duel.GetMatchingGroup(c44509529.costfilter,tp,LOCATION_GRAVE,0,nil)
+	local b=c:IsReleasable() and Duel.GetMZoneCount(tp,c)>1
+	local b1=c:IsSetCard(0x120) and g1:IsExists(c44509529.repfilter1,1,nil,tp) and g:GetClassCount(Card.GetCode)>=2
+	local b2=c:IsSetCard(0x120) and g2:IsExists(c44509529.repfilter2,1,nil,g) and Duel.GetMZoneCount(tp)>1
+	if chk==0 then return (b or b1 or b2) and not Duel.IsPlayerAffectedByEffect(tp,59822133) end
+	local off=0
+	local ops={}
+	local opval={}
+	off=1
+	if b then
+		ops[off]=aux.Stringid(44509529,1)
+		opval[off-1]=1
+		off=off+1
+	end
+	if b1 then
+		ops[off]=aux.Stringid(44509529,2)
+		opval[off-1]=2
+		off=off+1
+	end
+	if b2 then
+		ops[off]=aux.Stringid(44509529,3)
+		opval[off-1]=3
+		off=off+1
+	end
+	local op=Duel.SelectOption(tp,table.unpack(ops))
+	if opval[op]==1 then
+		Duel.Release(c,REASON_COST)
+	elseif opval[op]==2 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local rg=g1:FilterSelect(tp,c44509529.repfilter1,1,1,nil,tp)
+		Duel.Remove(rg,POS_FACEUP,REASON_COST+REASON_REPLACE)
+		Duel.RegisterFlagEffect(tp,101102049,RESET_PHASE+PHASE_END,0,1)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local rg=g2:FilterSelect(tp,c44509529.repfilter2,1,1,nil,g)
+		Duel.Remove(rg,POS_FACEUP,REASON_COST+REASON_REPLACE)
+		Duel.RegisterFlagEffect(tp,101102049,RESET_PHASE+PHASE_END,0,1)
+	end
+	g=Duel.GetMatchingGroup(c44509529.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g1=g:SelectSubGroup(tp,aux.dncheck,false,2,2)
-	Duel.SetTargetCard(g1)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g1,2,0,0)
+	local sg=g:SelectSubGroup(tp,aux.dncheck,false,2,2)
+	Duel.SetTargetCard(sg)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,sg,2,0,0)
 end
 function c44509529.spop(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/c44509529.lua
+++ b/c44509529.lua
@@ -57,7 +57,7 @@ function c44509529.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.GetMatchingGroup(c44509529.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp)
 	local g1=Duel.GetMatchingGroup(c44509529.costfilter,tp,LOCATION_MZONE,0,nil)
 	local g2=Duel.GetMatchingGroup(c44509529.costfilter,tp,LOCATION_GRAVE,0,nil)
-	local b=c:IsReleasable() and Duel.GetMZoneCount(tp,c)>1
+	local b=c:IsReleasable() and Duel.GetMZoneCount(tp,c)>1 and g:GetClassCount(Card.GetCode)>=2
 	local b1=c:IsSetCard(0x120) and g1:IsExists(c44509529.repfilter1,1,nil,tp) and g:GetClassCount(Card.GetCode)>=2
 	local b2=c:IsSetCard(0x120) and g2:IsExists(c44509529.repfilter2,1,nil,g) and Duel.GetMZoneCount(tp)>1
 	if chk==0 then return (b or b1 or b2) and not Duel.IsPlayerAffectedByEffect(tp,59822133) end


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro-pre-script/pull/486
fix: if there are only プランキッズ・ミュー and Rocksies in the GY, Weather Washer can banish プランキッズ・ミュー to activate it's effect and it won't be able to select 2 targets(after the banishment, only Rocksies left in the GY).