### PR TITLE
fix 餅カエル

### DIFF
--- a/c90809975.lua
+++ b/c90809975.lua
@@ -91,7 +91,7 @@ function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	if not Duel.NegateActivation(ev) then return end
 	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK)
 		and aux.NecroValleyFilter()(rc) then
-		if rc:IsType(TYPE_MONSTER) and (Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		if rc:IsType(TYPE_MONSTER) and (not rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 				or rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)
 			and rc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
 			and Duel.SelectYesNo(tp,aux.Stringid(90809975,3)) then

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -79,12 +79,11 @@ function c90809975.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
-		local cat=e:GetCategory()
-		if bit.band(re:GetHandler():GetOriginalType(),TYPE_MONSTER)~=0 then
-			e:SetCategory(bit.bor(cat,CATEGORY_SPECIAL_SUMMON))
-		else
-			e:SetCategory(bit.band(cat,bit.bnot(CATEGORY_SPECIAL_SUMMON)))
-		end
+	end
+	if bit.band(re:GetHandler():GetOriginalType(),TYPE_MONSTER)~=0 then
+		e:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON+CATEGORY_GRAVE_SPSUMMON)
+	else
+		e:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
 	end
 end
 function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
@@ -92,8 +91,8 @@ function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	if not Duel.NegateActivation(ev) then return end
 	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK)
 		and aux.NecroValleyFilter()(rc) then
-		if rc:IsType(TYPE_MONSTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-			and (not rc:IsLocation(LOCATION_EXTRA) or Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)
+		if rc:IsType(TYPE_MONSTER) and (Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+				or rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)
 			and rc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
 			and Duel.SelectYesNo(tp,aux.Stringid(90809975,3)) then
 			Duel.BreakEffect()


### PR DESCRIPTION
遊戯王カードゲーム事務局からのご連絡 [ ref:_00D10aOlP._5005F1IGCxt:ref ]
コナミデジタルエンタテインメントお客様相談室
收件人 我
5月1日详情
遊戯王カードゲーム事務局です。

いつも遊戯王オフィシャルカードゲームをお楽しみいただきありがとうございます。
お問い合わせいただいた件、下記のとおりご案内いたします。

Q.
1.相手が「ヘビーメタルフォーゼ・エレクトラム」の『①：このカードがリンク召喚に成功した場合に発動できる。デッキからPモンスター１体を選び、自分のEXデッキに表側表示で加える』モンスター効果を発動しました。

自分がその発動にチェーンして「餅カエル」の『②：１ターンに１度、相手がモンスターの効果・魔法・罠カードを発動した時、自分の手札・フィールドの水族モンスター１体を墓地へ送って発動できる。その発動を無効にし破壊する。その後、破壊したカードを自分フィールドにセットできる』モンスター効果を発動した場合、手札の「屋敷わらし」の効果を発動できますか？
A.
ご質問の場合、「屋敷わらし」の効果を発動できます。

Q.
2.相手が「レスキューキャット」の『①：フィールドのこのカードを墓地へ送って発動できる。デッキからレベル３以下の獣族モンスター２体を特殊召喚する。この効果で特殊召喚したモンスターの効果は無効化され、エンドフェイズに破壊される』モンスター効果を発動しました。

自分がその発動にチェーンして「餅カエル」の『②：１ターンに１度、相手がモンスターの効果・魔法・罠カードを発動した時、自分の手札・フィールドの水族モンスター１体を墓地へ送って発動できる。その発動を無効にし破壊する。その後、破壊したカードを自分フィールドにセットできる』モンスター効果を発動した場合、手札の「屋敷わらし」の効果を発動できますか？
A.
ご質問の場合、「屋敷わらし」の効果を発動できます。

Q.
1. 相手が「EMドクロバット・ジョーカー」の『①：このカードが召喚に成功した時に発動できる。デッキから「EMドクロバット・ジョーカー」以外の「EM」モンスター、「魔術師」Pモンスター、「オッドアイズ」モンスターの内、いずれか１体を手札に加える。』モンスター効果を発動しました。

自分がその発動にチェーンして「餅カエル」の『②：１ターンに１度、相手がモンスターの効果・魔法・罠カードを発動した時、自分の手札・フィールドの水族モンスター１体を墓地へ送って発動できる。その発動を無効にし破壊する。その後、破壊したカードを自分フィールドにセットできる』モンスター効果を発動した場合、手札の「屋敷わらし」の効果を発動できますか？
A.
ご質問の場合、「屋敷わらし」の効果を発動できます。

Q.
2.相手が手札の「EMドクロバット・ジョーカー」をペンデュラムゾーンに魔法カードとして発動しました。

自分がその発動にチェーンして「餅カエル」の『②：１ターンに１度、相手がモンスターの効果・魔法・罠カードを発動した時、自分の手札・フィールドの水族モンスター１体を墓地へ送って発動できる。その発動を無効にし破壊する。その後、破壊したカードを自分フィールドにセットできる』モンスター効果を発動した場合、手札の「屋敷わらし」の効果を発動できますか？
A.
ご質問の場合、「屋敷わらし」の効果を発動できます。
