### PR TITLE
fix for Blue-Eyes Spirit Dragon

### DIFF
--- a/c3493978.lua
+++ b/c3493978.lua
@@ -24,6 +24,7 @@ end
 function c3493978.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c3493978.filter,tp,LOCATION_HAND,0,1,ft,nil,e,tp)
 	if g:GetCount()>0 then

--- a/c41141943.lua
+++ b/c41141943.lua
@@ -74,9 +74,9 @@ function c41141943.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c41141943.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c41141943.spfilter,tp,LOCATION_HAND,0,nil,e,tp)
-	if g:GetCount()==0 then return end
-	local ft=Duel.GetLocationCount(1-tp,LOCATION_MZONE)
-	if ft>2 then ft=2 end
+	local ft=math.min((Duel.GetLocationCount(tp,LOCATION_MZONE)),2)
+	if g:GetCount()==0 or ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sg=g:Select(tp,1,ft,nil)
 	local ct=Duel.SpecialSummon(sg,0,tp,1-tp,false,false,POS_FACEUP_DEFENSE)

--- a/c47658964.lua
+++ b/c47658964.lua
@@ -16,6 +16,7 @@ end
 function c47658964.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c47658964.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(tp,c47658964.cfilter,tp,LOCATION_GRAVE,0,1,ft,nil)
 	e:SetLabel(g:GetCount())
@@ -29,7 +30,8 @@ function c47658964.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c47658964.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if ft<e:GetLabel() or not Duel.IsPlayerCanSpecialSummonMonster(tp,47658965,0x39,TYPES_TOKEN_MONSTER,0,0,1,RACE_PYRO,ATTRIBUTE_FIRE) then return end
+	if ft<e:GetLabel() or not Duel.IsPlayerCanSpecialSummonMonster(tp,47658965,0x39,TYPES_TOKEN_MONSTER,0,0,1,RACE_PYRO,ATTRIBUTE_FIRE)
+		or (e:GetLabel()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
 	for i=1,e:GetLabel() do
 		local token=Duel.CreateToken(tp,47658965)
 		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP_DEFENSE)

--- a/c55416843.lua
+++ b/c55416843.lua
@@ -18,10 +18,10 @@ function c55416843.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_GRAVE)
 end
 function c55416843.operation(e,tp,eg,ep,ev,re,r,rp)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local ft=math.min((Duel.GetLocationCount(tp,LOCATION_MZONE)),2)
 	if ft<=0 then return end
 	local c=e:GetHandler()
-	if ft>2 then ft=2 end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c55416843.filter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,ft,nil,e,tp)
 	if g:GetCount()>0 then

--- a/c64283880.lua
+++ b/c64283880.lua
@@ -37,6 +37,7 @@ function c64283880.spop(e,tp,eg,ep,ev,re,r,rp)
 		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(64283880,0)) then
 			Duel.BreakEffect()
 			if ct>2 then ct=2 end
+			if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local sg=g:Select(tp,1,ct,nil)
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)

--- a/c92609670.lua
+++ b/c92609670.lua
@@ -39,9 +39,9 @@ function c92609670.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_GRAVE)
 end
 function c92609670.spop(e,tp,eg,ep,ev,re,r,rp)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if ft<1 then return end
-	if ft>2 then ft=2 end
+	local ft=math.min((Duel.GetLocationCount(tp,LOCATION_MZONE)),2)
+	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c92609670.filter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,ft,nil,e,tp)
 	if g:GetCount()>0 then


### PR DESCRIPTION
fix: if Blue-Eyes Spirit Dragon has on the field, player can special summon 2 or more.