### PR TITLE
fix The First Monarch

### DIFF
--- a/c8522996.lua
+++ b/c8522996.lua
@@ -63,7 +63,7 @@ function c8522996.chop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
 	e1:SetCode(EFFECT_CHANGE_ATTRIBUTE)
 	e1:SetValue(att)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+	e1:SetReset(RESET_EVENT+RESET_DISABLE+RESETS_STANDARD)
 	c:RegisterEffect(e1)
 	--double tribute
 	local e2=Effect.CreateEffect(c)


### PR DESCRIPTION
fix: if The First Monarch's effect was negated, The First Monarch's attribute don't reset.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13669&keyword=&tag=-1
> その「始源の帝王」の特殊召喚に成功した時の効果処理が行われた後に「スキルドレイン」が発動された場合、『このカードは宣言した属性として扱い』の効果は無効になり、**元々の闇属性に戻ります**。