### PR TITLE
fix War Rock Fortia, War Rock Mammud and War Rock Orpis

### DIFF
--- a/c46169154.lua
+++ b/c46169154.lua
@@ -39,7 +39,7 @@ end
 function c46169154.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return (c46169154.check(Duel.GetAttacker(),tp) or c46169154.check(Duel.GetAttackTarget(),tp))
 		and Duel.IsExistingMatchingCard(c46169154.tgfilter,tp,LOCATION_DECK,0,1,nil)
-		and Duel.IsExistingMatchingCard(c83286340.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
+		and Duel.IsExistingMatchingCard(c46169154.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
 end
 function c46169154.atkfilter(c)

--- a/c46169154.lua
+++ b/c46169154.lua
@@ -38,11 +38,12 @@ function c46169154.check(c,tp)
 end
 function c46169154.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return (c46169154.check(Duel.GetAttacker(),tp) or c46169154.check(Duel.GetAttackTarget(),tp))
-		and Duel.IsExistingMatchingCard(c46169154.tgfilter,tp,LOCATION_DECK,0,1,nil) end
+		and Duel.IsExistingMatchingCard(c46169154.tgfilter,tp,LOCATION_DECK,0,1,nil)
+		and Duel.IsExistingMatchingCard(c83286340.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
 end
 function c46169154.atkfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x15f)
+	return c:IsFaceup() and c:IsSetCard(0x15f) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c46169154.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c83286340.lua
+++ b/c83286340.lua
@@ -32,11 +32,12 @@ function c83286340.check(c,tp)
 end
 function c83286340.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return (c83286340.check(Duel.GetAttacker(),tp) or c83286340.check(Duel.GetAttackTarget(),tp))
-		and Duel.IsExistingMatchingCard(c83286340.thfilter,tp,LOCATION_DECK,0,1,nil) end
+		and Duel.IsExistingMatchingCard(c83286340.thfilter,tp,LOCATION_DECK,0,1,nil)
+		and Duel.IsExistingMatchingCard(c83286340.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c83286340.atkfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x15f)
+	return c:IsFaceup() and c:IsSetCard(0x15f) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c83286340.thop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c84903021.lua
+++ b/c84903021.lua
@@ -37,13 +37,14 @@ end
 function c84903021.dstg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() and chkc:IsType(TYPE_SPELL+TYPE_TRAP) end
 	if chk==0 then return (c84903021.check(Duel.GetAttacker(),tp) or c84903021.check(Duel.GetAttackTarget(),tp))
-		and Duel.IsExistingTarget(Card.IsType,tp,0,LOCATION_ONFIELD,1,nil,TYPE_SPELL+TYPE_TRAP) end
+		and Duel.IsExistingTarget(Card.IsType,tp,0,LOCATION_ONFIELD,1,nil,TYPE_SPELL+TYPE_TRAP)
+		and Duel.IsExistingMatchingCard(c83286340.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,Card.IsType,tp,0,LOCATION_ONFIELD,1,1,nil,TYPE_SPELL+TYPE_TRAP)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function c84903021.atkfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x15f)
+	return c:IsFaceup() and c:IsSetCard(0x15f) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c84903021.dsop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c84903021.lua
+++ b/c84903021.lua
@@ -38,7 +38,7 @@ function c84903021.dstg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() and chkc:IsType(TYPE_SPELL+TYPE_TRAP) end
 	if chk==0 then return (c84903021.check(Duel.GetAttacker(),tp) or c84903021.check(Duel.GetAttackTarget(),tp))
 		and Duel.IsExistingTarget(Card.IsType,tp,0,LOCATION_ONFIELD,1,nil,TYPE_SPELL+TYPE_TRAP)
-		and Duel.IsExistingMatchingCard(c83286340.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
+		and Duel.IsExistingMatchingCard(c84903021.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,Card.IsType,tp,0,LOCATION_ONFIELD,1,1,nil,TYPE_SPELL+TYPE_TRAP)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)


### PR DESCRIPTION
fix: if War Rock Fortia would be destroy by battle, War Rock Fortia can activate search effect.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23359&keyword=&tag=-1
> その「ウォークライ・フォティア」については、ダメージ計算時に戦闘で破壊されることが確定しています。（その「ウォークライ・フォティア」が実際に破壊されフィールドを離れるのはダメージステップ終了時ですので、ダメージ計算後の時点ではまだフィールドに存在しています。）
> 
> **戦闘で破壊されることが確定しているモンスターに対して『自分フィールドの全ての「ウォークライ」モンスターの攻撃力は相手ターン終了時まで２００アップする』処理を適用することはできませんので、「ウォークライ・フォティア」の『①』の効果を発動することはできません**。