### PR TITLE
fix Crusadia Revival

### DIFF
--- a/c69039982.lua
+++ b/c69039982.lua
@@ -33,7 +33,7 @@ function c69039982.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()
 end
 function c69039982.eafilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x116) and c:IsType(TYPE_LINK)
+	return c:IsFaceup() and c:IsSetCard(0x116) and c:IsType(TYPE_LINK) and not c:IsHasEffect(EFFECT_CANNOT_ATTACK)
 end
 function c69039982.eatg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c69039982.eafilter(chkc) end


### PR DESCRIPTION
fix: Crusadia Revival can target monster that cannot attack.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12872&keyword=&tag=-1
> 「コンセントレイト」の効果を発動したターン、対象のモンスター以外のモンスターは攻撃を行う事ができなくなっていますので、質問の状況の場合、自分は「リユナイト・パラディオン」の効果を発動する事自体ができません。