### PR TITLE
add Duel.BreakEffect

### DIFF
--- a/c12255007.lua
+++ b/c12255007.lua
@@ -32,7 +32,7 @@ function c12255007.actcon(e)
 	return tc and tc:IsControler(tp) and tc:IsSetCard(0x9f,0x99)
 end
 function c12255007.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c12255007.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsSetCard,1,nil,0x9f) end
@@ -40,7 +40,8 @@ function c12255007.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c12255007.operation(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetHandler():IsRelateToEffect(e) and Duel.NegateAttack() then
+	if Duel.NegateAttack() then
+		Duel.BreakEffect()
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end

--- a/c14315573.lua
+++ b/c14315573.lua
@@ -11,7 +11,7 @@ function c14315573.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c14315573.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c14315573.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()
@@ -22,6 +22,7 @@ end
 function c14315573.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetAttacker()
 	if tc:IsRelateToEffect(e) and Duel.NegateAttack() then
+		Duel.BreakEffect()
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end

--- a/c18964575.lua
+++ b/c18964575.lua
@@ -13,7 +13,7 @@ function c18964575.initial_effect(c)
 end
 function c18964575.condition(e,tp,eg,ep,ev,re,r,rp)
 	local at=Duel.GetAttacker()
-	return at:GetControler()==1-tp and Duel.GetAttackTarget()==nil
+	return at:IsControler(1-tp) and Duel.GetAttackTarget()==nil
 end
 function c18964575.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end

--- a/c18964575.lua
+++ b/c18964575.lua
@@ -13,7 +13,7 @@ function c18964575.initial_effect(c)
 end
 function c18964575.condition(e,tp,eg,ep,ev,re,r,rp)
 	local at=Duel.GetAttacker()
-	return at:GetControler()~=tp and Duel.GetAttackTarget()==nil
+	return at:GetControler()==1-tp and Duel.GetAttackTarget()==nil
 end
 function c18964575.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end
@@ -21,6 +21,7 @@ function c18964575.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c18964575.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateAttack() then
+		Duel.BreakEffect()
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end

--- a/c21123811.lua
+++ b/c21123811.lua
@@ -61,7 +61,7 @@ end
 function c21123811.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return c:IsAbleToRemoveAsCost() end
-	if Duel.Remove(c,POS_FACEUP,REASON_COST+REASON_TEMPORARY)~=0 then
+	if Duel.Remove(c,0,REASON_COST+REASON_TEMPORARY)~=0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_END)
@@ -85,7 +85,7 @@ function c21123811.disop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c21123811.dscon(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=ep and Duel.GetCurrentChain()==0
+	return ep==1-tp and Duel.GetCurrentChain()==0
 end
 function c21123811.dstg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
@@ -97,10 +97,11 @@ function c21123811.dsop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(eg,REASON_EFFECT)
 end
 function c21123811.negcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c21123811.negop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateAttack() then
+		Duel.BreakEffect()
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end

--- a/c25857246.lua
+++ b/c25857246.lua
@@ -49,6 +49,7 @@ function c25857246.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c25857246.atkop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateAttack() then
+		Duel.BreakEffect()
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end

--- a/c276357.lua
+++ b/c276357.lua
@@ -31,7 +31,7 @@ function c276357.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c276357.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c276357.cfilter(c)
 	return c:IsType(TYPE_SPIRIT) and c:IsAbleToRemoveAsCost()
@@ -43,7 +43,8 @@ function c276357.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function c276357.activate(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetHandler():IsRelateToEffect(e) and Duel.NegateAttack() then
+	if Duel.NegateAttack() then
+		Duel.BreakEffect()
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end
@@ -62,7 +63,6 @@ function c276357.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function c276357.desop(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		Duel.Destroy(tc,REASON_EFFECT)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12998&request_locale=ja
■『●相手モンスターの攻撃宣言時に発動できる。その攻撃を無効にし、その後バトルフェイズを終了する』効果は、相手モンスターの攻撃宣言時に発動します。『その攻撃を無効にし』の処理と、『その後バトルフェイズを終了する』処理は同時に行われる扱いではありません。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4804&request_locale=ja
■『その攻撃を無効にする』処理と、『その後、バトルフェイズを終了する』処理は、同時に行われる扱いではありません。