### PR TITLE
Fix "Destiny HERO - Decider"

### DIFF
--- a/c64184058.lua
+++ b/c64184058.lua
@@ -10,7 +10,7 @@ function c64184058.initial_effect(c)
 	c:RegisterEffect(e1)
 	--to hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_GRAVE_ACTION)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetProperty(EFFECT_FLAG_DELAY)


### PR DESCRIPTION
No one could chain "Ghost Belle & Haunted Mansion" to Decider's on-Summon effect when they should. A similar example, which does work, can be found at https://db.ygorganization.com/qa#23079

Let me know if any other cards which need `CATEGORY_GRAVE_ACTION` and/or `CATEGORY_GRAVE_SPSUMMON`!