### PR TITLE
fix 明鏡止水の心

### DIFF
--- a/c64801562.lua
+++ b/c64801562.lua
@@ -35,6 +35,14 @@ function c64801562.initial_effect(c)
 	e5:SetCode(EFFECT_SELF_DESTROY)
 	e5:SetCondition(c64801562.descon)
 	c:RegisterEffect(e5)
+	--selfdes in damage step
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e6:SetRange(LOCATION_SZONE)
+	e6:SetCode(EVENT_ADJUST)
+	e6:SetOperation(c64801562.descheck)
+	c:RegisterEffect(e6)
 end
 function c64801562.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
@@ -56,6 +64,16 @@ function c64801562.indval(e,re,rp)
 		or (re:IsHasType(EFFECT_TYPE_CONTINUOUS) and rc:IsHasCardTarget(tc))
 end
 function c64801562.descon(e)
-	local tc=e:GetHandler():GetEquipTarget()
-	return tc and tc:GetAttack()>=1300
+	local c=e:GetHandler()
+	local tc=c:GetEquipTarget()
+	return tc and (tc:GetAttack()>=1300 or c:GetFlagEffect(64801562)>0)
+end
+function c64801562.descheck(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	local c=e:GetHandler()
+	local tc=c:GetEquipTarget()
+	if ph>=PHASE_DAMAGE and ph<=PHASE_DAMAGE_CAL
+		and tc and tc:GetAttack()>=1300 and c:GetFlagEffect(64801562)==0 then
+		c:RegisterFlagEffect(64801562,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+	end
 end

--- a/c64801562.lua
+++ b/c64801562.lua
@@ -64,16 +64,15 @@ function c64801562.indval(e,re,rp)
 		or (re:IsHasType(EFFECT_TYPE_CONTINUOUS) and rc:IsHasCardTarget(tc))
 end
 function c64801562.descon(e)
-	local c=e:GetHandler()
-	local tc=c:GetEquipTarget()
-	return tc and (tc:GetAttack()>=1300 or c:GetFlagEffect(64801562)>0)
+	local tc=e:GetHandler():GetEquipTarget()
+	return tc and tc:GetAttack()>=1300
 end
 function c64801562.descheck(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	local c=e:GetHandler()
 	local tc=c:GetEquipTarget()
 	if ph>=PHASE_DAMAGE and ph<=PHASE_DAMAGE_CAL
-		and tc and tc:GetAttack()>=1300 and c:GetFlagEffect(64801562)==0 then
-		c:RegisterFlagEffect(64801562,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE,0,1)
+		and tc and tc:GetAttack()>=1300 then
+		Duel.Destroy(c,REASON_EFFECT)
 	end
 end

--- a/c64801562.lua
+++ b/c64801562.lua
@@ -69,10 +69,11 @@ function c64801562.descon(e)
 end
 function c64801562.descheck(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
-	local c=e:GetHandler()
-	local tc=c:GetEquipTarget()
-	if ph>=PHASE_DAMAGE and ph<=PHASE_DAMAGE_CAL
-		and tc and tc:GetAttack()>=1300 then
-		Duel.Destroy(c,REASON_EFFECT)
+	if ph>=PHASE_DAMAGE and ph<=PHASE_DAMAGE_CAL then
+		local c=e:GetHandler()
+		local tc=c:GetEquipTarget()
+		if tc and tc:GetAttack()>=1300 then
+			Duel.Destroy(c,REASON_EFFECT)
+		end
 	end
 end


### PR DESCRIPTION
> ■『装備モンスターの攻撃力が１３００以上の場合、このカードを破壊する』効果はチェーンブロックの作られない効果です。（ダメージステップでも適用されます。）
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5386

>Q.
「明鏡止水の心」を装備した「お注射天使リリー」が表側攻撃表示の「黄金狂エルドリッチ」を攻撃し、ダメージ計算時に「お注射天使リリー」の効果を発動した場合、「明鏡止水の心」はどのタイミングにて自身の効果によって破壊されますか？
「お注射天使リリー」は戦闘によって破壊されますか？
A.
ご質問の場合、「明鏡止水の心」はダメージ計算時に破壊されますので、「お注射天使リリー」は戦闘によって破壊されることになります。
