### PR TITLE
fix Hope for Escape

### DIFF
--- a/c80036543.lua
+++ b/c80036543.lua
@@ -15,12 +15,27 @@ function c80036543.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetLP(tp)<=Duel.GetLP(1-tp)-1000
 end
 function c80036543.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	e:SetLabel(1)
 	if chk==0 then return Duel.CheckLPCost(tp,1000) end
 	Duel.PayLPCost(tp,1000)
 end
 function c80036543.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
-	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+	if chk==0 then
+		if e:GetLabel()==0 then return Duel.IsPlayerCanDraw(tp,math.floor(math.abs(Duel.GetLP(tp)-Duel.GetLP(1-tp))/2000)) end
+		e:SetLabel(0)
+		local cost=1000
+		local ce={Duel.IsPlayerAffectedByEffect(tp,EFFECT_LPCOST_CHANGE)}
+		for _,te in ipairs(ce) do
+			local con=te:GetCondition()
+			local val=te:GetValue()
+			if (not con or con(te)) then
+				cost=val(te,e,tp,1000)
+			end
+		end
+		local lp=Duel.GetLP(tp)-cost
+		return Duel.IsPlayerCanDraw(tp,math.floor(math.abs(lp-Duel.GetLP(1-tp))/2000))
+	end
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,math.floor(math.abs(Duel.GetLP(tp)-Duel.GetLP(1-tp))/2000))
 end
 function c80036543.activate(e,tp,eg,ep,ev,re,r,rp)
 	local p1=Duel.GetLP(tp)


### PR DESCRIPTION
fix: if player has 2 only decks when player has 3000 lp and opponent has 8000 lp, Hope for Escape can activate.
> mail:
> Q.
> 自分のデッキの枚数が2枚のみで、自分のLPが3000、相手のLPが8000の場合、自分は「活路への希望」を発動できますか？
> A.
> 発動できません。