### PR TITLE
fix Evil Dragon Ananta

### DIFF
--- a/c8400623.lua
+++ b/c8400623.lua
@@ -38,8 +38,8 @@ end
 function c8400623.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	return Duel.IsExistingMatchingCard(c8400623.cfilter,tp,LOCATION_MZONE,0,1,nil)
-		or (Duel.IsExistingMatchingCard(c8400623.cfilter,tp,LOCATION_GRAVE,0,1,nil) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0)
+	local g=Duel.GetMatchingGroup(c8400623.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+	return #g>0 and Duel.GetMZoneCount(tp,g)>0
 end
 function c8400623.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local g=Duel.GetMatchingGroup(c8400623.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
@@ -65,6 +65,8 @@ function c8400623.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c8400623.desop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() or c:IsControler(1-tp) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
 		Duel.Destroy(tc,REASON_EFFECT)


### PR DESCRIPTION
fix 1: if player has reptile in extra monster zone only and no space in main monster zone, Evil Dragon Ananta can banish by special summon.
fix 2: if Evil Dragon Ananta don't has on the field, target card is destroyed.

> https://twitter.com/YuGiOh_OCG_INFO/status/1468852918136758273
> このカードが自分フィールドに表側表示で存在する場合、対象のカードを破壊する。

> https://yugioh-wiki.net/index.php?%A1%D4%BC%D9%CE%B6%A5%A2%A5%CA%A5%F3%A5%BF%A1%D5#faq
> Ｑ：カードを破壊する効果処理時にこのカードのコントロールが相手に移った場合、(2)の破壊効果は適用されますか？
> Ａ：いいえ、適用されません。(12/10/29)