### PR TITLE
fix: change dice

### DIFF
--- a/c35772782.lua
+++ b/c35772782.lua
@@ -84,19 +84,20 @@ end
 function c35772782.diceop(e,tp,eg,ep,ev,re,r,rp)
 	local cc=Duel.GetCurrentChain()
 	local cid=Duel.GetChainInfo(cc,CHAININFO_CHAIN_ID)
-	if c35772782[0]~=cid and Duel.SelectYesNo(tp,aux.Stringid(35772782,1)) then
+	if aux.dice_chain_id~=cid and Duel.SelectYesNo(tp,aux.Stringid(35772782,1)) then
 		Duel.Hint(HINT_CARD,0,35772782)
 		e:GetHandler():RegisterFlagEffect(35772782,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
 		local dc={Duel.GetDiceResult()}
 		local ac=1
-		local ct=bit.band(ev,0xff)+bit.rshift(ev,16)
+		local ct=(ev&0xff)+(ev>>16&0xff)
 		if ct>1 then
+			--choose the index of results
 			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(35772782,2))
-			local val,idx=Duel.AnnounceNumber(tp,table.unpack(dc,1,ct))
+			local val,idx=Duel.AnnounceNumber(tp,table.unpack(aux.idx_table,1,ct))
 			ac=idx+1
 		end
 		dc[ac]=7
 		Duel.SetDiceResult(table.unpack(dc))
-		c35772782[0]=cid
+		aux.dice_chain_id=cid
 	end
 end

--- a/c39454112.lua
+++ b/c39454112.lua
@@ -16,19 +16,20 @@ end
 function c39454112.diceop(e,tp,eg,ep,ev,re,r,rp)
 	local cc=Duel.GetCurrentChain()
 	local cid=Duel.GetChainInfo(cc,CHAININFO_CHAIN_ID)
-	if c39454112[0]~=cid and Duel.SelectYesNo(tp,aux.Stringid(39454112,0)) then
+	if aux.dice_chain_id~=cid and Duel.SelectYesNo(tp,aux.Stringid(39454112,0)) then
 		Duel.Hint(HINT_CARD,0,39454112)
 		local dc={Duel.GetDiceResult()}
 		local ac=1
-		local ct=bit.band(ev,0xff)+bit.rshift(ev,16)
+		local ct=(ev&0xff)+(ev>>16&0xff)
 		if ct>1 then
+			--choose the index of results
 			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(39454112,1))
-			local val,idx=Duel.AnnounceNumber(tp,table.unpack(dc,1,ct))
+			local val,idx=Duel.AnnounceNumber(tp,table.unpack(aux.idx_table,1,ct))
 			ac=idx+1
 		end
 		if dc[ac]==1 or dc[ac]==3 or dc[ac]==5 then dc[ac]=6
 		else dc[ac]=1 end
 		Duel.SetDiceResult(table.unpack(dc))
-		c39454112[0]=cid
+		aux.dice_chain_id=cid
 	end
 end

--- a/utility.lua
+++ b/utility.lua
@@ -40,6 +40,10 @@ function bit.replace(r,v,field,width)
 	return (r&~(m<<f))|((v&m)<< f)
 end
 
+--the chain id of the results modified by EVENT_TOSS_DICE_NEGATE
+Auxiliary.dice_chain_id=0
+Auxiliary.idx_table=table.pack(1,2,3,4,5,6,7,8)
+
 function Auxiliary.Stringid(code,id)
 	return code*16+id
 end


### PR DESCRIPTION
@mercury233 
# Problem
![unknown](https://user-images.githubusercontent.com/2851577/133387585-f5828340-71dd-40bf-a264-e9d6406d31e5.png)
![unknown-1](https://user-images.githubusercontent.com/2851577/133387589-75a5f836-1187-456c-a18a-2aa43caf79d2.png)

If there are 2 dice with the same point, the player cannot select the dice he wants accurately.


# Solution
https://yugioh-wiki.net/index.php?%A1%D4%BD%D0%A4%BF%A4%E9%CC%DC%A1%D5
Ｑ：１枚目のこのカードの効果を適用して変更された出目に対して、さらに２枚目のこのカードの効果を適用できますか？
Ａ：いいえ、適用できません。(14/04/24)

1. Now the player will choose the index of the results, not the rolled number.
2. Now each result can be modified only once.
