### PR TITLE
fix 幻想召喚師 and 閃刀起動－リンケージ

### DIFF
--- a/c14644902.lua
+++ b/c14644902.lua
@@ -15,9 +15,13 @@ function c14644902.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c14644902.rfilter(c,e,tp)
 	return c:IsReleasableByEffect() and not c:IsImmuneToEffect(e)
+		and Duel.IsExistingMatchingCard(c14644902.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c)
 end
-function c14644902.filter(c,e,tp)
-	return c:IsType(TYPE_FUSION) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0
+function c14644902.filter(c,e,tp,mc)
+	return c:IsType(TYPE_FUSION) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCountFromEx(tp,tp,mc,c)>0
+end
+function c14644902.rfilter2(c,tp)
+	return c:IsReleasableByEffect() and Duel.GetLocationCountFromEx(tp,tp,c,TYPE_FUSION)>0
 end
 function c14644902.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -36,6 +40,12 @@ function c14644902.operation(e,tp,eg,ep,ev,re,r,rp)
 			e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 			e1:SetCountLimit(1)
 			sg:GetFirst():RegisterEffect(e1)
+		end
+	end
+	if #rg==0 then
+		rg=Duel.SelectReleaseGroup(tp,c14644902.rfilter2,1,1,aux.ExceptThisCard(e),tp)
+		if #rg>0 then
+			Duel.Release(rg,REASON_EFFECT)
 		end
 	end
 end

--- a/c9726840.lua
+++ b/c9726840.lua
@@ -17,7 +17,7 @@ function c9726840.condition(e,tp,eg,ep,ev,re,r,rp)
 	return not Duel.IsExistingMatchingCard(c9726840.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c9726840.tgfilter(c,e,tp)
-	return c:IsAbleToGrave()
+	return c:IsAbleToGrave() and not c:IsImmuneToEffect(e)
 		and Duel.IsExistingMatchingCard(c9726840.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c)
 end
 function c9726840.spfilter(c,e,tp,mc)
@@ -28,6 +28,9 @@ function c9726840.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c9726840.tgfilter,tp,LOCATION_ONFIELD,0,1,e:GetHandler(),e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_ONFIELD)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c9726840.tgfilter2(c,tp)
+	return c:IsAbleToGrave() and Duel.GetLocationCountFromEx(tp,tp,c,nil,0x60)>0
 end
 function c9726840.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -47,6 +50,13 @@ function c9726840.activate(e,tp,eg,ep,ev,re,r,rp)
 				e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 				sc:RegisterEffect(e1)
 			end
+		end
+	end
+	if not tc then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		tc=Duel.SelectMatchingCard(tp,c9726840.tgfilter2,tp,LOCATION_ONFIELD,0,1,1,c,tp):GetFirst()
+		if tc then
+			Duel.SendtoGrave(tc,REASON_EFFECT)
 		end
 	end
 	if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end


### PR DESCRIPTION
>「[幻想召喚師](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5249)」の効果処理時に、「[虚無魔人](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6881)」の効果が適用されている場合でも、「[幻想召喚師](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5249)」の誘発効果は発動し、効果を発動した「[幻想召喚師](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5249)」自身以外のモンスター１体をリリースする処理は行いますが、『融合モンスター1体をエクストラデッキから特殊召喚する』処理は行われません。
なお、その効果処理にて、「[虚無魔人](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6881)」をリリースし、その結果、『モンスターを特殊召喚できない』効果が適用されていない状態となる場合には、『融合モンスター1体をエクストラデッキから特殊召喚する』処理は行われる事になります。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12973&keyword=&tag=-1&request_locale=ja

![mail](https://user-images.githubusercontent.com/13391795/155911877-575b80ed-10e1-4720-8138-0a1e81e56c2b.jpg)
