### PR TITLE
fix 悲劇のデスピアン

### DIFF
--- a/c36577931.lua
+++ b/c36577931.lua
@@ -28,7 +28,7 @@ function c36577931.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c36577931.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
+	return e:GetHandler():IsReason(REASON_EFFECT+REASON_REDIRECT)
 end
 function c36577931.thfilter(c)
 	return c:IsSetCard(0x164) and not c:IsCode(36577931) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()


### PR DESCRIPTION
> ただし、「マクロコスモス」の効果が適用されている状態で上記の状況が発生した場合には、コストとして捨てられた「悲劇のデスピアン」は墓地へは行かず、「マクロコスモス」の効果により除外されます。これは『効果で除外された場合』にあたりますので、「悲劇のデスピアン」の『①』の効果を発動できます。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23227&keyword=&tag=-1