### PR TITLE
Fix Terror of Trishula

### DIFF
--- a/c6075533.lua
+++ b/c6075533.lua
@@ -28,15 +28,19 @@ function c6075533.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c6075533.cfilter,tp,LOCATION_MZONE,0,1,nil)
 	local ct=g:GetClassCount(Card.GetCode)
 	if chk==0 then return ct>=1 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,nil)
-		and (ct<2 or Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil))
-		and (ct<3 or Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil)) end
-	local rct=1
-	local loc=LOCATION_ONFIELD
-	if ct>=2 then
+		or ct>=2 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil)
+		or ct>=3 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) end
+	local rct=0
+	local loc=0
+	if ct>=1 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,nil) then
+		rct=rct+1
+		loc=loc+LOCATION_ONFIELD
+	end
+	if ct>=2 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil) then
 		rct=rct+1
 		loc=loc+LOCATION_GRAVE
 	end
-	if ct>=3 then
+	if ct>=3 and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) then
 		rct=rct+1
 		loc=loc+LOCATION_HAND
 	end
@@ -45,24 +49,29 @@ end
 function c6075533.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c6075533.cfilter,tp,LOCATION_MZONE,0,nil)
 	local ct=g:GetClassCount(Card.GetCode)
+	local rflag=false
 	if ct>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 		local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,1,nil)
 		if g:GetCount()>0 then
 			Duel.HintSelection(g)
 			Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+			rflag=true
 		end
 	end
 	if ct>1 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 		local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,1,nil)
 		if g:GetCount()>0 then
+			if rflag then Duel.BreakEffect() end
 			Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+			rflag=true
 		end
 	end
 	if ct>2 then
 		local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_HAND,nil)
 		if g:GetCount()>0 then
+			if rflag then Duel.BreakEffect() end
 			local sg=g:RandomSelect(tp,1)
 			Duel.Remove(sg,POS_FACEUP,REASON_EFFECT)
 		end


### PR DESCRIPTION
Fixed Terror of Trishula and now it can activate as long as any card can be banished under the requirements of Syncro monsters.
Q.
1、自分のフィールド上に「氷結界」Sモンスター3種類があります。相手のフィールド上と手札はカードがありますが、相手の墓地にはカードがありません。この場合、自分で「トリシューラの鼓動」を発動できますか？発動できるなら、相手のフィールドと手札のカードを除外できますか？
 
A.
ご質問の場合でも、「トリシューラの鼓動」は発動できます。
その際、『●１種類以上：相手フィールドのカード１枚を選んで除外する』効果と『●３種類以上：相手の手札をランダムに１枚選んで除外する』効果の処理を行います。
 
Q.
2、「トリシューラの鼓動」の①の効果は、『●１種類以上』『●2種類以上』『●3種類以上』は同時に処理されますか？自分は先に相手の手札1枚をランダムに除外して、相手の墓地のカード1枚を選んで除外してもいいですか？
 
A.
上の『●』から順に処理を行います。