### PR TITLE
Fix Toadally Awesome, Arcana Force VII - The Chariot, Zero Force, Book of Eclipse

### DIFF
--- a/c17521642.lua
+++ b/c17521642.lua
@@ -17,10 +17,10 @@ function c17521642.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c17521642.cfilter,1,nil,tp)
 end
 function c17521642.filter(c)
-    return c:IsFaceup() and c:GetAttack()>0
+	return c:IsFaceup() and c:GetAttack()>0
 end
 function c17521642.target(e,tp,eg,ep,ev,re,r,rp,chk)
-    if chk==0 then return Duel.IsExistingMatchingCard(c17521642.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c17521642.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 end
 function c17521642.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c17521642.lua
+++ b/c17521642.lua
@@ -16,8 +16,11 @@ end
 function c17521642.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c17521642.cfilter,1,nil,tp)
 end
+function c17521642.filter(c)
+    return c:IsFaceup() and c:GetAttack()>0
+end
 function c17521642.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+    if chk==0 then return Duel.IsExistingMatchingCard(c17521642.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 end
 function c17521642.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/c34568403.lua
+++ b/c34568403.lua
@@ -53,9 +53,9 @@ function c34568403.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c34568403.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=e:GetHandler():GetBattleTarget()
-	if chk==0 then return (tc:IsLocation(LOCATION_GRAVE) or tc:IsLocation(LOCATION_REMOVED) and tc:IsFaceup()) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		or tc:IsLocation(LOCATION_EXTRA) and tc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,tc)>0)
-		and tc:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	if chk==0 then return tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and ((tc:IsLocation(LOCATION_GRAVE) or tc:IsLocation(LOCATION_REMOVED) and tc:IsFaceup()) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+			or tc:IsLocation(LOCATION_EXTRA) and tc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,tc)>0) end
 	Duel.SetTargetCard(tc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tc,1,0,0)
 end

--- a/c34568403.lua
+++ b/c34568403.lua
@@ -53,8 +53,8 @@ function c34568403.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c34568403.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=e:GetHandler():GetBattleTarget()
-	if chk==0 then return (not tc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		or tc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp,tp,nil,tc)>0)
+	if chk==0 then return (tc:IsLocation(LOCATION_GRAVE) or tc:IsLocation(LOCATION_REMOVED) and tc:IsFaceup()) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		or tc:IsLocation(LOCATION_EXTRA) and tc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,tc)>0)
 		and tc:IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetTargetCard(tc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tc,1,0,0)

--- a/c35480699.lua
+++ b/c35480699.lua
@@ -35,5 +35,6 @@ end
 function c35480699.flipop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsFacedown,tp,0,LOCATION_MZONE,nil)
 	local ct=Duel.ChangePosition(g,POS_FACEUP_DEFENSE)
+	Duel.BreakEffect()
 	Duel.Draw(1-tp,ct,REASON_EFFECT)
 end

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -89,7 +89,7 @@ end
 function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if not Duel.NegateActivation(ev) then return end
-	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK)
+	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK) and not (tc:IsLocation(LOCATION_REMOVED) and tc:IsFacedown())
 		and aux.NecroValleyFilter()(rc) then
 		if rc:IsType(TYPE_MONSTER) and (not rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 				or rc:IsLocation(LOCATION_EXTRA) and rc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -92,7 +92,7 @@ function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK)
 		and aux.NecroValleyFilter()(rc) then
 		if rc:IsType(TYPE_MONSTER) and (not rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-				or rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)
+				or rc:IsLocation(LOCATION_EXTRA) and rc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)
 			and rc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
 			and Duel.SelectYesNo(tp,aux.Stringid(90809975,3)) then
 			Duel.BreakEffect()

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -89,7 +89,8 @@ end
 function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if not Duel.NegateActivation(ev) then return end
-	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not (rc:IsLocation(LOCATION_HAND+LOCATION_DECK) or tc:IsLocation(LOCATION_REMOVED) and tc:IsFacedown())
+	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0
+		and not (rc:IsLocation(LOCATION_HAND+LOCATION_DECK) or tc:IsLocation(LOCATION_REMOVED) and tc:IsFacedown())
 		and aux.NecroValleyFilter()(rc) then
 		if rc:IsType(TYPE_MONSTER) and (not rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 				or rc:IsLocation(LOCATION_EXTRA) and rc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -89,7 +89,7 @@ end
 function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if not Duel.NegateActivation(ev) then return end
-	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK) and not (tc:IsLocation(LOCATION_REMOVED) and tc:IsFacedown())
+	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not (rc:IsLocation(LOCATION_HAND+LOCATION_DECK) or tc:IsLocation(LOCATION_REMOVED) and tc:IsFacedown())
 		and aux.NecroValleyFilter()(rc) then
 		if rc:IsType(TYPE_MONSTER) and (not rc:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 				or rc:IsLocation(LOCATION_EXTRA) and rc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,rc)>0)


### PR DESCRIPTION
Fixed an issue with Toadally Awesome that it could special summon face-down monsters from extra deck.
Fixed an issue with Arcana Force VII - The Chariot that it could special summon monsters from deck or spell and trap zone and face-down monsters from extra deck.
Fixed an issue with Zero Force that it could activate when all monsters are 0 ATK. (Same ruling to Ghost of a Grudge.)
Added BreakEffect in Book of Eclipse.