### PR TITLE
fix flip effect

### DIFF
--- a/c10110717.lua
+++ b/c10110717.lua
@@ -42,10 +42,10 @@ function c10110717.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c10110717.damtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() end
+	if chkc then return chkc:IsOnField() and not chkc:IsStatus(STATUS_BATTLE_DESTROYED) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	local g=Duel.SelectTarget(tp,aux.NOT(Card.IsStatus),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil,STATUS_BATTLE_DESTROYED)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,g:GetFirst():GetControler(),500)
 end
 function c10110717.damop(e,tp,eg,ep,ev,re,r,rp)

--- a/c1347977.lua
+++ b/c1347977.lua
@@ -11,10 +11,10 @@ function c1347977.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c1347977.filter1(c)
-	return c:IsFaceup() and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
+	return c:IsFaceup() and c:IsType(TYPE_MONSTER) and not c:IsStatus(STATUS_BATTLE_DESTROYED) and c:IsAbleToDeck()
 end
 function c1347977.filter2(c)
-	return c:IsFaceup() and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+	return c:IsFaceup() and c:IsType(TYPE_MONSTER) and not c:IsStatus(STATUS_BATTLE_DESTROYED) and c:IsAbleToHand()
 end
 function c1347977.filter3(c)
 	return c:IsFaceup() and c:IsRace(RACE_WARRIOR)

--- a/c1571945.lua
+++ b/c1571945.lua
@@ -11,7 +11,7 @@ function c1571945.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c1571945.filter(c)
-	return c:IsDefensePos()
+	return c:IsDefensePos() and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c1571945.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c1571945.filter(chkc) end

--- a/c28357177.lua
+++ b/c28357177.lua
@@ -10,11 +10,14 @@ function c28357177.initial_effect(c)
 	e1:SetOperation(c28357177.operation)
 	c:RegisterEffect(e1)
 end
+function c28357177.filter(c)
+	return not c:IsStatus(STATUS_BATTLE_DESTROYED) and c:IsAbleToHand()
+end
 function c28357177.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsAbleToHand() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsAbleToHand,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c28357177.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c28357177.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_MZONE,LOCATION_MZONE,1,3,nil)
+	local g=Duel.SelectTarget(tp,c28357177.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,3,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
 function c28357177.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c30328508.lua
+++ b/c30328508.lua
@@ -24,10 +24,10 @@ function c30328508.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c30328508.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
-	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and not chkc:IsStatus(STATUS_BATTLE_DESTROYED) end
+	if chk==0 then return Duel.IsExistingTarget(aux.NOT(Card.IsStatus),tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,STATUS_BATTLE_DESTROYED) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,aux.NOT(Card.IsStatus),tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,STATUS_BATTLE_DESTROYED)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function c30328508.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c31759689.lua
+++ b/c31759689.lua
@@ -34,7 +34,8 @@ function c31759689.filter(c)
 end
 function c31759689.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c31759689.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c31759689.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler()) end
+	if chk==0 then return not c:IsStatus(STATUS_BATTLE_DESTROYED)
+		and Duel.IsExistingTarget(c31759689.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,c31759689.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,e:GetHandler())
 end

--- a/c34853266.lua
+++ b/c34853266.lua
@@ -24,10 +24,10 @@ function c34853266.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c34853266.filter(c)
-	return c:IsFaceup() and c:IsCanTurnSet()
+	return c:IsFaceup() and not c:IsStatus(STATUS_BATTLE_DESTROYED) and c:IsCanTurnSet()
 end
 function c34853266.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:GetLocation()==LOCATION_MZONE and c34853266.filter(chkc) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c34853266.filter(chkc) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	local g=Duel.SelectTarget(tp,c34853266.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)

--- a/c42679662.lua
+++ b/c42679662.lua
@@ -11,7 +11,7 @@ function c42679662.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c42679662.filter(c)
-	return c:IsSummonType(SUMMON_TYPE_SPECIAL) and c:IsAbleToDeck()
+	return c:IsSummonType(SUMMON_TYPE_SPECIAL) and not c:IsStatus(STATUS_BATTLE_DESTROYED) and c:IsAbleToDeck()
 end
 function c42679662.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c42679662.filter(chkc) end

--- a/c47556396.lua
+++ b/c47556396.lua
@@ -32,7 +32,7 @@ function c47556396.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c47556396.filter(c)
-	return c:IsDefensePos() or c:GetAttack()>0
+	return (c:IsDefensePos() or c:GetAttack()>0) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c47556396.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c47556396.filter(chkc) end

