### PR TITLE
add Card.IsExtraDeckMonster

### DIFF
--- a/c10406322.lua
+++ b/c10406322.lua
@@ -71,7 +71,7 @@ end
 function c10406322.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
-		if tc:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK)
+		if tc:IsExtraDeckMonster()
 			or Duel.SelectOption(tp,aux.Stringid(10406322,2),aux.Stringid(10406322,3))==0 then
 			Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
 		else

--- a/c12081875.lua
+++ b/c12081875.lua
@@ -59,8 +59,7 @@ function c12081875.effop(e,tp,eg,ep,ev,re,r,rp,chk)
 		local op=te:GetOperation()
 		if op then op(e,tp,eg,ep,ev,re,r,rp) end
 		Duel.BreakEffect()
-		local opt=Duel.SelectOption(tp,aux.Stringid(12081875,1),aux.Stringid(12081875,2))
-		if opt==0 then
+		if tc:IsExtraDeckMonster() or Duel.SelectOption(tp,aux.Stringid(12081875,1),aux.Stringid(12081875,2))==0 then
 			Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
 		else
 			Duel.SendtoDeck(tc,nil,1,REASON_EFFECT)

--- a/c30126992.lua
+++ b/c30126992.lua
@@ -52,7 +52,11 @@ function c30126992.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFacedown() then
 		Duel.ConfirmCards(tp,tc)
-		local opt=Duel.SelectOption(tp,aux.Stringid(30126992,1),aux.Stringid(30126992,2))
-		Duel.SendtoDeck(tc,nil,opt,REASON_EFFECT)
+		if tc:IsExtraDeckMonster()
+			or Duel.SelectOption(tp,aux.Stringid(30126992,1),aux.Stringid(30126992,2))==0 then
+			Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
+		else
+			Duel.SendtoDeck(tc,nil,1,REASON_EFFECT)
+		end
 	end
 end

--- a/c55591586.lua
+++ b/c55591586.lua
@@ -112,7 +112,11 @@ end
 function c55591586.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
-		local opt=Duel.SelectOption(tp,aux.Stringid(55591586,4),aux.Stringid(55591586,5))
-		Duel.SendtoDeck(tc,nil,opt,REASON_EFFECT)
+		if tc:IsExtraDeckMonster()
+			or Duel.SelectOption(tp,aux.Stringid(55591586,4),aux.Stringid(55591586,5))==0 then
+			Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
+		else
+			Duel.SendtoDeck(tc,nil,1,REASON_EFFECT)
+		end
 	end
 end

--- a/c58165765.lua
+++ b/c58165765.lua
@@ -50,8 +50,8 @@ function c58165765.operation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(tp,tc)
 		Duel.BreakEffect()
 		if tc:IsAbleToDeck() then
-			local opt=Duel.SelectOption(tp,aux.Stringid(58165765,1),aux.Stringid(58165765,2))
-			if opt==0 then
+			if tc:IsExtraDeckMonster()
+				or Duel.SelectOption(tp,aux.Stringid(58165765,1),aux.Stringid(58165765,2))==0 then
 				Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
 			else
 				Duel.SendtoDeck(tc,nil,1,REASON_EFFECT)

--- a/c67030233.lua
+++ b/c67030233.lua
@@ -115,7 +115,7 @@ end
 function c67030233.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local c=e:GetHandler()
-	if bit.band(c:GetOriginalType(),0x802040)~=0 and Duel.SendtoDeck(c,nil,0,REASON_EFFECT)~=0
+	if c:IsRelateToEffect(e) and c:IsExtraDeckMonster() and Duel.SendtoDeck(c,nil,0,REASON_EFFECT)~=0
 		and c:IsLocation(LOCATION_EXTRA) and tc and tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c71978434.lua
+++ b/c71978434.lua
@@ -92,7 +92,7 @@ end
 function c71978434.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
-		if tc:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK)
+		if tc:IsExtraDeckMonster()
 			or Duel.SelectOption(tp,aux.Stringid(71978434,2),aux.Stringid(71978434,3))==0 then
 			Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
 		else

--- a/c7841112.lua
+++ b/c7841112.lua
@@ -127,7 +127,7 @@ end
 function c7841112.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and bit.band(c:GetOriginalType(),0x802040)~=0 and Duel.SendtoDeck(c,nil,0,REASON_EFFECT)~=0
+	if c:IsRelateToEffect(e) and c:IsExtraDeckMonster() and Duel.SendtoDeck(c,nil,0,REASON_EFFECT)~=0
 		and c:IsLocation(LOCATION_EXTRA) and tc and tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c81028112.lua
+++ b/c81028112.lua
@@ -25,7 +25,11 @@ end
 function c81028112.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
-		local opt=Duel.SelectOption(tp,aux.Stringid(81028112,1),aux.Stringid(81028112,2))
-		Duel.SendtoDeck(tc,nil,opt,REASON_EFFECT)
+		if tc:IsExtraDeckMonster()
+			or Duel.SelectOption(tp,aux.Stringid(81028112,1),aux.Stringid(81028112,2))==0 then
+			Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
+		else
+			Duel.SendtoDeck(tc,nil,1,REASON_EFFECT)
+		end
 	end
 end

--- a/c88409165.lua
+++ b/c88409165.lua
@@ -33,7 +33,7 @@ end
 function c88409165.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
-		if tc:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK)
+		if tc:IsExtraDeckMonster()
 			or Duel.SelectOption(tp,aux.Stringid(88409165,1),aux.Stringid(88409165,2))==0 then
 			Duel.SendtoDeck(tc,nil,0,REASON_EFFECT)
 		else

--- a/c91650245.lua
+++ b/c91650245.lua
@@ -55,7 +55,7 @@ function c91650245.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c91650245.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK)
+	if c:IsExtraDeckMonster()
 		or Duel.SelectOption(tp,aux.Stringid(91650245,0),aux.Stringid(91650245,1))==0 then
 		Duel.SendtoDeck(c,nil,0,REASON_EFFECT)
 	else


### PR DESCRIPTION
fix: if Wattsychic Fighter targeted fusion, synchro, xyz or link monster,  show select the top or bottom.
(need: https://github.com/Fluorohydride/ygopro-core/pull/368)

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13764&keyword=&tag=-1
> その場合、融合モンスター等は相手のデッキではなく、相手のエクストラデッキに戻ります。
> （結果的に、**相手のデッキの一番上・一番下のどちらに戻すかを選ぶ事はありません**。）