### PR TITLE
fix Tri-Brigade Revolt

### DIFF
--- a/c40975243.lua
+++ b/c40975243.lua
@@ -39,6 +39,7 @@ function c40975243.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE+LOCATION_REMOVED)
 end
 function c40975243.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerCanSpecialSummonCount(tp,2) then return end
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c40975243.spfilter),tp,LOCATION_GRAVE+LOCATION_REMOVED,0,nil,e,tp)


### PR DESCRIPTION
fix: if El Shaddoll Winda has on the field before Tri-Brigade Revolt's effect resolve, Tri-Brigade Revolt's effect was resolve.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23222&keyword=&tag=-1
> なお、「鉄獣の抗戦」を発動した処理時に、「エルシャドール・ミドラーシュ」の『②』の効果が適用された場合、既にこの効果の適用中に自分が特殊召喚を行ったかどうかを問わず、**「鉄獣の抗戦」の効果処理を行いません**。（リンク召喚だけでなく、**その前の墓地及び除外されているモンスターを特殊召喚する処理も行いません**。）