### PR TITLE
fix 電脳堺

### DIFF
--- a/c12571621.lua
+++ b/c12571621.lua
@@ -32,7 +32,7 @@ end
 function c12571621.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c12571621.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()

--- a/c49088914.lua
+++ b/c49088914.lua
@@ -35,7 +35,7 @@ end
 function c49088914.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c49088914.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()

--- a/c49966326.lua
+++ b/c49966326.lua
@@ -35,7 +35,7 @@ end
 function c49966326.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c49966326.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()

--- a/c86483512.lua
+++ b/c86483512.lua
@@ -35,7 +35,7 @@ end
 function c86483512.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c,tc=e:GetHandler(),Duel.GetFirstTarget()
 	local type1=tc:GetType()&0x7
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,c86483512.tgfilter,tp,LOCATION_DECK,0,1,1,nil,type1)
 		local tgc=g:GetFirst()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23201&keyword=&tag=-1

Question
自分のモンスターゾーンの表側表示の「電脳堺姫－娘々」を対象として、「電脳堺媛－瑞々」の『①』の『このカードが手札に存在する場合、自分フィールドの「電脳堺」カード１枚を対象として発動できる。そのカードとは種類（モンスター・魔法・罠）が異なる「電脳堺」カード１枚をデッキから墓地へ送り、このカードを特殊召喚する。その後、対象のカード及び墓地へ送ったカードとは種類が異なる「電脳堺媛－瑞々」以外の「電脳堺」カード１枚をデッキから手札に加える事ができる』効果を発動しました。

その発動にチェーンして「月の書」が発動し、対象となった「電脳堺姫－娘々」が裏側守備表示になった場合、「電脳堺媛－瑞々」の効果の処理は適用されますか？
Answer
「電脳堺媛－瑞々」の効果の対象の「電脳堺姫－娘々」が、その処理時に裏側守備表示になっていた場合でも、対象のカードの種類をモンスターとして扱い、「電脳堺媛－瑞々」の効果処理が行われます。

この場合、『そのカードとは種類（モンスター・魔法・罠）が異なる「電脳堺」カード１枚をデッキから墓地へ送り』の処理によって「電脳堺」魔法・罠カード１枚をデッキから墓地へ送り、「電脳堺媛－瑞々」を手札から特殊召喚することになります。

さらに、『対象のカード及び墓地へ送ったカードとは種類が異なる「電脳堺媛－瑞々」以外の「電脳堺」カード１枚をデッキから手札に加える事ができる』の処理も行うことができます。