### PR TITLE
update Spell Counter

### DIFF
--- a/c34029630.lua
+++ b/c34029630.lua
@@ -1,6 +1,13 @@
 --漆黒のパワーストーン
 function c34029630.initial_effect(c)
 	c:EnableCounterPermit(0x1)
+	--special counter permit
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_COUNTER_PERMIT+0x1)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCondition(c34029630.ctpermit)
+	c:RegisterEffect(e1)
 	--Activate
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_COUNTER)
@@ -30,6 +37,10 @@ function c34029630.initial_effect(c)
 	e4:SetCode(EFFECT_SELF_DESTROY)
 	e4:SetCondition(c34029630.descon)
 	c:RegisterEffect(e4)
+end
+function c34029630.ctpermit(e)
+	local c=e:GetHandler()
+	return c:IsLocation(LOCATION_SZONE) and c:IsStatus(STATUS_CHAINING)
 end
 function c34029630.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and c34029630.filter(chkc) end

--- a/c3611830.lua
+++ b/c3611830.lua
@@ -66,13 +66,12 @@ function c3611830.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RemoveCounter(tp,1,0,0x1,6,REASON_COST)
 end
 function c3611830.cfilter(c)
-	return c:IsCanAddCounter(0x1)
+	return c:IsCanHaveCounter(0x1)
 end
 function c3611830.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and Duel.IsCanAddCounter(tp,0x1,1,c)
-		and Duel.IsExistingMatchingCard(c3611830.cfilter,tp,LOCATION_ONFIELD,0,1,nil) end
+		and Duel.IsCanAddCounter(tp,0x1,1,c) end
 	local g=Duel.GetMatchingGroup(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)

--- a/c38325384.lua
+++ b/c38325384.lua
@@ -51,7 +51,7 @@ function c38325384.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return rp==1-tp and c:IsReason(REASON_EFFECT) and c:IsPreviousControler(tp)
 end
 function c38325384.spfilter(c,e,tp)
-	return c:IsCanAddCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsCanHaveCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c38325384.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c39000945.lua
+++ b/c39000945.lua
@@ -66,7 +66,7 @@ function c39000945.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveCounter(tp,0x1,3,REASON_COST)
 end
 function c39000945.spfilter(c,e,tp)
-	return c:IsCanAddCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsCanHaveCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c39000945.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c54965929.lua
+++ b/c54965929.lua
@@ -49,7 +49,7 @@ function c54965929.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return not Duel.IsExistingMatchingCard(nil,tp,LOCATION_PZONE,0,1,e:GetHandler())
 end
 function c54965929.spfilter(c,e,tp)
-	return c:IsCanAddCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsCanHaveCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c54965929.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()

--- a/c66104644.lua
+++ b/c66104644.lua
@@ -79,7 +79,7 @@ function c66104644.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveCounter(tp,0x1,3,REASON_COST)
 end
 function c66104644.spfilter(c,e,tp)
-	return c:IsFaceup() and c:IsCanAddCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c)
+	return c:IsFaceup() and c:IsCanHaveCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0
 end
 function c66104644.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -121,7 +121,7 @@ function c66104644.spcost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RemoveCounter(tp,1,0,0x1,3,REASON_COST)
 end
 function c66104644.spfilter2(c,e,tp)
-	return c:IsCanAddCounter(0x1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsCanHaveCounter(0x1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c66104644.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c92559258.lua
+++ b/c92559258.lua
@@ -75,7 +75,7 @@ function c92559258.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveCounter(tp,0x1,3,REASON_COST)
 end
 function c92559258.spfilter(c,e,tp)
-	return c:IsAttackAbove(1000) and c:IsCanAddCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsAttackAbove(1000) and c:IsCanHaveCounter(0x1) and Duel.IsCanAddCounter(tp,0x1,1,c) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c92559258.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c94599451.lua
+++ b/c94599451.lua
@@ -47,7 +47,7 @@ function c94599451.ctop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c94599451.thfilter1(c,tp)
 	local lv=c:GetLevel()
-	return (c:IsLocation(LOCATION_DECK) or (c:IsFaceup() and c:IsType(TYPE_PENDULUM))) and lv>0 and c:IsCanAddCounter(0x1)
+	return (c:IsLocation(LOCATION_DECK) or (c:IsFaceup() and c:IsType(TYPE_PENDULUM))) and lv>0 and c:IsCanHaveCounter(0x1)
 		and Duel.IsCanRemoveCounter(tp,1,0,0x1,lv,REASON_COST) and c:IsAbleToHand()
 end
 function c94599451.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -72,7 +72,7 @@ function c94599451.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK+LOCATION_EXTRA)
 end
 function c94599451.thfilter2(c,lv)
-	return (c:IsLocation(LOCATION_DECK) or (c:IsFaceup() and c:IsType(TYPE_PENDULUM))) and c:IsCanAddCounter(0x1)
+	return (c:IsLocation(LOCATION_DECK) or (c:IsFaceup() and c:IsType(TYPE_PENDULUM))) and c:IsCanHaveCounter(0x1)
 		and c:IsLevel(lv) and c:IsAbleToHand()
 end
 function c94599451.thop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
@mercury233 
See  Fluorohydride/ygopro-core#367

漆黒のパワーストーン
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8188&keyword=&tag=-1
The only cards which grants EFFECT_COUNTER_PERMIT upon activation.
The script has a temporary EFFECT_COUNTER_PERMIT.

IsCanAddCounter
The scripts do not contain IsCanAddCounter() with 1 argument (countertype) now.
Searched by RegExp
:IsCanAddCounter\([^,]*\)
