### PR TITLE
fix & update draw replace effects

### DIFF
--- a/c66499018.lua
+++ b/c66499018.lua
@@ -7,36 +7,23 @@ function c66499018.initial_effect(c)
 	e1:SetCode(EVENT_PREDRAW)
 	e1:SetRange(LOCATION_GRAVE)
 	e1:SetCondition(c66499018.condition)
+	e1:SetCost(aux.DrawReplaceCost)
 	e1:SetTarget(c66499018.target)
 	e1:SetOperation(c66499018.operation)
 	c:RegisterEffect(e1)
 end
 function c66499018.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp==Duel.GetTurnPlayer() and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0
-		and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 and Duel.GetDrawCount(tp)>0
+	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
 end
 function c66499018.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
-	local dt=Duel.GetDrawCount(tp)
-	if dt~=0 then
-		aux.DrawReplaceCount=0
-		aux.DrawReplaceMax=dt
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_FIELD)
-		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-		e1:SetCode(EFFECT_DRAW_COUNT)
-		e1:SetTargetRange(1,0)
-		e1:SetReset(RESET_PHASE+PHASE_DRAW)
-		e1:SetValue(0)
-		Duel.RegisterEffect(e1,tp)
-	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c66499018.operation(e,tp,eg,ep,ev,re,r,rp)
+	if not aux.UseDrawReplace(e,tp) then return end
 	local c=e:GetHandler()
-	aux.DrawReplaceCount=aux.DrawReplaceCount+1
-	if aux.DrawReplaceCount<=aux.DrawReplaceMax and c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
+	if c:IsRelateToEffect(e) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)

--- a/c88851326.lua
+++ b/c88851326.lua
@@ -45,7 +45,7 @@ function c88851326.initial_effect(c)
 	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e6:SetCode(EVENT_PREDRAW)
 	e6:SetRange(LOCATION_SZONE)
-	e6:SetCondition(c88851326.thcon)
+	e6:SetCondition(aux.DrawReplaceCondition)
 	e6:SetTarget(c88851326.thtg)
 	e6:SetOperation(c88851326.thop)
 	c:RegisterEffect(e6)
@@ -96,52 +96,15 @@ end
 function c88851326.attg(e,c)
 	return c:IsStatus(STATUS_SPSUMMON_TURN) and c:IsSummonLocation(LOCATION_EXTRA)
 end
-function c88851326.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return tp==Duel.GetTurnPlayer() and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0
-		and Duel.GetDrawCount(tp)>0
-end
 function c88851326.thfilter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
 function c88851326.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c88851326.thfilter,tp,LOCATION_GRAVE,0,1,nil) end
-	local dt=Duel.GetDrawCount(tp)
-	if dt~=0 then
-		aux.DrawReplaceCount=0
-		aux.DrawReplaceMax=dt
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_FIELD)
-		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-		e1:SetCode(EFFECT_DRAW_COUNT)
-		e1:SetTargetRange(1,0)
-		e1:SetReset(RESET_PHASE+PHASE_DRAW)
-		e1:SetValue(0)
-		Duel.RegisterEffect(e1,tp)
-		local cid=Duel.GetChainInfo(0,CHAININFO_CHAIN_ID)
-		local e2=Effect.CreateEffect(e:GetHandler())
-		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-		e2:SetCode(EVENT_CHAIN_SOLVING)
-		e2:SetLabel(cid)
-		e2:SetLabelObject(e1)
-		e2:SetReset(RESET_PHASE+PHASE_DRAW)
-		e2:SetCondition(c88851326.checkcon1)
-		e2:SetOperation(c88851326.checkop1)
-		Duel.RegisterEffect(e2,tp)
-	end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_GRAVE)
 end
-function c88851326.checkcon1(e,tp,eg,ep,ev,re,r,rp)
-	local cid,orig_effect=Duel.GetChainInfo(ev,CHAININFO_CHAIN_ID,CHAININFO_TRIGGERING_EFFECT)
-	return cid==e:GetLabel() and not e:GetOwner():IsRelateToEffect(orig_effect)
-end
-function c88851326.checkop1(e,tp,eg,ep,ev,re,r,rp)
-	e:GetLabelObject():Reset()
-	e:Reset()
-end
 function c88851326.thop(e,tp,eg,ep,ev,re,r,rp)
-	aux.DrawReplaceCount=aux.DrawReplaceCount+1
-	if aux.DrawReplaceCount>aux.DrawReplaceMax or not e:GetHandler():IsRelateToEffect(e) then return end
+	if not aux.UseDrawReplace(e,tp) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,c88851326.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
 	if g:GetCount()>0 then

