### PR TITLE
Fix Terror of Trishula, Predaplant Moray Nepenthes, Infinitrack Xyz

### DIFF
--- a/c22011689.lua
+++ b/c22011689.lua
@@ -14,7 +14,7 @@ function c22011689.initial_effect(c)
 	e2:SetCategory(CATEGORY_EQUIP)
 	e2:SetCode(EVENT_BATTLE_DESTROYING)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e2:SetCondition(aux.bdocon)
+	e2:SetCondition(c22011689.eqcon)
 	e2:SetTarget(c22011689.eqtg)
 	e2:SetOperation(c22011689.eqop)
 	c:RegisterEffect(e2)
@@ -32,6 +32,12 @@ function c22011689.initial_effect(c)
 end
 function c22011689.atkval(e,c)
 	return Duel.GetCounter(0,1,1,0x1041)*200
+end
+function c22011689.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc:GetBattleTarget()
+	return c:IsRelateToBattle() and c:IsStatus(STATUS_OPPO_BATTLE) and bc:IsType(TYPE_MONSTER) and
+        	(bc:IsLocation(LOCATION_GRAVE) or bc:IsFaceup() and bc:IsLocation(LOCATION_EXTRA+LOCATION_REMOVED))
 end
 function c22011689.eqtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 end

--- a/c22011689.lua
+++ b/c22011689.lua
@@ -35,7 +35,7 @@ function c22011689.atkval(e,c)
 end
 function c22011689.eqcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local bc:GetBattleTarget()
+	local bc=c:GetBattleTarget()
 	return c:IsRelateToBattle() and c:IsStatus(STATUS_OPPO_BATTLE) and bc:IsType(TYPE_MONSTER) and
         	(bc:IsLocation(LOCATION_GRAVE) or bc:IsFaceup() and bc:IsLocation(LOCATION_EXTRA+LOCATION_REMOVED))
 end

--- a/c24701066.lua
+++ b/c24701066.lua
@@ -64,7 +64,8 @@ function c24701066.xyzcon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=c:GetBattleTarget()
 	if not c:IsRelateToBattle() then return false end
 	e:SetLabelObject(tc)
-	return tc and tc:IsType(TYPE_MONSTER) and tc:IsReason(REASON_BATTLE) and tc:IsCanOverlay()
+	return tc and tc:IsType(TYPE_MONSTER) and tc:IsReason(REASON_BATTLE) and
+		(tc:IsFaceup() and tc:IsLocation(LOCATION_EXTRA+LOCATION_REMOVED) or tc:IsLocation(LOCATION_GRAVE)) and tc:IsCanOverlay()
 end
 function c24701066.xyztg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsType(TYPE_XYZ) end

--- a/c24701066.lua
+++ b/c24701066.lua
@@ -65,7 +65,7 @@ function c24701066.xyzcon(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToBattle() then return false end
 	e:SetLabelObject(tc)
 	return tc and tc:IsType(TYPE_MONSTER) and tc:IsReason(REASON_BATTLE) and
-		(tc:IsFaceup() and tc:IsLocation(LOCATION_EXTRA+LOCATION_REMOVED) or tc:IsLocation(LOCATION_GRAVE)) and tc:IsCanOverlay()
+		(tc:IsLocation(LOCATION_GRAVE) or tc:IsFaceup() and tc:IsLocation(LOCATION_EXTRA+LOCATION_REMOVED)) and tc:IsCanOverlay()
 end
 function c24701066.xyztg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsType(TYPE_XYZ) end

--- a/c60195675.lua
+++ b/c60195675.lua
@@ -54,7 +54,8 @@ function c60195675.xyzcon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=c:GetBattleTarget()
 	if not c:IsRelateToBattle() then return false end
 	e:SetLabelObject(tc)
-	return tc and tc:IsType(TYPE_MONSTER) and tc:IsReason(REASON_BATTLE) and tc:IsCanOverlay()
+	return tc and tc:IsType(TYPE_MONSTER) and tc:IsReason(REASON_BATTLE) and
+		(tc:IsLocation(LOCATION_GRAVE) or tc:IsFaceup() and tc:IsLocation(LOCATION_EXTRA+LOCATION_REMOVED)) and tc:IsCanOverlay()
 end
 function c60195675.xyztg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsType(TYPE_XYZ) end

--- a/c6075533.lua
+++ b/c6075533.lua
@@ -28,15 +28,19 @@ function c6075533.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c6075533.cfilter,tp,LOCATION_MZONE,0,1,nil)
 	local ct=g:GetClassCount(Card.GetCode)
 	if chk==0 then return ct>=1 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,nil)
-		and (ct<2 or Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil))
-		and (ct<3 or Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil)) end
-	local rct=1
-	local loc=LOCATION_ONFIELD
-	if ct>=2 then
+		or ct>=2 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil)
+		or ct>=3 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) end
+	local rct=0
+	local loc=0
+	if ct>=1 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,nil) then
+		rct=rct+1
+		loc=loc+LOCATION_ONFIELD
+	end
+	if ct>=2 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil) then
 		rct=rct+1
 		loc=loc+LOCATION_GRAVE
 	end
-	if ct>=3 then
+	if ct>=3 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) then
 		rct=rct+1
 		loc=loc+LOCATION_HAND
 	end

--- a/c97584719.lua
+++ b/c97584719.lua
@@ -62,7 +62,8 @@ function c97584719.xyzcon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=c:GetBattleTarget()
 	if not c:IsRelateToBattle() then return false end
 	e:SetLabelObject(tc)
-	return tc and tc:IsType(TYPE_MONSTER) and tc:IsReason(REASON_BATTLE) and tc:IsCanOverlay()
+	return tc and tc:IsType(TYPE_MONSTER) and tc:IsReason(REASON_BATTLE) and
+		(tc:IsLocation(LOCATION_GRAVE) or tc:IsFaceup() and tc:IsLocation(LOCATION_EXTRA+LOCATION_REMOVED)) and tc:IsCanOverlay()
 end
 function c97584719.xyztg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsType(TYPE_XYZ) end


### PR DESCRIPTION
Fixed Predaplant Moray Nepenthes and Infinitrack Xyz monsters and now they can only capture GY, face-up banished and face-up Ex monsters.
Fixed Terror of Trishula and now it can activate as long as any card can be banished under the requirements of Syncro monsters.