### PR TITLE
fix X-Saber Pashuul

### DIFF
--- a/c23093604.lua
+++ b/c23093604.lua
@@ -30,7 +30,7 @@ function c23093604.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,0,0,tp,1000)
 end
 function c23093604.operation(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end
+	if not e:GetHandler():IsRelateToEffect(e) or not e:GetHandler():IsPosition(POS_FACEUP_DEFENSE) then return end
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Damage(p,d,REASON_EFFECT)
 end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7824
> （効果処理時に、「X－セイバー パシウル」が**表側守備表示で存在しなくなっている場合にはダメージを与える処理は適用されません**。）