### PR TITLE
fix ルイ・キューピット

### DIFF
--- a/c21915012.lua
+++ b/c21915012.lua
@@ -45,7 +45,11 @@ function c21915012.valcheck(e,c)
 	local mg=g:Filter(Card.IsType,nil,TYPE_TUNER)
 	if #mg==1 then
 		local tc=mg:GetFirst()
-		e:GetLabelObject():SetLabel(tc:GetLevel())
+		local lv=tc:GetSynchroLevel(c)
+		if tc:IsHasEffect(89818984) and not g:CheckWithSumEqual(Card.GetSynchroLevel,c:GetLevel(),#g,#g,c) then
+			lv=2
+		end
+		e:GetLabelObject():SetLabel(lv)
 	end
 end
 function c21915012.lvcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c21915012.lua
+++ b/c21915012.lua
@@ -46,6 +46,11 @@ function c21915012.valcheck(e,c)
 	if #mg==1 then
 		local tc=mg:GetFirst()
 		local lv=tc:GetSynchroLevel(c)
+		local lv2=lv>>16
+		lv=lv&0xffff
+		if lv2>0 and not g:CheckWithSumEqual(Card.GetLevel,c:GetLevel(),#g,#g,c) then
+			lv=lv2
+		end
 		if tc:IsHasEffect(89818984) and not g:CheckWithSumEqual(Card.GetSynchroLevel,c:GetLevel(),#g,#g,c) then
 			lv=2
 		end


### PR DESCRIPTION
> 上記のいずれの場合でも、「幻妖種ミトラ」「ロード・シンクロン」はレベル２のチューナーとしてS素材になっていますので、「ルイ・キューピット」の『①』の効果で変化するレベルは２です。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23302&keyword=&tag=-1