### PR TITLE
Fix "S-Force" monsters to work with "Chase"

### DIFF
--- a/c22180094.lua
+++ b/c22180094.lua
@@ -42,13 +42,15 @@ function c22180094.atlimit(e,c)
 	local lc=e:GetLabelObject()
 	return not lc:GetColumnGroup():IsContains(c)
 end
-function c22180094.costfilter(c)
-	return c:IsSetCard(0x156) and c:IsAbleToRemoveAsCost()
+function c22180094.costfilter(c,tp)
+	return (c:IsSetCard(0x156) and c:IsLocation(LOCATION_HAND) or c:IsHasEffect(55049722,tp) and c:IsLocation(LOCATION_GRAVE)) and c:IsAbleToRemoveAsCost()
 end
 function c22180094.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c22180094.costfilter,tp,LOCATION_HAND,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c22180094.costfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c22180094.costfilter,tp,LOCATION_HAND,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c22180094.costfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,tp)
+	local te=g:GetFirst():IsHasEffect(55049722,tp)
+	if te then te:UseCountLimit(tp) end
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c22180094.spfilter(c,e,tp)

--- a/c95974848.lua
+++ b/c95974848.lua
@@ -34,13 +34,15 @@ end
 function c95974848.descon(e,tp,eg,ep,ev,re,r,rp)
 	return re:GetHandler():IsRelateToEffect(re) and re:GetHandler():IsLocation(LOCATION_MZONE) and re:IsActiveType(TYPE_MONSTER) and rp==1-tp
 end
-function c95974848.costfilter(c)
-	return c:IsSetCard(0x156) and c:IsAbleToRemoveAsCost()
+function c95974848.costfilter(c,tp)
+	return (c:IsSetCard(0x156) and c:IsLocation(LOCATION_HAND) or c:IsHasEffect(55049722,tp) and c:IsLocation(LOCATION_GRAVE)) and c:IsAbleToRemoveAsCost()
 end
 function c95974848.descost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c95974848.costfilter,tp,LOCATION_HAND,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c95974848.costfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,c95974848.costfilter,tp,LOCATION_HAND,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c95974848.costfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,tp)
+	local te=g:GetFirst():IsHasEffect(55049722,tp)
+	if te then te:UseCountLimit(tp) end
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c95974848.destg(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
The scripter(s) forgot to implement the hardcoded effect of "S-Force Chase" into the monsters that need it.