### PR TITLE
update continuous cards, part 2

### DIFF
--- a/c10131855.lua
+++ b/c10131855.lua
@@ -44,7 +44,6 @@ function c10131855.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c10131855.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 then
 		local g=Group.CreateGroup()

--- a/c10833828.lua
+++ b/c10833828.lua
@@ -49,7 +49,6 @@ function c10833828.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c10833828.spop1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c10833828.spfilter1,tp,LOCATION_HAND,0,1,1,nil,e,tp)
@@ -110,7 +109,6 @@ function c10833828.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c10833828.spop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local chkf=tp
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c10833828.spfilter2,nil,e)
 	aux.FCheckAdditional=c10833828.fcheck1(c:GetFieldID())

--- a/c11163040.lua
+++ b/c11163040.lua
@@ -69,7 +69,6 @@ function c11163040.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c11163040.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) then return end
 	local cc=tc:GetControler()

--- a/c1197847.lua
+++ b/c1197847.lua
@@ -77,7 +77,6 @@ function c1197847.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c1197847.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c1197847.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp)

--- a/c12644061.lua
+++ b/c12644061.lua
@@ -90,7 +90,6 @@ function c12644061.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c12644061.damop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)

--- a/c12760674.lua
+++ b/c12760674.lua
@@ -64,7 +64,6 @@ function c12760674.atkcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c12760674.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ec=c:GetEquipTarget()
 	local tc=ec:GetBattleTarget()
 	if ec and tc and ec:IsFaceup() and tc:IsFaceup() then

--- a/c13629812.lua
+++ b/c13629812.lua
@@ -37,7 +37,6 @@ function c13629812.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c13629812.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	local val=aux.SequenceToGlobal(tc:GetControler(),LOCATION_MZONE,tc:GetSequence())
 	if tc:IsRelateToEffect(e) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 and tc:IsLocation(LOCATION_REMOVED) then

--- a/c13955608.lua
+++ b/c13955608.lua
@@ -25,7 +25,6 @@ function c13955608.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c13955608.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,13955608,0,TYPES_EFFECT_TRAP_MONSTER,0,2000,4,RACE_MACHINE,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_TRAP+TYPE_EFFECT)

--- a/c15447747.lua
+++ b/c15447747.lua
@@ -48,7 +48,6 @@ function c15447747.lktg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c15447747.lkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local mg=Duel.GetMatchingGroup(c15447747.matfilter,tp,LOCATION_MZONE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tg=Duel.SelectMatchingCard(tp,c15447747.lkfilter,tp,LOCATION_EXTRA,0,1,1,nil,mg)

--- a/c16269385.lua
+++ b/c16269385.lua
@@ -58,7 +58,6 @@ function c16269385.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c16269385.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
 	for tc in aux.Next(g) do
 		local e1=Effect.CreateEffect(c)
@@ -77,7 +76,6 @@ function c16269385.atktg2(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c16269385.atkop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
 	for tc in aux.Next(g) do
 		local e1=Effect.CreateEffect(c)

--- a/c17722185.lua
+++ b/c17722185.lua
@@ -36,7 +36,6 @@ function c17722185.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c17722185.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	c:RegisterFlagEffect(17722185,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
 	local flag=e:GetLabel()
 	local e1=Effect.CreateEffect(c)

--- a/c17787975.lua
+++ b/c17787975.lua
@@ -63,7 +63,6 @@ function c17787975.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c17787975.damop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=c:GetFirstCardTarget()
 	if not tc then return false end
 	local at=Duel.GetAttacker()

--- a/c17874674.lua
+++ b/c17874674.lua
@@ -59,7 +59,6 @@ function c17874674.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c17874674.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc and ((tc:IsFaceup() and not tc:IsDisabled()) or tc:IsType(TYPE_TRAPMONSTER)) and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)

--- a/c19814508.lua
+++ b/c19814508.lua
@@ -54,7 +54,6 @@ function c19814508.atkcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c19814508.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
 	local tc=g:GetFirst()
 	while tc do

--- a/c20426907.lua
+++ b/c20426907.lua
@@ -49,7 +49,6 @@ function c20426907.distg1(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c20426907.disop1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		Duel.NegateRelatedChain(tc,RESET_TURN_SET)

--- a/c20590515.lua
+++ b/c20590515.lua
@@ -35,7 +35,6 @@ function c20590515.filter(c)
 end
 function c20590515.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,20590515,0,TYPES_NORMAL_TRAP_MONSTER,500,1800,5,RACE_ZOMBIE,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_NORMAL+TYPE_TRAP)

--- a/c20960340.lua
+++ b/c20960340.lua
@@ -32,7 +32,6 @@ function c20960340.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c20960340.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local atk=Duel.GetLP(tp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,20960340,0,TYPES_EFFECT_TRAP_MONSTER,atk,0,4,RACE_WARRIOR,ATTRIBUTE_LIGHT) then return end

--- a/c21702241.lua
+++ b/c21702241.lua
@@ -53,7 +53,6 @@ function c21702241.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c21702241.damop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ec=c:GetEquipTarget()
 	Duel.Damage(ec:GetControler(),ec:GetBaseAttack(),REASON_EFFECT)
 end

--- a/c21768554.lua
+++ b/c21768554.lua
@@ -49,7 +49,6 @@ function c21768554.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c21768554.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	if g:GetCount()>Duel.GetLocationCount(tp,LOCATION_MZONE) then return end
 	local tc=g:GetFirst()

--- a/c21843307.lua
+++ b/c21843307.lua
@@ -25,7 +25,6 @@ function c21843307.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=eg:GetFirst()
 	if not ec:IsRelateToEffect(e) then return end
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,ec:GetCode(),0,TYPES_NORMAL_TRAP_MONSTER,0,0,ec:GetLevel(),RACE_WARRIOR,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_NORMAL+TYPE_TRAP,0,0,ec:GetLevel(),0,0)

--- a/c23626223.lua
+++ b/c23626223.lua
@@ -37,7 +37,6 @@ function c23626223.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c23626223.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,23626223,0,TYPES_EFFECT_TRAP_MONSTER,0,2500,7,RACE_ROCK,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c24010609.lua
+++ b/c24010609.lua
@@ -102,7 +102,6 @@ function c24010609.gselect(g,ft)
 end
 function c24010609.setop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c24010609.setfilter),tp,LOCATION_GRAVE,0,nil)
 	local ct=e:GetHandler():GetFlagEffectLabel(24010609) or 0
 	local ft=Duel.GetLocationCount(tp,LOCATION_SZONE)

