### PR TITLE
fix Necrovalley and Ghost Belle

### DIFF
--- a/c12215894.lua
+++ b/c12215894.lua
@@ -84,6 +84,7 @@ end
 function c12215894.operation2(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE+LOCATION_HAND,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	if g:GetCount()>0 then
 		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 	end

--- a/c12215894.lua
+++ b/c12215894.lua
@@ -79,7 +79,7 @@ end
 function c12215894.target2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToDeck,tp,0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,1,nil) end
 	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE)
 end
 function c12215894.operation2(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end

--- a/c14001430.lua
+++ b/c14001430.lua
@@ -40,6 +40,7 @@ end
 function c14001430.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c14001430.tdfilter,tp,LOCATION_GRAVE,0,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	if g:GetCount()>0 then
 		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 	end

--- a/c17469113.lua
+++ b/c17469113.lua
@@ -70,7 +70,7 @@ end
 function c17469113.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local g=Duel.GetMatchingGroup(c17469113.tdfilter,tp,LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED,LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED)
 	Duel.SetChainLimit(aux.FALSE)
 end
 function c17469113.tdop(e,tp,eg,ep,ev,re,r,rp)

--- a/c17469113.lua
+++ b/c17469113.lua
@@ -75,5 +75,6 @@ function c17469113.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c17469113.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c17469113.tdfilter,tp,LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED,LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED,aux.ExceptThisCard(e))
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 end

--- a/c19959563.lua
+++ b/c19959563.lua
@@ -59,6 +59,7 @@ function c19959563.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c19959563.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c19959563.filter,tp,LOCATION_GRAVE+LOCATION_REMOVED,LOCATION_GRAVE+LOCATION_REMOVED,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 end
 function c19959563.ddcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c19959563.lua
+++ b/c19959563.lua
@@ -55,7 +55,7 @@ end
 function c19959563.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c19959563.filter,tp,LOCATION_GRAVE+LOCATION_REMOVED,LOCATION_GRAVE+LOCATION_REMOVED,1,e:GetHandler()) end
 	local g=Duel.GetMatchingGroup(c19959563.filter,tp,LOCATION_GRAVE+LOCATION_REMOVED,LOCATION_GRAVE+LOCATION_REMOVED,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,LOCATION_GRAVE+LOCATION_REMOVED)
 end
 function c19959563.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c19959563.filter,tp,LOCATION_GRAVE+LOCATION_REMOVED,LOCATION_GRAVE+LOCATION_REMOVED,nil)

--- a/c2992036.lua
+++ b/c2992036.lua
@@ -3,7 +3,7 @@ function c2992036.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(2992036,0))
-	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON+CATEGORY_GRAVE_ACTION+CATEGORY_GRAVE_SPSUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -44,11 +44,10 @@ function c2992036.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	local tg=g:SelectSubGroup(tp,c2992036.fselect,false,3,3,e,tp)
 	Duel.SetTargetCard(tg)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,tg,0,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,0,0,0)
 end
 function c2992036.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if aux.NecroValleyNegateCheck(tg) then return end
 	if tg:GetCount()>0 then
 		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 		local b1=tg:IsExists(Card.IsAbleToHand,1,nil)

--- a/c33611061.lua
+++ b/c33611061.lua
@@ -27,6 +27,7 @@ function c33611061.thfilter(c)
 end
 function c33611061.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetMatchingGroup(c33611061.filter,tp,LOCATION_GRAVE,0,nil)
+	if aux.NecroValleyNegateCheck(tg) then return end
 	if tg:GetCount()>0 then
 		Duel.SendtoDeck(tg,nil,2,REASON_EFFECT)
 		local hg=Duel.GetFieldGroup(tp,LOCATION_HAND,0)

--- a/c3429238.lua
+++ b/c3429238.lua
@@ -90,7 +90,7 @@ function c3429238.filter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
 function c3429238.spop(e,tp,eg,ep,ev,re,r,rp)
