### PR TITLE
update aux.AddRitualProc*

### DIFF
--- a/c14094090.lua
+++ b/c14094090.lua
@@ -1,6 +1,7 @@
 --超戦士の儀式
 function c14094090.initial_effect(c)
-	aux.AddRitualProcEqual(c,c14094090.ritual_filter)
+	local e0=aux.AddRitualProcEqual(c,c14094090.ritual_filter)
+	c:RegisterEffect(e0)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)

--- a/c14735698.lua
+++ b/c14735698.lua
@@ -3,6 +3,7 @@ function c14735698.initial_effect(c)
 	--Activate
 	local e1=aux.AddRitualProcEqual2(c,c14735698.filter,nil,c14735698.filter)
 	e1:SetCountLimit(1,14735698)
+	c:RegisterEffect(e1)
 	--search
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)

--- a/c18803791.lua
+++ b/c18803791.lua
@@ -1,6 +1,7 @@
 --黒竜降臨
 function c18803791.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,71408082)
+	local e0=aux.AddRitualProcGreaterCode(c,71408082)
+	c:RegisterEffect(e0)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)

--- a/c21082832.lua
+++ b/c21082832.lua
@@ -1,7 +1,8 @@
 --カオス・フォーム
 function c21082832.initial_effect(c)
 	aux.AddCodeList(c,46986414,89631139)
-	aux.AddRitualProcEqual2(c,c21082832.filter,nil,c21082832.mfilter)
+	local e0=aux.AddRitualProcEqual2(c,c21082832.filter,nil,c21082832.mfilter)
+	c:RegisterEffect(e0)
 end
 function c21082832.filter(c,e,tp,m1,m2,ft)
 	return c:IsSetCard(0xcf)

--- a/c23160024.lua
+++ b/c23160024.lua
@@ -33,6 +33,7 @@ function c23160024.initial_effect(c)
 	e5:SetCode(0)
 	e5:SetRange(LOCATION_GRAVE)
 	e5:SetCost(aux.bfgcost)
+	c:RegisterEffect(e5)
 end
 function c23160024.cfilter(c,tp)
 	return c:IsPreviousSetCard(0xe0) and c:IsReason(REASON_RELEASE) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousControler(tp)

--- a/c23965037.lua
+++ b/c23965037.lua
@@ -1,4 +1,5 @@
 --ドリアードの祈り
 function c23965037.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,99414168)
+	local e0=aux.AddRitualProcGreaterCode(c,99414168)
+	c:RegisterEffect(e0)
 end

--- a/c25726386.lua
+++ b/c25726386.lua
@@ -10,6 +10,7 @@ function c25726386.initial_effect(c)
 	e1:SetCountLimit(1,25726386)
 	e1:SetCondition(c25726386.rscon)
 	e1:SetCost(c25726386.rscost)
+	c:RegisterEffect(e1)
 	--negate
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(25726386,1))

--- a/c30392583.lua
+++ b/c30392583.lua
@@ -1,6 +1,7 @@
 --聖占術の儀式
 function c30392583.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,94997874)
+	local e0=aux.AddRitualProcGreaterCode(c,94997874)
+	c:RegisterEffect(e0)
 	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)

--- a/c31066283.lua
+++ b/c31066283.lua
@@ -1,4 +1,5 @@
 --スカルライダーの復活
 function c31066283.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,99721536)
+	local e0=aux.AddRitualProcGreaterCode(c,99721536)
+	c:RegisterEffect(e0)
 end

--- a/c32828635.lua
+++ b/c32828635.lua
@@ -1,6 +1,7 @@
 --エンドレス・オブ・ザ・ワールド
 function c32828635.initial_effect(c)
-	aux.AddRitualProcGreater2Code2(c,46427957,72426662,nil,nil,c32828635.mfilter)
+	local e0=aux.AddRitualProcGreater2Code2(c,46427957,72426662,nil,nil,c32828635.mfilter)
+	c:RegisterEffect(e0)
 	--salvage
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(32828635,0))

