### PR TITLE
fix D - Time

### DIFF
--- a/c99075257.lua
+++ b/c99075257.lua
@@ -10,16 +10,20 @@ function c99075257.initial_effect(c)
 	e1:SetOperation(c99075257.operation)
 	c:RegisterEffect(e1)
 end
+function c99075257.cfilter(c,tp)
+	return c:IsSetCard(0x3008) and c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousControler(tp)
+end
 function c99075257.condition(e,tp,eg,ep,ev,re,r,rp)
-	local tc=eg:GetFirst()
-	return eg:GetCount()==1 and tc:IsSetCard(0x3008) and tc:IsPreviousPosition(POS_FACEUP) and tc:IsPreviousControler(tp)
+	return eg:IsExists(c99075257.cfilter,1,nil,tp)
 end
 function c99075257.filter(c,lv)
 	return c:IsLevelBelow(lv) and c:IsSetCard(0xc008) and c:IsAbleToHand()
 end
 function c99075257.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c99075257.filter,tp,LOCATION_DECK,0,1,nil,eg:GetFirst():GetLevel()) end
-	e:SetLabel(eg:GetFirst():GetLevel())
+	local g=eg:Filter(c99075257.cfilter,nil,tp)
+	local _,lv=g:GetMaxGroup(Card.GetLevel)
+	if chk==0 then return lv>0 and Duel.IsExistingMatchingCard(c99075257.filter,tp,LOCATION_DECK,0,1,nil,lv) end
+	e:SetLabel(lv)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c99075257.operation(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
> Mail:
> Q.
> 自分フィールドの「E・HERO ソリッドマン」と「E・HERO アイスエッジ」が相手の「サンダー・ボルト」で破壊された場合、自分は「D－タイム」を発動できますか？発動できる場合、その効果でレベル4の「D-HERO ダイヤモンドガイ」を加える事ができますか？
>  
> A.
> ご質問の場合、「D－タイム」を発動できます。
>  
> また、破壊された「E・HERO ソリッドマン」のレベルは４ですので、レベル４の「D-HERO ダイヤモンドガイ」を手札に加えることができます。