-	local tg=Duel.GetMatchingGroup(c3429238.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	local tg=Duel.GetMatchingGroup(c3429238.filter,tp,LOCATION_GRAVE,0,nil)
 	if aux.NecroValleyNegateCheck(tg) then return end
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end

--- a/c3429238.lua
+++ b/c3429238.lua
@@ -90,14 +90,14 @@ function c3429238.filter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
 function c3429238.spop(e,tp,eg,ep,ev,re,r,rp)
-	local ct=Duel.GetMatchingGroupCount(c3429238.filter,tp,LOCATION_GRAVE,0,nil)
-	if ct>0 and Duel.IsPlayerAffectedByEffect(tp,EFFECT_NECRO_VALLEY) and Duel.IsChainDisablable(0) then return end
+	local tg=Duel.GetMatchingGroup(c3429238.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	if aux.NecroValleyNegateCheck(tg) then return end
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-		local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c3429238.filter),tp,LOCATION_GRAVE,0,1,1,nil)
+		local g=tg:Select(tp,1,1,nil)
 		if g:GetCount()>0 then
 			Duel.SendtoHand(g,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,g)

--- a/c3429238.lua
+++ b/c3429238.lua
@@ -26,7 +26,7 @@ function c3429238.initial_effect(c)
 	--spsummon
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(3429238,2))
-	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_GRAVE_ACTION)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e3:SetCode(EVENT_PHASE+PHASE_STANDBY)
 	e3:SetRange(LOCATION_REMOVED)

--- a/c36039163.lua
+++ b/c36039163.lua
@@ -21,6 +21,7 @@ function c36039163.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c36039163.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,LOCATION_GRAVE,0)
+	if aux.NecroValleyNegateCheck(g) then return end
 	if Duel.SendtoDeck(g,nil,0,REASON_EFFECT)~=0 then
 		if g:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then Duel.ShuffleDeck(tp) end
 	end

--- a/c37061511.lua
+++ b/c37061511.lua
@@ -67,6 +67,7 @@ end
 function c37061511.teop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local g=Duel.GetMatchingGroup(c37061511.tefilter,tp,LOCATION_GRAVE,0,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	if g:GetCount()>0 and Duel.SendtoDeck(g,nil,2,REASON_EFFECT)~=0
 		and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())

--- a/c3828844.lua
+++ b/c3828844.lua
@@ -72,10 +72,9 @@ function c3828844.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c3828844.spfilter),tp,LOCATION_EXTRA+LOCATION_GRAVE,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if tc and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
-		if not c:IsRelateToEffect(e) or not c:IsCanOverlay() then return end
+		if not c:IsRelateToEffect(e) or not c:IsCanOverlay() or not aux.NecroValleyFilter()(c) then return end
 		if c:IsLocation(LOCATION_HAND+LOCATION_DECK) or (not c:IsLocation(LOCATION_GRAVE) and c:IsFacedown()) then return end
-		if not (c:IsLocation(LOCATION_GRAVE) and c:IsHasEffect(EFFECT_NECRO_VALLEY) and Duel.IsChainDisablable(0))
-			and Duel.SelectYesNo(tp,aux.Stringid(3828844,2)) then
+		if Duel.SelectYesNo(tp,aux.Stringid(3828844,2)) then
 			Duel.BreakEffect()
 			if not tc:IsImmuneToEffect(e) then
 				Duel.Overlay(tc,Group.FromCards(c))

--- a/c4017398.lua
+++ b/c4017398.lua
@@ -39,8 +39,8 @@ end
 function c4017398.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
+		if aux.NecroValleyNegateCheck(tc) then return end
 		if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
-			and not tc:IsHasEffect(EFFECT_NECRO_VALLEY)
 			and (not tc:IsAbleToHand() or Duel.SelectOption(tp,1190,1152)==1) then
 			Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 		else

--- a/c4017398.lua
+++ b/c4017398.lua
@@ -2,7 +2,7 @@
 function c4017398.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND+CATEGORY_GRAVE_ACTION+CATEGORY_GRAVE_SPSUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -33,8 +33,6 @@ function c4017398.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingTarget(c4017398.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	local g=Duel.SelectTarget(tp,c4017398.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,0,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,0,0,0)
 end
 function c4017398.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c46271408.lua
+++ b/c46271408.lua
@@ -2,7 +2,7 @@
 function c46271408.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON+CATEGORY_GRAVE_ACTION+CATEGORY_GRAVE_SPSUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -27,12 +27,11 @@ function c46271408.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingTarget(c46271408.thfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,spchk) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectTarget(tp,c46271408.thfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,spchk)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,0,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,0,0,0)
 end
 function c46271408.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
