### PR TITLE
fix センサー万別

### DIFF
--- a/c24207889.lua
+++ b/c24207889.lua
@@ -52,8 +52,23 @@ function c24207889.adjustop(e,tp,eg,ep,ev,re,r,rp)
 	if (phase==PHASE_DAMAGE and not Duel.IsDamageCalculated()) or phase==PHASE_DAMAGE_CAL then return end
 	local sg=Group.CreateGroup()
 	for p=0,1 do
-		local g=Duel.GetMatchingGroup(Card.IsFaceup,p,LOCATION_MZONE,0,nil)
 		local race=1
+		--update c24207889[p]
+		while bit.band(RACE_ALL,race)~=0 do
+			local rg=c24207889[p]:Filter(Card.IsRace,nil,race)
+			local rc=rg:GetCount()
+			if rc>1 then
+				Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TOGRAVE)
+				local dg=rg:Select(p,rc-1,rc-1,nil)
+				sg:Merge(dg)
+				c24207889[p]:Sub(dg)
+			end
+			race=race<<1
+		end
+		--update field
+		local g=Duel.GetMatchingGroup(Card.IsFaceup,p,LOCATION_MZONE,0,nil)
+		g:Sub(sg)
+		race=1
 		while bit.band(RACE_ALL,race)~=0 do
 			local rg=g:Filter(Card.IsRace,nil,race)
 			local rc=rg:GetCount()
@@ -63,7 +78,7 @@ function c24207889.adjustop(e,tp,eg,ep,ev,re,r,rp)
 				local dg=rg:Select(p,rc-1,rc-1,nil)
 				sg:Merge(dg)
 			end
-			race=race*2
+			race=race<<1
 		end
 	end
 	if sg:GetCount()>0 then


### PR DESCRIPTION
@mercury233 
c24207889[p]: The legal set after the last adjustment.
sg: The card set that will be sent to grave in this adjustment.

Problem
The current script assumes that c24207889[p] is legal and selects cards based on c24207889[p].
This assumption could be wrong if c24207889[p] is changed into the same race by DNA改造手術.

Solution
in order to keep c24207889[p] legal, we should check c24207889[p] first.
Then we can use the original script to check other cards on the field.

