### PR TITLE
fix The Unfriendly Amazon

### DIFF
--- a/c65475294.lua
+++ b/c65475294.lua
@@ -16,7 +16,7 @@ function c65475294.costcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c65475294.costop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if Duel.CheckReleaseGroup(tp,nil,1,c) then
+	if Duel.CheckReleaseGroup(tp,nil,1,c) and Duel.SelectEffectYesNo(tp,c,aux.Stringid(65475294,0)) then
 		local g=Duel.SelectReleaseGroup(tp,nil,1,1,c)
 		Duel.Release(g,REASON_COST)
 	else


### PR DESCRIPTION
fix: The Unfriendly Amazon's controller cannot choice whether destroy The Unfriendly Amazon.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5194
> ■自分のスタンバイフェイズに、「味方殺しの女騎士」をフィールドに維持するためにモンスターを**リリースするかどうかを選びます**。（モンスターをリリースする場合、「味方殺しの女騎士」自身以外のモンスターであれば、自分のモンスターゾーンの裏側守備表示のモンスターをリリースする事もできます。）