### PR TITLE
fix Lyrilusc - Bird Sanctuary vs Ghostrick Angel of Mischief

### DIFF
--- a/c71166481.lua
+++ b/c71166481.lua
@@ -63,7 +63,7 @@ function c71166481.xop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) then
 		local mg=c:GetOverlayGroup()
-		if mg:GetCount()>0 then Duel.Overlay(tc,mg) end
+		if mg:GetCount()>0 then Duel.Overlay(tc,mg,false) end
 		Duel.Overlay(tc,Group.FromCards(c))
 	end
 end

--- a/c72859417.lua
+++ b/c72859417.lua
@@ -37,6 +37,7 @@ function c72859417.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.GetMatchingGroup(c72859417.ovfilter,tp,LOCATION_MZONE,0,nil,e)
 	if chkc then return false end
 	if chk==0 then return g:CheckSubGroup(c72859417.fselect,2,2) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	local sg=g:SelectSubGroup(tp,c72859417.fselect,false,2,2)
 	Duel.SetTargetCard(sg)
 end
@@ -59,7 +60,7 @@ function c72859417.activate(e,tp,eg,ep,ev,re,r,rp)
 		c2=g:Filter(aux.TRUE,c1):GetFirst()
 	end
 	local mg=c1:GetOverlayGroup()
-	if mg:GetCount()>0 then Duel.Overlay(c2,mg) end
+	if mg:GetCount()>0 then Duel.Overlay(c2,mg,false) end
 	Duel.Overlay(c2,Group.FromCards(c1))
 end
 function c72859417.drfilter(c)


### PR DESCRIPTION
Use _Lyrilusc - Bird Sanctuary_ to overlay one Lyrilusc monster (2 materials) to _Ghostrick Angel of Mischief_ (8 materials), the material count of Ghostrick Angel of Mischief will be 11 and shouldn't trigger the win, but now when it overlay the 2 materials of Lyrilusc, it trigger _EVENT_ADJUST_ and trigger the win.

Require https://github.com/Fluorohydride/ygopro-core/pull/409