### PR TITLE
fix Diced Dice

### DIFF
--- a/c93078761.lua
+++ b/c93078761.lua
@@ -15,7 +15,7 @@ function c93078761.filter(c)
 	return c.toss_dice and c:IsAbleToHand()
 end
 function c93078761.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.IsExistingMatchingCard(c93078761.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function c93078761.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
fix: if player has no cards in deck that requires a die roll, Diced Dice can activate.

> Q.
> 自分のデッキにサイコロを振る効果を持つカードがない場合、自分は「賽挑戦」を発動できますか？
> A.
> 自分のデッキにサイコロを振る効果を持つカードが入っていない場合、「賽挑戦」を発動することはできません。