### PR TITLE
fix シンデレラ

### DIFF
--- a/c78527720.lua
+++ b/c78527720.lua
@@ -50,7 +50,7 @@ function c78527720.operation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 		local eqg=Duel.SelectMatchingCard(tp,c78527720.efilter,tp,LOCATION_DECK,0,1,1,nil,c)
-		Duel.Equip(tp,eqg:GetFirst(),c)
+		if eqg:GetCount()>0 then Duel.Equip(tp,eqg:GetFirst(),c) end
 	end
 end
 function c78527720.eqcon(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
Redtext occurs on line 53 while there are no available targets for her 1st effect to equip