### PR TITLE
fix negate effects and エマージェンシー・サイバー

### DIFF
--- a/c15180041.lua
+++ b/c15180041.lua
@@ -85,9 +85,7 @@ function c15180041.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c15180041.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end
 function c15180041.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c1527418.lua
+++ b/c1527418.lua
@@ -56,7 +56,5 @@ function c1527418.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c1527418.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c16006416.lua
+++ b/c16006416.lua
@@ -66,7 +66,5 @@ function c16006416.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c16006416.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c19502505.lua
+++ b/c19502505.lua
@@ -61,9 +61,7 @@ function c19502505.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c19502505.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end
 function c19502505.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c21834870.lua
+++ b/c21834870.lua
@@ -35,9 +35,7 @@ function c21834870.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c21834870.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end
 function c21834870.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c24027078.lua
+++ b/c24027078.lua
@@ -37,8 +37,6 @@ function c24027078.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectMatchingCard(tp,c24027078.filter2,tp,LOCATION_ONFIELD,0,1,1,nil)
 	if #g>0 and Duel.Destroy(g,REASON_EFFECT)~=0 then
-		if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
+		Duel.NegateActivation(ev)
 	end
 end

--- a/c27548199.lua
+++ b/c27548199.lua
@@ -89,7 +89,5 @@ function c27548199.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c27548199.disop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c32422602.lua
+++ b/c32422602.lua
@@ -72,7 +72,5 @@ function c32422602.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c32422602.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c33026283.lua
+++ b/c33026283.lua
@@ -83,7 +83,5 @@ function c33026283.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c33026283.disop(e,tp,eg,ep,ev,re,r,rp,chk)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c38916526.lua
+++ b/c38916526.lua
@@ -69,7 +69,5 @@ function c38916526.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c38916526.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c41175645.lua
+++ b/c41175645.lua
@@ -76,9 +76,7 @@ function c41175645.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c41175645.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end
 function c41175645.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c4145852.lua
+++ b/c4145852.lua
@@ -61,7 +61,5 @@ function c4145852.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
 function c4145852.disop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c4367330.lua
+++ b/c4367330.lua
@@ -60,7 +60,5 @@ function c4367330.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
 function c4367330.disop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c46031686.lua
+++ b/c46031686.lua
@@ -20,9 +20,7 @@ function c46031686.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,PLAYER_ALL,1)
 end
 function c46031686.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 	Duel.Draw(tp,1,REASON_EFFECT)
 	Duel.Draw(1-tp,1,REASON_EFFECT)
 end

--- a/c47297616.lua
+++ b/c47297616.lua
@@ -57,9 +57,6 @@ function c47297616.opdisable(e,tp,eg,ep,ev,re,r,rp)
 		return
 	end
 	if Duel.NegateActivation(ev) then
-		if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)

--- a/c47946130.lua
+++ b/c47946130.lua
@@ -84,9 +84,7 @@ function c47946130.negop(e,tp,eg,ep,ev,re,r,rp,chk)
 	e1:SetValue(-500)
 	c:RegisterEffect(e1)
 	if not c:IsImmuneToEffect(e1) and not c:IsHasEffect(EFFECT_REVERSE_UPDATE) then
-		if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
+		Duel.NegateActivation(ev)
 	end
 end
 function c47946130.atkcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c4810828.lua
+++ b/c4810828.lua
@@ -44,11 +44,7 @@ function c4810828.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c4810828.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) then
-		if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
-	end
+	Duel.NegateActivation(ev)
 end
 function c4810828.discon(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=ep and Duel.GetCurrentChain()==0

--- a/c49725936.lua
+++ b/c49725936.lua
@@ -45,9 +45,7 @@ function c49725936.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c49725936.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end
 function c49725936.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsStatus(STATUS_SPSUMMON_TURN)

--- a/c52068432.lua
+++ b/c52068432.lua
@@ -54,9 +54,7 @@ function c52068432.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c52068432.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end
 function c52068432.remcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_RITUAL)

--- a/c60600126.lua
+++ b/c60600126.lua
@@ -6,6 +6,7 @@ function c60600126.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,60600126+EFFECT_COUNT_CODE_OATH)
+	e1:SetCost(c60600126.negreg)
 	e1:SetTarget(c60600126.target)
 	e1:SetOperation(c60600126.activate)
 	c:RegisterEffect(e1)
@@ -21,6 +22,39 @@ function c60600126.initial_effect(c)
 	e2:SetTarget(c60600126.thtg)
 	e2:SetOperation(c60600126.thop)
 	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EVENT_CUSTOM+60600126)
