### PR TITLE
Fix 星遺物の守護竜

### DIFF
--- a/c87571563.lua
+++ b/c87571563.lua
@@ -9,7 +9,7 @@ function c87571563.initial_effect(c)
 	c:RegisterEffect(e1)
 	--move
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(87571563,0))
+	e2:SetDescription(571)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetRange(LOCATION_SZONE)
@@ -25,7 +25,7 @@ function c87571563.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c87571563.spfilter(chkc,e,tp) end
 	if chk==0 then return true end
 	if Duel.IsExistingTarget(c87571563.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
-		and Duel.SelectYesNo(tp,aux.Stringid(87571563,1)) then
+		and Duel.SelectYesNo(tp,aux.Stringid(87571563,0)) then
 		e:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND)
 		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
 		e:SetOperation(c87571563.activate)


### PR DESCRIPTION
When "World Legacy Guardragon" is activated, the user is asked, "Add to hand" instead of something like, "Add to hand or Special Summon?" This can get confusing for them, so...