### PR TITLE
fix The Agent of Judgment - Saturn

### DIFF
--- a/c91345518.lua
+++ b/c91345518.lua
@@ -25,7 +25,8 @@ function c91345518.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c91345518.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLP(tp)>Duel.GetLP(1-tp) end
+	if chk==0 then return Duel.GetLP(tp)>Duel.GetLP(1-tp)
+		and Duel.IsEnvironment(56433456,tp) end
 	Duel.SetTargetPlayer(1-tp)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
 end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5951
> ■自分フィールドに表側表示の「天空の聖域」が存在しない状況では発動できません。