### PR TITLE
fix Impenetrable Formation

### DIFF
--- a/c96631852.lua
+++ b/c96631852.lua
@@ -4,7 +4,7 @@ function c96631852.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_CONTINUOUS_TARGET)
 	e1:SetTarget(c96631852.target)
 	e1:SetOperation(c96631852.operation)
 	c:RegisterEffect(e1)
@@ -25,19 +25,16 @@ function c96631852.initial_effect(c)
 	e3:SetValue(700)
 	c:RegisterEffect(e3)
 end
-function c96631852.filter(c)
-	return c:IsFaceup() and c:IsDefenseAbove(0)
-end
 function c96631852.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c96631852.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c96631852.filter,tp,LOCATION_MZONE,0,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c96631852.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) end
+	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,nil,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c96631852.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)
 	end
 end


### PR DESCRIPTION
fix: Impenetrable Formation cannot target face-down or link monster.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6355
> ■「鉄壁の布陣」の対象として、自分のモンスターゾーンに裏側守備表示で存在するモンスターを選択する事もできます。（その後、対象のモンスターが表側表示になり、『自分フィールド上にモンスターが２体以上存在し全て守備表示』の状態であれば、守備力をアップする効果も通常通り適用されます。）
> 
> Mail:
> Q.
> リンクモンスターを対象として「鉄壁の布陣」のカードの発動を行えますか？
> A.
> リンクモンスターを対象として発動できます。