### PR TITLE
fix Ancient Gear Hydra

### DIFF
--- a/c81269231.lua
+++ b/c81269231.lua
@@ -52,7 +52,7 @@ function c81269231.regop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCondition(c81269231.rmcon)
 		e1:SetTarget(c81269231.rmtg)
 		e1:SetOperation(c81269231.rmop)
-		e1:SetReset(RESET_EVENT+0x1620000)
+		e1:SetReset(RESET_EVENT+RESET_TURN_SET+RESET_TOHAND+RESET_TODECK+RESET_TOFIELD)
 		c:RegisterEffect(e1)
 	end
 	if bit.band(flag,0x2)~=0 then

--- a/c81269231.lua
+++ b/c81269231.lua
@@ -52,7 +52,7 @@ function c81269231.regop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCondition(c81269231.rmcon)
 		e1:SetTarget(c81269231.rmtg)
 		e1:SetOperation(c81269231.rmop)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetReset(RESET_EVENT+0x1620000)
 		c:RegisterEffect(e1)
 	end
 	if bit.band(flag,0x2)~=0 then


### PR DESCRIPTION
fix: if Ancient Gear Hydra was destroyed by battle, Ancient Gear Hydra cannot activate effect.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19978&keyword=&tag=-1
> 質問の状況の場合でも、「アンティーク・ギア」と名のついたモンスターをリリースしてアドバンス召喚されている「古代の機械合成竜」が相手モンスターと戦闘を行い、**相手モンスターが戦闘で破壊されていませんので、そのモンスター効果を発動する事ができます**。
> 
> この場合、「古代の機械合成竜」は戦闘で破壊され墓地へ送られていますので、そのモンスター効果は墓地で発動する事になります。