### PR TITLE
fix Predaplant Triphyoverutum

### DIFF
--- a/c79864860.lua
+++ b/c79864860.lua
@@ -53,12 +53,14 @@ function c79864860.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c79864860.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0,CATEGORY_DISABLE_SUMMON,eg,eg:GetCount(),0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,eg:GetCount(),0,0)
+	local g=eg:Filter(c79864860.cfilter,nil,1-tp)
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE_SUMMON,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c79864860.operation(e,tp,eg,ep,ev,re,r,rp,chk)
-	Duel.NegateSummon(eg)
-	Duel.Destroy(eg,REASON_EFFECT)
+	local g=eg:Filter(c79864860.cfilter,nil,1-tp)
+	Duel.NegateSummon(g)
+	Duel.Destroy(g,REASON_EFFECT)
 end
 function c79864860.spfilter(c)
 	return c:IsFaceup() and c:GetCounter(0x1041)>0


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23518&keyword=&tag=-1
> その場合、EXデッキからP召喚される２体の特殊召喚は無効になり破壊されますが、**手札からP召喚される２体の特殊召喚は無効になりません**。