### PR TITLE
fix 電脳堺

### DIFF
--- a/c12571621.lua
+++ b/c12571621.lua
@@ -33,7 +33,7 @@ end
 function c12571621.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c12571621.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()

--- a/c49088914.lua
+++ b/c49088914.lua
@@ -36,7 +36,7 @@ end
 function c49088914.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c49088914.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()

--- a/c49966326.lua
+++ b/c49966326.lua
@@ -35,7 +35,7 @@ end
 function c49966326.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c49966326.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()

--- a/c86483512.lua
+++ b/c86483512.lua
@@ -35,7 +35,7 @@ end
 function c86483512.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c86483512.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()

--- a/c92519087.lua
+++ b/c92519087.lua
@@ -6,7 +6,7 @@ function c92519087.initial_effect(c)
 	--remove
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_IMMUNE)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCode(EFFECT_TO_GRAVE_REDIRECT)
 	e1:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)


### PR DESCRIPTION
Q.
「電脳堺媛－瑞々」を対象として手札の「電脳堺豸－豸々」の①効果を発動し、その発動にチェーンして相手が「月の書」を発動し、対象とした「電脳堺媛－瑞々」を裏側守備表示になりました。

この場合、「電脳堺豸－豸々」の①効果の処理はどうなりますか？
A.
ご質問の場合、『そのカードとは種類（モンスター・魔法・罠）が異なる「電脳堺」カード１枚をデッキから墓地へ送り、このカードを特殊召喚する』処理や、『このターンのエンドフェイズに、自分の墓地から「電脳堺豸－豸々」以外の「電脳堺」モンスター１体を選んで手札に加える事ができる』処理は行えません。

なお、『このターン、自分はレベルまたはランクが３以上のモンスターしか特殊召喚できない』処理は適用されます。