--- a/c33031674.lua
+++ b/c33031674.lua
@@ -1,4 +1,5 @@
 --灼熱の試練
 function c33031674.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,60258960)
+	local e0=aux.AddRitualProcGreaterCode(c,60258960)
+	c:RegisterEffect(e0)
 end

--- a/c34767865.lua
+++ b/c34767865.lua
@@ -1,6 +1,7 @@
 --サイバネット・リチューアル
 function c34767865.initial_effect(c)
-	aux.AddRitualProcGreater2(c,c34767865.ritual_filter)
+	local e0=aux.AddRitualProcGreater2(c,c34767865.ritual_filter)
+	c:RegisterEffect(e0)
 	--token
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)

--- a/c34834619.lua
+++ b/c34834619.lua
@@ -1,6 +1,7 @@
 --光子竜降臨
 function c34834619.initial_effect(c)
-	aux.AddRitualProcEqualCode(c,85346853)
+	local e0=aux.AddRitualProcEqualCode(c,85346853)
+	c:RegisterEffect(e0)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(34834619,0))

--- a/c37626500.lua
+++ b/c37626500.lua
@@ -1,6 +1,7 @@
 --精霊の祝福
 function c37626500.initial_effect(c)
-	aux.AddRitualProcEqual2(c,c37626500.ritual_filter)
+	local e0=aux.AddRitualProcEqual2(c,c37626500.ritual_filter)
+	c:RegisterEffect(e0)
 end
 function c37626500.ritual_filter(c)
 	return c:IsType(TYPE_RITUAL) and c:IsAttribute(ATTRIBUTE_LIGHT)

--- a/c39399168.lua
+++ b/c39399168.lua
@@ -1,4 +1,5 @@
 --チャクラの復活
 function c39399168.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,65393205)
+	local e0=aux.AddRitualProcGreaterCode(c,65393205)
+	c:RegisterEffect(e0)
 end

--- a/c39996157.lua
+++ b/c39996157.lua
@@ -1,6 +1,7 @@
 --機械天使の儀式
 function c39996157.initial_effect(c)
-	aux.AddRitualProcGreater2(c,c39996157.ritual_filter)
+	local e0=aux.AddRitualProcGreater2(c,c39996157.ritual_filter)
+	c:RegisterEffect(e0)
 	--destroy replace
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c41182875.lua
+++ b/c41182875.lua
@@ -1,4 +1,5 @@
 --ジャベリンビートルの契約
 function c41182875.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,26932788)
+	local e0=aux.AddRitualProcGreaterCode(c,26932788)
+	c:RegisterEffect(e0)
 end

--- a/c41426869.lua
+++ b/c41426869.lua
@@ -1,4 +1,5 @@
 --イリュージョンの儀式
 function c41426869.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,64631466)
+	local e0=aux.AddRitualProcGreaterCode(c,64631466)
+	c:RegisterEffect(e0)
 end

--- a/c43417563.lua
+++ b/c43417563.lua
@@ -1,4 +1,5 @@
 --踊りによる誘発
 function c43417563.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,4849037)
+	local e0=aux.AddRitualProcGreaterCode(c,4849037)
+	c:RegisterEffect(e0)
 end

--- a/c43694075.lua
+++ b/c43694075.lua
@@ -1,4 +1,5 @@
 --ローの祈り
 function c43694075.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,3627449)
+	local e0=aux.AddRitualProcGreaterCode(c,3627449)
+	c:RegisterEffect(e0)
 end

--- a/c44221928.lua
+++ b/c44221928.lua
@@ -1,6 +1,7 @@
 --褒誉の息吹
 function c44221928.initial_effect(c)
