### PR TITLE
fix for trap monster

### DIFF
--- a/c19261966.lua
+++ b/c19261966.lua
@@ -36,7 +36,7 @@ function c19261966.splimit(e,se,sp,st)
 end
 function c19261966.sumlimit(e,c,sump,sumtype,sumpos,targetp,se)
 	return se:IsActiveType(TYPE_SPELL+TYPE_TRAP) and se:IsHasType(EFFECT_TYPE_ACTIONS)
-		and c:IsLocation(LOCATION_GRAVE+LOCATION_HAND)
+		and c:IsLocation(LOCATION_GRAVE+LOCATION_HAND) and c:IsType(TYPE_MONSTER)
 end
 function c19261966.thfilter(c)
 	return c:IsSetCard(0x9d) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToHand()

--- a/c23085002.lua
+++ b/c23085002.lua
@@ -53,5 +53,5 @@ function c23085002.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e2,tp)
 end
 function c23085002.splimit(e,c)
-	return c:IsLocation(LOCATION_GRAVE)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsType(TYPE_MONSTER)
 end

--- a/c3966653.lua
+++ b/c3966653.lua
@@ -53,5 +53,5 @@ function c3966653.aclimit(e,re,tp)
 	return re:GetActivateLocation()==LOCATION_GRAVE
 end
 function c3966653.sumlimit(e,c,sump,sumtype,sumpos,targetp,se)
-	return c:IsLocation(LOCATION_GRAVE)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsType(TYPE_MONSTER)
 end


### PR DESCRIPTION
fix: if El Shaddoll Anoyatyllis has on the field, Paleozoic cannot special summon from grave(but Paleozoic can activate from grave).

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11488&keyword=&tag=-1
> 「エルシャドール・アノマリリス」の『①：このカードがモンスターゾーンに存在する限り、お互いに魔法・罠カードの効果で手札・墓地からモンスターを特殊召喚できない』効果が適用されている場合でも、墓地の「幻影騎士団シャドーベイル」の効果を発動する事はできます。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7518&keyword=&tag=-1
> 「王宮の牢獄」の『このカードがフィールド上に存在する限り、お互いのプレイヤーは墓地のモンスターを特殊召喚できない』効果が適用されている場合でも、墓地の「幻影騎士団シャドーベイル」の効果を発動する事はできます。