### PR TITLE
fix 王家の財宝

### DIFF
--- a/c63571750.lua
+++ b/c63571750.lua
@@ -18,7 +18,8 @@ function c63571750.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	c:CancelToGrave()
-	Duel.SendtoDeck(c,nil,2,REASON_EFFECT)
+	Duel.SendtoDeck(c,tp,2,REASON_EFFECT)
+	if not c:IsLocation(LOCATION_DECK) then return end
 	Duel.ShuffleDeck(tp)
 	c:ReverseInDeck()
 	local e1=Effect.CreateEffect(c)
@@ -41,7 +42,7 @@ function c63571750.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c63571750.thop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and Duel.SendtoGrave(c,REASON_EFFECT)~=0 then
+	if c:IsRelateToEffect(e) and Duel.SendtoGrave(c,REASON_EFFECT)~=0 and c:IsLocation(LOCATION_GRAVE) then
 		local tc=Duel.GetFirstTarget()
 		if tc and tc:IsRelateToEffect(e) then
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)


### PR DESCRIPTION
Ｑ：《エクスチェンジ》によって、元々の持ち主は自分(Ａ)である《王家の財宝》が相手(Ｂ)の手札に渡りました。
　　相手(Ｂ)がそれをセット・発動した場合どのような処理になりますか？
Ａ：《王家の財宝》は相手(Ｂ)のデッキに表向き状態で混ざります。
　　相手(Ｂ)がその《王家の財宝》をドローした場合、《王家の財宝》は自分(Ａ)の墓地に送られますが、相手(Ｂ)が相手(Ｂ)の墓地のカードを１枚相手(Ｂ)の手札に加えます。

Ｑ：《マクロコスモス》が存在する時に表向きのこのカードをドローし、このカードが墓地へ送られる代わりに除外された場合、手札に加える効果は適用されますか？
Ａ：いいえ、適用されません。