### PR TITLE
fix 珠玉獣－アルゴザウルス

### DIFF
--- a/c98022050.lua
+++ b/c98022050.lua
@@ -15,9 +15,9 @@ function c98022050.initial_effect(c)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e2)
 end
-function c98022050.desfilter(c,tp)
+function c98022050.desfilter(c,tp,solve)
 	return c:IsRace(RACE_DINOSAUR) and not c:IsCode(98022050) and (c:IsFaceup() or c:IsLocation(LOCATION_HAND))
-		and Duel.IsExistingMatchingCard(c98022050.thfilter,tp,LOCATION_DECK,0,1,nil,c:GetOriginalLevel())
+		and (solve or Duel.IsExistingMatchingCard(c98022050.thfilter,tp,LOCATION_DECK,0,1,nil,c:GetOriginalLevel()))
 end
 function c98022050.thfilter(c,lv)
 	return ((c:GetOriginalLevel()==lv and c:IsRace(RACE_REPTILE+RACE_SEASERPENT+RACE_WINDBEAST))
@@ -33,6 +33,10 @@ function c98022050.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectMatchingCard(tp,c98022050.desfilter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil,tp)
+	if g:GetCount()==0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		g=Duel.SelectMatchingCard(tp,c98022050.desfilter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil,tp,true)
+	end
 	local tc=g:GetFirst()
 	if tc and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		local lv=tc:GetOriginalLevel()


### PR DESCRIPTION
Q.
自分のデッキに「進化薬」魔法カードが存在せず、自分の手札に「珠玉獣－アルゴザウルス」１体のみ、自分フィールドにレベル２の「ベビケラサウルス」とレベル４の「縄張恐竜」が存在する状態です。

自分は「珠玉獣－アルゴザウルス」を手札から召喚に成功した時、その「珠玉獣－アルゴザウルス」の①の効果の発動にチェーンして「針虫の巣窟」を発動し、デッキのカードが墓地へ送られた事によって、自分のデッキに存在する爬虫類族・海竜族・鳥獣族モンスターがレベル４の「カゲトカゲ」１体のみとなった場合、「珠玉獣－アルゴザウルス」の効果処理はどうなりますか？「ベビケラサウルス」を選んで破壊することはできますか？
A.
ご質問の場合、『手札及び自分フィールドの表側表示モンスターの中から、「珠玉獣－アルゴザウルス」以外の恐竜族モンスター１体を選んで破壊する』処理として、「縄張恐竜」を破壊しなければなりません。

Q.
自分のデッキに「進化薬」魔法カードが存在せず、自分の手札に「珠玉獣－アルゴザウルス」１体のみ、自分フィールドにレベル２の「ベビケラサウルス」とレベル４の「縄張恐竜」が存在する状態です。

自分は「珠玉獣－アルゴザウルス」を手札から召喚に成功した時、その「珠玉獣－アルゴザウルス」の①の効果の発動にチェーンして「針虫の巣窟」を発動し、デッキのカードが墓地へ送られた事によって、自分のデッキに爬虫類族・海竜族・鳥獣族モンスターが１体も存在しない状態となった場合、「珠玉獣－アルゴザウルス」の効果処理はどうなりますか？「ベビケラサウルス」や「縄張恐竜」を選んで破壊することはできますか？
A.
ご質問の場合、『手札及び自分フィールドの表側表示モンスターの中から、「珠玉獣－アルゴザウルス」以外の恐竜族モンスター１体を選んで破壊する』処理として、「縄張恐竜」または「ベビケラサウルス」のいずれか1枚を選んで破壊します。
