### PR TITLE
fix Broww, Huntsman of Dark World

### DIFF
--- a/c79126789.lua
+++ b/c79126789.lua
@@ -19,15 +19,17 @@ end
 function c79126789.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
 	if tp==rp or tp~=e:GetLabel() then
-		Duel.SetTargetParam(1)
 		Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 	else
-		Duel.SetTargetParam(2)
 		Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)
 	end
 end
 function c79126789.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
-	Duel.Draw(p,d,REASON_EFFECT)
+	if Duel.Draw(p,d,REASON_EFFECT)~=0 and tp==e:GetLabel() then
+		Duel.BreakEffect()
+		Duel.Draw(tp,1,REASON_EFFECT)
+	end
 end

--- a/c79126789.lua
+++ b/c79126789.lua
@@ -28,7 +28,7 @@ function c79126789.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c79126789.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
-	if Duel.Draw(p,d,REASON_EFFECT)~=0 and tp==e:GetLabel() then
+	if Duel.Draw(p,d,REASON_EFFECT)~=0 and tp~=rp and tp==e:GetLabel() then
 		Duel.BreakEffect()
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end


### PR DESCRIPTION
fix: first draw and second draw are the same.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6502
> ■相手のカードの効果によって手札から墓地へ捨てられた場合、『自分のデッキからカードを１枚ドローする』処理と、『相手のカードの効果によって捨てられた場合、さらにもう１枚ドローする』処理は**同時に行われる扱いではありません**。