### PR TITLE
fix Tellus the Little Angel, White Aura Bihamut, Duel Link Dragon, the Duel Dragon

### DIFF
--- a/c19280589.lua
+++ b/c19280589.lua
@@ -56,7 +56,7 @@ function c19280589.ctkfilter(c)
 	return c:IsFaceup() and c:IsCode(19280590)
 end
 function c19280589.tkcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c19280589.ctkfilter,tp,LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c19280589.ctkfilter,tp,LOCATION_ONFIELD,0,1,nil)
 end
 function c19280589.tktg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)

--- a/c60025883.lua
+++ b/c60025883.lua
@@ -102,5 +102,5 @@ function c60025883.tgfilter(c)
 	return c:GetOriginalCode()==60025884
 end
 function c60025883.tgcon(e)
-	return Duel.IsExistingMatchingCard(c60025883.tgfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+	return Duel.IsExistingMatchingCard(c60025883.tgfilter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,1,nil)
 end

--- a/c89907227.lua
+++ b/c89907227.lua
@@ -73,7 +73,7 @@ end
 function c89907227.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_MZONE,0,1,nil,89907228) end
+		and Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_ONFIELD,0,1,nil,89907228) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c89907227.spop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
fix: if monster equipped with token(s) has on the field, these monsters cannot activate.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23167&keyword=&tag=-1
> 「テルスの羽トークン」が自分の魔法＆罠ゾーンに存在する場合でも、**自分フィールドに「テルスの羽トークン」が存在する場合にあたります**。