### PR TITLE
Update "Predaplant Verte Anaconda"

### DIFF
--- a/c70369116.lua
+++ b/c70369116.lua
@@ -46,7 +46,7 @@ function c70369116.attop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c70369116.cpfilter(c)
 	return (c:GetType()==TYPE_SPELL or c:IsType(TYPE_QUICKPLAY)) and c:IsSetCard(0x46) and c:IsAbleToGraveAsCost()
-		and c:CheckActivateEffect(false,true,false)~=nil
+		and c:CheckActivateEffect(true,true,false)~=nil
 end
 function c70369116.cpcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)


### PR DESCRIPTION
Problem: by setting the second parameter of `CheckActivateEffect` to false, the card will be unable to ignore activation conditions, which is incorrect.

A realistic scenario: if the player changes the name of `Predaplant Verte Anaconda`, so it's no longer a "Predaplant" monster - and controls no other "Predaplant" monster - he will be unable to apply the effects of `Predaprime Fusion`, even though controlling a "Predaplant" monster is the condition to **activate** Predaprime Fusion, as[ the database mentions](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14604&request_locale=ja) and thus, should be ignored by Verte Anaconda.

This Pull request changes the parameter to true, so the activation condition is ignored, as you can see [in your own version of Spellbook of the Master](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c56981417.lua#L30).

