### PR TITLE
fix Kryuel

### DIFF
--- a/c82642348.lua
+++ b/c82642348.lua
@@ -5,6 +5,7 @@ function c82642348.initial_effect(c)
 	e1:SetDescription(aux.Stringid(82642348,0))
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_COIN)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_BATTLE_DESTROYED)
 	e1:SetCondition(c82642348.descon)
 	e1:SetTarget(c82642348.destg)
@@ -15,17 +16,21 @@ c82642348.toss_coin=true
 function c82642348.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end
-function c82642348.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c82642348.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) end
 	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
 end
 function c82642348.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if not tc or not tc:IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_COIN)
 	local coin=Duel.AnnounceCoin(tp)
 	local res=Duel.TossCoin(tp,1)
 	if coin~=res then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-		local g=Duel.SelectMatchingCard(tp,aux.TRUE,tp,0,LOCATION_MZONE,1,1,nil)
-		Duel.Destroy(g,REASON_EFFECT)
+		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end

--- a/c82642348.lua
+++ b/c82642348.lua
@@ -21,7 +21,7 @@ function c82642348.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_MZONE,1,1,nil)
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
 end
 function c82642348.desop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
fix: Kryuel's effect is not target effect.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5022
> ■「クルーエル」のモンスター効果は、墓地で発動する誘発効果です。（**相手のモンスターゾーンに存在するモンスター１体を対象に取る効果です**。「クルーエル」自身が戦闘によって破壊され墓地へ送られたダメージステップ終了時に必ず発動する効果です。）