### PR TITLE
fix Dragunity Primus Pilus

### DIFF
--- a/c18060565.lua
+++ b/c18060565.lua
@@ -20,7 +20,8 @@ end
 function c18060565.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c18060565.filter(chkc) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c18060565.filter,tp,LOCATION_MZONE,0,1,nil) end
+		and Duel.IsExistingTarget(c18060565.filter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c18060565.eqfilter,tp,LOCATION_DECK,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,c18060565.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,nil,1,tp,LOCATION_DECK)


### PR DESCRIPTION
fix: if deck has no Level 3 or lower Dragon Dragunity, Dragunity Primus Pilus can activate effect.