### PR TITLE
fix Gravekeeper's Oracle

### DIFF
--- a/c25524823.lua
+++ b/c25524823.lua
@@ -141,22 +141,28 @@ function c25524823.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 	if bit.band(sel,2)~=0 then
 		local g=Duel.GetMatchingGroup(c25524823.filter,tp,0,LOCATION_MZONE,nil)
-		Duel.Destroy(g,REASON_EFFECT)
+		if g:GetCount()>0 then
+			Duel.BreakEffect()
+			Duel.Destroy(g,REASON_EFFECT)
+		end
 	end
 	if bit.band(sel,4)~=0 then
 		local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
 		local tc=g:GetFirst()
-		while tc do
-			local e1=Effect.CreateEffect(c)
-			e1:SetType(EFFECT_TYPE_SINGLE)
-			e1:SetCode(EFFECT_UPDATE_ATTACK)
-			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-			e1:SetValue(-2000)
-			tc:RegisterEffect(e1)
-			local e2=e1:Clone()
-			e2:SetCode(EFFECT_UPDATE_DEFENSE)
-			tc:RegisterEffect(e2)
-			tc=g:GetNext()
+		if tc then
+			Duel.BreakEffect()
+			while tc do
+				local e1=Effect.CreateEffect(c)
+				e1:SetType(EFFECT_TYPE_SINGLE)
+				e1:SetCode(EFFECT_UPDATE_ATTACK)
+				e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+				e1:SetValue(-2000)
+				tc:RegisterEffect(e1)
+				local e2=e1:Clone()
+				e2:SetCode(EFFECT_UPDATE_DEFENSE)
+				tc:RegisterEffect(e2)
+				tc=g:GetNext()
+			end
 		end
 	end
 end


### PR DESCRIPTION
fix: Gravekeeper's Oracle's three effects are the same.

> https://yugioh-wiki.net/index.php?%A1%D4%CA%E8%BC%E9%A4%CE%BF%B3%BF%C0%BC%D4%A1%D5#faq
> Ｑ：複数の処理を行う場合、それは同時扱いですか？
> Ａ：いいえ、同時扱いではありません。
> 　　よって２つ目の効果のあとに３つ目の効果を処理した場合タイミングを逃す要因となります。(13/11/18)