### PR TITLE
fix 機怪獣ダレトン

### DIFF
--- a/c86271510.lua
+++ b/c86271510.lua
@@ -6,8 +6,15 @@ function c86271510.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_IGNITION)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)
+	e1:SetTarget(c86271510.target)
 	e1:SetOperation(c86271510.operation)
 	c:RegisterEffect(e1)
+end
+function c86271510.filter(c)
+	return c:IsFaceup() and not c:IsAttack(c:GetBaseAttack())
+end
+function c86271510.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c86271510.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 end
 function c86271510.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16838
> ■**モンスターゾーンに、元々の攻撃力と現在の攻撃力が異なる表側表示のモンスターが存在する状況で発動できます**。（元々の攻撃力を持たず、カードに記載された攻撃力が？のモンスターが存在する場合、その元々の攻撃力は０として扱います。）