### PR TITLE
fix PSY-Framelord Lambda and so on

### DIFF
--- a/c18716735.lua
+++ b/c18716735.lua
@@ -22,7 +22,6 @@ function c18716735.initial_effect(c)
 	e2:SetCode(EVENT_DESTROYED)
 	e2:SetCountLimit(1,18716735)
 	e2:SetCondition(c18716735.regcon)
-	e2:SetTarget(c18716735.regtg)
 	e2:SetOperation(c18716735.regop)
 	c:RegisterEffect(e2)
 end
@@ -59,12 +58,6 @@ end
 function c18716735.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
-function c18716735.thfilter(c)
-	return c:IsSetCard(0xe1) and c:IsType(TYPE_MONSTER)
-end
-function c18716735.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c18716735.thfilter,tp,LOCATION_DECK,0,1,nil) end
-end
 function c18716735.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -75,16 +68,16 @@ function c18716735.regop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 end
-function c18716735.thfilter2(c)
-	return c18716735.thfilter(c) and c:IsAbleToHand()
+function c18716735.thfilter(c)
+	return c:IsSetCard(0xe1) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
 function c18716735.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c18716735.thfilter2,tp,LOCATION_DECK,0,1,nil)
+	return Duel.IsExistingMatchingCard(c18716735.thfilter,tp,LOCATION_DECK,0,1,nil)
 end
 function c18716735.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,18716735)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectMatchingCard(tp,c18716735.thfilter2,tp,LOCATION_DECK,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c18716735.thfilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)

--- a/c5506791.lua
+++ b/c5506791.lua
@@ -9,7 +9,6 @@ function c5506791.initial_effect(c)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e2:SetCountLimit(1,5506791)
-	e2:SetTarget(c5506791.regtg)
 	e2:SetOperation(c5506791.regop)
 	c:RegisterEffect(e2)
 	local e3=e2:Clone()
@@ -34,9 +33,6 @@ function c5506791.initial_effect(c)
 end
 function c5506791.thfilter(c)
 	return c:IsSetCard(0xd0) and c:IsAbleToHand()
-end
-function c5506791.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
 end
 function c5506791.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c595626.lua
+++ b/c595626.lua
@@ -23,7 +23,6 @@ function c595626.initial_effect(c)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetCountLimit(1,595627)
 	e2:SetCondition(c595626.thcon)
-	e2:SetTarget(c595626.thtg)
 	e2:SetOperation(c595626.thop)
 	c:RegisterEffect(e2)
 end
@@ -79,9 +78,6 @@ function c595626.thcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c595626.thfilter(c)
 	return c:IsCode(83764718) and c:IsAbleToHand()
-end
-function c595626.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil,83764718) end
 end
 function c595626.thop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c65472618.lua
+++ b/c65472618.lua
@@ -19,7 +19,6 @@ function c65472618.initial_effect(c)
 	e3:SetCode(EVENT_DESTROYED)
 	e3:SetProperty(EFFECT_FLAG_DELAY)
 	e3:SetCondition(c65472618.regcon)
-	e3:SetTarget(c65472618.regtg)
 	e3:SetOperation(c65472618.regop)
 	c:RegisterEffect(e3)
 end
@@ -55,12 +54,6 @@ function c65472618.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE)
 		and (c:IsReason(REASON_EFFECT) and rp==1-tp or c:IsReason(REASON_BATTLE) and Duel.GetAttacker():IsControler(1-tp))
 end
-function c65472618.thfilter(c)
-	return c:IsAttackBelow(2000) and c:IsRace(RACE_WARRIOR+RACE_SPELLCASTER) and not c:IsCode(65472618)
-end
-function c65472618.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c65472618.thfilter,tp,LOCATION_DECK,0,1,nil) end
-end
 function c65472618.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -72,15 +65,15 @@ function c65472618.regop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c65472618.thfilter2(c)
-	return c65472618.thfilter(c) and c:IsAbleToHand()
+	return c:IsAttackBelow(2000) and c:IsRace(RACE_WARRIOR+RACE_SPELLCASTER) and not c:IsCode(65472618) and c:IsAbleToHand()
 end
 function c65472618.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c65472618.thfilter2,tp,LOCATION_DECK,0,1,nil)
+	return Duel.IsExistingMatchingCard(c65472618.thfilter,tp,LOCATION_DECK,0,1,nil)
 end
 function c65472618.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,65472618)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectMatchingCard(tp,c65472618.thfilter2,tp,LOCATION_DECK,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c65472618.thfilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)

--- a/c79206925.lua
+++ b/c79206925.lua
@@ -33,7 +33,6 @@ function c79206925.initial_effect(c)
 	e4:SetType(EFFECT_TYPE_IGNITION)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetCountLimit(1,79206925)
