### PR TITLE
fix Last Resort

### DIFF
--- a/c97970833.lua
+++ b/c97970833.lua
@@ -31,9 +31,10 @@ function c97970833.activate(e,tp,eg,ep,ev,re,r,rp)
 		fc=Duel.GetFieldCard(1-tp,LOCATION_FZONE,0)
 		local te=tc:GetActivateEffect()
 		te:UseCountLimit(tp,1,true)
-		if fc and fc:IsFaceup() and Duel.IsPlayerCanDraw(1-tp,1) and Duel.SelectYesNo(tp,aux.Stringid(97970833,0)) then
+		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
+		if fc and fc:IsFaceup() and Duel.IsPlayerCanDraw(1-tp,1) and Duel.SelectYesNo(1-tp,aux.Stringid(97970833,0)) then
+			Duel.BreakEffect()
 			Duel.Draw(1-tp,1,REASON_EFFECT)
 		end
-		Duel.RaiseEvent(tc,4179255,te,0,tp,tp,Duel.GetCurrentChain())
 	end
 end


### PR DESCRIPTION
fix:
activate and draw are the same.
opponent cannot select whether to draw.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7081
> ■『自分のデッキから「虹の古代都市－レインボー・ルイン」１枚を選択して発動する』処理と、『この時、相手のフィールド魔法が発動している場合、相手プレイヤーはカードを１枚ドローする事ができる』処理は**同時に行われる扱いではありません**。
> （『相手プレイヤーはカードを１枚ドローする事ができる』処理を適用するかどうかを決めるのは**相手プレイヤーとなります**。）