--- a/c26905245.lua
+++ b/c26905245.lua
@@ -23,7 +23,6 @@ function c26905245.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c26905245.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,26905245,0,TYPES_EFFECT_TRAP_MONSTER,0,3000,10,RACE_AQUA,ATTRIBUTE_WATER) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c27918963.lua
+++ b/c27918963.lua
@@ -69,7 +69,6 @@ function c27918963.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c27918963.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if e:GetLabel()==0 then
 		local g=Duel.GetMatchingGroup(c27918963.filter1,tp,LOCATION_MZONE,0,nil)
 		local tc=g:GetFirst()

--- a/c28053763.lua
+++ b/c28053763.lua
@@ -29,7 +29,6 @@ function c28053763.tktg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c28053763.tkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)

--- a/c28529976.lua
+++ b/c28529976.lua
@@ -42,7 +42,6 @@ end
 function c28529976.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c28529976.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e:GetLabel(),e,tp)
 	local tc=g:GetFirst()

--- a/c28649820.lua
+++ b/c28649820.lua
@@ -21,7 +21,6 @@ function c28649820.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c28649820.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,28649820,0,TYPES_NORMAL_TRAP_MONSTER,1600,1800,4,RACE_REPTILE,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_NORMAL+TYPE_TRAP)

--- a/c28927782.lua
+++ b/c28927782.lua
@@ -55,7 +55,6 @@ function c28927782.eftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c28927782.efop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if e:GetLabel()==0 then
 		local tc=Duel.GetFirstTarget()
 		if tc and tc:IsRelateToEffect(e) then

--- a/c30834988.lua
+++ b/c30834988.lua
@@ -23,7 +23,6 @@ function c30834988.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c30834988.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=eg:Filter(Card.IsRelateToEffect,nil,e)
 	Duel.ChangePosition(g,POS_FACEUP_ATTACK)
 	local tc=g:GetFirst()

--- a/c3129635.lua
+++ b/c3129635.lua
@@ -28,7 +28,6 @@ function c3129635.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c3129635.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,3129635,0,TYPES_EFFECT_TRAP_MONSTER,1800,1000,4,RACE_ROCK,ATTRIBUTE_DARK) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c33971095.lua
+++ b/c33971095.lua
@@ -54,7 +54,6 @@ function c33971095.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c33971095.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		local e1=Effect.CreateEffect(c)
@@ -72,7 +71,6 @@ function c33971095.atkcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c33971095.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetAttacker()
 	if tc:IsFaceup() then
 		local e1=Effect.CreateEffect(c)

--- a/c34029630.lua
+++ b/c34029630.lua
@@ -60,7 +60,6 @@ function c34029630.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c34029630.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) and c:IsCanRemoveCounter(tp,0x1,1,REASON_EFFECT) and tc:IsCanAddCounter(0x1,1) then
 		c:RemoveCounter(tp,0x1,1,REASON_EFFECT)

