### PR TITLE
fix Inspector Boarder

### DIFF
--- a/c15397015.lua
+++ b/c15397015.lua
@@ -17,6 +17,7 @@ function c15397015.initial_effect(c)
 	--activate limit
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e3:SetCode(EVENT_CHAINING)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetOperation(c15397015.counterop)
@@ -45,9 +46,9 @@ end
 function c15397015.counterop(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsActiveType(TYPE_MONSTER) then return end
 	if ep==tp then
-		e:GetHandler():RegisterFlagEffect(15397015,RESET_EVENT+0x3ff0000+RESET_PHASE+PHASE_END,0,1)
+		e:GetHandler():RegisterFlagEffect(15397015,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
 	else
-		e:GetHandler():RegisterFlagEffect(15397016,RESET_EVENT+0x3ff0000+RESET_PHASE+PHASE_END,0,1)
+		e:GetHandler():RegisterFlagEffect(15397016,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
 	end
 end
 function c15397015.cfilter(c,type)


### PR DESCRIPTION
fix 1: if Inspector Boarder was changed controller or negated effects, activated counts was reset.
fix 2: activated counts don't increase while Inspector Boarder that negated effects has on the field.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23452&keyword=&tag=-1
> **「インスペクト・ボーダー」の効果が無効化されている状況で発動したモンスター効果も、「インスペクト・ボーダー」がモンスターゾーンに存在する状況で発動したモンスター効果の回数に数えます**。ただし、「インスペクト・ボーダー」の効果が無効化されている限り、回数にかかわらずモンスター効果を発動できなくなることはありません。