### PR TITLE
update クロシープ and ベイオネット・パニッシャー

### DIFF
--- a/c36092504.lua
+++ b/c36092504.lua
@@ -47,11 +47,15 @@ function c36092504.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.HintSelection(rg)
 		res=Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	end
+	g1=Duel.GetMatchingGroup(c36092504.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil)
+	g2=Duel.GetMatchingGroup(aux.NecroValleyFilter(Card.IsAbleToRemove),tp,0,LOCATION_ONFIELD+LOCATION_EXTRA+LOCATION_GRAVE,nil)
 	if g1:IsExists(Card.IsType,1,nil,TYPE_SYNCHRO) and g2:IsExists(c36092504.rmfilter1,3,nil) then
 		if res~=0 then Duel.BreakEffect() end
 		local rg=g2:Filter(c36092504.rmfilter1,nil):RandomSelect(tp,3)
 		res=Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	end
+	g1=Duel.GetMatchingGroup(c36092504.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil)
+	g2=Duel.GetMatchingGroup(aux.NecroValleyFilter(Card.IsAbleToRemove),tp,0,LOCATION_ONFIELD+LOCATION_EXTRA+LOCATION_GRAVE,nil)
 	if g1:IsExists(Card.IsType,1,nil,TYPE_XYZ) and g2:IsExists(c36092504.rmfilter2,1,nil) then
 		if res~=0 then Duel.BreakEffect() end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
@@ -59,6 +63,8 @@ function c36092504.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.HintSelection(rg)
 		res=Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	end
+	g1=Duel.GetMatchingGroup(c36092504.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil)
+	g2=Duel.GetMatchingGroup(aux.NecroValleyFilter(Card.IsAbleToRemove),tp,0,LOCATION_ONFIELD+LOCATION_EXTRA+LOCATION_GRAVE,nil)
 	if g1:IsExists(Card.IsType,1,nil,TYPE_LINK) and g2:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE) then
 		if res~=0 then Duel.BreakEffect() end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)

--- a/c50277355.lua
+++ b/c50277355.lua
@@ -47,12 +47,8 @@ end
 function c50277355.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local lg=e:GetHandler():GetLinkedGroup()
-	local b1=Duel.IsPlayerCanDraw(tp,2) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_RITUAL)
-	local b2=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c50277355.spfilter),tp,LOCATION_GRAVE,0,1,nil,e,tp) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_FUSION)
-	local b3=Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_SYNCHRO)
-	local b4=Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_XYZ)
 	local res=0
+	local b1=Duel.IsPlayerCanDraw(tp,2) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_RITUAL)
 	if b1 then
 		res=Duel.Draw(tp,2,REASON_EFFECT)
 		if res==2 then
@@ -61,6 +57,9 @@ function c50277355.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.DiscardHand(tp,aux.TRUE,2,2,REASON_EFFECT+REASON_DISCARD)
 		end
 	end
+	lg=e:GetHandler():GetLinkedGroup()
+	local b2=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c50277355.spfilter),tp,LOCATION_GRAVE,0,1,nil,e,tp) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_FUSION)
 	if b2 then
 		if res~=0 then Duel.BreakEffect() end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
@@ -69,6 +68,8 @@ function c50277355.activate(e,tp,eg,ep,ev,re,r,rp)
 			res=Duel.SpecialSummon(g1,0,tp,tp,false,false,POS_FACEUP)
 		end
 	end
+	lg=e:GetHandler():GetLinkedGroup()
+	local b3=Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_SYNCHRO)
 	if b3 then
 		if res~=0 then Duel.BreakEffect() end
 		local g2=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
@@ -85,6 +86,8 @@ function c50277355.activate(e,tp,eg,ep,ev,re,r,rp)
 			tc1=g2:GetNext()
 		end
 	end
+	lg=e:GetHandler():GetLinkedGroup()
+	local b4=Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) and lg:IsExists(c50277355.lkfilter,1,nil,TYPE_XYZ)
 	if b4 then
 		if res~=0 then Duel.BreakEffect() end
 		local g3=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)


### PR DESCRIPTION
> Q.
「クロシープ」のリンク先に融合モンスターが特殊召喚され、「クロシープ」のモンスター効果を発動しました。
その『●融合：』の処理によって、墓地から「虹光の宣告者」を「クロシープ」のもう片方のリンク先に特殊召喚された場合、さらに『●S：』の処理を適用されますか？
A.
ご質問の場合、『●S：』の効果が適用されます。

> Q.
「クロシープ」のリンク先に融合モンスターが特殊召喚され、「クロシープ」のモンスター効果を発動しました。
その『●融合：』の処理によって、墓地から「サクリファイス」を「クロシープ」のもう片方のリンク先に特殊召喚された場合、さらに『●儀式：』の処理を適用されますか？
A.
ご質問の場合、『●儀式：』の効果は適用されません。

> Q.
自分フィールドに「ヴァレルロード・X・ドラゴン」1体と「ヴァレルソード・ドラゴン」1体が存在し、相手が「大捕り物」を発動し、「ヴァレルソード・ドラゴン」のコントロールが相手に移りました。
この時、自分のフィールド・墓地に存在する「ヴァレル」モンスターが、モンスターゾーンの「ヴァレルロード・X・ドラゴン」のみの状況です。
自分が「ベイオネット・パニッシャー」を発動し、『●X：』の処理で相手フィールドの「大捕り物」を除外して、相手フィールドの「ヴァレルソード・ドラゴン」を自分フィールドに戻った場合、自分フィールドに“リンク”の種類が増えているため、さらに『●リンク：』の処理は行えますか？
A.
ご質問の場合、『●リンク：』の効果が適用されます。

> Q.
自分フィールドに「ヴァレルロード・X・ドラゴン」1体と「ヴァレルロード・F・ドラゴン」1体が存在し、相手が「大捕り物」を発動し、「ヴァレルロード・F・ドラゴン」のコントロールが相手に移りました。
この時、自分のフィールド・墓地に存在する「ヴァレル」モンスターが、モンスターゾーンの「ヴァレルロード・X・ドラゴン」のみの状況です。
自分が「ベイオネット・パニッシャー」を発動し、『●X：』の処理で相手フィールドの「大捕り物」を除外して、相手フィールドの「ヴァレルロード・F・ドラゴン」を自分フィールドに戻った場合、自分フィールドに“融合”の種類が増えているため、さらに『●融合：』の処理は行えますか？
A.
ご質問の場合、『●融合：』の効果は適用されません。