--- a/c34884015.lua
+++ b/c34884015.lua
@@ -50,7 +50,6 @@ function c34884015.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c34884015.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local tg=g:Filter(Card.IsRelateToEffect,nil,e)
 	local tc=tg:GetFirst()
@@ -98,7 +97,6 @@ function c34884015.exptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c34884015.expop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(34884015,4))
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c35011819.lua
+++ b/c35011819.lua
@@ -40,7 +40,6 @@ end
 function c35011819.activate1(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetLabel()~=1 then return end
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ct=Duel.GetChainInfo(0,CHAININFO_CHAIN_COUNT)
 	Duel.NegateActivation(ct-1)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)

--- a/c35100834.lua
+++ b/c35100834.lua
@@ -28,7 +28,6 @@ function c35100834.eqfilter(c,tp)
 end
 function c35100834.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,35100834,0,TYPES_EFFECT_TRAP_MONSTER,0,0,4,RACE_MACHINE,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c35884610.lua
+++ b/c35884610.lua
@@ -93,7 +93,6 @@ function c35884610.atcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c35884610.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=e:GetHandler():GetEquipTarget()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c36415522.lua
+++ b/c36415522.lua
@@ -39,7 +39,6 @@ function c36415522.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c36415522.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if not Duel.NegateAttack() then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/c36560997.lua
+++ b/c36560997.lua
@@ -42,7 +42,6 @@ function c36560997.attg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c36560997.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c36560997.filter,tp,LOCATION_MZONE,0,nil)
 	local tc=g:GetFirst()
 	while tc do

--- a/c37209439.lua
+++ b/c37209439.lua
@@ -36,7 +36,6 @@ function c37209439.negcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c37209439.negop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local fid=c:GetFieldID()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c39712330.lua
+++ b/c39712330.lua
@@ -50,7 +50,6 @@ function c39712330.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c39712330.activate1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if e:GetLabel()~=1 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
 	local g=Duel.SelectMatchingCard(tp,c39712330.filter,tp,LOCATION_HAND,0,1,1,nil)

--- a/c41359411.lua
+++ b/c41359411.lua
@@ -69,7 +69,6 @@ function c41359411.dircost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c41359411.dirop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_EQUIP)
 	e1:SetCode(EFFECT_DIRECT_ATTACK)

--- a/c42167046.lua
+++ b/c42167046.lua
@@ -32,7 +32,6 @@ function c42167046.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c42167046.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	local tc=g:GetFirst()
 	while tc do

--- a/c42199039.lua
+++ b/c42199039.lua
@@ -63,7 +63,6 @@ function c42199039.dttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c42199039.dtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.ConfirmCards(1-tp,tc)

--- a/c42237854.lua
+++ b/c42237854.lua
@@ -59,7 +59,6 @@ function c42237854.tgfilter(c,e)
 end
 function c42237854.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,42237854,0,TYPES_EFFECT_TRAP_MONSTER,0,0,4,RACE_MACHINE,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c42776855.lua
+++ b/c42776855.lua
@@ -68,7 +68,6 @@ function c42776855.atkcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c42776855.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=c:GetFirstCardTarget()
 	if not tc then return false end
 	local bc=tc:GetBattleTarget()

--- a/c43664494.lua
+++ b/c43664494.lua
@@ -45,7 +45,6 @@ function c43664494.tktg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c43664494.tkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,43664495,0x120,TYPES_TOKEN_MONSTER,0,0,1,RACE_PYRO,ATTRIBUTE_FIRE,POS_FACEUP) then return end
 	local token=Duel.CreateToken(tp,43664495)

--- a/c43959432.lua
+++ b/c43959432.lua
@@ -45,7 +45,6 @@ function c43959432.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c43959432.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,43959432,0,TYPES_EFFECT_TRAP_MONSTER,1000,1000,4,RACE_ROCK,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c44822037.lua
+++ b/c44822037.lua
@@ -38,7 +38,6 @@ function c44822037.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c44822037.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,44822037,0,TYPES_EFFECT_TRAP_MONSTER,1800,1800,4,RACE_FAIRY,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c46984349.lua
+++ b/c46984349.lua
@@ -28,7 +28,6 @@ function c46984349.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c46984349.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local lv=e:GetLabel()
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,46984349,0,TYPES_NORMAL_TRAP_MONSTER,0,0,lv,RACE_SPELLCASTER,ATTRIBUTE_LIGHT) then return end

--- a/c47233801.lua
+++ b/c47233801.lua
@@ -27,7 +27,6 @@ function c47233801.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47233801.damop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local dam=c:GetFlagEffectLabel(47233801)
 	if dam==nil then
 		c:RegisterFlagEffect(47233801,RESET_EVENT+RESETS_STANDARD,0,0,200)

