### PR TITLE
fix Pendransaction

### DIFF
--- a/c58720904.lua
+++ b/c58720904.lua
@@ -21,10 +21,7 @@ function c58720904.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c58720904.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=Duel.GetFieldGroupCount(tp,LOCATION_EXTRA,0)-Duel.GetFieldGroupCount(tp,0,LOCATION_EXTRA)
-	if chk==0 then
-		if ct>=10 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,nil) end
-		return ct>0
-	end
+	if chk==0 then return ct>0 end
 	if ct>=10 then
 		Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,1-tp,LOCATION_ONFIELD)
 	end


### PR DESCRIPTION
fix: if player has 10 more cards in player's extra than opponent's and opponent has no card, Pendransaction cannot activate effect.

> Q.
> 自分のエクストラデッキの枚数が相手より11枚多くて、相手フィールドにカードがない場合、『１０枚以上』の処理が行えないですが自分は「ペンドラザクション」の効果を発動できますか？
> A.
> ご質問の場合でも、「ペンドラザクション」の効果を発動できます。
> その場合、条件を満たした『●』の処理は全て適用します。