### PR TITLE
fix Mermail Abysstrite, Blackwing Tamer - Obsidian Hawk Joe

### DIFF
--- a/c59170782.lua
+++ b/c59170782.lua
@@ -15,7 +15,7 @@ function c59170782.initial_effect(c)
 	c:RegisterEffect(e1)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(59170782,0))
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetCondition(c59170782.tgcon2)
@@ -58,7 +58,7 @@ function c59170782.tgop1(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c59170782.tgcon2(e,tp,eg,ep,ev,re,r,rp)
-	if tp==Duel.GetTurnPlayer() then return false end
+	if tp==Duel.GetTurnPlayer() or e:GetHandler():IsStatus(STATUS_CHAINING) then return false end
 	local at=Duel.GetAttackTarget()
 	if at and at:IsFaceup() and at:IsSetCard(0x74) then
 		local ag=eg:GetFirst():GetAttackableTarget()

--- a/c81983656.lua
+++ b/c81983656.lua
@@ -16,7 +16,7 @@ function c81983656.initial_effect(c)
 	c:RegisterEffect(e1)
 	--change battle target
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetCode(EVENT_BE_BATTLE_TARGET)
 	e2:SetRange(LOCATION_MZONE)
@@ -55,7 +55,7 @@ function c81983656.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c81983656.cbcon(e,tp,eg,ep,ev,re,r,rp)
-	return r~=REASON_REPLACE
+	return r~=REASON_REPLACE and Duel.GetAttackTarget()==e:GetHandler()
 end
 function c81983656.cbfilter(c,at)
 	return c:IsFaceup() and c:IsSetCard(0x33) and at:IsContains(c)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9463
> ■『②：このカードが相手の効果の対象になった時、または相手モンスターの攻撃対象になった時、このカード以外の自分フィールドの「BF」モンスター１体を対象として発動できる。その対象を正しい対象となるそのモンスターに移し替える』効果は**誘発即時効果です**。（「BF T－漆黒のホーク・ジョー」自身以外の、自分のモンスターゾーンに表側表示で存在する「BF」と名のついたモンスター１体を対象に取る効果です。ダメージステップにて発動する事はできません。）