-	e4:SetTarget(c79206925.regtg)
 	e4:SetOperation(c79206925.regop)
 	c:RegisterEffect(e4)
 end
@@ -63,12 +62,6 @@ end
 function c79206925.indtg(e,c)
 	return c==e:GetHandler() or c:IsLocation(LOCATION_FZONE)
 end
-function c79206925.thfilter(c)
-	return (c:IsSetCard(0x2e) and c:IsType(TYPE_MONSTER)) or c:IsSetCard(0x91)
-end
-function c79206925.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c79206925.thfilter,tp,LOCATION_DECK,0,1,nil) end
-end
 function c79206925.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -79,16 +72,16 @@ function c79206925.regop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 end
-function c79206925.thfilter2(c)
-	return c79206925.thfilter(c) and c:IsAbleToHand()
+function c79206925.thfilter(c)
+	return (c:IsSetCard(0x2e) and c:IsType(TYPE_MONSTER)) or c:IsSetCard(0x91) and c:IsAbleToHand()
 end
 function c79206925.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c79206925.thfilter2,tp,LOCATION_DECK,0,1,nil)
+	return Duel.IsExistingMatchingCard(c79206925.thfilter,tp,LOCATION_DECK,0,1,nil)
 end
 function c79206925.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,79206925)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectMatchingCard(tp,c79206925.thfilter2,tp,LOCATION_DECK,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c79206925.thfilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)

--- a/c8802510.lua
+++ b/c8802510.lua
@@ -21,7 +21,6 @@ function c8802510.initial_effect(c)
 	e2:SetCode(EVENT_REMOVE)
 	e2:SetCountLimit(1,8802510)
 	e2:SetCondition(c8802510.regcon)
-	e2:SetTarget(c8802510.regtg)
 	e2:SetOperation(c8802510.regop)
 	c:RegisterEffect(e2)
 end
@@ -31,9 +30,6 @@ function c8802510.cfilter(c,tp)
 end
 function c8802510.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c8802510.cfilter,1,nil,tp)
-end
-function c8802510.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_DECK,0,1,nil,0xc1) end
 end
 function c8802510.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c88722973.lua
+++ b/c88722973.lua
@@ -10,7 +10,6 @@ function c88722973.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetCondition(c88722973.regcon)
-	e1:SetTarget(c88722973.regtg)
 	e1:SetOperation(c88722973.regop)
 	c:RegisterEffect(e1)
 	--spsummon
@@ -27,9 +26,6 @@ function c88722973.initial_effect(c)
 end
 function c88722973.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_XYZ)
-end
-function c88722973.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_DECK,0,1,nil,TYPE_PENDULUM) end
 end
 function c88722973.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())

--- a/c93169863.lua
+++ b/c93169863.lua
@@ -8,7 +8,6 @@ function c93169863.initial_effect(c)
 	e1:SetCode(EVENT_SUMMON_SUCCESS)
 	e1:SetProperty(EFFECT_FLAG_DELAY)
 	e1:SetCountLimit(1,93169863)
-	e1:SetTarget(c93169863.regtg)
 	e1:SetOperation(c93169863.regop)
 	c:RegisterEffect(e1)
 	local e2=e1:Clone()
@@ -26,14 +25,8 @@ function c93169863.initial_effect(c)
 	e3:SetOperation(c93169863.spop)
 	c:RegisterEffect(e3)
 end
-function c93169863.thfilter1(c)
-	return c:IsLevelAbove(5) and c:IsAttribute(ATTRIBUTE_WATER)
-end
-function c93169863.thfilter2(c)
+function c93169863.thfilter(c)
 	return c:IsLevelAbove(5) and c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToHand()
-end
-function c93169863.regtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c93169863.thfilter1,tp,LOCATION_DECK,0,1,nil) end
 end
 function c93169863.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
@@ -46,12 +39,12 @@ function c93169863.regop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c93169863.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c93169863.thfilter2,tp,LOCATION_DECK,0,1,nil)
+	return Duel.IsExistingMatchingCard(c93169863.thfilter,tp,LOCATION_DECK,0,1,nil)
 end
 function c93169863.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,93169863)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectMatchingCard(tp,c93169863.thfilter2,tp,LOCATION_DECK,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c93169863.thfilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)


### PR DESCRIPTION
fix: if deck has no PSY-Frame, PSY-Framelord Lambda cannot activate search effect.

> Mail:
> Q.
> 自分のデッキに「PSYフレーム」カードがない状態で、「PSYフレームロード・Λ」の②の効果を発動できますか？
> A.
> ご質問の場合でも、「PSYフレームロード・Λ」の『②』の効果は発動できます。