### PR TITLE
fix Tamtam the Melodious Diva

### DIFF
--- a/c79757784.lua
+++ b/c79757784.lua
@@ -45,11 +45,14 @@ end
 function c79757784.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return r==REASON_FUSION and e:GetHandler():IsLocation(LOCATION_GRAVE)
 end
+function c79757784.atkfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x9b) and c:IsAttackAbove(500)
+end
 function c79757784.damtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c79757784.cfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c79757784.cfilter,tp,LOCATION_MZONE,0,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c79757784.atkfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c79757784.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,c79757784.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c79757784.atkfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
 end
 function c79757784.damop(e,tp,eg,ep,ev,re,r,rp)
@@ -61,6 +64,8 @@ function c79757784.damop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetValue(-500)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1)
-		Duel.Damage(1-tp,500,REASON_EFFECT)
+		if not tc:IsHasEffect(EFFECT_REVERSE_UPDATE) then
+			Duel.Damage(1-tp,500,REASON_EFFECT)
+		end
 	end
 end


### PR DESCRIPTION
fix: If Melodious cannot lose ATK by Tamtam's effect, opponent took damage.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=15615&keyword=&tag=-1
> 融合素材となった「幻奏の音女タムタム」の効果の対象として、**攻撃力が400の「幻奏の音女セレナ」を対象とすることはできません**。 

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=15616&keyword=&tag=-1
> その場合、『そのモンスターの攻撃力を５００ダウンし』の処理によって攻撃力は500ダウンする代わりに500アップします。
> 
> この処理によって**結果的に攻撃力を５００ダウンさせることができていませんので、『相手に５００ダメージ与える』処理は適用されません**。 