### PR TITLE
fix サイバネット・バックドア

### DIFF
--- a/c43839002.lua
+++ b/c43839002.lua
@@ -17,7 +17,7 @@ function c43839002.rmfilter(c,tp)
 		and Duel.IsExistingMatchingCard(c43839002.thfilter,tp,LOCATION_DECK,0,1,nil,c:GetTextAttack())
 end
 function c43839002.thfilter(c,atk)
-	return c:IsRace(RACE_CYBERSE) and c:GetAttack()>=0 and c:GetAttack()<atk and c:IsAbleToHand()
+	return c:IsRace(RACE_CYBERSE) and c:GetTextAttack()>=0 and c:GetTextAttack()<atk and c:IsAbleToHand()
 end
 function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43839002.rmfilter(chkc,tp) end

--- a/c43839002.lua
+++ b/c43839002.lua
@@ -17,7 +17,7 @@ function c43839002.rmfilter(c,tp)
 		and Duel.IsExistingMatchingCard(c43839002.thfilter,tp,LOCATION_DECK,0,1,nil,c:GetTextAttack())
 end
 function c43839002.thfilter(c,atk)
-	return c:IsRace(RACE_CYBERSE) and c:GetAttack()>=0 and c:GetAttack()<atk and c:IsAbleToHand()
+	return c:IsRace(RACE_CYBERSE) and c:GetTextAttack()>=0 and c:GetAttack()<atk and c:IsAbleToHand()
 end
 function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43839002.rmfilter(chkc,tp) end

--- a/c43839002.lua
+++ b/c43839002.lua
@@ -17,7 +17,7 @@ function c43839002.rmfilter(c,tp)
 		and Duel.IsExistingMatchingCard(c43839002.thfilter,tp,LOCATION_DECK,0,1,nil,c:GetTextAttack())
 end
 function c43839002.thfilter(c,atk)
-	return c:IsRace(RACE_CYBERSE) and c:GetTextAttack()>=0 and c:GetTextAttack()<atk and c:IsAbleToHand()
+	return c:IsRace(RACE_CYBERSE) and c:GetAttack()>=0 and c:GetAttack()<atk and c:IsAbleToHand()
 end
 function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43839002.rmfilter(chkc,tp) end

--- a/c43839002.lua
+++ b/c43839002.lua
@@ -13,11 +13,11 @@ function c43839002.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c43839002.rmfilter(c,tp)
-	return c:IsFaceup() and c:IsRace(RACE_CYBERSE) and c:IsAbleToRemove() and c:GetBaseAttack()>0
-		and Duel.IsExistingMatchingCard(c43839002.thfilter,tp,LOCATION_DECK,0,1,nil,c)
+	return c:IsFaceup() and c:IsRace(RACE_CYBERSE) and c:IsAbleToRemove() and c:GetTextAttack()>0 and c:GetOriginalType()&TYPE_MONSTER~=0
+		and Duel.IsExistingMatchingCard(c43839002.thfilter,tp,LOCATION_DECK,0,1,nil,c:GetTextAttack())
 end
-function c43839002.thfilter(c,rc)
-	return c:IsRace(RACE_CYBERSE) and c:GetAttack()>=0 and c:GetAttack()<rc:GetBaseAttack() and c:IsAbleToHand()
+function c43839002.thfilter(c,atk)
+	return c:IsRace(RACE_CYBERSE) and c:GetAttack()>=0 and c:GetAttack()<atk and c:IsAbleToHand()
 end
 function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43839002.rmfilter(chkc,tp) end
@@ -52,7 +52,7 @@ function c43839002.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.RegisterEffect(e1,tp)
 		if tc:IsFacedown() then return end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-		local g=Duel.SelectMatchingCard(tp,c43839002.thfilter,tp,LOCATION_DECK,0,1,1,nil,tc)
+		local g=Duel.SelectMatchingCard(tp,c43839002.thfilter,tp,LOCATION_DECK,0,1,1,nil,tc:GetTextAttack())
 		if g:GetCount()>0 then
 			Duel.SendtoHand(g,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,g)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21111&keyword=&tag=-1

Question
自身の『①：種族と属性を１つずつ宣言して発動できる。このカードは発動後、宣言した種族・属性を持つ通常モンスター（星４・攻１８００／守１０００）となり、モンスターゾーンに特殊召喚する。このカードは罠カードとしても扱う』効果の発動時に宣言された、サイバース族・光属性のモンスターとして扱われている「鏡像のスワンプマン」が自分のモンスターゾーンに存在しています。

その「鏡像のスワンプマン」を対象として「サイバネット・バックドア」を発動する事はできますか？
Answer
「鏡像のスワンプマン」はモンスターカードとして扱われていますが、元々は罠カードですので、除外された際にはモンスターカードとしては扱われず、攻撃力を持たないカードとなります。

したがって、「サイバネット・バックドア」を発動する際に、モンスターカードとして扱われている「鏡像のスワンプマン」を対象として選択する事自体ができません。