+		if aux.NecroValleyNegateCheck(tc) then return end
 		if Duel.GetMatchingGroupCount(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_SPELL)>=3
 			and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 			and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c47355498.lua
+++ b/c47355498.lua
@@ -85,14 +85,6 @@ function c47355498.discheck(ev,category,re,im0,im1)
 	end
 	return false
 end
-function c47355498.discheck2(ev,category,re)
-	local ex,tg,ct,p,v=Duel.GetOperationInfo(ev,category)
-	if not ex then return false end
-	if v==LOCATION_GRAVE and ct>0 and tg then
-		return tg:IsExists(c47355498.disfilter,1,nil,re)
-	end
-	return false
-end
 function c47355498.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=re:GetHandler()
 	if not Duel.IsChainDisablable(ev) or tc:IsHasEffect(EFFECT_NECRO_VALLEY_IM) then return end
@@ -104,6 +96,6 @@ function c47355498.disop(e,tp,eg,ep,ev,re,r,rp)
 	if not res and c47355498.discheck(ev,CATEGORY_TODECK,re,im0,im1) then res=true end
 	if not res and c47355498.discheck(ev,CATEGORY_TOEXTRA,re,im0,im1) then res=true end
 	if not res and c47355498.discheck(ev,CATEGORY_LEAVE_GRAVE,re,im0,im1) then res=true end
-	if not res and c47355498.discheck2(ev,CATEGORY_REMOVE,re) then res=true end
+	if not res and c47355498.discheck(ev,CATEGORY_REMOVE,re,im0,im1) then res=true end
 	if res then Duel.NegateEffect(ev) end
 end

--- a/c51227866.lua
+++ b/c51227866.lua
@@ -2,7 +2,7 @@
 function c51227866.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetCategory(CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON+CATEGORY_GRAVE_ACTION+CATEGORY_GRAVE_SPSUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)
@@ -27,12 +27,11 @@ function c51227866.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingTarget(c51227866.filter,tp,0,LOCATION_GRAVE,1,nil,e,tp,spchk) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectTarget(tp,c51227866.filter,tp,0,LOCATION_GRAVE,1,1,nil,e,tp,spchk)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,0,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,0,1-tp,LOCATION_GRAVE)
 end
 function c51227866.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
+		if aux.NecroValleyNegateCheck(tc) then return end
 		if Duel.GetMatchingGroupCount(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_SPELL)>=3
 			and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
 			and (not tc:IsAbleToRemove() or Duel.SelectYesNo(tp,aux.Stringid(51227866,0))) then

--- a/c64681263.lua
+++ b/c64681263.lua
@@ -12,7 +12,7 @@ end
 function c64681263.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_HAND+LOCATION_GRAVE,0)>0 end
 	local g=Duel.GetFieldGroup(tp,LOCATION_HAND+LOCATION_GRAVE,0)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,LOCATION_HAND+LOCATION_GRAVE)
 end
 function c64681263.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,LOCATION_HAND+LOCATION_GRAVE,0)

--- a/c64681263.lua
+++ b/c64681263.lua
@@ -16,5 +16,6 @@ function c64681263.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c64681263.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,LOCATION_HAND+LOCATION_GRAVE,0)
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 end

--- a/c68223137.lua
+++ b/c68223137.lua
@@ -2,7 +2,7 @@
 function c68223137.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_TOEXTRA+CATEGORY_SPECIAL_SUMMON)
+	e1:SetCategory(CATEGORY_TOEXTRA+CATEGORY_SPECIAL_SUMMON+CATEGORY_GRAVE_ACTION+CATEGORY_GRAVE_SPSUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -20,12 +20,11 @@ function c68223137.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingTarget(c68223137.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(68223137,0))
 	local g=Duel.SelectTarget(tp,c68223137.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,e,tp)
-	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,g,0,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,0,0,0)
 end
 function c68223137.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) then return end
+	if aux.NecroValleyNegateCheck(tc) then return end
 	local p=tc:GetControler()
 	local ft=Duel.GetLocationCount(p,LOCATION_MZONE,tp)
 	if tc:IsAbleToExtra() and (not tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,p) or ft<=0 or Duel.SelectOption(tp,aux.Stringid(68223137,1),1152)==0) then