-	aux.AddRitualProcEqual2(c,c44221928.ritual_filter)
+	local e0=aux.AddRitualProcEqual2(c,c44221928.ritual_filter)
+	c:RegisterEffect(e0)
 end
 function c44221928.ritual_filter(c)
 	return c:IsType(TYPE_RITUAL) and c:IsAttribute(ATTRIBUTE_WIND)

--- a/c45410988.lua
+++ b/c45410988.lua
@@ -1,6 +1,7 @@
 --レッドアイズ・トランスマイグレーション
 function c45410988.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,19025379,nil,c45410988.mfilter)
+	local e0=aux.AddRitualProcGreaterCode(c,19025379,nil,c45410988.mfilter)
+	c:RegisterEffect(e0)
 end
 function c45410988.mfilter(c)
 	return c:IsSetCard(0x3b)

--- a/c46159582.lua
+++ b/c46159582.lua
@@ -1,6 +1,7 @@
 --リチュアの儀水鏡
 function c46159582.initial_effect(c)
-	aux.AddRitualProcEqual2(c,c46159582.ritual_filter)
+	local e0=aux.AddRitualProcEqual2(c,c46159582.ritual_filter)
+	c:RegisterEffect(e0)
 	--salvage
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(46159582,0))

--- a/c47435107.lua
+++ b/c47435107.lua
@@ -1,6 +1,7 @@
 --原初の叫喚
 function c47435107.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,10441498)
+	local e0=aux.AddRitualProcGreaterCode(c,10441498)
+	c:RegisterEffect(e0)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(47435107,0))

--- a/c52913738.lua
+++ b/c52913738.lua
@@ -1,6 +1,7 @@
 --破滅の儀式
 function c52913738.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,30646525)
+	local e0=aux.AddRitualProcGreaterCode(c,30646525)
+	c:RegisterEffect(e0)
 	--To Deck
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(52913738,0))

--- a/c54539105.lua
+++ b/c54539105.lua
@@ -1,4 +1,5 @@
 --ライオンの儀式
 function c54539105.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,33951077)
+	local e0=aux.AddRitualProcGreaterCode(c,33951077)
+	c:RegisterEffect(e0)
 end

--- a/c55761792.lua
+++ b/c55761792.lua
@@ -1,4 +1,5 @@
 --カオスの儀式
 function c55761792.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,5405694)
+	local e0=aux.AddRitualProcGreaterCode(c,5405694)
+	c:RegisterEffect(e0)
 end

--- a/c58827995.lua
+++ b/c58827995.lua
@@ -1,6 +1,7 @@
 --鎧竜降臨
 function c58827995.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,75901113)
+	local e0=aux.AddRitualProcGreaterCode(c,75901113)
+	c:RegisterEffect(e0)
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_REMOVE)
 	e1:SetType(EFFECT_TYPE_IGNITION)

--- a/c59820352.lua
+++ b/c59820352.lua
@@ -1,6 +1,7 @@
 --大地讃頌
 function c59820352.initial_effect(c)
-	aux.AddRitualProcEqual2(c,c59820352.ritual_filter)
+	local e0=aux.AddRitualProcEqual2(c,c59820352.ritual_filter)
+	c:RegisterEffect(e0)
 end
 function c59820352.ritual_filter(c)
 	return c:IsType(TYPE_RITUAL) and c:IsAttribute(ATTRIBUTE_EARTH)

--- a/c60234913.lua
+++ b/c60234913.lua
@@ -1,6 +1,7 @@
 --救世の儀式
 function c60234913.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,61757117)
+	local e0=aux.AddRitualProcGreaterCode(c,61757117)
+	c:RegisterEffect(e0)
 	--untargetable
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(60234913,0))

--- a/c60365591.lua
+++ b/c60365591.lua
@@ -1,4 +1,5 @@
 --奇跡の方舟
 function c60365591.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,86327225)
+	local e0=aux.AddRitualProcGreaterCode(c,86327225)
+	c:RegisterEffect(e0)
 end

