### PR TITLE
Update c17841166.lua

### DIFF
--- a/c17841166.lua
+++ b/c17841166.lua
@@ -21,6 +21,6 @@ function c17841166.etarget(e,c)
 	return bit.band(c:GetOriginalRace(),RACE_MACHINE+RACE_ROCK)~=0
 end
 function c17841166.efilter(e,te,c)
-	return te:IsActiveType(TYPE_MONSTER) and te:GetOwner()~=c
+	return te:IsActiveType(TYPE_MONSTER) and (te:GetOwner()~=c or te:GetOwner()==c and not c:IsRelateToEffect(te))
 		and te:GetOwnerPlayer()~=e:GetHandlerPlayer()
 end

--- a/c17841166.lua
+++ b/c17841166.lua
@@ -21,6 +21,6 @@ function c17841166.etarget(e,c)
 	return bit.band(c:GetOriginalRace(),RACE_MACHINE+RACE_ROCK)~=0
 end
 function c17841166.efilter(e,te,c)
-	return te:IsActiveType(TYPE_MONSTER) and (te:GetOwner()~=c or te:GetOwner()==c and not c:IsRelateToEffect(te))
+	return te:IsActiveType(TYPE_MONSTER) and (te:GetOwner()~=c or te:IsActivated() and not c:IsRelateToEffect(te))
 		and te:GetOwnerPlayer()~=e:GetHandlerPlayer()
 end


### PR DESCRIPTION
Add IsRelateToEffect check to enable opponent's monster to be immune to its own effect when it leaves field and returns.
Q.
自分の「マグネット・フォース」の効果が適用されているターン、相手の「天霆號アーゼウス」の①効果を発動し、チェーンして相手の「対壊獣用決戦兵器メカサンダー・キング」の①効果を発動し、チェーンして自分の「サンダー・ブレイク」を発動し、「天霆號アーゼウス」が破壊され墓地へ送られ、「対壊獣用決戦兵器メカサンダー・キング」の①効果処理でこの「天霆號アーゼウス」の特殊召喚した場合、「天霆號アーゼウス」の①効果処理でこの「天霆號アーゼウス」は墓地へ送られますか？
A.
その「天霆號アーゼウス」は墓地へ送られません。