### PR TITLE
fix F.A. Shining Star GT

### DIFF
--- a/c37414347.lua
+++ b/c37414347.lua
@@ -73,8 +73,9 @@ function c37414347.discon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==1-tp and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev)
 end
 function c37414347.discost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsCanRemoveCounter(tp,1,1,0x4a,1,REASON_COST) end
-	Duel.RemoveCounter(tp,1,1,0x4a,1,REASON_COST)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsCanRemoveCounter(tp,0x4a,1,REASON_COST) end
+	c:RemoveCounter(tp,0x4a,1,REASON_COST)
 end
 function c37414347.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
fix: F.A. Shining Star GT can remove Athlete Counter on other monster.

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=14051
> ④：相手がモンスターの効果を発動した時、**このカードのアスリートカウンターを１つ取り除いて発動できる**。その発動を無効にし破壊する。