--- a/c60369732.lua
+++ b/c60369732.lua
@@ -1,4 +1,5 @@
 --大邪神の儀式
 function c60369732.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,62420419)
+	local e0=aux.AddRitualProcGreaterCode(c,62420419)
+	c:RegisterEffect(e0)
 end

--- a/c62835876.lua
+++ b/c62835876.lua
@@ -1,6 +1,7 @@
 --善悪の彼岸
 function c62835876.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,35330871)
+	local e0=aux.AddRitualProcGreaterCode(c,35330871)
+	c:RegisterEffect(e0)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)

--- a/c63233638.lua
+++ b/c63233638.lua
@@ -9,6 +9,7 @@ function c63233638.initial_effect(c)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCountLimit(1,63233638)
 	e1:SetCost(c63233638.rscost)
+	c:RegisterEffect(e1)
 	--atk/def up
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)

--- a/c69035382.lua
+++ b/c69035382.lua
@@ -1,6 +1,7 @@
 --奈落との契約
 function c69035382.initial_effect(c)
-	aux.AddRitualProcEqual2(c,c69035382.ritual_filter)
+	local e0=aux.AddRitualProcEqual2(c,c69035382.ritual_filter)
+	c:RegisterEffect(e0)
 end
 function c69035382.ritual_filter(c)
 	return c:IsType(TYPE_RITUAL) and c:IsAttribute(ATTRIBUTE_DARK)

--- a/c72446038.lua
+++ b/c72446038.lua
@@ -1,4 +1,5 @@
 --合成魔術
 function c72446038.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,84385264)
+	local e0=aux.AddRitualProcGreaterCode(c,84385264)
+	c:RegisterEffect(e0)
 end

--- a/c73055622.lua
+++ b/c73055622.lua
@@ -1,6 +1,7 @@
 --霊魂の降神
 function c73055622.initial_effect(c)
-	aux.AddRitualProcGreater2Code2(c,25415052,52900000,nil,c73055622.mfilter)
+	local e0=aux.AddRitualProcGreater2Code2(c,25415052,52900000,nil,c73055622.mfilter)
+	c:RegisterEffect(e0)
 end
 function c73055622.mfilter(c)
 	return c:IsType(TYPE_SPIRIT)

--- a/c76792184.lua
+++ b/c76792184.lua
@@ -1,4 +1,5 @@
 --カオス－黒魔術の儀式
 function c76792184.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,30208479)
+	local e0=aux.AddRitualProcGreaterCode(c,30208479)
+	c:RegisterEffect(e0)
 end

--- a/c76806714.lua
+++ b/c76806714.lua
@@ -1,4 +1,5 @@
 --亀の誓い
 function c76806714.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,91782219)
+	local e0=aux.AddRitualProcGreaterCode(c,91782219)
+	c:RegisterEffect(e0)
 end

--- a/c77454922.lua
+++ b/c77454922.lua
@@ -1,4 +1,5 @@
 --要塞クジラの誓い
 function c77454922.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,62337487)
+	local e0=aux.AddRitualProcGreaterCode(c,62337487)
+	c:RegisterEffect(e0)
 end

--- a/c78577570.lua
+++ b/c78577570.lua
@@ -1,4 +1,5 @@
 --ガルマソードの誓い
 function c78577570.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,90844184)
+	local e0=aux.AddRitualProcGreaterCode(c,90844184)
+	c:RegisterEffect(e0)
 end

--- a/c78990927.lua
+++ b/c78990927.lua
@@ -21,6 +21,7 @@ function c78990927.initial_effect(c)
 	e2:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_MAIN_END)
 	e2:SetCountLimit(1,78990928)
 	e2:SetCondition(c78990927.rscon)
+	c:RegisterEffect(e2)
 end
 function c78990927.thfilter(c,lv)
 	return c:IsType(TYPE_RITUAL) and c:IsType(TYPE_MONSTER) and not c:IsLevel(lv) and c:IsAbleToHand()

