### PR TITLE
fix Criosphinx

### DIFF
--- a/c18654201.lua
+++ b/c18654201.lua
@@ -17,7 +17,7 @@ function c18654201.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c18654201.filter(c,tp)
-	return c:IsControler(tp) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsType(TYPE_MONSTER)
+	return c:IsControler(tp) and c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousTypeOnField()&TYPE_MONSTER~=0
 end
 function c18654201.regop(e,tp,eg,ep,ev,re,r,rp)
 	local p1=false local p2=false


### PR DESCRIPTION
fix: if trap monster returned to hand, Criosphinx's effect don't activate.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6789&keyword=&tag=-1
> 質問の状況の場合のように、モンスターとして扱われている「アポピスの化神」が手札に戻った場合でも、「クリオスフィンクス」の効果は発動します。