### PR TITLE
fix ヴァンパイア・サッカー

### DIFF
--- a/c37129797.lua
+++ b/c37129797.lua
@@ -71,7 +71,7 @@ function c37129797.drfilter(c)
 	return c:IsRace(RACE_ZOMBIE) and c:IsPreviousLocation(LOCATION_GRAVE)
 end
 function c37129797.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c37129797.drfilter,1,nil)
+	return eg:IsExists(c37129797.drfilter,1,e:GetHandler())
 end
 function c37129797.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c37129797.lua
+++ b/c37129797.lua
@@ -71,7 +71,7 @@ function c37129797.drfilter(c)
 	return c:IsRace(RACE_ZOMBIE) and c:IsPreviousLocation(LOCATION_GRAVE)
 end
 function c37129797.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c37129797.drfilter,1,nil) and not eg:IsContains(e:GetHandler())
+	return eg:IsExists(c37129797.drfilter,1,nil)
 end
 function c37129797.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21709&request_locale=ja

Question
自分は「ソウル・チャージ」の『①：自分の墓地のモンスターを任意の数だけ対象として発動できる。そのモンスターを特殊召喚し、自分はこの効果で特殊召喚したモンスターの数×１０００LPを失う』効果を発動し、自分の墓地から「ヴァンパイア・サッカー」と「ヴァンパイア・ソーサラー」を特殊召喚しました。

この場合、「ヴァンパイア・サッカー」の『②：自分・相手の墓地からアンデット族モンスターが特殊召喚された場合に発動する。自分はデッキから１枚ドローする』モンスター効果は発動しますか？
Answer
質問の状況のように、「ヴァンパイア・サッカー」と、他のアンデット族モンスターが同時に特殊召喚に成功した場合でも、「ヴァンパイア・サッカー」の『自分はデッキから１枚ドローする』モンスター効果は発動します。