### PR TITLE
fix Number 18: Heraldry Patriarch

### DIFF
--- a/c23649496.lua
+++ b/c23649496.lua
@@ -52,6 +52,7 @@ function c23649496.operation(e,tp,eg,ep,ev,re,r,rp)
 	if tc then
 		local dg=Duel.GetMatchingGroup(c23649496.filter,tp,LOCATION_MZONE,LOCATION_MZONE,tc,tc:GetCode())
 		Duel.Destroy(dg,REASON_EFFECT)
+		if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_FIELD)
 		e1:SetRange(LOCATION_MZONE)


### PR DESCRIPTION
fix: if Number 18: Heraldry Patriarch was face-down in resolved, monsters with the same name as chosen cannot summon.

> Q.
> 「No.18 紋章祖プレイン・コート」の①の効果処理時に、効果を発動した「No.18 紋章祖プレイン・コート」自身が裏側守備表示になっていた場合、効果処理はどうなりますか？
> A.
> ご質問の場合、「No.18 紋章祖プレイン・コート」の『①』の効果の処理を通常通り行います。
>  
> Q.
> また、その後「No.18 紋章祖プレイン・コート」の表示形式が裏側守備表示から表側表示に変更された場合、②の効果は適用されますか？
> A.
> ご質問の場合、「No.18 紋章祖プレイン・コート」の『②』の効果は適用されませんので、**同名モンスターを特殊召喚することができます**。