--- a/c4740489.lua
+++ b/c4740489.lua
@@ -68,7 +68,6 @@ function c4740489.atcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c4740489.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=e:GetLabelObject()
 	if tc:IsRelateToBattle() then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)

--- a/c47598941.lua
+++ b/c47598941.lua
@@ -49,7 +49,6 @@ function c47598941.settg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47598941.setop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if not (Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1)) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)
 	local g=Duel.SelectMatchingCard(tp,c47598941.filter,tp,LOCATION_DECK,0,1,1,nil)

--- a/c47810543.lua
+++ b/c47810543.lua
@@ -33,7 +33,6 @@ function c47810543.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47810543.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c47810543.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)

--- a/c48308134.lua
+++ b/c48308134.lua
@@ -70,7 +70,6 @@ function c48308134.posfilter(c)
 end
 function c48308134.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c48308134.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp)

--- a/c4904633.lua
+++ b/c4904633.lua
@@ -36,7 +36,6 @@ function c4904633.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c4904633.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,4904633,0,TYPES_EFFECT_TRAP_MONSTER,1450,1950,9,RACE_SPELLCASTER,ATTRIBUTE_DARK) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c49306994.lua
+++ b/c49306994.lua
@@ -88,7 +88,6 @@ function c49306994.disfilter(c)
 end
 function c49306994.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c49306994.disfilter,tp,0,LOCATION_ONFIELD,c)
 	local tc=g:GetFirst()
 	while tc do

--- a/c49514333.lua
+++ b/c49514333.lua
@@ -29,7 +29,6 @@ function c49514333.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c49514333.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,49514333,0,TYPES_EFFECT_TRAP_MONSTER,1000,1800,4,RACE_ROCK,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c50277973.lua
+++ b/c50277973.lua
@@ -46,7 +46,6 @@ function c50277973.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c50277973.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local rac=e:GetLabel()
 	local att=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0

--- a/c51053997.lua
+++ b/c51053997.lua
@@ -49,7 +49,6 @@ function c51053997.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c51053997.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
 		local ct=1

--- a/c51670553.lua
+++ b/c51670553.lua
@@ -40,7 +40,6 @@ function c51670553.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c51670553.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)

--- a/c53363708.lua
+++ b/c53363708.lua
@@ -72,7 +72,6 @@ function c53363708.postg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c53363708.posop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=c:GetEquipTarget()
 	if tc and Duel.ChangePosition(tc,POS_FACEUP_DEFENSE,POS_FACEUP_DEFENSE,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK)~=0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)

--- a/c54407825.lua
+++ b/c54407825.lua
@@ -31,7 +31,6 @@ function c54407825.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c54407825.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
 		Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)

--- a/c54828837.lua
+++ b/c54828837.lua
@@ -64,7 +64,6 @@ function c54828837.protcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c54828837.protop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)

--- a/c55838342.lua
+++ b/c55838342.lua
@@ -28,7 +28,6 @@ function c55838342.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c55838342.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,55838342,0,TYPES_EFFECT_TRAP_MONSTER,300,2100,2,RACE_INSECT,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c5641251.lua
+++ b/c5641251.lua
@@ -57,7 +57,6 @@ function c5641251.lvlcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c5641251.lvlop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetAttacker()
 	local bc=Duel.GetAttackTarget()
 	if not bc then return false end

--- a/c56460688.lua
+++ b/c56460688.lua
@@ -35,7 +35,6 @@ function c56460688.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c56460688.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
 	if Duel.Remove(tg,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
 		local g=Duel.GetOperatedGroup()

--- a/c56995655.lua
+++ b/c56995655.lua
@@ -23,7 +23,6 @@ function c56995655.con(e,tp,eg,ep,ev,re,r,rp)
 end
 function c56995655.op(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetFieldGroup(tp,0,LOCATION_HAND):RandomSelect(tp,1,nil)
 	local tc=g:GetFirst()
 	if not tc then return end

--- a/c58012707.lua
+++ b/c58012707.lua
@@ -47,7 +47,6 @@ function c58012707.spfilter(c,e,tp,code)
 end
 function c58012707.dmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)

--- a/c59258334.lua
+++ b/c59258334.lua
@@ -55,7 +55,6 @@ function c59258334.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c59258334.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:GetCounter(0x100e)>0 and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)

--- a/c60168186.lua
+++ b/c60168186.lua
@@ -89,7 +89,6 @@ function c60168186.filter(c,tp,typ)
 end
 function c60168186.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=eg:Filter(c60168186.filter,nil,tp,e:GetLabel())
 	local tc=g:GetFirst()
 	while tc do

