### PR TITLE
fix Helping Robo for Combat

### DIFF
--- a/c47025270.lua
+++ b/c47025270.lua
@@ -16,6 +16,7 @@ function c47025270.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47025270.drop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.Draw(tp,1,REASON_EFFECT)~=0 then
+		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 		local g=Duel.SelectMatchingCard(tp,nil,tp,LOCATION_HAND,0,1,1,nil)
 		Duel.SendtoDeck(g,nil,SEQ_DECKBOTTOM,REASON_EFFECT)


### PR DESCRIPTION
fix: draw and send to deck are the same.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5596
> ■ドローする処理と、手札を選びデッキの一番下に戻す処理は同時に行われる扱いではありません。