### PR TITLE
fix クリボール

### DIFF
--- a/c33245030.lua
+++ b/c33245030.lua
@@ -3,7 +3,7 @@ function c33245030.initial_effect(c)
 	--pos
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_POSITION)
-	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCondition(c33245030.condition)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11964&request_locale=ja

■『①：相手モンスターの攻撃宣言時、このカードを手札から墓地へ送って発動できる。その攻撃モンスターを守備表示にする』モンスター効果は、手札にて発動する誘発効果です。（対象を取る効果ではありません。また、この効果を発動する際に、コストとして、手札の「クリボール」自身を墓地へ送ります。）