### PR TITLE
fix Cynet Storm

### DIFF
--- a/c42461852.lua
+++ b/c42461852.lua
@@ -51,6 +51,10 @@ function c42461852.spop(e,tp,eg,ep,ev,re,r,rp)
 	if not Duel.IsPlayerCanSpecialSummon(tp)
 		or Duel.GetMatchingGroupCount(Card.IsFacedown,tp,LOCATION_EXTRA,0,nil)==0 then return end
 	Duel.ShuffleExtra(tp)
+	local sg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_EXTRA,0,nil)
+	for sc in aux.Next(sg) do
+		Duel.MoveSequence(sc,SEQ_DECKBOTTOM)
+	end
 	Duel.ConfirmExtratop(tp,1)
 	local tc=Duel.GetExtraTopGroup(tp,1):GetFirst()
 	if tc:IsType(TYPE_LINK) and tc:IsRace(RACE_CYBERSE) then


### PR DESCRIPTION
fix: face-up pendulum monster is shuffled by Cynet Storm.
(Might be better to update `Duel.ShuffleExtra`.)

> Mail:
> Q.
> 「サイバネット・ストーム」の③の効果処理で、エクストラデッキに表側表示で加わっている「人攻智能ME－PSY－YA」も含めてシャッフルしますか？また、エクストラデッキに表側表示で加わっている「人攻智能ME－PSY－YA」も含めた上でめくって確認することになりますか？
> A.
> 「サイバネット・ストーム」の『③』の効果を発動した場合、**エクストラデッキに裏側表示で存在するカードだけでシャッフルを行い、その一番上のカードをめくることになります**。 
> 
> したがって、**エクストラデッキに表側表示で存在する「人攻智能ME－PSY－YA」等のペンデュラムモンスターはシャッフルするカードに含めず、めくるカードにも含めません**。