### PR TITLE
Update Goddess Urd's Verdict

### DIFF
--- a/c91969909.lua
+++ b/c91969909.lua
@@ -50,7 +50,7 @@ end
 function c91969909.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local ac=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	local tc=Duel.GetFirstTarget()
-	if not (e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e)) then return end
+	if not (e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFacedown()) then return end
 	Duel.ConfirmCards(tp,tc)
 	if tc:IsCode(ac) then
 		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)


### PR DESCRIPTION
> ■『そのセットされたカードをお互いに確認し、宣言したカードだった場合、そのカードを除外する。違った場合、自分フィールドのカード１枚を選んで除外する』効果の対象となった、裏側表示の魔法・罠カードがチェーンして発動された場合には、『そのセットされたカードをお互いに確認し』の処理を適用する事ができませんので、カードを除外する処理も適用されません。