### PR TITLE
fix Performapal Trump Girl and so on

### DIFF
--- a/c42002073.lua
+++ b/c42002073.lua
@@ -51,7 +51,7 @@ end
 function c42002073.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c42002073.filter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c42002073.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil

--- a/c46136942.lua
+++ b/c46136942.lua
@@ -150,7 +150,7 @@ end
 function c46136942.mfop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c46136942.mffilter1,nil,e)
 	mg1:Merge(Duel.GetMatchingGroup(c46136942.mffilter0,tp,LOCATION_PZONE,0,nil,e))
 	local sg1=Duel.GetMatchingGroup(c46136942.mffilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)

--- a/c58657303.lua
+++ b/c58657303.lua
@@ -43,7 +43,7 @@ end
 function c58657303.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c58657303.filter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c58657303.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil

--- a/c6205579.lua
+++ b/c6205579.lua
@@ -59,7 +59,7 @@ end
 function c6205579.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c6205579.spfilter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c6205579.spfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil

--- a/c62895219.lua
+++ b/c62895219.lua
@@ -65,7 +65,7 @@ end
 function c62895219.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c62895219.filter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c62895219.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil

--- a/c71736213.lua
+++ b/c71736213.lua
@@ -69,7 +69,7 @@ end
 function c71736213.fusop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c71736213.filter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c71736213.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil

--- a/c7241272.lua
+++ b/c7241272.lua
@@ -66,7 +66,7 @@ end
 function c7241272.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c7241272.spfilter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c7241272.spfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil

--- a/c73511233.lua
+++ b/c73511233.lua
@@ -100,7 +100,7 @@ end
 function c73511233.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) or c:IsControler(1-tp) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) or c:IsControler(1-tp) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c73511233.spfilter1,nil,e)
 	mg1:AddCard(c)
 	local sg1=Duel.GetMatchingGroup(c73511233.spfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)

--- a/c84040113.lua
+++ b/c84040113.lua
@@ -55,7 +55,7 @@ end
 function c84040113.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c84040113.spfilter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c84040113.spfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil


### PR DESCRIPTION
fix: if Performapal Trump Girl was facedown, Performapal Trump Girl's effect don't resolve.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17451&keyword=&tag=-1
> 「EMトランプ・ガール」の『その融合モンスター１体をエクストラデッキから融合召喚する』モンスター効果の処理時に、**「EMトランプ・ガール」自身が裏側守備表示になっている場合でも、効果処理は適用されます**。
> （『このカードを含む融合素材モンスターを自分フィールドから墓地へ送り』の処理も、『その融合モンスター１体をエクストラデッキから融合召喚する』処理も通常通り行われます。） 

ref:
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17869&keyword=&tag=-1
> 質問の状況の場合でも、「獄炎のカース・オブ・ドラゴン」の効果処理は通常通り行う事ができます。
> 
> 裏側守備表示になったその「獄炎のカース・オブ・ドラゴン」と、他の自分のモンスターゾーンに存在するモンスターを、融合モンスターカードによって決められた組み合わせとなるように墓地へ送り、エクストラデッキから融合モンスターを融合召喚します。
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20254&keyword=&tag=-1
>  質問の状況の場合でも、その裏側守備表示になった「捕食植物サンデウ・キンジー」自身を融合素材モンスターに含めて墓地へ送り、融合モンスターを融合召喚する効果処理を行う事ができます。
