### PR TITLE
fix 驚楽園の大使 ＜Bufo＞ and 驚楽園の案内人 ＜Comica＞

### DIFF
--- a/c30829071.lua
+++ b/c30829071.lua
@@ -1,4 +1,4 @@
---驚楽園の大使 ＜Ｂｕｆｏ＞
+--驚楽園の大使 ＜Bufo＞
 function c30829071.initial_effect(c)
 	--equip
 	local e1=Effect.CreateEffect(c)
@@ -43,7 +43,7 @@ function c30829071.eqop1(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local tc=g:GetFirst()
 	if tc==ec then tc=g:GetNext() end
-	if ec:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if ec:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
 		Duel.Equip(tp,ec,tc)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -60,37 +60,35 @@ function c30829071.eqlimit(e,c)
 end
 function c30829071.eqfilter1(c,tp)
 	return c:IsSetCard(0x15c) and c:IsType(TYPE_TRAP) and c:IsFaceup() and c:GetEquipTarget()
-		and Duel.IsExistingTarget(c30829071.eqfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,c:GetEquipTarget(),tp)
+		and Duel.IsExistingMatchingCard(c30829071.eqfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,c:GetEquipTarget(),tp)
 end
 function c30829071.eqfilter2(c,tp)
 	return c:IsFaceup() and (c:IsSetCard(0x15b) or not c:IsControler(tp))
 end
 function c30829071.eqtg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return false end
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsControler(tp) and c30829071.eqfilter1(chkc,tp) end
 	if chk==0 then return Duel.IsExistingTarget(c30829071.eqfilter1,tp,LOCATION_SZONE,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local g1=Duel.SelectTarget(tp,c30829071.eqfilter1,tp,LOCATION_SZONE,0,1,1,nil,tp)
-	local tc=g1:GetFirst()
-	e:SetLabelObject(tc)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g2=Duel.SelectTarget(tp,c30829071.eqfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,tc:GetEquipTarget(),tp)
+	local g=Duel.SelectTarget(tp,c30829071.eqfilter1,tp,LOCATION_SZONE,0,1,1,nil,tp)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
 end
 function c30829071.eqop2(e,tp,eg,ep,ev,re,r,rp)
-	local ec=e:GetLabelObject()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local tc=g:GetFirst()
-	if tc==ec then tc=g:GetNext() end
-	if ec:IsFaceup() and ec:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
-		Duel.Equip(tp,ec,tc)
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT+EFFECT_FLAG_OWNER_RELATE)
-		e1:SetCode(EFFECT_EQUIP_LIMIT)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-		e1:SetValue(c30829071.eqlimit2)
-		ec:RegisterEffect(e1)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+		local g=Duel.SelectMatchingCard(tp,c30829071.eqfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,tc:GetEquipTarget(),tp)
+		local ec=g:GetFirst()
+		if ec then
+			Duel.HintSelection(g)
+			Duel.Equip(tp,tc,ec)
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e1:SetCode(EFFECT_EQUIP_LIMIT)
+			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+			e1:SetValue(c30829071.eqlimit)
+			e1:SetLabelObject(ec)
+			tc:RegisterEffect(e1)
+		end
 	end
-end
-function c30829071.eqlimit2(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
 end

--- a/c67314110.lua
+++ b/c67314110.lua
@@ -35,37 +35,38 @@ function c67314110.setop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c67314110.eqfilter1(c,tp)
 	return c:IsSetCard(0x15c) and c:IsType(TYPE_TRAP) and c:IsFaceup() and c:GetEquipTarget()
-		and Duel.IsExistingTarget(c67314110.eqfilter2,0,LOCATION_MZONE,LOCATION_MZONE,1,c:GetEquipTarget(),tp)
+		and Duel.IsExistingMatchingCard(c67314110.eqfilter2,0,LOCATION_MZONE,LOCATION_MZONE,1,c:GetEquipTarget(),tp)
 end
 function c67314110.eqfilter2(c,tp)
 	return c:IsFaceup() and (c:IsSetCard(0x15b) or not c:IsControler(tp))
 end
 function c67314110.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return false end
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsControler(tp) and c67314110.eqfilter1(chkc,tp) end
 	if chk==0 then return Duel.IsExistingTarget(c67314110.eqfilter1,tp,LOCATION_SZONE,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local g1=Duel.SelectTarget(tp,c67314110.eqfilter1,tp,LOCATION_SZONE,0,1,1,nil,tp)
-	local tc=g1:GetFirst()
-	e:SetLabelObject(tc)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g2=Duel.SelectTarget(tp,c67314110.eqfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,tc:GetEquipTarget(),tp)
+	local g=Duel.SelectTarget(tp,c67314110.eqfilter1,tp,LOCATION_SZONE,0,1,1,nil,tp)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
 end
 function c67314110.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local ec=e:GetLabelObject()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local tc=g:GetFirst()
-	if tc==ec then tc=g:GetNext() end
-	if ec:IsFaceup() and ec:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
-		Duel.Equip(tp,ec,tc)
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT+EFFECT_FLAG_OWNER_RELATE)
-		e1:SetCode(EFFECT_EQUIP_LIMIT)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-		e1:SetValue(c67314110.eqlimit)
-		ec:RegisterEffect(e1)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+		local g=Duel.SelectMatchingCard(tp,c67314110.eqfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,tc:GetEquipTarget(),tp)
+		local ec=g:GetFirst()
+		if ec then
+			Duel.HintSelection(g)
+			Duel.Equip(tp,tc,ec)
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e1:SetCode(EFFECT_EQUIP_LIMIT)
+			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+			e1:SetValue(c67314110.eqlimit)
+			e1:SetLabelObject(ec)
+			tc:RegisterEffect(e1)
+		end
 	end
 end
 function c67314110.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return c==e:GetLabelObject()
 end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23196&keyword=&tag=-1

Question
「驚楽園の大使 ＜Bufo＞」の『②：モンスターに装備されている自分の「アトラクション」罠カード１枚を対象として発動できる。そのカードを自分フィールドの「アメイズメント」モンスターまたは相手フィールドの表側表示モンスター１体に装備する』効果を発動しました。

その効果の処理時に、『②：このカードがモンスターゾーンに存在する限り、自分フィールドの天使族モンスターは相手の効果の対象にならない』効果を持つ、相手フィールドの「黎明の堕天使ルシフェル」を選んで対象のカードを装備できますか？
Answer
できます。

「驚楽園の大使 ＜Bufo＞」の『②』の効果は、モンスターを対象に取る効果ではありません。また、効果の対象にならないモンスターにも『②』の効果で「アトラクション」罠カードを装備することができます。
