### PR TITLE
fix 銀河眼の光波竜

### DIFF
--- a/c18963306.lua
+++ b/c18963306.lua
@@ -41,7 +41,7 @@ function c18963306.operation(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.GetControl(tc,tp,PHASE_END,1)~=0 then
+	if tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) and tc:IsControlerCanBeChanged() then
 		Duel.NegateRelatedChain(tc,RESET_TURN_SET)
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
@@ -65,6 +65,7 @@ function c18963306.operation(e,tp,eg,ep,ev,re,r,rp)
 		e5:SetValue(18963306)
 		e5:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e5)
+		Duel.GetControl(tc,tp,PHASE_END,1)
 	end
 end
 function c18963306.atktg(e,c)


### PR DESCRIPTION
@mercury233 
https://yugioh-wiki.net/index.php?%A1%D4%B6%E4%B2%CF%B4%E3%A4%CE%B8%F7%C7%C8%CE%B5%A1%D5
Ｑ：自分フィールドに《怒炎壊獣ドゴラン》《銀河眼の光波竜》、相手フィールドに《海亀壊獣ガメシエル》が存在する時、《海亀壊獣ガメシエル》を対象に効果を発動できますか？
Ａ：はい、発動できます。
　　「コントロールの移動」「効果無効化」「名前の変更」は全て同時に行われ、こちらのフィールドに来る時はすでに《海亀壊獣ガメシエル》の名前は《銀河眼の光波竜》になっているため、壊獣の効果で《海亀壊獣ガメシエル》が破壊されることはありません。(16/11/02)

Problem
Suppose that A has a 銀河眼の光波竜/Galaxy-Eyes Cipher Dragon
Now it will destroy the Kaiju after A get its control.

Solution
The name should be changed before getting control.
It is treated as "getting the control of 銀河眼の光波竜/Galaxy-Eyes Cipher Dragon".

Test replay:
[bug_cipher.zip](https://github.com/Fluorohydride/ygopro-scripts/files/6292121/bug_cipher.zip)