--- a/c78706415.lua
+++ b/c78706415.lua
@@ -16,6 +16,7 @@ end
 function c78706415.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetFieldGroup(tp,0x1e,0x1e)
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 	local tg=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_DECK)
 	if tg:IsExists(Card.IsControler,1,nil,tp) then Duel.ShuffleDeck(tp) end

--- a/c78706415.lua
+++ b/c78706415.lua
@@ -11,7 +11,7 @@ end
 function c78706415.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local g=Duel.GetFieldGroup(tp,0x1e,0x1e)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0x1e)
 end
 function c78706415.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c82821760.lua
+++ b/c82821760.lua
@@ -90,5 +90,6 @@ function c82821760.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c82821760.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c82821760.tdfilter,tp,LOCATION_GRAVE,0,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 end

--- a/c86346643.lua
+++ b/c86346643.lua
@@ -97,5 +97,6 @@ function c86346643.tdtg3(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c86346643.tdop3(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_GRAVE,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 end

--- a/c87571563.lua
+++ b/c87571563.lua
@@ -26,13 +26,11 @@ function c87571563.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end
 	if Duel.IsExistingTarget(c87571563.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
 		and Duel.SelectYesNo(tp,aux.Stringid(87571563,1)) then
-		e:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND)
+		e:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND+CATEGORY_GRAVE_ACTION+CATEGORY_GRAVE_SPSUMMON)
 		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
 		e:SetOperation(c87571563.activate)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 		local g=Duel.SelectTarget(tp,c87571563.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
-		Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,0,0,0)
-		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,0,0,0)
 	else
 		e:SetCategory(0)
 		e:SetProperty(0)

--- a/c87571563.lua
+++ b/c87571563.lua
@@ -41,9 +41,9 @@ function c87571563.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c87571563.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) then
+		if aux.NecroValleyNegateCheck(tc) then return end
 		if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
-			and not tc:IsHasEffect(EFFECT_NECRO_VALLEY)
 			and (not tc:IsAbleToHand() or Duel.SelectOption(tp,1190,1152)==1) then
 			Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 		else

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -91,7 +91,7 @@ function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if not Duel.NegateActivation(ev) then return end
 	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK)
-		and not rc:IsHasEffect(EFFECT_NECRO_VALLEY) then
+		and aux.NecroValleyFilter()(rc) then
 		if rc:IsType(TYPE_MONSTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 			and (not rc:IsLocation(LOCATION_EXTRA) or Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)
 			and rc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)

--- a/c91588074.lua
+++ b/c91588074.lua
@@ -62,5 +62,6 @@ function c91588074.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c91588074.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c91588074.tdfilter,tp,0x5e,0x5e,aux.ExceptThisCard(e))
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 end

--- a/c91588074.lua
+++ b/c91588074.lua
@@ -57,7 +57,7 @@ end
 function c91588074.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local g=Duel.GetMatchingGroup(c91588074.tdfilter,tp,0x5e,0x5e,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0x5e)
 	Duel.SetChainLimit(aux.FALSE)
 end
 function c91588074.tdop(e,tp,eg,ep,ev,re,r,rp)

--- a/c92435533.lua
+++ b/c92435533.lua
@@ -83,6 +83,7 @@ function c92435533.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92435533.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_GRAVE,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	if g:GetCount()>0 then
 		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 	end

--- a/c98076754.lua
+++ b/c98076754.lua
@@ -71,7 +71,7 @@ end
 function c98076754.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToDeck,tp,0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,1,nil) end
 	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE)
 end
 function c98076754.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(Card.IsAbleToDeck),tp,0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,nil)

--- a/c98076754.lua
+++ b/c98076754.lua
@@ -75,5 +75,6 @@ function c98076754.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c98076754.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(Card.IsAbleToDeck),tp,0,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,nil)
+	if aux.NecroValleyNegateCheck(g) then return end
 	Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
 end

--- a/utility.lua
+++ b/utility.lua
@@ -2266,6 +2266,18 @@ function Auxiliary.NecroValleyFilter(f)
 				return (not f or f(target,...)) and not (target:IsHasEffect(EFFECT_NECRO_VALLEY) and Duel.IsChainDisablable(0))
 			end
 end