--- a/c80566312.lua
+++ b/c80566312.lua
@@ -1,6 +1,7 @@
 --祝祷の聖歌
 function c80566312.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,56350972)
+	locale e0=aux.AddRitualProcGreaterCode(c,56350972)
+	c:RegisterEffect(e0)
 	--destroy replace
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c80811661.lua
+++ b/c80811661.lua
@@ -1,4 +1,5 @@
 --ハンバーガーのレシピ
 function c80811661.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,30243636)
+	local e0=aux.AddRitualProcGreaterCode(c,30243636)
+	c:RegisterEffect(e0)
 end

--- a/c81756897.lua
+++ b/c81756897.lua
@@ -1,4 +1,5 @@
 --ゼラの儀式
 function c81756897.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,69123138)
+	local e0=aux.AddRitualProcGreaterCode(c,69123138)
+	c:RegisterEffect(e0)
 end

--- a/c81933259.lua
+++ b/c81933259.lua
@@ -1,4 +1,5 @@
 --悪魔鏡の儀式
 function c81933259.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,31890399)
+	local e0=aux.AddRitualProcGreaterCode(c,31890399)
+	c:RegisterEffect(e0)
 end

--- a/c8198712.lua
+++ b/c8198712.lua
@@ -1,4 +1,5 @@
 --エンド・オブ・ザ・ワールド
 function c8198712.initial_effect(c)
-	aux.AddRitualProcEqual2Code2(c,72426662,46427957)
+	local e0=aux.AddRitualProcEqual2Code2(c,72426662,46427957)
+	c:RegisterEffect(e0)
 end

--- a/c84388461.lua
+++ b/c84388461.lua
@@ -11,7 +11,7 @@ function c84388461.initial_effect(c)
 	e2:SetTargetRange(1,0)
 	e2:SetTarget(c84388461.splimit)
 	c:RegisterEffect(e2)
-	--spsummon
+	--ritual summon
 	local e3=aux.AddRitualProcEqual2(c,c84388461.filter,nil,nil,c84388461.mfilter)
 	e3:SetDescription(aux.Stringid(84388461,1))
 	e3:SetType(EFFECT_TYPE_IGNITION)
@@ -19,6 +19,7 @@ function c84388461.initial_effect(c)
 	e3:SetCountLimit(1,84388461)
 	e3:SetRange(LOCATION_MZONE+LOCATION_HAND)
 	e3:SetCost(c84388461.cost)
+	c:RegisterEffect(e3)
 end
 function c84388461.splimit(e,c,sump,sumtype,sumpos,targetp)
 	if c:IsSetCard(0xb4,0xc4) then return false end

--- a/c86758915.lua
+++ b/c86758915.lua
@@ -3,6 +3,7 @@ function c86758915.initial_effect(c)
 	--Activate
 	local e1=aux.AddRitualProcGreater2(c,nil,nil,nil,c86758915.mfilter)
 	e1:SetDescription(aux.Stringid(86758915,0))
+	c:RegisterEffect(e1)
 	--to hand
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(86758915,1))

--- a/c8955148.lua
+++ b/c8955148.lua
@@ -1,6 +1,7 @@
 --リトマスの死儀式
 function c8955148.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,72566043)
+	local e0=aux.AddRitualProcGreaterCode(c,72566043)
+	c:RegisterEffect(e0)
 	--to deck
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TODECK+CATEGORY_DRAW)

--- a/c94377247.lua
+++ b/c94377247.lua
@@ -1,4 +1,5 @@
 --仮面魔獣の儀式
 function c94377247.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,49064413)
+	local e0=aux.AddRitualProcGreaterCode(c,49064413)
+	c:RegisterEffect(e0)
 end

--- a/c94666032.lua
+++ b/c94666032.lua
@@ -1,7 +1,8 @@
 --リヴェンデット・ボーン
 function c94666032.initial_effect(c)
 	aux.AddCodeList(c,4388680)
