### PR TITLE
remove EFFECT_FLAG2_MILLENNIUM_RESTRICT

### DIFF
--- a/c41578483.lua
+++ b/c41578483.lua
@@ -32,7 +32,6 @@ function c41578483.initial_effect(c)
 	--disable
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD)
-	e4:SetProperty(0,EFFECT_FLAG2_MILLENNIUM_RESTRICT)
 	e4:SetCode(EFFECT_DISABLE)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
@@ -122,12 +121,12 @@ function c41578483.disfilter(c)
 end
 function c41578483.distg(e,c)
 	local g=e:GetHandler():GetEquipGroup():Filter(c41578483.disfilter,nil)
-	return g:IsExists(Card.IsCode,1,nil,c:GetCode()) and (c:IsType(TYPE_EFFECT) or c:GetOriginalType()&TYPE_EFFECT~=0)
+	return (c:IsType(TYPE_EFFECT) or c:GetOriginalType()&TYPE_EFFECT~=0) and g:IsExists(Card.IsOriginalCodeRule,1,nil,c:GetOriginalCodeRule())
 end
 function c41578483.discon(e,tp,eg,ep,ev,re,r,rp)
 	local g=e:GetHandler():GetEquipGroup():Filter(c41578483.disfilter,nil)
-	local code,type=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CODE,CHAININFO_TYPE)
-	return type==TYPE_MONSTER and g:IsExists(Card.IsCode,1,nil,code)
+	local rc=re:GetHandler()
+	return re:IsActiveType(TYPE_MONSTER) and g:IsExists(Card.IsOriginalCodeRule,1,nil,rc:GetOriginalCodeRule())
 end
 function c41578483.disop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateEffect(ev)

--- a/constant.lua
+++ b/constant.lua
@@ -317,7 +317,7 @@ EFFECT_FLAG_COF					=0x20000000 --N/A
 EFFECT_FLAG_CVAL_CHECK			=0x40000000	--N/A
 EFFECT_FLAG_IMMEDIATELY_APPLY	=0x80000000	--卡在发动时效果就立即适用
 
-EFFECT_FLAG2_MILLENNIUM_RESTRICT	=0x0001 --卡名為X的卡的效果無效（千年眼納祭神）
+EFFECT_FLAG2_MILLENNIUM_RESTRICT	=0x0001 --N/A
 EFFECT_FLAG2_COF					=0x0002 --通常魔法卡在MP1以外发动（邪恶的仪式的特殊处理）
 --========== Codes ==========	--对永续性效果表示效果类型(EFFECT开头)，对诱发型效果表示触发效果的事件/时点(EVENT开头)
 EFFECT_IMMUNE_EFFECT			=1		--效果免疫

--- a/utility.lua
+++ b/utility.lua
@@ -255,16 +255,6 @@ function Auxiliary.EnableUnionAttribute(c,f)
 	e2:SetValue(f)
 	c:RegisterEffect(e2)
 end
-function Auxiliary.ChangeCodeCondition(check,condition)
-	return	function(e)
-				if condition and not condition(e) then return false end
-				local le={e:GetHandler():IsHasEffect(EFFECT_DISABLE)}
-				for _,te in ipairs(le) do
-					if not te:IsHasProperty(0,EFFECT_FLAG2_MILLENNIUM_RESTRICT) then return check end
-				end
-				return not check
-			end
-end
 function Auxiliary.EnableChangeCode(c,code,location,condition)
 	Auxiliary.AddCodeList(c,code)
 	local loc=c:GetOriginalType()&TYPE_MONSTER~=0 and LOCATION_MZONE or LOCATION_SZONE
@@ -275,13 +265,8 @@ function Auxiliary.EnableChangeCode(c,code,location,condition)
 	e1:SetCode(EFFECT_CHANGE_CODE)
 	e1:SetRange(loc)
 	e1:SetValue(code)
-	e1:SetCondition(Auxiliary.ChangeCodeCondition(true,condition))
 	c:RegisterEffect(e1)
-	local e2=e1:Clone()
-	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE+EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetCondition(Auxiliary.ChangeCodeCondition(false,condition))
-	c:RegisterEffect(e2)
-	return e1,e2
+	return e1
 end
 function Auxiliary.TargetEqualFunction(f,value,...)
 	local ext_params={...}


### PR DESCRIPTION
@chronogenexx  @mercury233 

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13466
③：このカードの効果で装備したモンスターと元々のカード名が同じモンスターは攻撃できず、その効果は無効化される。 

Now it check the original card name, so EFFECT_FLAG2_MILLENNIUM_RESTRICT can be removed.

