### PR TITLE
マドルチェ・シャトー must be interact with necrovalley

### DIFF
--- a/c14001430.lua
+++ b/c14001430.lua
@@ -39,7 +39,7 @@ function c14001430.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c14001430.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
-	local g=Duel.GetMatchingGroup(c14001430.tdfilter,tp,LOCATION_GRAVE,0,nil)
+	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c14001430.tdfilter),tp,LOCATION_GRAVE,0,nil)
 	if g:GetCount()>0 then
 		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 	end


### PR DESCRIPTION
While the effect of my opponent's Necrovalley is applying, if I activate Madolche Chateau, which effects will be negated?
A:
The effect of Madolche Chateau that returns any "Madolche" monsters in your Graveyard to the Deck when it is first activated is an effect that is applied to a card(s) in the Graveyard, and that effect will be negated by Necrovalley, but Madolche Chateau will remain on the field and its effect that increases the ATK and DEF of all "Madolche" monsters on the field by 500 applies normally. Note that since the effects of "Madolche" monsters such as Madolche Mewfeuille that return them to the Deck when they are destroyed by the opponent's cards are effects that are applied to a card(s) in the Graveyard, and are negated by Necrovalley, the effect of Madolche Chateau that adds them to your hand instead cannot be applied as a result.