-	aux.AddRitualProcGreater2(c,c94666032.filter,LOCATION_HAND+LOCATION_GRAVE,c94666032.mfilter)
+	local e0=aux.AddRitualProcGreater2(c,c94666032.filter,LOCATION_HAND+LOCATION_GRAVE,c94666032.mfilter)
+	c:RegisterEffect(e0)
 	--destroy replace
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c95612049.lua
+++ b/c95612049.lua
@@ -3,6 +3,7 @@ function c95612049.initial_effect(c)
 	--Activate
 	local e1=aux.AddRitualProcGreater2Code2(c,46427957,72426662,LOCATION_HAND+LOCATION_DECK,nil,c95612049.mfilter)
 	e1:SetCountLimit(1,95612049+EFFECT_COUNT_CODE_OATH)
+	c:RegisterEffect(e1)
 end
 function c95612049.mfilter(c)
 	return not c:IsOnField() and c:IsType(TYPE_RITUAL)

--- a/c96420087.lua
+++ b/c96420087.lua
@@ -1,4 +1,5 @@
 --闇の支配者との契約
 function c96420087.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,97642679)
+	local e0=aux.AddRitualProcGreaterCode(c,97642679)
+	c:RegisterEffect(e0)
 end

--- a/c97211663.lua
+++ b/c97211663.lua
@@ -3,6 +3,7 @@ function c97211663.initial_effect(c)
 	--Activate
 	local e1=aux.AddRitualProcEqual2(c,c97211663.filter,LOCATION_HAND+LOCATION_GRAVE)
 	e1:SetCountLimit(1,97211663)
+	c:RegisterEffect(e1)
 	--search
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)

--- a/c9786492.lua
+++ b/c9786492.lua
@@ -1,4 +1,5 @@
 --白竜降臨
 function c9786492.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,73398797)
+	local e0=aux.AddRitualProcGreaterCode(c,73398797)
+	c:RegisterEffect(e0)
 end

--- a/c9845733.lua
+++ b/c9845733.lua
@@ -1,4 +1,5 @@
 --覚醒の証
 function c9845733.initial_effect(c)
-	aux.AddRitualProcGreaterCode(c,10789972)
+	local e0=aux.AddRitualProcGreaterCode(c,10789972)
+	c:RegisterEffect(e0)
 end

--- a/c99628747.lua
+++ b/c99628747.lua
@@ -9,6 +9,7 @@ function c99628747.initial_effect(c)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCountLimit(1,99628747)
 	e1:SetCost(c99628747.rscost)
+	c:RegisterEffect(e1)
 	--destroy
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(99628747,1))

--- a/utility.lua
+++ b/utility.lua
@@ -1584,7 +1584,6 @@ function Auxiliary.AddRitualProcUltimate(c,filter,level_function,greater_or_equa
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetTarget(Auxiliary.RitualUltimateTarget(filter,level_function,greater_or_equal,summon_location,grave_filter,mat_filter))
 	e1:SetOperation(Auxiliary.RitualUltimateOperation(filter,level_function,greater_or_equal,summon_location,grave_filter,mat_filter))
-	c:RegisterEffect(e1)
 	return e1
 end
 function Auxiliary.RitualCheckGreater(g,c,lv)


### PR DESCRIPTION
@mercury233 

# Problem
in `int32 card::add_effect(effect* peffect)`
```c++
if (peffect->type & EFFECT_TYPE_SINGLE)
...
else if (peffect->type & EFFECT_TYPE_EQUIP)
...
else if(peffect->type & EFFECT_TYPE_TARGET)
...
```
`add_effect()` will go into different branches based on the type and other data of the effect.
If the script register the effect and then modify the data, it will make `add_effect()` go into the wrong branch.

# Solution
Now all  `aux.AddRitualProc*` functions will NOT register the effect, and they only return it.
The script should register the effect after modifying it.
