### PR TITLE
fix Cubic Wave

### DIFF
--- a/c35058588.lua
+++ b/c35058588.lua
@@ -47,7 +47,6 @@ function c35058588.atkop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1)
 		if hc:IsFaceup() and hc:IsRelateToEffect(e) then
-			Duel.BreakEffect()
 			local e2=Effect.CreateEffect(e:GetHandler())
 			e2:SetType(EFFECT_TYPE_SINGLE)
 			e2:SetCode(EFFECT_SET_ATTACK_FINAL)


### PR DESCRIPTION
fix: Cubic Wave's effects are not the same.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12525
> ■『その自分のモンスターの攻撃力を倍にし』の処理と、『その相手のモンスターの攻撃力を半分にする』処理は**同時に行われる扱いとなります**。