### PR TITLE
update setcode

### DIFF
--- a/c1969506.lua
+++ b/c1969506.lua
@@ -27,7 +27,7 @@ function c1969506.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e1,tp)
 end
 function c1969506.filter(c,e,tp)
-	return c:IsSetCard(0x83) and c:IsLevel(8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x1083) and c:IsLevel(8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c1969506.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c1969506.filter(chkc,e,tp) end

--- a/c20032555.lua
+++ b/c20032555.lua
@@ -11,7 +11,7 @@ function c20032555.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c20032555.cfilter(c)
-	return c:IsSetCard(0x83) and c:IsType(TYPE_MONSTER) and c:IsDiscardable()
+	return c:IsSetCard(0x1083) and c:IsType(TYPE_MONSTER) and c:IsDiscardable()
 end
 function c20032555.efftg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c20032555.cfilter,tp,LOCATION_HAND,0,1,nil) end

--- a/c29216967.lua
+++ b/c29216967.lua
@@ -12,7 +12,7 @@ function c29216967.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c29216967.tgfilter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x83) and c:IsAbleToGrave()
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x1083) and c:IsAbleToGrave()
 end
 function c29216967.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c29216967.tgfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c32875265.lua
+++ b/c32875265.lua
@@ -12,7 +12,7 @@ function c32875265.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c32875265.spfilter(c,e,tp)
-	return c:IsSetCard(0x83) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x1083) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c32875265.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -53,5 +53,5 @@ function c32875265.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c32875265.splimit(e,c)
-	return not c:IsSetCard(0x83)
+	return not c:IsSetCard(0x1083)
 end

--- a/c39806198.lua
+++ b/c39806198.lua
@@ -18,5 +18,5 @@ function c39806198.spcon(e,c)
 		and not Duel.IsExistingMatchingCard(c39806198.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c39806198.cfilter(c)
-	return c:IsFacedown() or not c:IsSetCard(0x83)
+	return c:IsFacedown() or not c:IsSetCard(0x1083)
 end

--- a/c43598843.lua
+++ b/c43598843.lua
@@ -20,7 +20,7 @@ function c43598843.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c43598843.spfilter(c,e,tp)
-	return c:IsSetCard(0x83) and not c:IsCode(43598843) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+	return c:IsSetCard(0x1083) and not c:IsCode(43598843) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c43598843.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c43598843.spfilter(chkc,e,tp) end
@@ -46,7 +46,7 @@ function c43598843.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c43598843.actop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
-	if re:IsActiveType(TYPE_MONSTER) and rc:IsSetCard(0x83) and ep==tp then
+	if re:IsActiveType(TYPE_MONSTER) and rc:IsSetCard(0x1083) and ep==tp then
 		Duel.SetChainLimit(c43598843.chainlm)
 	end
 end

--- a/c55204071.lua
+++ b/c55204071.lua
@@ -75,5 +75,5 @@ function c55204071.spop3(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.RegisterEffect(e1,tp)
 end
 function c55204071.splimit(e,c)
-	return not c:IsSetCard(0x83)
+	return not c:IsSetCard(0x1083)
 end

--- a/c56427559.lua
+++ b/c56427559.lua
@@ -19,7 +19,7 @@ function c56427559.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c56427559.lvfilter(c,lv)
-	return c:IsFaceup() and c:IsSetCard(0x83) and not c:IsLevel(lv) and c:IsLevelAbove(1)
+	return c:IsFaceup() and c:IsSetCard(0x1083) and not c:IsLevel(lv) and c:IsLevelAbove(1)
 end
 function c56427559.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c56427559.lvfilter(chkc,e:GetHandler():GetLevel()) end

--- a/c57093995.lua
+++ b/c57093995.lua
@@ -23,7 +23,7 @@ function c57093995.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c57093995.tgfilter(c)
-	return c:IsSetCard(0x83) and c:IsType(TYPE_MONSTER) and c:IsAbleToGrave()
+	return c:IsSetCard(0x1083) and c:IsType(TYPE_MONSTER) and c:IsAbleToGrave()
 end
 function c57093995.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c57093995.tgfilter,tp,LOCATION_DECK,0,1,nil) end

--- a/c6471156.lua
+++ b/c6471156.lua
@@ -28,7 +28,7 @@ function c6471156.initial_effect(c)
 end
 function c6471156.cfilter(c,tp)
 	local lv=c:GetLevel()
-	return lv>0 and c:IsSetCard(0x83) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
+	return lv>0 and c:IsSetCard(0x1083) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
 		and Duel.IsExistingMatchingCard(c6471156.lvfilter,tp,LOCATION_MZONE,0,1,nil,lv)
 end
 function c6471156.lvfilter(c,lv)
@@ -57,7 +57,7 @@ function c6471156.lvop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c6471156.cfilter2(c,tp)
-	return c:IsSetCard(0x83) and c:IsReason(REASON_DESTROY)
+	return c:IsSetCard(0x1083) and c:IsReason(REASON_DESTROY)
 		and (c:IsReason(REASON_BATTLE) or c:GetReasonPlayer()==1-tp and c:IsReason(REASON_DESTROY))
 		and c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
 end
@@ -65,7 +65,7 @@ function c6471156.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c6471156.cfilter2,1,nil,tp)
 end
 function c6471156.spfilter(c,e,tp)
