### PR TITLE
fix 星遺物を巡る戦い

### DIFF
--- a/c93236220.lua
+++ b/c93236220.lua
@@ -13,21 +13,15 @@ function c93236220.initial_effect(c)
 	e1:SetOperation(c93236220.activate)
 	c:RegisterEffect(e1)
 end
-function c93236220.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	e:SetLabel(100)
-end
 function c93236220.cfilter(c)
-	return c:IsFaceup() and (c:GetBaseAttack()>0 or c:GetBaseDefense()>0) and c:IsAbleToRemoveAsCost()
+	return c:IsFaceup() and (c:GetTextAttack()>0 or c:GetTextDefense()>0) and c:IsAbleToRemoveAsCost()
 end
-function c93236220.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingMatchingCard(c93236220.cfilter,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+function c93236220.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c93236220.cfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local rc=Duel.SelectMatchingCard(tp,c93236220.cfilter,tp,LOCATION_MZONE,0,1,1,nil):GetFirst()
-	if Duel.Remove(rc,POS_FACEUP,REASON_COST+REASON_TEMPORARY)~=0 then
-		e:SetLabelObject(rc)
+	e:SetLabel(rc:GetTextAttack(),rc:GetTextDefense())
+	if Duel.Remove(rc,0,REASON_COST+REASON_TEMPORARY)~=0 then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_END)
@@ -37,15 +31,17 @@ function c93236220.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		e1:SetOperation(c93236220.retop)
 		Duel.RegisterEffect(e1,tp)
 	end
+end
+function c93236220.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
 end
 function c93236220.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	local rc=e:GetLabelObject()
-	if rc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
-		local atk=rc:GetBaseAttack()
-		local def=rc:GetBaseDefense()
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local atk,def=e:GetLabel()
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)

--- a/c93236220.lua
+++ b/c93236220.lua
@@ -42,6 +42,8 @@ function c93236220.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		local atk,def=e:GetLabel()
+		atk=math.max(atk,0)
+		def=math.max(def,0)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10100&keyword=&tag=-1

Question
自分のモンスターゾーンに表側表示で存在する「神獣王バルバロス」をコストとして除外し、「星遺物を巡る戦い」を発動した場合、対象とした相手モンスターの攻撃力・守備力はいくつダウンしますか？
Answer
「神獣王バルバロス」は元々の攻撃力が3000・元々の守備力が1200のモンスターです。
「神獣王バルバロス」をコストとして除外し、「星遺物を巡る戦い」を発動したのであれば、その数値分相手モンスターの攻撃力・守備力がダウンします。

なお、その「神獣王バルバロス」が自身のモンスター効果によってリリースなしで召喚され、『②：このカードの①の方法で通常召喚したこのカードの元々の攻撃力は１９００になる』モンスター効果が適用されている状態であったとしても、処理に違いはありません。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6279&keyword=&tag=-1

Question
「クローラー・デンドライト」をコストとして除外し、「星遺物を巡る戦い」の『①：自分フィールドの表側表示モンスター１体をエンドフェイズまで除外し、相手フィールドの表側表示モンスター１体を対象として発動できる。その相手モンスターの攻撃力・守備力は、このカードを発動するために除外したモンスターのそれぞれの元々の数値分ダウンする』効果を発動しました。

その発動にチェーンして発動した「異次元からの埋葬」の効果によって、その「クローラー・デンドライト」が墓地に戻っている場合、効果処理はどうなりますか？
Answer
質問の状況の場合でも、「星遺物を巡る戦い」の『その相手モンスターの攻撃力・守備力は、このカードを発動するために除外したモンスターのそれぞれの元々の数値分ダウンする』処理は通常通り適用され、コストとして除外された「クローラー・デンドライト」の数値分、対象の相手モンスターの攻撃力は1300ダウンし、守備力は600ダウンする事になります。

なお、「異次元からの埋葬」の効果によって墓地に戻っている「クローラー・デンドライト」がエンドフェイズにモンスターゾーンに戻る事はありません。