--- a/c60226558.lua
+++ b/c60226558.lua
@@ -86,7 +86,6 @@ function c60226558.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c60226558.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ec=c:GetEquipTarget()
 	if ec:IsControler(1-tp) or ec:IsImmuneToEffect(e) then return end
 	local chkf=tp

--- a/c60433216.lua
+++ b/c60433216.lua
@@ -31,7 +31,6 @@ function c60433216.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(1)
 	e1:SetReset(RESET_PHASE+PHASE_DAMAGE)
 	tc:RegisterEffect(e1)
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,60433216,0,TYPES_NORMAL_TRAP_MONSTER+TYPE_TUNER,0,0,1,RACE_FIEND,ATTRIBUTE_FIRE) then return end
 	c:AddMonsterAttribute(TYPE_NORMAL+TYPE_TUNER+TYPE_TRAP)

--- a/c60675348.lua
+++ b/c60675348.lua
@@ -27,7 +27,6 @@ function c60675348.filter(c)
 end
 function c60675348.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c60675348.filter,tp,LOCATION_DECK,0,nil)
 	local ct=0
 	if Duel.CheckLocation(tp,LOCATION_PZONE,0) then ct=ct+1 end

--- a/c61529473.lua
+++ b/c61529473.lua
@@ -66,7 +66,6 @@ function c61529473.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c61529473.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)

--- a/c61557074.lua
+++ b/c61557074.lua
@@ -49,7 +49,6 @@ function c61557074.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c61557074.thop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,c61557074.thfilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 and Duel.SendtoHand(g,nil,REASON_EFFECT)~=0 then

--- a/c61583217.lua
+++ b/c61583217.lua
@@ -48,7 +48,6 @@ function c61583217.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c61583217.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)

--- a/c61840587.lua
+++ b/c61840587.lua
@@ -46,7 +46,6 @@ function c61840587.sfilter(c,e,tp)
 end
 function c61840587.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local sg=g:Filter(c61840587.sfilter,nil,e,tp)
 	local sct=sg:GetCount()

--- a/c62437430.lua
+++ b/c62437430.lua
@@ -30,7 +30,6 @@ function c62437430.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c62437430.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local tc=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c62437430.filter),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,1,1,nil):GetFirst()
 	if tc and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_REMOVED) then

--- a/c62784717.lua
+++ b/c62784717.lua
@@ -29,7 +29,6 @@ function c62784717.cointg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c62784717.coinop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local res=Duel.TossCoin(tp,1)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c63881033.lua
+++ b/c63881033.lua
@@ -59,7 +59,6 @@ function c63881033.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c63881033.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c63881033.filter,tp,LOCATION_MZONE,0,nil)
 	local tc=g:GetFirst()
 	while tc do

--- a/c6430659.lua
+++ b/c6430659.lua
@@ -32,7 +32,6 @@ function c6430659.attg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c6430659.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)

--- a/c6471156.lua
+++ b/c6471156.lua
@@ -44,7 +44,6 @@ end
 function c6471156.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local lv=e:GetLabel()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c6471156.lvfilter,tp,LOCATION_MZONE,0,nil,0)
 	local lc=g:GetFirst()
 	while lc do

--- a/c65959844.lua
+++ b/c65959844.lua
@@ -59,7 +59,6 @@ function c65959844.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c65959844.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(tp,c65959844.rmfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	local rc=g:GetFirst()

--- a/c66719533.lua
+++ b/c66719533.lua
@@ -69,7 +69,6 @@ function c66719533.filter(c)
 end
 function c66719533.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c66719533.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	for tc in aux.Next(g) do
 		local e1=Effect.CreateEffect(c)

--- a/c67007102.lua
+++ b/c67007102.lua
@@ -38,7 +38,6 @@ function c67007102.filter(c)
 end
 function c67007102.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,67007102,0,TYPES_NORMAL_TRAP_MONSTER,800,2500,8,RACE_ZOMBIE,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_NORMAL+TYPE_TRAP)

--- a/c69217334.lua
+++ b/c69217334.lua
@@ -42,7 +42,6 @@ function c69217334.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c69217334.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	local ec=tc
 	if not tc:IsRelateToEffect(e) then ec=nil end

--- a/c69553552.lua
+++ b/c69553552.lua
@@ -47,7 +47,6 @@ function c69553552.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c69553552.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,1,1,nil)
 	local tc=g:GetFirst()

