### PR TITLE
fix Virtual World Gate - Xuanwu

### DIFF
--- a/c18249921.lua
+++ b/c18249921.lua
@@ -39,7 +39,7 @@ function c18249921.cfilter(c)
 end
 function c18249921.cpcon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
-	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and Duel.IsExistingMatchingCard(c18249921.cfilter,tp,LOCATION_SZONE,0,1,e:GetHandler())
+	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and Duel.IsExistingMatchingCard(c18249921.cfilter,tp,LOCATION_ONFIELD,0,1,e:GetHandler())
 end
 function c18249921.cpfilter(c)
 	return c:IsFaceup() and c:IsCanChangePosition()


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=15766
> ①：自分**フィールド**に他の「電脳堺門」カードが存在する場合、自分・相手のバトルフェイズに、フィールドの表側表示モンスター１体を対象として発動できる。