### PR TITLE
fix スカーレッド・レイン

### DIFF
--- a/c5376159.lua
+++ b/c5376159.lua
@@ -46,7 +46,6 @@ function c5376159.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c5376159.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c5376159.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	if g:GetCount()<=0 then return end
 	local tg=g:GetMaxGroup(Card.GetLevel)
 	local mg=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,tg)
 	local rg=mg:Filter(Card.IsAbleToRemove,nil)


### PR DESCRIPTION
should be able to remove other monsters even though there are not existing the highest level monster(s).

自己场上存在攻击表示的「饥鳄龙 古鱼龙」和1只连接怪兽，对方场上存在2只连接怪兽的状况，发动「真红莲星雨」时，连锁发动「雷破」把「饥鳄龙 古鱼龙」破坏的场合，「真红莲星雨」的效果处理时3只连接怪兽都被除外。