### PR TITLE
fix Rank-Up-Magic Zexal Force

### DIFF
--- a/c36224040.lua
+++ b/c36224040.lua
@@ -39,7 +39,7 @@ function c36224040.dtfilter(c)
 end
 function c36224040.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c36224040.filter1(chkc,e,tp) end
-	if chk==0 then return Duel.IsExistingTarget(c36224040.filter1,tp,LOCATION_MZONE,0,1,nil,e,tp) and Duel.IsExistingMatchingCard(c36224040.dtfilter,tp,LOCATION_DECK,0,1,nil) and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>1 end
+	if chk==0 then return Duel.IsExistingTarget(c36224040.filter1,tp,LOCATION_MZONE,0,1,nil,e,tp) and Duel.IsExistingMatchingCard(c36224040.dtfilter,tp,LOCATION_DECK,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,c36224040.filter1,tp,LOCATION_MZONE,0,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)


### PR DESCRIPTION
fix: if deck has only card, Rank-Up-Magic Zexal Force cannot activate.

> Mail:
> Q.
> 自分のデッキが「ZS－幻影賢者」1枚のみの場合、自分は「RUM－ゼアル・フォース」の①の効果を発動できますか？
>  
> A.
> ご質問の場合でも、「RUM－ゼアル・フォース」の『①』の効果は発動できます。