### PR TITLE
fix Token Stampede and Aqua Chorus

### DIFF
--- a/c14342283.lua
+++ b/c14342283.lua
@@ -6,6 +6,7 @@ function c14342283.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetHintTiming(TIMING_DAMAGE_STEP)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(aux.dscon)
 	c:RegisterEffect(e1)
 	--atk up
 	local e2=Effect.CreateEffect(c)

--- a/c95132338.lua
+++ b/c95132338.lua
@@ -3,7 +3,10 @@ function c95132338.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetCondition(aux.dscon)
 	c:RegisterEffect(e1)
 	--
 	local e2=Effect.CreateEffect(c)


### PR DESCRIPTION
fix 1: Aqua Chorus cannot activate in damage step.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5006
> ■「アクアの合唱」のカードの発動をダメージステップに行う場合、ダメージステップ開始時からダメージ計算前までに発動する事ができます。

fix 2: Token Stampede don't use `aux.dscon`.