### PR TITLE
fix 原始生命態ニビル

### DIFF
--- a/c27204311.lua
+++ b/c27204311.lua
@@ -48,6 +48,9 @@ function c27204311.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),2,0,0)
 end
+function c27204311.adfilter(c,f)
+	return math.max(f(c),0)
+end
 function c27204311.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c27204311.relfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	if g:GetCount()>0 and Duel.Release(g,REASON_EFFECT)~=0 then
@@ -55,8 +58,8 @@ function c27204311.spop(e,tp,eg,ep,ev,re,r,rp)
 		local c=e:GetHandler()
 		if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
 			if og:GetCount()==0 then return end
-			local atk=og:GetSum(Card.GetBaseAttack)
-			local def=og:GetSum(Card.GetBaseDefense)
+			local atk=og:GetSum(c27204311.adfilter,Card.GetTextAttack)
+			local def=og:GetSum(c27204311.adfilter,Card.GetTextDefense)
 			if Duel.GetLocationCount(1-tp,LOCATION_MZONE,tp)>0
 				and Duel.IsPlayerCanSpecialSummonMonster(tp,27204312,0,0x4011,atk,def,11,RACE_ROCK,ATTRIBUTE_LIGHT) then
 				Duel.BreakEffect()


### PR DESCRIPTION
should be able to calculate the atk/def of the trap monster and token.