### PR TITLE
Fix War Rock Bashileos Summoning Condition

### DIFF
--- a/c18558867.lua
+++ b/c18558867.lua
@@ -73,7 +73,7 @@ function c18558867.draop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c18558867.spfilter(c,tp)
-	return c:IsPreviousControler(tp) and c:IsSetCard(0x15f) and c:IsType(TYPE_MONSTER)
+	return c:IsPreviousControler(tp) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsRace(RACE_WARRIOR)
 end
 function c18558867.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c18558867.spfilter,1,nil,tp)


### PR DESCRIPTION
Should trigger on battle destruction of EARTH Warrior monster, not only on War Rock battle destruction.