### PR TITLE
fix for Pandemonium

### DIFF
--- a/c35606858.lua
+++ b/c35606858.lua
@@ -44,8 +44,10 @@ function c35606858.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c35606858.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if (Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852)) and Duel.SelectYesNo(tp,aux.Stringid(35606858,2)) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+	if (Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852))
+		and Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(35606858,2)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,500)
 		end
 	else

--- a/c35606858.lua
+++ b/c35606858.lua
@@ -44,8 +44,10 @@ function c35606858.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c35606858.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,500) and Duel.SelectYesNo(tp,aux.Stringid(35606858,2)) then
-		Duel.PayLPCost(tp,500)
+	if (Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852)) and Duel.SelectYesNo(tp,aux.Stringid(35606858,2)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,500)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c35798491.lua
+++ b/c35798491.lua
@@ -24,7 +24,8 @@ function c35798491.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c35798491.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,500)
 		end
 	else

--- a/c35798491.lua
+++ b/c35798491.lua
@@ -23,8 +23,10 @@ function c35798491.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c35798491.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,500) then
-		Duel.PayLPCost(tp,500)
+	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,500)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c35975813.lua
+++ b/c35975813.lua
@@ -46,7 +46,8 @@ function c35975813.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c35975813.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,800) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,800)
 		end
 	else

--- a/c35975813.lua
+++ b/c35975813.lua
@@ -45,8 +45,10 @@ function c35975813.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c35975813.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,800) then
-		Duel.PayLPCost(tp,800)
+	if Duel.CheckLPCost(tp,800) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,800)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c52248570.lua
+++ b/c52248570.lua
@@ -28,7 +28,8 @@ function c52248570.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c52248570.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,1000) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,1000)
 		end
 	else

--- a/c52248570.lua
+++ b/c52248570.lua
@@ -27,8 +27,10 @@ function c52248570.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c52248570.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,1000) then
-		Duel.PayLPCost(tp,1000)
+	if Duel.CheckLPCost(tp,1000) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,1000)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c61370518.lua
+++ b/c61370518.lua
@@ -24,7 +24,8 @@ function c61370518.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c61370518.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,500)
 		end
 	else

--- a/c61370518.lua
+++ b/c61370518.lua
@@ -23,8 +23,10 @@ function c61370518.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c61370518.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,500) then
-		Duel.PayLPCost(tp,500)
+	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,500)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c70780151.lua
+++ b/c70780151.lua
@@ -55,7 +55,8 @@ function c70780151.discon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c70780151.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,1000) or Duel.IsPlayerAffectedByEffect(tp,94585852) end
-	if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+	if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+		or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 		Duel.PayLPCost(tp,1000)
 	end
 end

--- a/c70780151.lua
+++ b/c70780151.lua
@@ -54,8 +54,10 @@ function c70780151.discon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
 end
 function c70780151.discost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckLPCost(tp,1000) end
-	Duel.PayLPCost(tp,1000)
+	if chk==0 then return Duel.CheckLPCost(tp,1000) or Duel.IsPlayerAffectedByEffect(tp,94585852) end
+	if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		Duel.PayLPCost(tp,1000)
+	end
 end
 function c70780151.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c72192100.lua
+++ b/c72192100.lua
@@ -36,7 +36,8 @@ function c72192100.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c72192100.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,500)
 		end
 	else

--- a/c72192100.lua
+++ b/c72192100.lua
@@ -35,8 +35,10 @@ function c72192100.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c72192100.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,500) then
-		Duel.PayLPCost(tp,500)
+	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,500)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c73219648.lua
+++ b/c73219648.lua
@@ -32,7 +32,8 @@ function c73219648.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c73219648.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,500)
 		end
 	else

--- a/c73219648.lua
+++ b/c73219648.lua
@@ -31,8 +31,10 @@ function c73219648.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c73219648.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,500) then
-		Duel.PayLPCost(tp,500)
+	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,500)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c84341431.lua
+++ b/c84341431.lua
@@ -24,7 +24,8 @@ end
 function c84341431.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsReason(REASON_EFFECT) and not e:GetHandler():IsReason(REASON_REPLACE) and (Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852)) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,500)
 		end
 		return true

--- a/c84341431.lua
+++ b/c84341431.lua
@@ -22,9 +22,11 @@ function c84341431.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c84341431.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsReason(REASON_EFFECT) and not e:GetHandler():IsReason(REASON_REPLACE) and Duel.CheckLPCost(tp,500) end
+	if chk==0 then return e:GetHandler():IsReason(REASON_EFFECT) and not e:GetHandler():IsReason(REASON_REPLACE) and (Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852)) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		Duel.PayLPCost(tp,500)
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,500)
+		end
 		return true
 	else return false end
 end

--- a/c8581705.lua
+++ b/c8581705.lua
@@ -35,7 +35,8 @@ function c8581705.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c8581705.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,500)
 		end
 	else

--- a/c8581705.lua
+++ b/c8581705.lua
@@ -34,8 +34,10 @@ function c8581705.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c8581705.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,500) then
-		Duel.PayLPCost(tp,500)
+	if Duel.CheckLPCost(tp,500) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,500)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end

--- a/c94585852.lua
+++ b/c94585852.lua
@@ -8,11 +8,11 @@ function c94585852.initial_effect(c)
 	--cost change
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_LPCOST_CHANGE)
+	e2:SetCode(94585852)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e2:SetRange(LOCATION_FZONE)
 	e2:SetTargetRange(1,1)
-	e2:SetValue(c94585852.costchange)
+	e2:SetCondition(c94585852.costcon)
 	c:RegisterEffect(e2)
 	--search
 	local e4=Effect.CreateEffect(c)
@@ -34,12 +34,8 @@ function c94585852.initial_effect(c)
 		Duel.RegisterEffect(ge1,0)
 	end
 end
-function c94585852.costchange(e,re,rp,val)
-	if Duel.GetCurrentPhase()==PHASE_STANDBY and re and re:GetHandler():IsSetCard(0x45) and re:GetHandler():IsType(TYPE_MONSTER) then
-		return 0
-	else
-		return val
-	end
+function c94585852.costcon(e)
+	return Duel.GetCurrentPhase()==PHASE_STANDBY
 end
 function c94585852.regop(e,tp,eg,ep,ev,re,r,rp)
 	local lv1=0

--- a/c9603356.lua
+++ b/c9603356.lua
@@ -30,7 +30,8 @@ function c9603356.mtcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c9603356.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.CheckLPCost(tp,900) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
-		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852)
+			or not Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(94585852,1)) then
 			Duel.PayLPCost(tp,900)
 		end
 	else

--- a/c9603356.lua
+++ b/c9603356.lua
@@ -29,8 +29,10 @@ function c9603356.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c9603356.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckLPCost(tp,900) then
-		Duel.PayLPCost(tp,900)
+	if Duel.CheckLPCost(tp,900) or Duel.IsPlayerAffectedByEffect(tp,94585852) then
+		if not Duel.IsPlayerAffectedByEffect(tp,94585852) or not Duel.SelectYesNo(tp,aux.Stringid(94585852,1)) then
+			Duel.PayLPCost(tp,900)
+		end
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)
 	end


### PR DESCRIPTION
fix: if Pandemonium has on the field, Archfiend cannot pay lp.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5791
> ■「デーモン」と名のついたモンスターがスタンバイフェイズにフィールドに維持するためにライフポイントを払わなくてもよくなります。（**通常通り、ライフポイントを払う事もできます**。）