### PR TITLE
fix 烈風帝ライザー

### DIFF
--- a/c69327790.lua
+++ b/c69327790.lua
@@ -65,20 +65,25 @@ function c69327790.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 			local g3=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,g1:GetFirst())
 			Duel.SetOperationInfo(0,CATEGORY_TOHAND,g3,1,0,0)
 		end
-		g1:Merge(g2)
+		e:SetLabelObject(g2:GetFirst())
 		Duel.SetOperationInfo(0,CATEGORY_TODECK,g1,2,0,0)
 	end
 end
 function c69327790.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local ex,g1=Duel.GetOperationInfo(0,CATEGORY_TODECK)
 	local ex2,g2=Duel.GetOperationInfo(0,CATEGORY_TOHAND)
+	local gc=e:GetLabelObject()
 	if not g1 then return end
 	local sg1=g1:Filter(Card.IsRelateToEffect,nil,e)
+	local fc=sg1:GetFirst()
+	if gc and gc:IsRelateToEffect(e) then sg1:AddCard(gc) end
 	if sg1:GetCount()>0 and Duel.SendtoDeck(sg1,nil,0,REASON_EFFECT)>1 then
-		local tc1=sg1:GetFirst()
-		local tc2=sg1:GetNext()
-		if tc1:GetControler()==tc2:GetControler() and tc1:IsLocation(LOCATION_DECK) and tc2:IsLocation(LOCATION_DECK) then
-			Duel.SortDecktop(tp,tc1:GetControler(),2)
+		if fc:GetControler()==gc:GetControler() and fc:IsLocation(LOCATION_DECK) and gc:IsLocation(LOCATION_DECK) then
+			if Duel.SelectYesNo(tp,aux.Stringid(69327790,3)) then
+				Duel.MoveSequence(fc,0)
+			else
+				Duel.MoveSequence(gc,0)
+			end
 		end
 	end
 	if e:GetLabel()==1 and g2 then


### PR DESCRIPTION
@mercury233 
![p1](https://user-images.githubusercontent.com/2851577/123131058-eaca6580-d47f-11eb-95cf-ea5cab4f28bc.png)
![p2](https://user-images.githubusercontent.com/2851577/123131137-fe75cc00-d47f-11eb-8c52-9033793d7390.png)

# Problem
Duel.SortDecktop() will let the player know the card on deck top.

# Solution
Use Duel.MoveSequence() instead.

aux.Stringid(69327790,3)
Do you want to put the target card on the field at the top?
