### PR TITLE
fix Terror of Trishula

### DIFF
--- a/c6075533.lua
+++ b/c6075533.lua
@@ -2,7 +2,7 @@
 function c6075533.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetCategory(CATEGORY_REMOVE+CATEGORY_GRAVE_ACTION)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,6075533)


### PR DESCRIPTION
fix: when Terror of Trishula activated, Ghost Belle & Haunted Mansion cannot activate.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23145&keyword=&tag=-1
> 発動できます。
> 
> 「トリシューラの鼓動」の発動時に、**そのプレイヤーのフィールドに「氷結界」シンクロモンスターが１種類しか存在しなかった場合でも同様です**。