### PR TITLE
workaround for 電脳堺姫-娘々

### DIFF
--- a/c8736823.lua
+++ b/c8736823.lua
@@ -4,6 +4,7 @@ function c8736823.initial_effect(c)
 	local e0=Effect.CreateEffect(c)
 	e0:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e0:SetCode(EVENT_TO_GRAVE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e0:SetOperation(c8736823.checkop)
 	c:RegisterEffect(e0)
 	--spsummon
@@ -36,11 +37,12 @@ function c8736823.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c8736823.checkop(e,tp,eg,ep,ev,re,r,rp)
-	if re and re:GetHandler():IsSetCard(0x14e) then
+	if re and re:GetHandler() then
 		e:SetLabelObject(re:GetHandler())
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_CHAIN_END)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e1:SetOperation(c8736823.resetop)
 		e1:SetLabelObject(e)
 		Duel.RegisterEffect(e1,tp)

--- a/c8736823.lua
+++ b/c8736823.lua
@@ -1,5 +1,11 @@
 --電脳堺姫-娘々
 function c8736823.initial_effect(c)
+	--Datascape monster send this card to grave and spsummon check
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e0:SetCode(EVENT_TO_GRAVE)
+	e0:SetOperation(c8736823.checkop)
+	c:RegisterEffect(e0)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(8736823,0))
@@ -9,6 +15,7 @@ function c8736823.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_DELAY)
 	e1:SetRange(LOCATION_GRAVE)
 	e1:SetCountLimit(1,8736823)
+	e1:SetLabelObject(e0)
 	e1:SetCondition(c8736823.spcon)
 	e1:SetTarget(c8736823.sptg)
 	e1:SetOperation(c8736823.spop)
@@ -28,11 +35,28 @@ function c8736823.initial_effect(c)
 	e3:SetOperation(c8736823.tdop)
 	c:RegisterEffect(e3)
 end
+function c8736823.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if re and re:GetHandler():IsSetCard(0x14e) then
+		e:SetLabelObject(re:GetHandler())
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_CHAIN_END)
+		e1:SetOperation(c8736823.resetop)
+		e1:SetLabelObject(e)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function c8736823.resetop(e,tp,eg,ep,ev,re,r,rp)
+	--this will run after EVENT_SPSUMMON_SUCCESS
+	e:GetLabelObject():SetLabelObject(nil)
+	e:Reset()
+end
 function c8736823.cfilter(c,tp)
 	return c:IsFaceup() and c:IsLevel(3) and c:IsControler(tp)
 end
 function c8736823.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c8736823.cfilter,1,nil,tp)
+	local ec=e:GetLabelObject():GetLabelObject()
+	return eg:IsExists(c8736823.cfilter,1,ec,tp)
 end
 function c8736823.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end

--- a/c8736823.lua
+++ b/c8736823.lua
@@ -1,6 +1,7 @@
 --電脳堺姫-娘々
 function c8736823.initial_effect(c)
-	--Datascape monster send this card to grave and spsummon check
+	--same effect send this card to grave and spsummon another card check
+	--not fully implemented
 	local e0=Effect.CreateEffect(c)
 	e0:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e0:SetCode(EVENT_TO_GRAVE)
@@ -37,8 +38,8 @@ function c8736823.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c8736823.checkop(e,tp,eg,ep,ev,re,r,rp)
-	if re and re:GetHandler() then
-		e:SetLabelObject(re:GetHandler())
+	if (r&REASON_EFFECT)>0 then
+		e:SetLabelObject(re)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_CHAIN_END)
@@ -53,12 +54,12 @@ function c8736823.resetop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetLabelObject():SetLabelObject(nil)
 	e:Reset()
 end
-function c8736823.cfilter(c,tp)
-	return c:IsFaceup() and c:IsLevel(3) and c:IsControler(tp)
+function c8736823.cfilter(c,tp,se)
+	return c:IsFaceup() and c:IsLevel(3) and c:IsControler(tp) and (se==nil or c:GetReasonEffect()~=se)
 end
 function c8736823.spcon(e,tp,eg,ep,ev,re,r,rp)
-	local ec=e:GetLabelObject():GetLabelObject()
-	return eg:IsExists(c8736823.cfilter,1,ec,tp)
+	local se=e:GetLabelObject():GetLabelObject()
+	return eg:IsExists(c8736823.cfilter,1,nil,tp,se)
 end
 function c8736823.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end


### PR DESCRIPTION
> Q.
「電脳堺媛－瑞々」の効果により「電脳堺姫－娘々」を墓地へ送り「電脳堺媛－瑞々」が特殊召喚された場合、その「電脳堺姫－娘々」の①の効果を発動する事はできますか？
A.
「電脳堺姫－娘々」の『①』の効果は、すでに「電脳堺姫－娘々」が墓地に存在している状態で、レベル3モンスターが召喚・特殊召喚された場合に発動することができます。
また、「電脳堺媛－瑞々」の『①』の効果の『そのカードとは種類（モンスター・魔法・罠）が異なる「電脳堺」カード１枚をデッキから墓地へ送り』の処理と『このカードを特殊召喚する』の処理は同時に行われますので、ご質問のように、「電脳堺媛－瑞々」の『①』の効果で、「電脳堺姫－娘々」をデッキから墓地へ送った場合、その「電脳堺姫－娘々」の『①』の効果を発動することはできません。

If 電脳堺媛－瑞々 send this card to grave and summon itself, this card shouldn't be able to summon itself.