### PR TITLE
fix level up/down effect(select option in operation)

### DIFF
--- a/c11234702.lua
+++ b/c11234702.lua
@@ -65,8 +65,13 @@ end
 function c11234702.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local sel=0
 		local lvl=1
-		local sel=Duel.SelectOption(tp,aux.Stringid(11234702,1),aux.Stringid(11234702,2))
+		if tc:IsLevel(1) then
+			sel=Duel.SelectOption(tp,aux.Stringid(11234702,1))
+		else
+			sel=Duel.SelectOption(tp,aux.Stringid(11234702,1),aux.Stringid(11234702,2))
+		end
 		if sel==1 then
 			lvl=-1
 		end

--- a/c13364097.lua
+++ b/c13364097.lua
@@ -73,8 +73,13 @@ end
 function c13364097.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local sel=0
 		local lvl=3
-		local sel=Duel.SelectOption(tp,aux.Stringid(13364097,2),aux.Stringid(13364097,3))
+		if tc:IsLevelBelow(3) or tc:IsRankBelow(3) then
+			sel=Duel.SelectOption(tp,aux.Stringid(13364097,2))
+		else
+			sel=Duel.SelectOption(tp,aux.Stringid(13364097,2),aux.Stringid(13364097,3))
+		end
 		if sel==1 then
 			lvl=-3
 		end

--- a/c74148483.lua
+++ b/c74148483.lua
@@ -55,7 +55,12 @@ end
 function c74148483.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) and c:IsFaceup() then
-		local opt=Duel.SelectOption(tp,aux.Stringid(74148483,1),aux.Stringid(74148483,2))
+		local opt=0
+		if c:IsLevel(1) then
+			opt=Duel.SelectOption(tp,aux.Stringid(74148483,1))
+		else
+			opt=Duel.SelectOption(tp,aux.Stringid(74148483,1),aux.Stringid(74148483,2))
+		end
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_LEVEL)


### PR DESCRIPTION
Q.
「電脳堺媛－瑞々」を対象として墓地の「電脳堺門－朱雀」の②効果を発動し、レベルを３つ下げる処理を選んで行うことはできますか？
A.
レベル3の「電脳堺媛－瑞々」のレベルを、3つ下げることはできません。

Q.
「電脳堺甲－甲々」を対象として墓地の「電脳堺門－朱雀」の②効果を発動し、ランクを３つ下げる処理を選んで行うことはできますか？
A.
ランク3の「電脳堺甲－甲々」のランクを、3つ下げることはできません。