### PR TITLE
fix サンダー・ディスチャージ, リザレクション・ブレス

### DIFF
--- a/c27623932.lua
+++ b/c27623932.lua
@@ -39,22 +39,27 @@ function c27623932.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local dg=Duel.GetMatchingGroup(c27623932.desfilter,tp,0,LOCATION_MZONE,nil,g:GetFirst():GetAttack())
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,dg,dg:GetCount(),0,0)
 end
-function c27623932.efilter(c,tp)
-	return c:IsType(TYPE_EQUIP) and aux.IsCodeListed(c,3285552) and c:CheckUniqueOnField(tp) and not c:IsForbidden()
+function c27623932.CanEquipFilter(c,eqc)
+	return c:IsFaceup() and eqc:CheckEquipTarget(c)
+end
+function c27623932.eqfilter(c,tp)
+	return aux.IsCodeListed(c,3285552) and c:IsType(TYPE_EQUIP) and c:CheckUniqueOnField(tp) and not c:IsForbidden() 
+		and Duel.IsExistingMatchingCard(c27623932.CanEquipFilter,tp,LOCATION_MZONE,0,1,nil,c)
 end
 function c27623932.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		local dg=Duel.GetMatchingGroup(c27623932.desfilter,tp,0,LOCATION_MZONE,nil,tc:GetAttack())
 		if Duel.Destroy(dg,REASON_EFFECT)~=0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-			and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c27623932.efilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,tp)
+			and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c27623932.eqfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,tp)
 			and Duel.SelectYesNo(tp,aux.Stringid(27623932,0)) then
 			Duel.BreakEffect()
-			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(27623932,1))
-			local eg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c27623932.efilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,tp)
-			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(27623932,2))
-			local mg=Duel.SelectMatchingCard(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
-			Duel.Equip(tp,eg:GetFirst(),mg:GetFirst())
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+			local eqg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c27623932.eqfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,tp)
+			local eqc=eqg:GetFirst()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+			local mg=Duel.SelectMatchingCard(tp,c27623932.CanEquipFilter,tp,LOCATION_MZONE,0,1,1,nil,eqc)
+			Duel.Equip(tp,eqc,mg:GetFirst())
 		end
 	end
 end

--- a/c64018647.lua
+++ b/c64018647.lua
@@ -22,11 +22,12 @@ function c64018647.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsCanBeSpecialSummoned,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_GRAVE)
 end
-function c64018647.filter(c,tp)
-	return c:IsFaceup() and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c64018647.eqfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,tp,c)
+function c64018647.CanEquipFilter(c,eqc)
+	return c:IsFaceup() and eqc:CheckEquipTarget(c)
 end
-function c64018647.eqfilter(c,tp,tc)
-	return c:CheckUniqueOnField(tp) and not c:IsForbidden() and c:CheckEquipTarget(tc) and aux.IsCodeListed(c,3285552)
+function c64018647.eqfilter(c,tp)
+	return aux.IsCodeListed(c,3285552) and c:IsType(TYPE_EQUIP) and c:CheckUniqueOnField(tp) and not c:IsForbidden() 
+		and Duel.IsExistingMatchingCard(c64018647.CanEquipFilter,tp,LOCATION_MZONE,0,1,nil,c)
 end
 function c64018647.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -49,13 +50,13 @@ function c64018647.activate(e,tp,eg,ep,ev,re,r,rp)
 		end
 	end
 	Duel.SpecialSummonComplete()
-	local g2=Duel.GetMatchingGroup(c64018647.filter,tp,LOCATION_MZONE,0,1,nil,tp)
-	if Duel.GetLocationCount(tp,LOCATION_SZONE)>0 and #g2>0 and Duel.SelectYesNo(tp,aux.Stringid(64018647,0)) then
+	local eqg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c64018647.eqfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,tp)
+	if Duel.GetLocationCount(tp,LOCATION_SZONE)>0 and #eqg>0 and Duel.SelectYesNo(tp,aux.Stringid(64018647,0)) then
 		Duel.BreakEffect()
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-		local sc=g2:Select(tp,1,1,nil):GetFirst()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-		local mg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c64018647.eqfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,tp,sc)
-		Duel.Equip(tp,mg:GetFirst(),sc)
+		local eqc=eqg:Select(tp,1,1,nil):GetFirst()
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+		local mg=Duel.SelectMatchingCard(tp,c64018647.CanEquipFilter,tp,LOCATION_MZONE,0,1,1,nil,eqc)
+		Duel.Equip(tp,eqc,mg:GetFirst())
 	end
 end


### PR DESCRIPTION
@mercury233 
The 2 cards have similar effects, and they should use the same process.
Now:
1 Choose the equip card.
2. Choose the monster to equip.

aux.Stringid(27623932,1)
aux.Stringid(27623932,2)
removed
They can be replaced by system string.