-	return c:IsFaceup() and c:IsSetCard(0x83) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsFaceup() and c:IsSetCard(0x1083) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c6471156.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_REMOVED) and chkc:IsControler(tp) and c6471156.spfilter(chkc,e,tp) end

--- a/c67968069.lua
+++ b/c67968069.lua
@@ -12,7 +12,7 @@ function c67968069.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c67968069.filter(c,e,tp)
-	return c:IsSetCard(0x83) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x1083) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c67968069.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c67968069.filter(chkc,e,tp) end

--- a/c7593748.lua
+++ b/c7593748.lua
@@ -1,7 +1,7 @@
 --ギミック・パペット－ギガンテス・ドール
 function c7593748.initial_effect(c)
 	--xyz summon
-	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x83),4,2)
+	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x1083),4,2)
 	c:EnableReviveLimit()
 	--control
 	local e1=Effect.CreateEffect(c)
@@ -64,7 +64,7 @@ function c7593748.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e2,tp)
 end
 function c7593748.splimit(e,c)
-	return not c:IsSetCard(0x83)
+	return not c:IsSetCard(0x1083)
 end
 function c7593748.atktg(e,c)
 	return not c:IsType(TYPE_XYZ)

--- a/c76543119.lua
+++ b/c76543119.lua
@@ -24,7 +24,7 @@ function c76543119.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c76543119.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x83)
+	return c:IsFaceup() and c:IsSetCard(0x1083)
 end
 function c76543119.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c76543119.filter(chkc) end
@@ -43,7 +43,7 @@ function c76543119.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c76543119.spfilter(c,e,tp)
-	return c:IsSetCard(0x83) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x1083) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c76543119.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c79086452.lua
+++ b/c79086452.lua
@@ -20,7 +20,7 @@ function c79086452.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c79086452.spfilter(c)
-	return c:IsSetCard(0x83) and c:IsType(TYPE_MONSTER)
+	return c:IsSetCard(0x1083) and c:IsType(TYPE_MONSTER)
 end
 function c79086452.spcon(e,c)
 	if c==nil then return true end
@@ -45,5 +45,5 @@ function c79086452.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c79086452.efftg(e,c)
-	return c:IsSetCard(0x83)
+	return c:IsSetCard(0x1083)
 end

--- a/c8226374.lua
+++ b/c8226374.lua
@@ -16,7 +16,7 @@ function c8226374.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c8226374.filter(c,e,tp)
-	return c:IsSetCard(0x83) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x1083) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c8226374.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0

--- a/c92418590.lua
+++ b/c92418590.lua
@@ -20,7 +20,7 @@ function c92418590.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c92418590.cfilter(c)
-	return c:IsSetCard(0x83) and c:IsAbleToRemoveAsCost() and c:IsType(TYPE_MONSTER)
+	return c:IsSetCard(0x1083) and c:IsAbleToRemoveAsCost() and c:IsType(TYPE_MONSTER)
 end
 function c92418590.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c92418590.cfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler()) end
@@ -41,5 +41,5 @@ function c92418590.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function c92418590.xyzlimit(e,c)
 	if not c then return false end
-	return not c:IsSetCard(0x83)
+	return not c:IsSetCard(0x1083)
 end

--- a/c92821268.lua
+++ b/c92821268.lua
@@ -14,7 +14,7 @@ function c92821268.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c92821268.cfilter(c,tp)
-	return c:IsControler(tp) and c:IsLocation(LOCATION_GRAVE) and c:IsSetCard(0x83)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_GRAVE) and c:IsSetCard(0x1083)
 		and c:IsPreviousControler(tp) and c:IsAbleToRemoveAsCost()
 end
 function c92821268.cost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c97520532.lua
+++ b/c97520532.lua
@@ -19,7 +19,7 @@ function c97520532.thcon(e)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)
 end
 function c97520532.thfilter(c)
-	return c:IsSetCard(0x83) and c:IsType(TYPE_MONSTER) and (c:IsAbleToHand() or c:IsAbleToGrave())
+	return c:IsSetCard(0x1083) and c:IsType(TYPE_MONSTER) and (c:IsAbleToHand() or c:IsAbleToGrave())
 end
 function c97520532.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c97520532.thfilter,tp,LOCATION_DECK,0,1,nil) end
@@ -27,10 +27,10 @@ function c97520532.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
 end
 function c97520532.cfilter(c)
-	return c:IsFacedown() or not c:IsSetCard(0x83)
+	return c:IsFacedown() or not c:IsSetCard(0x1083)
 end
 function c97520532.spfilter(c,e,tp)
-	return c:IsSetCard(0x83) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x1083) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c97520532.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_OPERATECARD)


### PR DESCRIPTION
https://yugioh-wiki.net/index.php?%A1%D4%A5%D7%A5%ED%A5%E2%A1%BC%A5%B7%A5%E7%A5%F3%A1%D5
プロモーション
このカード名のカードは１ターンに１枚しか発動できない。
(1)：自分フィールドのレベル３以下の戦士族・地属性モンスター１体を対象として発動できる。
そのモンスターを墓地へ送り、デッキからレベル４以上の戦士族・地属性モンスター１体を特殊召喚する。
その後、元々の種族・属性が戦士族・地属性となる「パペット」モンスターが自分フィールドに存在する場合、
この効果で特殊召喚したモンスターの攻撃力・守備力は相手の墓地のカードの数×１００アップする。

After 「パペット」appears, the setcode will become:
!setname 0x83 Puppet
!setname 0x1083 Gimmick Puppet