+	e3:SetCondition(c60600126.thcon2)
+	c:RegisterEffect(e3)
+end
+function c60600126.negreg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_CHAIN_NEGATED)
+	e1:SetLabelObject(e)
+	e1:SetOperation(c60600126.negcheck)
+	e1:SetReset(RESET_CHAIN)
+	Duel.RegisterEffect(e1,tp)
+end
+function c60600126.negcheck(e,tp,eg,ep,ev,re,r,rp)
+	local te=e:GetLabelObject()
+	local de,dp=Duel.GetChainInfo(ev,CHAININFO_DISABLE_REASON,CHAININFO_DISABLE_PLAYER)
+	if rp==tp and de and dp==1-tp and re==te then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_CHAIN_END)
+		e1:SetOperation(c60600126.negevent)
+		e1:SetLabelObject(te)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function c60600126.negevent(e,tp,eg,ep,ev,re,r,rp)
+	local te=e:GetLabelObject()
+	Duel.RaiseEvent(te:GetHandler(),EVENT_CUSTOM+60600126,te,0,tp,tp,0)
+	e:Reset()
 end
 function c60600126.filter(c)
 	return ((c:IsSetCard(0x1093) and c:IsType(TYPE_MONSTER)) or (c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_MACHINE) and not c:IsSummonableCard()))
@@ -55,6 +89,9 @@ function c60600126.thop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
-		Duel.ConfirmCards(1-tp,c)
 	end
+end
+function c60600126.thcon2(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c==re:GetHandler() and c:GetReasonEffect()==nil
 end

--- a/c64454614.lua
+++ b/c64454614.lua
@@ -56,9 +56,7 @@ function c64454614.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c64454614.negop(e,tp,eg,ep,ev,re,r,rp,chk)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end
 function c64454614.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c65240384.lua
+++ b/c65240384.lua
@@ -30,9 +30,8 @@ function c65240384.negcon(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c65240384.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.ChangePosition(e:GetHandler(),POS_FACEUP_DEFENSE) then
-		if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and Duel.ChangePosition(c,POS_FACEUP_DEFENSE) then
+		Duel.NegateActivation(ev)
 	end
 end

--- a/c66547759.lua
+++ b/c66547759.lua
@@ -69,8 +69,7 @@ function c66547759.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c66547759.disop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetCurrentChain()==ev+1 and Duel.NegateActivation(ev)
-		and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
+	if Duel.GetCurrentChain()==ev+1 then
+		Duel.NegateActivation(ev)
 	end
 end

--- a/c70335319.lua
+++ b/c70335319.lua
@@ -159,7 +159,5 @@ function c70335319.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c70335319.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c70628672.lua
+++ b/c70628672.lua
@@ -36,9 +36,6 @@ function c70628672.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c70628672.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateActivation(ev) then
-		if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
 		local cd=re:GetHandler():GetCode()
 		local g=Duel.GetMatchingGroup(Card.IsCode,rp,LOCATION_DECK+LOCATION_EXTRA,0,nil,cd)
 		if g:GetCount()>0 then

--- a/c73026394.lua
+++ b/c73026394.lua
@@ -23,9 +23,7 @@ function c73026394.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_EXTRA)
 end
 function c73026394.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 	local g=Duel.GetMatchingGroup(c73026394.filter,tp,LOCATION_EXTRA,0,nil):RandomSelect(tp,1)
 	Duel.SendtoGrave(g,REASON_EFFECT)
 end

--- a/c73642296.lua
+++ b/c73642296.lua
@@ -43,9 +43,5 @@ function c73642296.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c73642296.disop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) then
-		if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c74762582.lua
+++ b/c74762582.lua
@@ -47,9 +47,6 @@ function c74762582.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c74762582.disop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateActivation(ev) then
-		if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
 		local tc=Duel.GetFirstTarget()
 		if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 			Duel.BreakEffect()

--- a/c75487237.lua
+++ b/c75487237.lua
@@ -39,8 +39,9 @@ function c75487237.negcon(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c75487237.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
+	Duel.NegateActivation(ev)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.ChangePosition(,POS_FACEUP_DEFENSE)
 	end
-	Duel.ChangePosition(e:GetHandler(),POS_FACEUP_DEFENSE)
 end

--- a/c7841112.lua
+++ b/c7841112.lua
@@ -68,9 +68,7 @@ function c7841112.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c7841112.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
 	Duel.Destroy(g,REASON_EFFECT)
 end

--- a/c82744076.lua
+++ b/c82744076.lua
@@ -80,7 +80,5 @@ function c82744076.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c82744076.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end

--- a/c94919024.lua
+++ b/c94919024.lua
@@ -60,9 +60,6 @@ function c94919024.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c94919024.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateActivation(ev) then
-		if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-			Duel.SendtoGrave(eg,REASON_EFFECT)
-		end
 		Duel.Recover(tp,1000,REASON_EFFECT)
 		Duel.Recover(1-tp,1000,REASON_EFFECT)
 	end

--- a/c95372220.lua
+++ b/c95372220.lua
@@ -93,7 +93,5 @@ function c95372220.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 end
 function c95372220.negop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.NegateActivation(ev) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.SendtoGrave(eg,REASON_EFFECT)
-	end
+	Duel.NegateActivation(ev)
 end


### PR DESCRIPTION
According to the recent answer from konami, the cards negated in chain shouldn't be sent to grave immediately (if the negate effect don't say destroy), so https://github.com/Fluorohydride/ygopro-scripts/commit/105b41cfc0560fe247019698182a773bf9a39c52 https://github.com/Fluorohydride/ygopro-scripts/commit/bf0a77923a863118316c949d2ddb58a479cf362e should be reverted, and some other cards need to be updated.

But for this card, it can use its 2nd effect if it is negated, and sent to grave after the chain resolve, so it need an extra check.