### PR TITLE
ZW equip

### DIFF
--- a/c12927849.lua
+++ b/c12927849.lua
@@ -68,9 +68,9 @@ function c12927849.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c12927849.equip_monster(c,tp,tc)
+	c12927849.zw_equip_monster(c,tp,tc)
 end
-function c12927849.equip_monster(c,tp,tc)
+function c12927849.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c18865703.lua
+++ b/c18865703.lua
@@ -47,9 +47,9 @@ function c18865703.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c18865703.equip_monster(c,tp,tc)
+	c18865703.zw_equip_monster(c,tp,tc)
 end
-function c18865703.equip_monster(c,tp,tc)
+function c18865703.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c2648201.lua
+++ b/c2648201.lua
@@ -46,9 +46,9 @@ function c2648201.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c2648201.equip_monster(c,tp,tc)
+	c2648201.zw_equip_monster(c,tp,tc)
 end
-function c2648201.equip_monster(c,tp,tc)
+function c2648201.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c2896663.lua
+++ b/c2896663.lua
@@ -79,9 +79,9 @@ function c2896663.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c2896663.equip_monster(c,tp,tc)
+	c2896663.zw_equip_monster(c,tp,tc)
 end
-function c2896663.equip_monster(c,tp,tc)
+function c2896663.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c29353756.lua
+++ b/c29353756.lua
@@ -57,9 +57,9 @@ function c29353756.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c29353756.equip_monster(c,tp,tc)
+	c29353756.zw_equip_monster(c,tp,tc)
 end
-function c29353756.equip_monster(c,tp,tc)
+function c29353756.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c32164201.lua
+++ b/c32164201.lua
@@ -57,9 +57,9 @@ function c32164201.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c32164201.equip_monster(c,tp,tc)
+	c32164201.zw_equip_monster(c,tp,tc)
 end
-function c32164201.equip_monster(c,tp,tc)
+function c32164201.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c40941889.lua
+++ b/c40941889.lua
@@ -41,9 +41,9 @@ function c40941889.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c40941889.equip_monster(c,tp,tc)
+	c40941889.zw_equip_monster(c,tp,tc)
 end
-function c40941889.equip_monster(c,tp,tc)
+function c40941889.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c45082499.lua
+++ b/c45082499.lua
@@ -51,9 +51,9 @@ function c45082499.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c45082499.equip_monster(c,tp,tc)
+	c45082499.zw_equip_monster(c,tp,tc)
 end
-function c45082499.equip_monster(c,tp,tc)
+function c45082499.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c60992364.lua
+++ b/c60992364.lua
@@ -78,9 +78,9 @@ function c60992364.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c60992364.equip_monster(c,tp,tc)
+	c60992364.zw_equip_monster(c,tp,tc)
 end
-function c60992364.equip_monster(c,tp,tc)
+function c60992364.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c6330307.lua
+++ b/c6330307.lua
@@ -46,9 +46,9 @@ function c6330307.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c6330307.equip_monster(c,tp,tc)
+	c6330307.zw_equip_monster(c,tp,tc)
 end
-function c6330307.equip_monster(c,tp,tc)
+function c6330307.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c75402014.lua
+++ b/c75402014.lua
@@ -38,7 +38,8 @@ function c75402014.eqcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsContains(e:GetHandler())
 end
 function c75402014.eqfilter(c,tp)
-	return c:IsSetCard(0x107e) and c:IsType(TYPE_MONSTER) and not c:IsForbidden() and c:CheckUniqueOnField(tp,LOCATION_SZONE)
+	local mt=_G["c"..c:GetCode()]
+	return mt.zw_equip_monster and c:IsSetCard(0x107e) and c:IsType(TYPE_MONSTER) and not c:IsForbidden() and c:CheckUniqueOnField(tp,LOCATION_SZONE)
 end
 function c75402014.eqtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
@@ -53,21 +54,8 @@ function c75402014.eqop(e,tp,eg,ep,ev,re,r,rp)
 		local g=Duel.SelectMatchingCard(tp,c75402014.eqfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,tp)
 		local tc=g:GetFirst()
 		if not tc then return end
-		local mt=_G["c"..tc:GetOriginalCode()]
-		if mt.equip_monster then
-			mt.equip_monster(tc,tp,c)
-		else
-			if not Duel.Equip(tp,tc,c) then return end
-			--equip limit
-			local e1=Effect.CreateEffect(c)
-			e1:SetType(EFFECT_TYPE_SINGLE)
-			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-			e1:SetCode(EFFECT_EQUIP_LIMIT)
-			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-			e1:SetLabelObject(c)
-			e1:SetValue(c75402014.eqlimit)
-			tc:RegisterEffect(e1)
-		end
+		local mt=_G["c"..tc:GetCode()]
+		mt.zw_equip_monster(tc,tp,c)
 	end
 end
 function c75402014.eqlimit(e,c)

--- a/c76080032.lua
+++ b/c76080032.lua
@@ -54,9 +54,9 @@ function c76080032.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c76080032.equip_monster(c,tp,tc)
+	c76080032.zw_equip_monster(c,tp,tc)
 end
-function c76080032.equip_monster(c,tp,tc)
+function c76080032.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c81471108.lua
+++ b/c81471108.lua
@@ -49,9 +49,9 @@ function c81471108.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c81471108.equip_monster(c,tp,tc)
+	c81471108.zw_equip_monster(c,tp,tc)
 end
-function c81471108.equip_monster(c,tp,tc)
+function c81471108.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c87008374.lua
+++ b/c87008374.lua
@@ -44,9 +44,9 @@ function c87008374.eqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(c,REASON_EFFECT)
 		return
 	end
-	c87008374.equip_monster(c,tp,tc)
+	c87008374.zw_equip_monster(c,tp,tc)
 end
-function c87008374.equip_monster(c,tp,tc)
+function c87008374.zw_equip_monster(c,tp,tc)
 	if not Duel.Equip(tp,c,tc) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
@mercury233 
Problem
1. The equip functions of ZW and that of the Relinquished family have the same name.
2. The target of 1st effect of 竜装合体 ドラゴニック・ホープレイ should be limited to ZW with a equip function.

Solution
1. The equip functions of ZW are renamed to zw_equip_monster()
2. eqfilter() is fixed.
