### PR TITLE
fix スプリガンズ・コール

### DIFF
--- a/c83199011.lua
+++ b/c83199011.lua
@@ -21,7 +21,7 @@ function c83199011.initial_effect(c)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_END_PHASE)
 	e2:SetCountLimit(1,83199012)
-	e2:SetCondition(aux.exccon)
+	e2:SetCondition(c83199011.ovcon)
 	e2:SetCost(c83199011.ovcost)
 	e2:SetTarget(c83199011.ovtg)
 	e2:SetOperation(c83199011.ovop)
@@ -42,6 +42,10 @@ function c83199011.spop(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
+end
+function c83199011.ovcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnCount()~=e:GetHandler():GetTurnID() or e:GetHandler():IsReason(REASON_RETURN)
+		and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
 end
 function c83199011.costfilter(c)
 	return c:IsType(TYPE_FUSION) and c:IsAbleToRemoveAsCost()

--- a/c83199011.lua
+++ b/c83199011.lua
@@ -44,8 +44,8 @@ function c83199011.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c83199011.ovcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnCount()~=e:GetHandler():GetTurnID() or e:GetHandler():IsReason(REASON_RETURN)
-		and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
+	return (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
+		and Duel.GetTurnCount()~=e:GetHandler():GetTurnID() or e:GetHandler():IsReason(REASON_RETURN)
 end
 function c83199011.costfilter(c)
 	return c:IsType(TYPE_FUSION) and c:IsAbleToRemoveAsCost()


### PR DESCRIPTION
Target 1 "Springans" monster or "Fallen of Albaz" in your GY; Special Summon it. During the `Main Phase`, except the turn this card was sent to the GY: You can banish this card and 1 Fusion Monster from your GY, then target 1 "Springans" Xyz Monster you control; attach 1 Fusion Monster that lists "Fallen of Albaz" as material from your Extra Deck to that monster as material. You can only use each effect of "Springans Call!" once per turn.

should not be able to activate during battle phase or next standby phase