### PR TITLE
fix サイバー・ダーク・キメラ

### DIFF
--- a/c5370235.lua
+++ b/c5370235.lua
@@ -84,7 +84,7 @@ function c5370235.thop(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetTargetRange(LOCATION_GRAVE,0)
 	--e2:SetCountLimit(1,5370237)
 	e2:SetTarget(c5370235.mttg)
-	e2:SetValue(c5370235.fuslimit)
+	e2:SetValue(1)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e2,tp)
 end


### PR DESCRIPTION
@mercury233 

# Problem
[bug_chimera.zip](https://github.com/Fluorohydride/ygopro-scripts/files/6796193/bug_chimera.zip)
Turn 2
There are 1 キメラテック・ランページ・ドラゴン/Chimeratech Rampage Dragon in the Extra Deck and many "Cyber Dragon" monsters in the GY.

However, the player cannot activate the effect of オーバーロード・フュージョン/Overload Fusion in the deck by 捕食植物ヴェルテ・アナコンダ/Predaplant Verte Anaconda.

# Reason
After the 1st effect of サイバー・ダーク・キメラ is activated, Card.IsCanBeFusionMaterial() returns false for cards in grave.

# Solution
Unlike other EFFECT_EXTRA_FUSION_MATERIAL effects, サイバー・ダーク・キメラ does not have any restriction on the fusion monster.
So the value function should always be true.

# Test replay
[_LastReplay.zip](https://github.com/Fluorohydride/ygopro-scripts/files/6796199/_LastReplay.zip)
