### PR TITLE
fix Myutant M-05, ST-46 and 変異体ミュートリア

### DIFF
--- a/c26561172.lua
+++ b/c26561172.lua
@@ -43,13 +43,13 @@ function c26561172.spcostexcheckfilter(c,e,tp,code)
 end
 function c26561172.spcostexcheck(c,e,tp)
 	local result=false
-	if c:IsType(TYPE_MONSTER) then
+	if c:GetOriginalType()&TYPE_MONSTER~=0 then
 		result=result or Duel.IsExistingMatchingCard(c26561172.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,34695290)
 	end
-	if c:IsType(TYPE_SPELL) then
+	if c:GetOriginalType()&TYPE_SPELL~=0 then
 		result=result or Duel.IsExistingMatchingCard(c26561172.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,61089209)
 	end
-	if c:IsType(TYPE_TRAP) then
+	if c:GetOriginalType()&TYPE_TRAP~=0 then
 		result=result or Duel.IsExistingMatchingCard(c26561172.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,7574904)
 	end
 	return result
@@ -66,7 +66,7 @@ function c26561172.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local cost=Duel.SelectMatchingCard(tp,c26561172.spcostfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp):GetFirst()
-	e:SetLabel(cost:GetType())
+	e:SetLabel(cost:GetOriginalType())
 	Duel.Remove(cost,POS_FACEUP,REASON_COST)
 end
 function c26561172.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -78,9 +78,9 @@ function c26561172.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c26561172.spopfilter(c,e,tp,typ)
-	return (((typ & TYPE_MONSTER)>0 and c:IsCode(34695290))
-		or ((typ & TYPE_SPELL)>0 and c:IsCode(61089209))
-		or ((typ & TYPE_TRAP)>0 and c:IsCode(7574904)))
+	return (((typ&TYPE_MONSTER)>0 and c:IsCode(34695290))
+		or ((typ&TYPE_SPELL)>0 and c:IsCode(61089209))
+		or ((typ&TYPE_TRAP)>0 and c:IsCode(7574904)))
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c26561172.spop(e,tp,eg,ep,ev,re,r,rp)

--- a/c62201847.lua
+++ b/c62201847.lua
@@ -45,13 +45,13 @@ function c62201847.spcostexcheckfilter(c,e,tp,code)
 end
 function c62201847.spcostexcheck(c,e,tp)
 	local result=false
-	if c:IsType(TYPE_MONSTER) then
+	if c:GetOriginalType()&TYPE_MONSTER~=0 then
 		result=result or Duel.IsExistingMatchingCard(c62201847.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,34695290)
 	end
-	if c:IsType(TYPE_SPELL) then
+	if c:GetOriginalType()&TYPE_SPELL~=0 then
 		result=result or Duel.IsExistingMatchingCard(c62201847.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,61089209)
 	end
-	if c:IsType(TYPE_TRAP) then
+	if c:GetOriginalType()&TYPE_TRAP~=0 then
 		result=result or Duel.IsExistingMatchingCard(c62201847.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,7574904)
 	end
 	return result
@@ -71,7 +71,7 @@ function c62201847.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local cost=Duel.SelectMatchingCard(tp,c62201847.spcostfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,e:GetHandler(),e,tp,e:GetHandler()):GetFirst()
-	e:SetLabel(cost:GetType())
+	e:SetLabel(cost:GetOriginalType())
 	Duel.Remove(cost,POS_FACEUP,REASON_COST)
 end
 function c62201847.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -83,9 +83,9 @@ function c62201847.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c62201847.spopfilter(c,e,tp,typ)
-	return (((typ & TYPE_MONSTER)>0 and c:IsCode(34695290))
-		or ((typ & TYPE_SPELL)>0 and c:IsCode(61089209))
-		or ((typ & TYPE_TRAP)>0 and c:IsCode(7574904)))
+	return (((typ&TYPE_MONSTER)>0 and c:IsCode(34695290))
+		or ((typ&TYPE_SPELL)>0 and c:IsCode(61089209))
+		or ((typ&TYPE_TRAP)>0 and c:IsCode(7574904)))
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c62201847.spop(e,tp,eg,ep,ev,re,r,rp)

--- a/c8200556.lua
+++ b/c8200556.lua
@@ -45,13 +45,13 @@ function c8200556.spcostexcheckfilter(c,e,tp,code)
 end
 function c8200556.spcostexcheck(c,e,tp)
 	local result=false
-	if c:IsType(TYPE_MONSTER) then
+	if c:GetOriginalType()&TYPE_MONSTER~=0 then
 		result=result or Duel.IsExistingMatchingCard(c8200556.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,34695290)
 	end
-	if c:IsType(TYPE_SPELL) then
+	if c:GetOriginalType()&TYPE_SPELL~=0 then
 		result=result or Duel.IsExistingMatchingCard(c8200556.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,61089209)
 	end
-	if c:IsType(TYPE_TRAP) then
+	if c:GetOriginalType()&TYPE_TRAP~=0 then
 		result=result or Duel.IsExistingMatchingCard(c8200556.spcostexcheckfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,7574904)
 	end
 	return result
@@ -71,7 +71,7 @@ function c8200556.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local cost=Duel.SelectMatchingCard(tp,c8200556.spcostfilter,tp,LOCATION_HAND+LOCATION_ONFIELD,0,1,1,e:GetHandler(),e,tp,e:GetHandler()):GetFirst()
-	e:SetLabel(cost:GetType())
+	e:SetLabel(cost:GetOriginalType())
 	Duel.Remove(cost,POS_FACEUP,REASON_COST)
 end
 function c8200556.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -83,9 +83,9 @@ function c8200556.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function c8200556.spopfilter(c,e,tp,typ)
-	return (((typ & TYPE_MONSTER)>0 and c:IsCode(34695290))
-		or ((typ & TYPE_SPELL)>0 and c:IsCode(61089209))
-		or ((typ & TYPE_TRAP)>0 and c:IsCode(7574904)))
+	return (((typ&TYPE_MONSTER)>0 and c:IsCode(34695290))
+		or ((typ&TYPE_SPELL)>0 and c:IsCode(61089209))
+		or ((typ&TYPE_TRAP)>0 and c:IsCode(7574904)))
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c8200556.spop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
fix: if trap monster banished by Myutant M-05's cost, Myutant Arsenal cannot special summon by that effect.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23355&keyword=&tag=-1
> **装備カードとして装備されているモンスターカードを除外した場合、『●モンスター』つまり「ミュートリアル・ビースト」を特殊召喚することになります**。（デッキに「ミュートリアル・ビースト」が存在しない状況では、モンスターカードを除外して「被検体ミュートリアM－０５」の『②』の効果を発動することはできません。）
> 
> **モンスターとしてモンスターゾーンに存在する罠カードを除外した場合、『●罠』つまり「ミュートリアル・アームズ」を特殊召喚することになります**。（デッキに「ミュートリアル・アームズ」が存在しない状況では、罠カードを除外して「被検体ミュートリアM－０５」の『②』の効果を発動することはできません。）なお、そのモンスターゾーンの罠カードが罠カードとしても扱われているかどうかによって違いはありません。