### PR TITLE
fix Lair of Darkness vs  Hex-Sealed Fusion

### DIFF
--- a/c15717011.lua
+++ b/c15717011.lua
@@ -28,6 +28,9 @@ end
 function c15717011.mfilter(c,tp)
 	return c:IsLocation(LOCATION_MZONE) and c:IsCanBeFusionMaterial() and (c:IsControler(tp) or c:IsFaceup())
 end
+function c15717011.fcheck(tp,sg,fc)
+	return Duel.CheckReleaseGroup(tp,Auxiliary.IsInGroup,#sg,nil,sg)
+end
 function c15717011.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
 	return true
@@ -39,12 +42,21 @@ function c15717011.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if e:GetLabel()~=1 then return false end
 		e:SetLabel(0)
 		local mg=Duel.GetReleaseGroup(tp):Filter(c15717011.mfilter,nil,tp)
-		return Duel.IsExistingMatchingCard(c15717011.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,c,chkf)
+		Auxiliary.FCheckAdditional=c15717011.fcheck
+		if c59160188 then c59160188.re_activated=true end
+		local res=Duel.IsExistingMatchingCard(c15717011.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,c,chkf)
+		Auxiliary.FCheckAdditional=nil
+		if c59160188 then c59160188.re_activated=false end
+		return res
 	end
 	local mg=Duel.GetReleaseGroup(tp):Filter(c15717011.mfilter,nil,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	Auxiliary.FCheckAdditional=c15717011.fcheck
+	if c59160188 then c59160188.re_activated=true end
 	local g=Duel.SelectMatchingCard(tp,c15717011.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,mg,c,chkf)
 	local mat=Duel.SelectFusionMaterial(tp,g:GetFirst(),mg,c,chkf)
+	Auxiliary.FCheckAdditional=nil
+	if c59160188 then c59160188.re_activated=false end
 	Duel.Release(mat,REASON_COST)
 	e:SetLabel(g:GetFirst():GetCode())
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)

--- a/c52101615.lua
+++ b/c52101615.lua
@@ -28,6 +28,9 @@ end
 function c52101615.mfilter(c,tp)
 	return c:IsLocation(LOCATION_MZONE) and c:IsCanBeFusionMaterial() and (c:IsControler(tp) or c:IsFaceup())
 end
+function c52101615.fcheck(tp,sg,fc)
+	return Duel.CheckReleaseGroup(tp,Auxiliary.IsInGroup,#sg,nil,sg)
+end
 function c52101615.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
 	return true
@@ -39,12 +42,21 @@ function c52101615.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if e:GetLabel()~=1 then return false end
 		e:SetLabel(0)
 		local mg=Duel.GetReleaseGroup(tp):Filter(c52101615.mfilter,nil,tp)
-		return Duel.IsExistingMatchingCard(c52101615.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,c,chkf)
+		Auxiliary.FCheckAdditional=c52101615.fcheck
+		if c59160188 then c59160188.re_activated=true end
+		local res=Duel.IsExistingMatchingCard(c52101615.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,c,chkf)
+		Auxiliary.FCheckAdditional=nil
+		if c59160188 then c59160188.re_activated=false end
+		return res
 	end
 	local mg=Duel.GetReleaseGroup(tp):Filter(c52101615.mfilter,nil,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	Auxiliary.FCheckAdditional=c52101615.fcheck
+	if c59160188 then c59160188.re_activated=true end
 	local g=Duel.SelectMatchingCard(tp,c52101615.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,mg,c,chkf)
 	local mat=Duel.SelectFusionMaterial(tp,g:GetFirst(),mg,c,chkf)
+	Auxiliary.FCheckAdditional=nil
+	if c59160188 then c59160188.re_activated=false end
 	Duel.Release(mat,REASON_COST)
 	e:SetLabel(g:GetFirst():GetCode())
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)

--- a/c59160188.lua
+++ b/c59160188.lua
@@ -43,7 +43,7 @@ function c59160188.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c59160188.relval(e,re,r,rp)
-	return re:IsActivated() and bit.band(r,REASON_COST)~=0
+	return (c59160188.re_activated or re:IsActivated()) and bit.band(r,REASON_COST)~=0
 end
 function c59160188.regfilter(c)
 	return c:GetPreviousTypeOnField()&TYPE_MONSTER>0

--- a/c88696724.lua
+++ b/c88696724.lua
@@ -28,6 +28,9 @@ end
 function c88696724.mfilter(c,tp)
 	return c:IsLocation(LOCATION_MZONE) and c:IsCanBeFusionMaterial() and (c:IsControler(tp) or c:IsFaceup())
 end
+function c88696724.fcheck(tp,sg,fc)
+	return Duel.CheckReleaseGroup(tp,Auxiliary.IsInGroup,#sg,nil,sg)
+end
 function c88696724.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
 	return true
@@ -39,12 +42,21 @@ function c88696724.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if e:GetLabel()~=1 then return false end
 		e:SetLabel(0)
 		local mg=Duel.GetReleaseGroup(tp):Filter(c88696724.mfilter,nil,tp)
-		return Duel.IsExistingMatchingCard(c88696724.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,c,chkf)
+		Auxiliary.FCheckAdditional=c88696724.fcheck
+		if c59160188 then c59160188.re_activated=true end
+		local res=Duel.IsExistingMatchingCard(c88696724.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,c,chkf)
+		Auxiliary.FCheckAdditional=nil
+		if c59160188 then c59160188.re_activated=false end
+		return res
 	end
 	local mg=Duel.GetReleaseGroup(tp):Filter(c88696724.mfilter,nil,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	Auxiliary.FCheckAdditional=c88696724.fcheck
+	if c59160188 then c59160188.re_activated=true end
 	local g=Duel.SelectMatchingCard(tp,c88696724.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,mg,c,chkf)
 	local mat=Duel.SelectFusionMaterial(tp,g:GetFirst(),mg,c,chkf)
+	Auxiliary.FCheckAdditional=nil
+	if c59160188 then c59160188.re_activated=false end
 	Duel.Release(mat,REASON_COST)
 	e:SetLabel(g:GetFirst():GetCode())
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)


### PR DESCRIPTION
Fix: The Hex-Sealed Fusion monsters can use more than 1 monsters from opponent field to fusion.