### PR TITLE
fix 熾天龍 ジャッジメント

### DIFF
--- a/c41659072.lua
+++ b/c41659072.lua
@@ -36,7 +36,13 @@ function c41659072.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c41659072.syncheck(g)
-	return g:GetClassCount(Card.GetAttribute)==1
+	local sg=g:Clone()
+	local attr=0x7f
+	for c in aux.Next(sg) do
+		attr=attr&c:GetAttribute()
+		if attr==0 then break end
+	end
+	return attr~=0
 end
 function c41659072.sumlimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_SYNCHRO)~=SUMMON_TYPE_SYNCHRO or not se


### PR DESCRIPTION
If the monsters have same attribute, they are the same attribute, even though some of them have other attributes.

Example: 

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20237&keyword=&tag=-1

Question
「召喚獣エリュシオン」の『②：１ターンに１度、自分のフィールド・墓地の「召喚獣」モンスター１体を対象として発動できる。そのモンスター及びそのモンスターと同じ属性を持つ相手フィールドのモンスターを全て除外する。この効果は相手ターンでも発動できる』モンスター効果によって、自分のモンスターゾーンに表側表示で存在する「召喚獣エリュシオン」自身を選択した場合、処理はどうなりますか？

また、「召喚獣エリュシオン」の『②：１ターンに１度、自分のフィールド・墓地の「召喚獣」モンスター１体を対象として発動できる。そのモンスター及びそのモンスターと同じ属性を持つ相手フィールドのモンスターを全て除外する。この効果は相手ターンでも発動できる』モンスター効果によって、自分の墓地に存在する他の「召喚獣エリュシオン」を選択した場合、処理はどうなりますか？
Answer
「召喚獣エリュシオン」のモンスター効果の対象として、自分のモンスターゾーンに表側表示で存在する「召喚獣エリュシオン」を選択した場合、その「召喚獣エリュシオン」の『①：このカードがモンスターゾーンに存在する限り、このカードの属性は「闇」「地」「水」「炎」「風」としても扱う』モンスター効果も適用されていますので、対象となった「召喚獣エリュシオン」と、相手のモンスターゾーンに表側表示で存在する光・闇・地・水・炎・風属性のモンスターを全て除外する事になります。

また、「召喚獣エリュシオン」のモンスター効果の対象として、自分の墓地に存在する他の「召喚獣エリュシオン」を選択した場合、その「召喚獣エリュシオン」の『①：このカードがモンスターゾーンに存在する限り、このカードの属性は「闇」「地」「水」「炎」「風」としても扱う』モンスター効果は適用されていませんので、対象となった「召喚獣エリュシオン」と、相手のモンスターゾーンに表側表示で存在する光属性のモンスターを全て除外する事になります。