--- a/c70406920.lua
+++ b/c70406920.lua
@@ -51,7 +51,6 @@ function c70406920.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c70406920.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,70406920,0,TYPES_EFFECT_TRAP_MONSTER,1000,1000,4,RACE_MACHINE,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c71645242.lua
+++ b/c71645242.lua
@@ -115,7 +115,6 @@ function c71645242.sptg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c71645242.spop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local dg=Duel.GetMatchingGroup(c71645242.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	dg:AddCard(c)
 	if Duel.Destroy(dg,REASON_EFFECT)==dg:GetCount() then

--- a/c72043279.lua
+++ b/c72043279.lua
@@ -47,7 +47,6 @@ function c72043279.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c72043279.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=e:GetLabelObject()
 	if tc:IsRelateToBattle() and tc:IsFaceup() and tc:IsControler(tp) then
 		local e1=Effect.CreateEffect(c)

--- a/c73206827.lua
+++ b/c73206827.lua
@@ -48,7 +48,6 @@ function c73206827.cointg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c73206827.coinop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local res=Duel.TossCoin(tp,1)
 	if res==0 then
 		c:RegisterFlagEffect(73206828,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN,0,2)

--- a/c75223115.lua
+++ b/c75223115.lua
@@ -29,7 +29,6 @@ function c75223115.actfilter(c,tp)
 end
 function c75223115.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c75223115.actfilter,tp,LOCATION_DECK,0,nil,tp)
 	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(75223115,0)) then
 		Duel.BreakEffect()

--- a/c75304793.lua
+++ b/c75304793.lua
@@ -73,7 +73,6 @@ function c75304793.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c75304793.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ct=Duel.GetMatchingGroupCount(c75304793.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	if ct==0 then return end
 	if e:GetLabel()==0 then

--- a/c75702749.lua
+++ b/c75702749.lua
@@ -71,7 +71,6 @@ function c75702749.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c75702749.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c75702749.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp)

--- a/c75987257.lua
+++ b/c75987257.lua
@@ -89,7 +89,6 @@ function c75987257.poscon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c75987257.posop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ec=c:GetEquipTarget()
 	if ec then
 		Duel.ChangePosition(ec,POS_FACEUP_DEFENSE,0,POS_FACEUP_ATTACK,0)

--- a/c76136345.lua
+++ b/c76136345.lua
@@ -50,7 +50,6 @@ function c76136345.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c76136345.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c76136345.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)

--- a/c77565204.lua
+++ b/c77565204.lua
@@ -77,7 +77,6 @@ function c77565204.filter2(c,m)
 end
 function c77565204.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local mg=Duel.GetMatchingGroup(c77565204.filter1,tp,LOCATION_DECK,0,nil,e)
 	local sg=Duel.GetMatchingGroup(c77565204.filter2,tp,LOCATION_EXTRA,0,nil,mg)
 	if sg:GetCount()>0 then

--- a/c77584012.lua
+++ b/c77584012.lua
@@ -30,7 +30,6 @@ function c77584012.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c77584012.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local code=e:GetLabel()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c77778835.lua
+++ b/c77778835.lua
@@ -38,7 +38,6 @@ function c77778835.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c77778835.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c77778835.filter,tp,LOCATION_GRAVE,0,nil,e,tp)
 	if ft<=0 or tg:GetCount()==0 then return end

--- a/c79852326.lua
+++ b/c79852326.lua
@@ -27,7 +27,6 @@ function c79852326.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c79852326.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,79852326,0,TYPES_EFFECT_TRAP_MONSTER,1800,500,4,RACE_ZOMBIE,ATTRIBUTE_DARK) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c79922118.lua
+++ b/c79922118.lua
@@ -33,7 +33,6 @@ function c79922118.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c79922118.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c79922118.filter,tp,0,LOCATION_MZONE,nil)
 	local tc=g:GetFirst()
 	while tc do

--- a/c80560728.lua
+++ b/c80560728.lua
@@ -72,7 +72,6 @@ function c80560728.atcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c80560728.atop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local tc=c:GetFirstCardTarget()
 	if tc:IsRelateToBattle() then
 		local e1=Effect.CreateEffect(c)

--- a/c80604091.lua
+++ b/c80604091.lua
@@ -45,7 +45,6 @@ function c80604091.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c80604091.activate1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if e:GetLabel()~=1 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
 	local g=Duel.SelectMatchingCard(tp,c80604091.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)

--- a/c80921533.lua
+++ b/c80921533.lua
@@ -71,7 +71,6 @@ function c80921533.sfilter(c,se,ct)
 end
 function c80921533.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ct=e:GetLabel()
 	local se=e:GetLabelObject()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)

--- a/c8323633.lua
+++ b/c8323633.lua
@@ -9,7 +9,6 @@ function c8323633.initial_effect(c)
 end
 function c8323633.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CODE)
 	local ac=Duel.AnnounceCard(tp,TYPE_MONSTER,OPCODE_ISTYPE)
 	c:SetHint(CHINT_CARD,ac)
