### PR TITLE
fix 死霊王 ドーハスーラ

### DIFF
--- a/c39185163.lua
+++ b/c39185163.lua
@@ -32,7 +32,7 @@ function c39185163.disrmcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c39185163.disrmcon(e,tp,eg,ep,ev,re,r,rp)
 	local race,code1,code2=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_RACE,CHAININFO_TRIGGERING_CODE,CHAININFO_TRIGGERING_CODE2)
-	return race&RACE_ZOMBIE>0 and code1~=39185163 and code2~=39185163
+	return re:IsActiveType(TYPE_MONSTER) and race&RACE_ZOMBIE>0 and code1~=39185163 and code2~=39185163
 end
 function c39185163.disrmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local b1=Duel.IsChainDisablable(ev) and Duel.GetFlagEffect(tp,39185163)==0


### PR DESCRIPTION
fix: can react to the effect that is activated by a spell card whose original type is a Zombie monster.