### PR TITLE
fix Spell Gear

### DIFF
--- a/c313513.lua
+++ b/c313513.lua
@@ -45,14 +45,10 @@ function c313513.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ft=math.min((Duel.GetLocationCount(tp,LOCATION_MZONE)),2)
 	local g=Duel.GetMatchingGroup(c313513.filter,tp,LOCATION_HAND+LOCATION_DECK,0,nil,e,tp)
 	if ft>0 and g:GetCount()>0 then
-		local ct=0
 		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local sg=g:SelectSubGroup(tp,c313513.fselect,false,1,ft)
-		if sg and sg:GetCount()>0 then
-			ct=Duel.SpecialSummon(sg,0,tp,tp,true,false,POS_FACEUP)
-		end
-		if ct>0 then
+		if sg and Duel.SpecialSummon(sg,0,tp,tp,true,false,POS_FACEUP)>0 then
 			local dg=Duel.GetMatchingGroup(c313513.dfilter,tp,LOCATION_MZONE,0,nil)
 			if dg:GetCount()>0 then
 				Duel.BreakEffect()

--- a/c313513.lua
+++ b/c313513.lua
@@ -36,7 +36,7 @@ function c313513.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK)
 end
 function c313513.dfilter(c)
-	return c:IsFacedown() or c:GetCode()~=83104731
+	return c:IsFacedown() or not c:IsCode(83104731)
 end
 function c313513.fselect(g)
 	return g:GetClassCount(Card.GetLocation)==g:GetCount()

--- a/c313513.lua
+++ b/c313513.lua
@@ -15,40 +15,14 @@ function c313513.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x7) and c:IsAbleToGraveAsCost()
 end
 function c313513.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local ct=-ft+1
 	local tg=Duel.GetMatchingGroup(c313513.cfilter,tp,LOCATION_ONFIELD,0,nil)
 	if chk==0 then
 		e:SetLabel(1)
-		return ct<=3 and tg:GetCount()>=3
-			and (ct<=0 or tg:IsExists(Card.IsLocation,ct,nil,LOCATION_MZONE))
+		return tg:CheckSubGroup(aux.mzctcheck,3,3,tp)
 	end
-	local g=nil
-	if ct>0 then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		g=tg:FilterSelect(tp,Card.IsLocation,ct,ct,nil,LOCATION_MZONE)
-		if ct<3 then
-			tg:Sub(g)
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-			local g2=tg:Select(tp,3-ct,3-ct,nil)
-			g:Merge(g2)
-		end
-	else
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		g=tg:Select(tp,3,3,nil)
-	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=tg:SelectSubGroup(tp,aux.mzctcheck,false,3,3,tp)
 	Duel.SendtoGrave(g,REASON_COST)
-	if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_CANNOT_SUMMON)
-	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
-	e1:SetReset(RESET_SELF_TURN+RESET_PHASE+PHASE_END,2)
-	e1:SetTargetRange(1,0)
-	Duel.RegisterEffect(e1,tp)
-	local e2=e1:Clone()
-	e2:SetCode(EFFECT_CANNOT_MSET)
-	Duel.RegisterEffect(e2,tp)
 end
 function c313513.filter(c,e,tp)
 	return c:IsCode(83104731) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
@@ -62,30 +36,38 @@ function c313513.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK)
 end
 function c313513.dfilter(c)
-	return c:IsFacedown() or not c:IsCode(83104731)
+	return c:IsFacedown() or c:GetCode()~=83104731
+end
+function c313513.fselect(g)
+	return g:GetClassCount(Card.GetLocation)==g:GetCount()
 end
 function c313513.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if ft<=0 then return end
-	local ct=0
-	if ft==1 then
+	local ft=math.min((Duel.GetLocationCount(tp,LOCATION_MZONE)),2)
+	local g=Duel.GetMatchingGroup(c313513.filter,tp,LOCATION_HAND+LOCATION_DECK,0,nil,e,tp)
+	if ft>0 and g:GetCount()>0 then
+		local ct=0
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local g=Duel.SelectMatchingCard(tp,c313513.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp)
-		ct=Duel.SpecialSummon(g,0,tp,tp,true,false,POS_FACEUP)
-	else
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local g1=Duel.SelectMatchingCard(tp,c313513.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
-		if g1:GetCount()>0 and Duel.SpecialSummonStep(g1:GetFirst(),0,tp,tp,true,false,POS_FACEUP) then ct=ct+1 end
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local g2=Duel.SelectMatchingCard(tp,c313513.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
-		if g2:GetCount()>0 and Duel.SpecialSummonStep(g2:GetFirst(),0,tp,tp,true,false,POS_FACEUP) then ct=ct+1 end
-		Duel.SpecialSummonComplete()
-	end
-	if ct>0 then
-		local dg=Duel.GetMatchingGroup(c313513.dfilter,tp,LOCATION_MZONE,0,nil)
-		if dg:GetCount()>0 then
-			Duel.BreakEffect()
-			Duel.Destroy(dg,REASON_EFFECT)
+		local sg=g:SelectSubGroup(tp,c313513.fselect,false,1,ft)
+		if sg and sg:GetCount()>0 then
+			ct=Duel.SpecialSummon(sg,0,tp,tp,true,false,POS_FACEUP)
+		end
+		if ct>0 then
+			local dg=Duel.GetMatchingGroup(c313513.dfilter,tp,LOCATION_MZONE,0,nil)
+			if dg:GetCount()>0 then
+				Duel.BreakEffect()
+				Duel.Destroy(dg,REASON_EFFECT)
+			end
 		end
 	end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetReset(RESET_SELF_TURN+RESET_PHASE+PHASE_END,2)
+	e1:SetTargetRange(1,0)
+	Duel.RegisterEffect(e1,tp)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_CANNOT_MSET)
+	Duel.RegisterEffect(e2,tp)
 end


### PR DESCRIPTION
fix 1: "You cannot Normal Summon or Set until the end of your next turn" is not effect.
> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=7622
> この**効果の発動後**、自分のターンで数えて２ターンの間、自分は通常召喚できない。

fix 2: if Blue-Eyes Spirit Dragon has on the field, player can special summon 2 Ancient Gear.
update: use `Group.CheckSubGroup` and `Group.SelectSubGroup`.