@@ -47,7 +46,6 @@ function c8323633.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c8323633.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=eg:Filter(c8323633.filter,nil,e:GetLabel()):Filter(Card.IsRelateToEffect,nil,e)
 	if g:GetCount()>0 then
 		g:AddCard(c)

--- a/c83407038.lua
+++ b/c83407038.lua
@@ -54,7 +54,6 @@ function c83407038.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c83407038.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc=Duel.SelectMatchingCard(tp,c83407038.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp):GetFirst()

--- a/c84171830.lua
+++ b/c84171830.lua
@@ -63,7 +63,6 @@ function c84171830.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c84171830.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(84171830,1))
 	local g=Duel.SelectMatchingCard(tp,c84171830.filter,tp,LOCATION_HAND,0,1,1,nil)
 	if g:GetCount()>0 then

--- a/c8522996.lua
+++ b/c8522996.lua
@@ -37,7 +37,6 @@ function c8522996.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c8522996.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,8522996,0,TYPES_EFFECT_TRAP_MONSTER,1000,2400,6,RACE_FIEND,ATTRIBUTE_DARK) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c85638822.lua
+++ b/c85638822.lua
@@ -68,7 +68,6 @@ function c85638822.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c85638822.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local tg=Duel.GetMatchingGroup(c85638822.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil,e,tp)
 	if tg:GetCount()==0 or ft<=0 then return end

--- a/c86885905.lua
+++ b/c86885905.lua
@@ -37,7 +37,6 @@ function c86885905.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c86885905.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,86885905,0x103,TYPES_EFFECT_TRAP_MONSTER,1400,1800,4,RACE_SPELLCASTER,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_TRAP+TYPE_EFFECT)

--- a/c87046457.lua
+++ b/c87046457.lua
@@ -66,7 +66,6 @@ function c87046457.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c87046457.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local atkg=e:GetLabelObject()
 	if c:GetFlagEffect(87046457)==0 then
 		c:RegisterFlagEffect(87046457,RESET_EVENT+RESETS_STANDARD+RESET_DISABLE,0,1)

--- a/c87772572.lua
+++ b/c87772572.lua
@@ -46,7 +46,6 @@ function c87772572.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c87772572.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local rac=e:GetLabel()
 	local att=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0

--- a/c89405199.lua
+++ b/c89405199.lua
@@ -58,7 +58,6 @@ function c89405199.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c89405199.damop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ct1=c:GetFlagEffectLabel(89405199+tp)
 	local ct2=c:GetFlagEffectLabel(89405199+1-tp)
 	if ct1 then Duel.Damage(tp,ct1*500,REASON_EFFECT,true) end

--- a/c90200789.lua
+++ b/c90200789.lua
@@ -49,7 +49,6 @@ function c90200789.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c90200789.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
 	local tg=g:Filter(Card.IsRelateToEffect,nil,e)
 	if tg:GetCount()==0 then return end

--- a/c90246973.lua
+++ b/c90246973.lua
@@ -54,7 +54,6 @@ function c90246973.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c90246973.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ec=c:GetEquipTarget()
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)~=0 then

--- a/c90440725.lua
+++ b/c90440725.lua
@@ -41,7 +41,6 @@ function c90440725.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c90440725.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,90440725,0,TYPES_EFFECT_TRAP_MONSTER,-2,-2,4,RACE_MACHINE,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c91407982.lua
+++ b/c91407982.lua
@@ -46,7 +46,6 @@ function c91407982.indcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c91407982.indop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)

--- a/c91654806.lua
+++ b/c91654806.lua
@@ -86,7 +86,6 @@ function c91654806.drop(e,tp,eg,ep,ev,re,r,rp)
 		tc=g:GetNext()
 	end
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if res and Duel.SendtoGrave(c,REASON_EFFECT)~=0 and c:IsLocation(LOCATION_GRAVE) then
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end

--- a/c92092092.lua
+++ b/c92092092.lua
@@ -31,7 +31,6 @@ function c92092092.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92092092.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,92092092,0,TYPES_EFFECT_TRAP_MONSTER+TYPE_TUNER,0,1800,1,RACE_MACHINE,ATTRIBUTE_FIRE) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TUNER+TYPE_TRAP)

--- a/c92099232.lua
+++ b/c92099232.lua
@@ -17,7 +17,6 @@ function c92099232.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92099232.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,92099232,0,TYPES_NORMAL_TRAP_MONSTER+TYPE_TUNER,0,0,2,RACE_FIEND,ATTRIBUTE_EARTH) then return end
 	c:AddMonsterAttribute(TYPE_NORMAL+TYPE_TUNER+TYPE_TRAP)