+--Necrovalley test for effect with not certain target or not certain action
+function Auxiliary.NecroValleyNegateCheck(v)
+	if not Duel.IsChainDisablable(0) then return false end
+	local g=Group.CreateGroup()
+	if Auxiliary.GetValueType(v)=="Card" then g:AddCard(v) end
+	if Auxiliary.GetValueType(v)=="Group" then g:Merge(v) end
+	if g:IsExists(Card.IsHasEffect,1,nil,EFFECT_NECRO_VALLEY) then
+		Duel.NegateEffect(0)
+		return true
+	end
+	return false
+end
 --shortcut for self-banish costs
 function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end


### PR DESCRIPTION
fix https://github.com/Fluorohydride/ygopro-scripts/pull/1559

For effects that target cards in grave with definite action (eg. _Monster Reborn_):
- `SetOperationInfo` with the target, without location
- Necrovalley negate them in Necrovalley's script, by checking `tg:IsExists`
- Ghost Belle negate them by checking `tg:IsExists`

For effects that target cards in grave but with not definite action (eg. _World Legacy Guardragon_):
- SetOperationInfo without the part of grave
- `SetCategory` with `CATEGORY_GRAVE_ACTION` or `CATEGORY_GRAVE_SPSUMMON`
- Use `aux.NecroValleyNegateCheck(tg)` in the script of the effect
- Ghost Belle negate them by checking `IsHasCategory(CATEGORY_GRAVE_ACTION)`

For effects that don't target but only affect 1 card in grave and won't resolve without card in grave (eg. _Salamangreat Sunlight Wolf_):
- `SetOperationInfo` with `nil` as target, with `count`>0 and `param`==`LOCATION_GRAVE` exactly
- Necrovalley negate them in Necrovalley's script, by checking `v==LOCATION_GRAVE and ct>0`
- Ghost Belle negate them by checking `dv&LOCATION_GRAVE==LOCATION_GRAVE`

For effects that don't target but affect cards in grave and won't resolve without card in grave (eg. _Lazion, the Timelord_):
- `SetOperationInfo` with affected cards as target, with `count`>0
- Use `aux.NecroValleyNegateCheck(g)` in the script of the effect
- Ghost Belle negate them by checking `tg:IsExists`

For effects that don't target but affect cards in grave and may resolve without card in grave (eg. _Preparation of Rites_):
- `SetOperationInfo` without the part of grave
- `SetCategory` with `CATEGORY_GRAVE_ACTION` or `CATEGORY_GRAVE_SPSUMMON`
- Use `aux.NecroValleyFilter` in the script of the effect
- Ghost Belle negate them by checking `IsHasCategory(CATEGORY_GRAVE_ACTION)`

For effects that don't target but may affect cards in grave and may resolve without card in grave (eg. _Miracle Fusion_):
- `SetOperationInfo` with `nil` as target, with `count`>0 and `param` including `LOCATION_GRAVE`
- `SetCategory` don't need `CATEGORY_GRAVE_ACTION` or `CATEGORY_GRAVE_SPSUMMON`
- Use `aux.NecroValleyFilter` in the script of the effect
- Ghost Belle negate them by checking `dv&LOCATION_GRAVE==LOCATION_GRAVE`

For effects that don't target but must affect cards both in grave and other place, but not including banish, and may resolve without card in grave (eg. _Localized Tornado_):
- `SetOperationInfo` with affected cards as target, with `count`>0 and `param` including `LOCATION_GRAVE`
- `SetCategory` don't need `CATEGORY_GRAVE_ACTION` or `CATEGORY_GRAVE_SPSUMMON`
- Use `aux.NecroValleyNegateCheck(g)` in the script of the effect (The effect won't resolve if it "touch" the grave)
- Ghost Belle negate them by checking `dv&LOCATION_GRAVE==LOCATION_GRAVE`

For effects that don't target but must banish cards both in grave and other place, and may resolve without card in grave (eg. _System Down_):
- `SetOperationInfo` with affected cards as target, with `count`>0 and `param` including `LOCATION_GRAVE`
- `SetCategory` don't need `CATEGORY_GRAVE_ACTION` or `CATEGORY_GRAVE_SPSUMMON`
- Use `aux.NecroValleyFilter` in the script of the effect (The effect will resolve because cards in grave can't be banished so it don't "touch" the grave)
- Ghost Belle negate them by checking `dv&LOCATION_GRAVE==LOCATION_GRAVE`
