### PR TITLE
fix 黄金郷の七摩天

### DIFF
--- a/c95034141.lua
+++ b/c95034141.lua
@@ -95,7 +95,7 @@ function c95034141.alfilter(c)
 	return c:IsRace(RACE_ZOMBIE) and c:IsFaceup()
 end
 function c95034141.alcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c95034141.alfilter,1,nil) and re:IsHasType(EFFECT_TYPE_ACTIONS)
+	return eg:IsExists(c95034141.alfilter,1,nil) and aux.IsSpecialSummonedByEffect(re)
 end
 function c95034141.cfilter(c)
 	return c:IsFacedown() and c:GetSequence()<5

--- a/utility.lua
+++ b/utility.lua
@@ -2801,3 +2801,6 @@ end
 function Auxiliary.ExtraReleaseFilter(c,tp)
 	return c:IsControler(1-tp) and c:IsHasEffect(EFFECT_EXTRA_RELEASE_NONSUM,tp)
 end
+function Auxiliary.IsSpecialSummonedByEffect(e)
+	return not ((e:GetCode()==EFFECT_SPSUMMON_PROC or e:GetCode()==EFFECT_SPSUMMON_PROC_G) and e:GetProperty()&(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)==(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE))
+end


### PR DESCRIPTION
Special Summoned by card effect:
not Synchro, Xyz, Link, Pendulum Summon
not the procedure of a Special Summon Monster

# Reference
https://ocg-rule.readthedocs.io/zh_CN/latest/c06/2021.html#id326
