### PR TITLE
add EVENT_BREAK_EFFECT

### DIFF
--- a/c8736823.lua
+++ b/c8736823.lua
@@ -1,7 +1,6 @@
 --電脳堺姫-娘々
 function c8736823.initial_effect(c)
 	--same effect send this card to grave and spsummon another card check
-	--not fully implemented
 	local e0=Effect.CreateEffect(c)
 	e0:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e0:SetCode(EVENT_TO_GRAVE)
@@ -47,11 +46,23 @@ function c8736823.checkop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetOperation(c8736823.resetop)
 		e1:SetLabelObject(e)
 		Duel.RegisterEffect(e1,tp)
+		local e2=e1:Clone()
+		e2:SetCode(EVENT_BREAK_EFFECT)
+		e2:SetOperation(c8736823.resetop2)
+		e2:SetReset(RESET_CHAIN)
+		e2:SetLabelObject(e1)
+		Duel.RegisterEffect(e2,tp)
 	end
 end
 function c8736823.resetop(e,tp,eg,ep,ev,re,r,rp)
 	--this will run after EVENT_SPSUMMON_SUCCESS
 	e:GetLabelObject():SetLabelObject(nil)
+	e:Reset()
+end
+function c8736823.resetop2(e,tp,eg,ep,ev,re,r,rp)
+	local e1=e:GetLabelObject()
+	e1:GetLabelObject():SetLabelObject(nil)
+	e1:Reset()
 	e:Reset()
 end
 function c8736823.cfilter(c,tp,se)

--- a/c94142993.lua
+++ b/c94142993.lua
@@ -1,5 +1,12 @@
 --ティンダングル・イントルーダー
 function c94142993.initial_effect(c)
+	--same effect send this card to grave and spsummon another card check
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e0:SetCode(EVENT_TO_GRAVE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e0:SetOperation(c94142993.checkop)
+	c:RegisterEffect(e0)
 	--flip
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(94142993,0))
@@ -28,10 +35,40 @@ function c94142993.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e3:SetRange(LOCATION_GRAVE)
 	e3:SetCountLimit(1,94142995)
+	e3:SetLabelObject(e0)
 	e3:SetCondition(c94142993.spcon)
 	e3:SetTarget(c94142993.sptg)
 	e3:SetOperation(c94142993.spop)
 	c:RegisterEffect(e3)
+end
+function c94142993.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if (r&REASON_EFFECT)>0 then
+		e:SetLabelObject(re)
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_CHAIN_END)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetOperation(c94142993.resetop)
+		e1:SetLabelObject(e)
+		Duel.RegisterEffect(e1,tp)
+		local e2=e1:Clone()
+		e2:SetCode(EVENT_BREAK_EFFECT)
+		e2:SetOperation(c94142993.resetop2)
+		e2:SetReset(RESET_CHAIN)
+		e2:SetLabelObject(e1)
+		Duel.RegisterEffect(e2,tp)
+	end
+end
+function c94142993.resetop(e,tp,eg,ep,ev,re,r,rp)
+	--this will run after EVENT_SPSUMMON_SUCCESS
+	e:GetLabelObject():SetLabelObject(nil)
+	e:Reset()
+end
+function c94142993.resetop2(e,tp,eg,ep,ev,re,r,rp)
+	local e1=e:GetLabelObject()
+	e1:GetLabelObject():SetLabelObject(nil)
+	e1:Reset()
+	e:Reset()
 end
 function c94142993.thfilter(c)
 	return c:IsSetCard(0x10b) and c:IsAbleToHand()
@@ -62,11 +99,12 @@ function c94142993.tgop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(g,REASON_EFFECT)
 	end
 end
-function c94142993.cfilter(c,tp)
-	return c:IsPosition(POS_FACEDOWN_DEFENSE) and c:IsControler(tp)
+function c94142993.cfilter(c,tp,se)
+	return c:IsPosition(POS_FACEDOWN_DEFENSE) and c:IsControler(tp) and (se==nil or c:GetReasonEffect()~=se)
 end
 function c94142993.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c94142993.cfilter,1,nil,tp)
+	local se=e:GetLabelObject():GetLabelObject()
+	return eg:IsExists(c94142993.cfilter,1,nil,tp,se)
 end
 function c94142993.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/constant.lua
+++ b/constant.lua
@@ -585,6 +585,7 @@ EVENT_BECOME_TARGET				=1028	--成为效果对象时
 EVENT_DESTROYED					=1029	--被破坏时
 EVENT_MOVE						=1030	--移動卡片(急兔馬)
 EVENT_ADJUST					=1040	--adjust_all()调整後（御前试合）
+EVENT_BREAK_EFFECT				=1050	--Duel.BreakEffect()被调用时
 EVENT_SUMMON_SUCCESS			=1100	--通常召唤成功时
 EVENT_FLIP_SUMMON_SUCCESS		=1101	--翻转召唤成功时
 EVENT_SPSUMMON_SUCCESS			=1102	--特殊召唤成功时


### PR DESCRIPTION
Fix: If _Nekroz Cycle_ release _Datascape Princess - Niangniang_ and spsummon _Nekroz of Clausolas_, Niangniang should be able to activate because send to grave and spsummon aren't done at the same time.