### PR TITLE
fix Frozen Rose

### DIFF
--- a/c53503015.lua
+++ b/c53503015.lua
@@ -24,6 +24,7 @@ function c53503015.thfilter(c)
 end
 function c53503015.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local chk1=Duel.IsExistingMatchingCard(c53503015.cfilter,tp,LOCATION_MZONE,0,1,nil,0,true)
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>1
 	local chk2=Duel.IsExistingMatchingCard(c53503015.cfilter,tp,LOCATION_MZONE,0,1,nil,0,false)
 		and Duel.IsExistingMatchingCard(c53503015.thfilter,tp,LOCATION_DECK,0,1,nil)
 	if chk==0 then


### PR DESCRIPTION
fix: if deck has only 1 card, Frozen Rose can choice draw effect.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22220
> 植物族モンスターを墓地へ送って「冷薔薇の抱香」を発動する場合には、『●植物族：このターンのエンドフェイズに、自分はデッキから２枚ドローし、その後手札を１枚選んで捨てる』効果を適用する事になりますので、**自分のデッキの枚数が1枚以下の場合には、植物族モンスターを墓地へ送って「冷薔薇の抱香」を発動する事自体ができません**。

> ref:
> Q.
> 「強欲で金満な壺」を発動したターンに、自分は植物族モンスターを墓地へ送って「冷薔薇の抱香」を発動できますか？
> A.
> 「強欲で金満な壺」を発動したターンであっても、植物族モンスターを墓地へ送って「冷薔薇の抱香」を発動することはできますが、エンドフェイズにおいて『自分はデッキから２枚ドローし、その後手札を１枚選んで捨てる』処理は行えません。
> Q.
> 相手フィールドに「神殿を守る者」が存在する状態で自分は植物族モンスターを墓地へ送って「冷薔薇の抱香」を発動できますか？
> A.
> ご質問の場合でも、「冷薔薇の抱香」を発動できますが、エンドフェイズに「神殿を守る者」が存在している場合はドローできません。