--- a/c49729312.lua
+++ b/c49729312.lua
@@ -52,10 +52,10 @@ function c49729312.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c49729312.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() end
-	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	if chkc then return chkc:IsOnField() and not chkc:IsStatus(STATUS_BATTLE_DESTROYED) end
+	if chk==0 then return Duel.IsExistingTarget(aux.NOT(Card.IsStatus),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil,STATUS_BATTLE_DESTROYED) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,2,nil)
+	local g=Duel.SelectTarget(tp,aux.NOT(Card.IsStatus),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,2,nil,STATUS_BATTLE_DESTROYED)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c49729312.desop(e,tp,eg,ep,ev,re,r,rp)

--- a/c54652250.lua
+++ b/c54652250.lua
@@ -11,10 +11,10 @@ function c54652250.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c54652250.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and not chkc:IsStatus(STATUS_BATTLE_DESTROYED) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,aux.NOT(Card.IsStatus),tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,STATUS_BATTLE_DESTROYED)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c54652250.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c65878864.lua
+++ b/c65878864.lua
@@ -10,11 +10,11 @@ function c65878864.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c65878864.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and not chkc:IsStatus(STATUS_BATTLE_DESTROYED) end
 	if chk==0 then return true end
-	if Duel.IsExistingTarget(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,2,nil) then
+	if Duel.IsExistingTarget(aux.NOT(Card.IsStatus),tp,LOCATION_MZONE,LOCATION_MZONE,2,nil,STATUS_BATTLE_DESTROYED) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-		local g=Duel.SelectTarget(tp,aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,2,2,nil)
+		local g=Duel.SelectTarget(tp,aux.NOT(Card.IsStatus),tp,LOCATION_MZONE,LOCATION_MZONE,2,2,nil,STATUS_BATTLE_DESTROYED)
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 	end
 end

--- a/c66675911.lua
+++ b/c66675911.lua
@@ -28,7 +28,7 @@ function c66675911.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
 end
 function c66675911.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x9d)
+	return c:IsFaceup() and c:IsSetCard(0x9d) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c66675911.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c66675911.filter(chkc) end

--- a/c7089711.lua
+++ b/c7089711.lua
@@ -10,11 +10,14 @@ function c7089711.initial_effect(c)
 	e1:SetOperation(c7089711.operation)
 	c:RegisterEffect(e1)
 end
+function c7089711.filter(c)
+	return not c:IsStatus(STATUS_BATTLE_DESTROYED) and c:IsAbleToHand()
+end
 function c7089711.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:GetLocation()==LOCATION_MZONE and chkc:IsAbleToHand() end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c7089711.filter(chkc) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,c7089711.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
 function c7089711.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c75421661.lua
+++ b/c75421661.lua
@@ -25,11 +25,14 @@ function c75421661.atkop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
 	e:GetHandler():RegisterEffect(e1)
 end
+function c75421661.filter(c)
+	return c:IsFaceup() and not c:IsStatus(STATUS_BATTLE_DESTROYED)
+end
 function c75421661.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and Card.IsFaceup(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c75421661.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c75421661.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,2,nil)
+	local g=Duel.SelectTarget(tp,c75421661.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,2,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c75421661.desop(e,tp,eg,ep,ev,re,r,rp)

--- a/c84472026.lua
+++ b/c84472026.lua
@@ -44,11 +44,14 @@ function c84472026.posop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ChangePosition(c,POS_FACEDOWN_DEFENSE)
 	end
 end
+function c84472026.indfilter(c)
+	return c84472026.sfilter(c) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
+end
 function c84472026.indestg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c84472026.sfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c84472026.sfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c84472026.indfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c84472026.indfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c84472026.sfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c84472026.indfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 end
 function c84472026.indesop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c8634636.lua
+++ b/c8634636.lua
@@ -10,15 +10,18 @@ function c8634636.initial_effect(c)
 	e1:SetOperation(c8634636.operation)
 	c:RegisterEffect(e1)
 end
+function c8634636.filter(c)
+	return c:IsAbleToHand() and not c:IsStatus(STATUS_BATTLE_DESTROYED)
+end
 function c8634636.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return true end
-	if Duel.IsExistingTarget(Card.IsAbleToHand,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.IsExistingTarget(Card.IsAbleToHand,tp,0,LOCATION_MZONE,2,nil) then
+	if Duel.IsExistingTarget(c8634636.filter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingTarget(c8634636.filter,tp,0,LOCATION_MZONE,2,nil) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-		local g1=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,0,LOCATION_MZONE,2,2,nil)
+		local g1=Duel.SelectTarget(tp,c8634636.filter,tp,0,LOCATION_MZONE,2,2,nil)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-		local g2=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_MZONE,0,1,1,nil)
+		local g2=Duel.SelectTarget(tp,c8634636.filter,tp,LOCATION_MZONE,0,1,1,nil)
 		g1:Merge(g2)
 		Duel.SetOperationInfo(0,CATEGORY_TOHAND,g1,g1:GetCount(),0,0)
 	end

--- a/c88316955.lua
+++ b/c88316955.lua
@@ -24,10 +24,10 @@ function c88316955.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c88316955.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
-	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and not chkc:IsStatus(STATUS_BATTLE_DESTROYED) end
+	if chk==0 then return Duel.IsExistingTarget(aux.NOT(Card.IsStatus),tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,STATUS_BATTLE_DESTROYED) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,aux.NOT(Card.IsStatus),tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,STATUS_BATTLE_DESTROYED)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function c88316955.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c90365482.lua
+++ b/c90365482.lua
@@ -22,11 +22,14 @@ function c90365482.initial_effect(c)
 	e3:SetCode(EVENT_FLIP)
 	c:RegisterEffect(e3)
 end
