### PR TITLE
fix Forbidden Trapezohedron

### DIFF
--- a/c49033797.lua
+++ b/c49033797.lua
@@ -22,7 +22,6 @@ function c49033797.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if Duel.IsExistingMatchingCard(c49033797.cfilter,tp,LOCATION_MZONE,0,1,nil,TYPE_FUSION) then flag=flag+1 end
 		if Duel.IsExistingMatchingCard(c49033797.cfilter,tp,LOCATION_MZONE,0,1,nil,TYPE_SYNCHRO) then flag=flag+2 end
 		if Duel.IsExistingMatchingCard(c49033797.cfilter,tp,LOCATION_MZONE,0,1,nil,TYPE_XYZ) then flag=flag+4 end
-		e:SetLabel(flag)
 		if flag==3 then
 			return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingMatchingCard(c49033797.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,0xb6)
 				and e:GetHandler():IsCanOverlay()
@@ -35,7 +34,10 @@ function c49033797.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c49033797.activate(e,tp,eg,ep,ev,re,r,rp)
-	local flag=e:GetLabel()
+	local flag=0
+	if Duel.IsExistingMatchingCard(c49033797.cfilter,tp,LOCATION_MZONE,0,1,nil,TYPE_FUSION) then flag=flag+1 end
+	if Duel.IsExistingMatchingCard(c49033797.cfilter,tp,LOCATION_MZONE,0,1,nil,TYPE_SYNCHRO) then flag=flag+2 end
+	if Duel.IsExistingMatchingCard(c49033797.cfilter,tp,LOCATION_MZONE,0,1,nil,TYPE_XYZ) then flag=flag+4 end
 	if flag==3 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c49033797.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,0xb6)
@@ -54,7 +56,7 @@ function c49033797.activate(e,tp,eg,ep,ev,re,r,rp)
 		if g:GetCount()>0 then
 			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 		end
-	else
+	elseif flag==5 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c49033797.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,0xb8)
 		if g:GetCount()>0 then


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=17136&keyword=&tag=-1
> 「禁断のトラペゾヘドロン」の効果処理時に、融合・シンクロ・エクシーズモンスターのうち、**いずれか1種類しか自分のモンスターゾーンに表側表示で存在しなくなっているような場合には、「禁断のトラペゾヘドロン」の効果処理は適用されません**。
> 
> また、「禁断のトラペゾヘドロン」の効果処理時に、**融合・シンクロ・エクシーズモンスターの3種類全てが自分のモンスターゾーンに表側表示で存在するような場合にも、「禁断のトラペゾヘドロン」の効果処理は適用されません**。