### PR TITLE
fix 時の魔導士

### DIFF
--- a/c26273196.lua
+++ b/c26273196.lua
@@ -14,10 +14,24 @@ function c26273196.initial_effect(c)
 	e1:SetTarget(c26273196.destg)
 	e1:SetOperation(c26273196.desop)
 	c:RegisterEffect(e1)
+	--fusion check
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetCondition(c26273196.matcon)
+	e2:SetOperation(c26273196.matop)
+	c:RegisterEffect(e2)
 end
 c26273196.toss_coin=true
-function c26273196.descon(e,tp,eg,ep,ev,re,r,rp)
+function c26273196.matcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_FUSION)
+end
+function c26273196.matop(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(26273196,RESET_EVENT+0x1ec0000,0,1)
+end
+function c26273196.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(26273196)>0
 end
 function c26273196.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23046&keyword=&tag=-1&request_locale=ja

Question
融合召喚されている「スターヴ・ヴェノム・フュージョン・ドラゴン」が『②』のモンスター効果を発動し、「時の魔導士」のカード名とモンスター効果を得ました。

その場合、その「スターヴ・ヴェノム・フュージョン・ドラゴン」が得ている「時の魔導士」のモンスター効果は発動する事ができますか？
Answer
融合召喚された「スターヴ・ヴェノム・フュージョン・ドラゴン」が自身の『②』のモンスター効果によって、「時の魔導士」のカード名とモンスター効果を得た場合でも、その「スターヴ・ヴェノム・フュージョン・ドラゴン」は得ている「時の魔導士」のモンスター効果を発動する事はできません。