--- a/c92223430.lua
+++ b/c92223430.lua
@@ -53,7 +53,6 @@ function c92223430.trcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92223430.trop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_DECREASE_TRIBUTE)
@@ -78,7 +77,6 @@ function c92223430.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92223430.sumop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
 	local g=Duel.SelectMatchingCard(tp,c92223430.sumfilter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)
 	local tc=g:GetFirst()

--- a/c92408984.lua
+++ b/c92408984.lua
@@ -55,7 +55,6 @@ end
 function c92408984.operation1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if e:GetLabel()~=1 then return end
-	if not c:IsRelateToEffect(e) then return end
 	local ct=Duel.GetChainInfo(0,CHAININFO_CHAIN_COUNT)
 	local tc=Duel.GetFirstTarget()
 	if Duel.NegateEffect(ct-1) and tc and tc:IsRelateToEffect(e) then
@@ -83,7 +82,6 @@ function c92408984.target2(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92408984.operation2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end

--- a/c93016201.lua
+++ b/c93016201.lua
@@ -71,7 +71,6 @@ end
 function c93016201.activate1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if e:GetLabel()~=1 then return end
-	if not c:IsRelateToEffect(e) then return end
 	local ct=Duel.GetChainInfo(0,CHAININFO_CHAIN_COUNT)
 	local te=Duel.GetChainInfo(ct-1,CHAININFO_TRIGGERING_EFFECT)
 	local tc=te:GetHandler()

--- a/c93191801.lua
+++ b/c93191801.lua
@@ -36,7 +36,6 @@ function c93191801.filter(c)
 end
 function c93191801.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,93191801,0,TYPES_NORMAL_TRAP_MONSTER,1800,1500,5,RACE_ZOMBIE,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_NORMAL+TYPE_TRAP)

--- a/c93394164.lua
+++ b/c93394164.lua
@@ -65,7 +65,6 @@ function c93394164.seqtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c93394164.seqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ec=c:GetEquipTarget()
 	if not ec or ec:IsImmuneToEffect(e) then return end
 	local p=ec:GetControler()

--- a/c94212438.lua
+++ b/c94212438.lua
@@ -47,7 +47,6 @@ function c94212438.plfilter(c,id)
 end
 function c94212438.plop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local ids={31893528,67287533,94772232,30170981}
 	local id=ids[c:GetFlagEffect(94212438)+1]
 	local res=Duel.IsPlayerAffectedByEffect(tp,16625614) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c95034141.lua
+++ b/c95034141.lua
@@ -59,7 +59,6 @@ function c95034141.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c95034141.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local chkf=tp
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c95034141.filter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c95034141.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)

--- a/c95784434.lua
+++ b/c95784434.lua
@@ -63,7 +63,6 @@ function c95784434.adcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c95784434.adop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_ATTACK)

--- a/c97232518.lua
+++ b/c97232518.lua
@@ -25,7 +25,6 @@ function c97232518.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c97232518.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
 		or not Duel.IsPlayerCanSpecialSummonMonster(tp,97232518,0,TYPES_EFFECT_TRAP_MONSTER,1900,0,5,RACE_THUNDER,ATTRIBUTE_LIGHT) then return end
 	c:AddMonsterAttribute(TYPE_EFFECT+TYPE_TRAP)

--- a/c97342942.lua
+++ b/c97342942.lua
@@ -31,7 +31,6 @@ function c97342942.rfilter(c,e)
 end
 function c97342942.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
 	local rg=Duel.SelectReleaseGroup(tp,c97342942.rfilter,1,1,e:GetHandler(),e)
 	if Duel.Release(rg,REASON_EFFECT)>0 then
 		local atk=math.floor(rg:GetFirst():GetBaseAttack()/2)


### PR DESCRIPTION
# Problem
### By continuous Spell/Trap Cards, I mean TYPE_CONTINUOUS, TYPE_EQUIP, TYPE_FIELD cards.

The continuous Spell/Trap Cards has this property:
"The effect resolution will do nothing if the card is no longer on the field."
It is checked by the flag CHAIN_CONTINUOUS_CARD in field::solve_chain().

It is a property of continuous Spell/Trap Cards, not the effect itself.
When a monster copies that effect, the monster effect will not have this property.
Therefore, it should NOT be written in the script.

# Solution
```lua
if not c:IsRelateToEffect(e) then return end
```
For effects of continuous Spell/Trap Cards activated on the field, this condition is unnecessary.
It is checked by the flag CHAIN_CONTINUOUS_CARD in field::solve_chain().

I removed this condition from the script of continuous Spell/Trap Cards by using replacement of Notepad++.

Total:
130 cards

The list:
[list2.txt](https://github.com/Fluorohydride/ygopro-scripts/files/7007634/list2.txt)
