### PR TITLE
fix disable attack target effects

### DIFF
--- a/c12735388.lua
+++ b/c12735388.lua
@@ -57,6 +57,7 @@ function c12735388.disop1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=c:GetEquipTarget():GetBattleTarget()
 	tc:RegisterFlagEffect(12735388,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+	Duel.AdjustInstantly(c)
 end
 function c12735388.distg(e,c)
 	return c:GetFlagEffect(12735388)~=0

--- a/c27331568.lua
+++ b/c27331568.lua
@@ -64,6 +64,7 @@ function c27331568.distg(e,c)
 	if c:GetFlagEffect(27331568)>0 then return true end
 	if c:GetSummonLocation()==LOCATION_EXTRA and c:GetBattleTarget()~=nil and c:GetBattleTarget():GetFieldID()==e:GetLabel() then
 		c:RegisterFlagEffect(27331568,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+		Duel.AdjustInstantly(e:GetHandler())
 		return true
 	end
 	return false

--- a/c35220244.lua
+++ b/c35220244.lua
@@ -82,6 +82,7 @@ end
 function c35220244.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetHandler():GetEquipTarget():GetBattleTarget()
 	tc:RegisterFlagEffect(35220244,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+	Duel.AdjustInstantly(e:GetHandler())
 end
 function c35220244.distg(e,c)
 	return c:GetFlagEffect(35220244)~=0

--- a/c40509732.lua
+++ b/c40509732.lua
@@ -53,6 +53,7 @@ function c40509732.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetHandler():GetBattleTarget()
 	if not tc then return end
 	tc:RegisterFlagEffect(40509732,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+	Duel.AdjustInstantly(e:GetHandler())
 end
 function c40509732.distg(e,c)
 	return c:GetFlagEffect(40509732)~=0

--- a/c71345905.lua
+++ b/c71345905.lua
@@ -73,6 +73,7 @@ function c71345905.disop(e,tp,eg,ep,ev,re,r,rp)
 	local bc=c:GetBattleTarget()
 	if bc then
 		bc:RegisterFlagEffect(71345905,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+		Duel.AdjustInstantly(e:GetHandler())
 	end
 end
 function c71345905.distg(e,c)

--- a/c76080032.lua
+++ b/c76080032.lua
@@ -77,6 +77,7 @@ end
 function c76080032.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetHandler():GetEquipTarget():GetBattleTarget()
 	tc:RegisterFlagEffect(76080032,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+	Duel.AdjustInstantly(e:GetHandler())
 end
 function c76080032.distg(e,c)
 	return c:GetFlagEffect(76080032)~=0

--- a/c87460579.lua
+++ b/c87460579.lua
@@ -80,6 +80,7 @@ function c87460579.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetAttackTarget()
 	if tc:IsControler(tp) then tc=Duel.GetAttacker() end
 	tc:RegisterFlagEffect(87460579,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+	Duel.AdjustInstantly(c)
 end
 function c87460579.distg(e,c)
 	return c:GetFlagEffect(87460579)~=0


### PR DESCRIPTION
The attack target monster wasn't disabled until damage step or some chain resolves