### PR TITLE
fix 粘着落とし穴

### DIFF
--- a/c62325062.lua
+++ b/c62325062.lua
@@ -31,7 +31,7 @@ function c62325062.activate(e,tp,eg,ep,ev,re,r,rp)
 	while tc do
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetCode(EFFECT_SET_BASE_ATTACK)
 		e1:SetValue(c62325062.atkval)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5624
■「粘着落とし穴」の効果が適用された場合、半分になった元々の攻撃力の数値は、元々の攻撃力として扱われます。