--- a/c91819979.lua
+++ b/c91819979.lua
@@ -14,7 +14,7 @@ function c91819979.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_PREDRAW)
 	e2:SetRange(LOCATION_GRAVE)
-	e2:SetCondition(c91819979.thcon)
+	e2:SetCondition(aux.DrawReplaceCondition)
 	e2:SetTarget(c91819979.thtg)
 	e2:SetOperation(c91819979.thop)
 	c:RegisterEffect(e2)
@@ -34,31 +34,14 @@ function c91819979.damop(e,tp,eg,ep,ev,re,r,rp)
 	local ct=Duel.GetMatchingGroupCount(c91819979.cfilter,tp,LOCATION_MZONE,0,nil)
 	Duel.Damage(p,ct*200,REASON_EFFECT)
 end
-function c91819979.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return tp==Duel.GetTurnPlayer() and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0
-		and Duel.GetDrawCount(tp)>0
-end
 function c91819979.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToHand() end
-	local dt=Duel.GetDrawCount(tp)
-	if dt~=0 then
-		aux.DrawReplaceCount=0
-		aux.DrawReplaceMax=dt
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_FIELD)
-		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-		e1:SetCode(EFFECT_DRAW_COUNT)
-		e1:SetTargetRange(1,0)
-		e1:SetReset(RESET_PHASE+PHASE_DRAW)
-		e1:SetValue(0)
-		Duel.RegisterEffect(e1,tp)
-	end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,e:GetHandler(),1,0,0)
 end
 function c91819979.thop(e,tp,eg,ep,ev,re,r,rp)
+	if not aux.UseDrawReplace(e,tp) then return end
 	local c=e:GetHandler()
-	aux.DrawReplaceCount=aux.DrawReplaceCount+1
-	if aux.DrawReplaceCount<=aux.DrawReplaceMax and c:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) then
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,c)
 	end

--- a/utility.lua
+++ b/utility.lua
@@ -2690,3 +2690,31 @@ end
 function Auxiliary.ExtraReleaseFilter(c,tp)
 	return c:IsControler(1-tp) and c:IsHasEffect(EFFECT_EXTRA_RELEASE_NONSUM,tp)
 end
+--for "You can give up your normal draw this turn" or "instead of conducting your normal draw" effects
+function Auxiliary.DrawReplaceCondition(e,tp)
+	return tp==Duel.GetTurnPlayer() and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 and Duel.GetDrawCount(tp)>0
+end
+function Auxiliary.UseDrawReplace(e,tp,activating)
+	if not Auxiliary.DrawReplaceCondition(e,tp) then return false end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e1:SetCode(EFFECT_DRAW_COUNT)
+	e1:SetTargetRange(1,0)
+	e1:SetReset(RESET_PHASE+PHASE_DRAW)
+	if activating then
+		e1:SetValue(Auxiliary.DrawWillBeReplaced)
+	else
+		e1:SetValue(0)
+	end
+	Duel.RegisterEffect(e1,tp)
+	return true
+end
+function Auxiliary.DrawWillBeReplaced(e)
+	if Duel.CheckEvent(EVENT_PREDRAW) then return 1 end
+	return 0
+end
+function Auxiliary.DrawReplaceCost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Auxiliary.DrawReplaceCondition(e,tp) end
+	Auxiliary.UseDrawReplace(e,tp,true)
+end


### PR DESCRIPTION
There are 2 types of draw replace effect.
Type A: The replace is cost, if it is negated, player can't draw.
Type B: The replace is effect, if it is negated, player can draw as usual.

Type A:
Example: _Gearbreed_, _Flame Tiger_, _Malefic World_
After activated, another draw replace effect can be chained? **Confirming.** (If we can confirm _Iron Core of Koa'ki Meiru_ is this type, this will be answered by the [database](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8393&tag=-1))
Effect negated: Can't draw.
Card destroyed: Can't draw. [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9232&request_locale=ja)
Activation negated: **Confirming** (the wiki says can draw)
If you got no card in deck when the effect process: **Confirming**
If the effect is processed, but the replacement action can't be performed: Can't draw. [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10975&tag=-1)

Type B:
Example: _Legacy of the Duelist_, _Magical Blast_
After activated, another draw replace effect can be chained? Yes. [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11358&tag=-1) [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13838&tag=-1)
Effect negated: Can draw. [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8133&tag=-1)
Card destroyed: Can draw. [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20352&tag=-1)
Activation negated: Can draw. [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21764&tag=-1)
If you got no card in deck when the effect process: You draw and lose. [source](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20404&tag=-1)
If the effect is processed, but the replacement action can't be performed: **Confirming**

Both Type A and B:
Can't be activated if you got no card in deck.
Can activate when D-Force in effect? Confirming
If 1 replacement is processed, the other in chain can't process.
