### PR TITLE
Fix "Desperado Barrel Dragon"

### DIFF
--- a/c76728962.lua
+++ b/c76728962.lua
@@ -83,6 +83,7 @@ function c76728962.desop(e,tp,eg,ep,ev,re,r,rp)
 	local dg=g:Select(tp,1,ct,nil)
 	Duel.HintSelection(dg)
 	if Duel.Destroy(dg,REASON_EFFECT)~=0 and c1+c2+c3==3 then
+		Duel.BreakEffect()
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Destroying and drawing are considered to happen at different timings. From the database: 『表が出た数までフィールドの表側表示モンスターを選んで破壊する』処理と、『３回とも表だった場合、さらに自分はデッキから１枚ドローする』処理は同時に行われる扱いではありません。