### PR TITLE
fix Extra Gate

### DIFF
--- a/c7405310.lua
+++ b/c7405310.lua
@@ -9,7 +9,7 @@ function c7405310.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c7405310.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)~=0
+	if chk==0 then return Duel.IsExistingMatchingCard(nil,tp,LOCATION_HAND,0,1,e:GetHandler())
 		and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_EXTRA,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINGMSG_LVRANK)
 	local lv=Duel.AnnounceLevel(tp)
@@ -19,15 +19,13 @@ function c7405310.filter(c,lv)
 	return c:IsLevel(lv)
 end
 function c7405310.operation(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerCanRemove(tp) then return end
 	local g=Duel.GetMatchingGroup(c7405310.filter,1-tp,LOCATION_EXTRA,0,nil,e:GetLabel())
 	if g:GetCount()~=0 then
 		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_REMOVE)
 		local rg=g:FilterSelect(1-tp,Card.IsAbleToRemove,1,1,nil)
 		if rg:GetCount()~=0 then
 			Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
-		else
-			local cg=Duel.GetFieldGroup(1-tp,LOCATION_EXTRA,0)
-			Duel.ConfirmCards(tp,cg)
 		end
 	else
 		Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)


### PR DESCRIPTION
fix:
if player's hand has Extra Gate only, Extra Gate can activate in hand.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6251&keyword=&tag=-1
> 自分の手札が0枚の場合や、**自分の手札が「エクストラゲート」1枚のみの場合、「エクストラゲート」を発動する事はできません**。

if Imperial Iron Wall has on the field before Extra Gate's effect resolve, activated player can see opponents extra deck.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6394&keyword=&tag=-1
> また、「エクストラゲート」の効果処理時に「王宮の鉄壁」の効果が適用されている場合には、**「エクストラゲート」の効果処理は適用されません**。
> （エクストラデッキのモンスターを除外する事もなく、手札を捨てる事もありません。）