+function c90365482.posfilter(c)
+	return c:IsFaceup() and not c:IsStatus(STATUS_BATTLE_DESTROYED)
+end
 function c90365482.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c90365482.posfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c90365482.posfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SelectTarget(tp,c90365482.posfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 end
 function c90365482.posop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c91133740.lua
+++ b/c91133740.lua
@@ -12,7 +12,7 @@ function c91133740.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c91133740.filter(c)
-	return c:IsFaceup()
+	return c:IsFaceup() and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c91133740.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c91133740.filter(chkc) end

--- a/c93724592.lua
+++ b/c93724592.lua
@@ -40,11 +40,14 @@ function c93724592.posop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
 	end
 end
+function c93724592.tgfilter(c)
+	return c:IsFaceup() and not c:IsStatus(STATUS_BATTLE_DESTROYED)
+end
 function c93724592.tgtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c93724592.tgfilter(chkc) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,c93724592.tgfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,g,g:GetCount(),0,0)
 end
 function c93724592.tgop(e,tp,eg,ep,ev,re,r,rp)

--- a/c93920745.lua
+++ b/c93920745.lua
@@ -10,11 +10,14 @@ function c93920745.initial_effect(c)
 	e1:SetOperation(c93920745.operation)
 	c:RegisterEffect(e1)
 end
+function c93920745.filter(c)
+	return not c:IsStatus(STATUS_BATTLE_DESTROYED) and c:IsAbleToHand()
+end
 function c93920745.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsAbleToHand() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsAbleToHand,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c93920745.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_MZONE,LOCATION_MZONE,1,2,nil)
+	local g=Duel.SelectTarget(tp,c93920745.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,2,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
 function c93920745.operation(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
fix: if the monster would be destroyed, flip effect can target that destroyed monster.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4507
> ■『①』のモンスター効果によって、「人喰い虫」自身を対象に選択する事もできます。しかしながら、「人喰い虫」自身が戦闘によってリバースしその戦闘によって破壊されている場合は、「人喰い虫」自身を対象に選択する事はできません。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4547
> ■『①』のモンスター効果によって、「ハネハネ」自身を対象に選択する事もできます。しかしながら、「ハネハネ」自身が戦闘によってリバースしその戦闘によって破壊されている場合は、「ハネハネ」自身を対象に選択する事はできません。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4608
> ■「ペンギン・ソルジャー」のモンスター効果によって、「ペンギン・ソルジャー」自身を対象に選択する事もできます。しかしながら、「ペンギン・ソルジャー」自身が戦闘によってリバースしその戦闘によって破壊されている場合は、「ペンギン・ソルジャー」自身を対象に選択する事はできません。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5667
> ■「尾も白い黒猫」のモンスター効果によって、「尾も白い黒猫」自身を対象に選択する事もできます。しかしながら、「尾も白い黒猫」自身が戦闘によってリバースしその戦闘によって破壊されている場合には、「尾も白い黒猫」自身を対象に選択する事はできません。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9992
> ■「ヴェルズ・アザトホース」のモンスター効果によって、「ヴェルズ・アザトホース」自身を対象に選択する事もできます。しかしながら、「ヴェルズ・アザトホース」自身が戦闘によってリバースしその戦闘によって破壊されている場合には、「ヴェルズ・アザトホース」自身を対象に選択する事はできません。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10986
> ■『そのモンスターはこのターン戦闘・効果では破壊されない』モンスター効果の対象として「ゴーストリック・イエティ」自身を選択する事もできますが、「ゴーストリック・イエティ」が相手モンスターの攻撃によってリバースし、その「ゴーストリック・イエティ」自身が戦闘で破壊されている場合には、「ゴーストリック・イエティ」自身を対象として発動する事はできません。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21512&keyword=&tag=-1
> 「ティンダングル・ハウンド」の『このカードの攻撃力は対象のモンスターの元々の攻撃力分アップする。その後、対象のモンスターを裏側守備表示にする』モンスター効果は、「ティンダングル・ハウンド」自身がリバースしている場合でも、自身がその戦闘で破壊されている際には発動する事自体ができません。