### PR TITLE
fix Raiza the Mega Monarch and Thestalos the Mega Monarch

### DIFF
--- a/c69230391.lua
+++ b/c69230391.lua
@@ -57,15 +57,16 @@ function c69230391.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c69230391.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,0,LOCATION_HAND)
-	if g:GetCount()==0 then return end
-	Duel.ConfirmCards(tp,g)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
-	local hg=g:Select(tp,1,1,nil)
-	Duel.SendtoGrave(hg,REASON_EFFECT+REASON_DISCARD)
-	Duel.ShuffleHand(1-tp)
-	local tc=hg:GetFirst()
-	if tc:IsType(TYPE_MONSTER) then
-		Duel.Damage(1-tp,tc:GetLevel()*200,REASON_EFFECT)
+	if g:GetCount()>0 then
+		Duel.ConfirmCards(tp,g)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
+		local hg=g:Select(tp,1,1,nil)
+		Duel.SendtoGrave(hg,REASON_EFFECT+REASON_DISCARD)
+		Duel.ShuffleHand(1-tp)
+		local tc=hg:GetFirst()
+		if tc:IsType(TYPE_MONSTER) then
+			Duel.Damage(1-tp,tc:GetLevel()*200,REASON_EFFECT)
+		end
 	end
 	if e:GetLabel()==1 then
 		Duel.BreakEffect()

--- a/c69327790.lua
+++ b/c69327790.lua
@@ -69,6 +69,8 @@ function c69327790.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 		local g3=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,g1)
 		Duel.SetOperationInfo(0,CATEGORY_TOHAND,g3,1,0,0)
+	else
+		e:SetCategory(CATEGORY_TODECK)
 	end
 end
 function c69327790.tdop(e,tp,eg,ep,ev,re,r,rp)

--- a/c69327790.lua
+++ b/c69327790.lua
@@ -51,40 +51,42 @@ end
 function c69327790.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return true end
+	local g1=nil
 	if Duel.IsExistingTarget(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
 		and Duel.IsExistingTarget(nil,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-		local g1=Duel.SelectTarget(tp,nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+		g1=Duel.SelectTarget(tp,nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 		local g2=Duel.SelectTarget(tp,nil,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil)
-		if e:GetLabel()==1
-			and Duel.IsExistingTarget(Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,g1:GetFirst())
-			and Duel.SelectYesNo(tp,aux.Stringid(69327790,2)) then
-			e:SetCategory(CATEGORY_TODECK+CATEGORY_TOHAND)
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-			local g3=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,g1:GetFirst())
-			Duel.SetOperationInfo(0,CATEGORY_TOHAND,g3,1,0,0)
-		end
 		e:SetLabelObject(g2:GetFirst())
 		g1:Merge(g2)
 		Duel.SetOperationInfo(0,CATEGORY_TODECK,g1,2,0,0)
+	end
+	if e:GetLabel()==1
+		and Duel.IsExistingTarget(Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,g1)
+		and Duel.SelectYesNo(tp,aux.Stringid(69327790,2)) then
+		e:SetCategory(CATEGORY_TODECK+CATEGORY_TOHAND)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+		local g3=Duel.SelectTarget(tp,Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,g1)
+		Duel.SetOperationInfo(0,CATEGORY_TOHAND,g3,1,0,0)
 	end
 end
 function c69327790.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local ex,g1=Duel.GetOperationInfo(0,CATEGORY_TODECK)
 	local ex2,g2=Duel.GetOperationInfo(0,CATEGORY_TOHAND)
-	if not g1 then return end
-	local sg1=g1:Filter(Card.IsRelateToEffect,nil,e)
-	if sg1:GetCount()>0 and Duel.SendtoDeck(sg1,nil,SEQ_DECKTOP,REASON_EFFECT)>1 then
-		local gc=e:GetLabelObject()
-		local fc=sg1:GetFirst()
-		if fc==gc then fc=sg1:GetNext() end
-		if fc:GetControler()==gc:GetControler() and fc:IsLocation(LOCATION_DECK) and gc:IsLocation(LOCATION_DECK) then
-			local op=Duel.SelectOption(tp,aux.Stringid(69327790,3),aux.Stringid(69327790,4))
-			if op==0 then
-				Duel.MoveSequence(fc,0)
-			else
-				Duel.MoveSequence(gc,0)
+	if g1 then
+		local sg1=g1:Filter(Card.IsRelateToEffect,nil,e)
+		if sg1:GetCount()>0 and Duel.SendtoDeck(sg1,nil,SEQ_DECKTOP,REASON_EFFECT)>1 then
+			local gc=e:GetLabelObject()
+			local fc=sg1:GetFirst()
+			if fc==gc then fc=sg1:GetNext() end
+			if fc:GetControler()==gc:GetControler() and fc:IsLocation(LOCATION_DECK) and gc:IsLocation(LOCATION_DECK) then
+				local op=Duel.SelectOption(tp,aux.Stringid(69327790,3),aux.Stringid(69327790,4))
+				if op==0 then
+					Duel.MoveSequence(fc,0)
+				else
+					Duel.MoveSequence(gc,0)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23458&keyword=&tag=-1
> Question
> お互いの墓地にカードが存在しない状況で、「ふわんだりぃず×いぐるん」と「ふわんだりぃず×ろびーな」をリリースして「烈風帝ライザー」をアドバンス召喚し、「烈風帝ライザー」の効果が発動しました。
> 
> その場合、『このカードが風属性モンスターをリリースしてアドバンス召喚に成功した場合、その時の効果に以下の効果を加える。●フィールドのカード１枚を対象として持ち主の手札に戻す事ができる』効果の対象のみ選択することはできますか？
> Answer
> できます。
> 
> その場合、**フィールドのカード１枚のみを対象にとって発動することになります**。 

ref:

> http://yugioh-wiki.net/index.php?%A1%D4%B9%E4%C3%CF%C4%EB%A5%B0%A5%E9%A5%F3%A5%DE%A1%BC%A5%B0%A1%D5#faq
> Ｑ：セットされたカードがない状態で地属性をリリースしアドバンス召喚に成功した場合、どのように処理しますか？
> Ａ：その場合、発生したチェーンブロック内で**ドローのみを行います**。(13/12/11)