### PR TITLE
update NecroValley new ruling

### DIFF
--- a/c83764718.lua
+++ b/c83764718.lua
@@ -23,7 +23,7 @@ function c83764718.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c83764718.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and aux.NecroValleyFilter()(tc) then
 		Duel.SpecialSummon(tc,SUMMON_VALUE_MONSTER_REBORN,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/c87571563.lua
+++ b/c87571563.lua
@@ -41,6 +41,7 @@ function c87571563.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		if aux.NecroValleyNegateCheck(tc) then return end
+		if not aux.NecroValleyFilter()(tc) then return end
 		if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
 			and (not tc:IsAbleToHand() or Duel.SelectOption(tp,1190,1152)==1) then
 			Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)

--- a/utility.lua
+++ b/utility.lua
@@ -2377,7 +2377,7 @@ end
 --filter for necro_valley test
 function Auxiliary.NecroValleyFilter(f)
 	return	function(target,...)
-				return (not f or f(target,...)) and not (target:IsHasEffect(EFFECT_NECRO_VALLEY) and Duel.IsChainDisablable(0))
+				return (not f or f(target,...)) and not target:IsHasEffect(EFFECT_NECRO_VALLEY)
 			end
 end
 --Necrovalley test for effect with not certain target or not certain action


### PR DESCRIPTION
>Question
相手のフィールドゾーンに「[王家の眠る谷－ネクロバレー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5533)」が表側表示で存在し、『②』の『お互いに墓地のカードを除外できず、墓地のカードへ及ぶ効果は無効化され、適用されない』効果が適用されています。また、自分の魔法＆罠ゾーンに「[オルターガイスト・プロトコル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13287)」が表側表示で存在し、『①』の『自分フィールドの「オルターガイスト」カードの効果の発動及びその発動した効果は無効化されない』効果が適用されています。
この状況で、自分がモンスターゾーンの「[オルターガイスト・マリオネッター](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13228)」の『②』の『自分フィールドの「オルターガイスト」カード１枚と、自分の墓地の「オルターガイスト」モンスター１体を対象として発動できる。対象のフィールドのカードを墓地へ送り、対象の墓地のモンスターを特殊召喚する』効果を発動した場合、処理はどうなりますか？
Answer
『対象のフィールドのカードを墓地へ送り』の処理を行い、『対象の墓地のモンスターを特殊召喚する』処理は適用されません。（対象としたフィールドのカードが「[オルターガイスト・プロトコル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13287)」だった場合でも、それ以外のカードだった場合でも、処理に違いはありません。）
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14915&keyword=&tag=-1&request_locale=ja

**王谷旧裁定：**
1. 以墓地的卡为对象令其离开墓地的效果（死者苏生），会被王谷整个无效
2. 处理时必须不取对象地令墓地的卡离开墓地的效果（七精的解门②③，墓地有怪兽时的钻头战士回场），会被王谷整个无效
3. 处理时可以但不是必定不取对象地令墓地的卡离开墓地的效果（仪式的准备，黑魔术的帷幕），涉及墓地的那部分会被王谷变得不适用，但其他部分不会被无效（仪式的准备可以从卡组检索但不能从墓地回收，黑魔术的帷幕只能从手卡特殊召唤）
4. 效果不会被无效化时（华丽金星，幻变骚灵协议），1类的效果不会被王谷无效，也不会不适用（网络傀儡师②效果只要不把协议送去墓地就会正常从墓地特殊召唤对象怪兽）
5. 效果不会被无效化时，2类的效果是否会不适用？无明确答案（YGOPro中不会不适用）
6. 效果不会被无效化时，3类的效果涉及墓地的那部分仍然会被王谷变得不适用（地中族的决战适用中，地中族妖魔②效果仍然不能从墓地特殊召唤）（YGOPro中不会不适用，未实现此裁定）

**王谷新裁定：**
1236类效果不变
4类效果不会被王谷无效，但涉及墓地的部分会不适用（网络傀儡师②效果会把卡送去墓地，但不会特殊召唤）
5类效果可以推测结论同第4点

**我们需要：**
- 更新`aux.NecroValleyFilter`，不检查效果是否会被无效化
- 更新所有依赖王谷的`c47355498.disop`（OperationInfo设置的位置只有墓地，或对象存在于墓地）来把整个效果无效化的脚本，以确保涉及墓地的部分即使没有被无效化也会不适用
- 更新所有使用`aux.NecroValleyNegateCheck`来把整个效果无效化的脚本

-----

**The old ruling of _Necrovalley_:**
1. Effects that target cards in grave and let them leave grave (_Monster Reborn_), will be negated by _Necrovalley_ totally.
2. Effects that must let cards in grave leave them leave grave (_Opening of the Spirit Gates_, _Drill Warrior_ return effect when there is monster in grave), will be negated by _Necrovalley_ totally.
3. Effects that can let cards in grave leave them leave grave but not mandatory (_Preparation of Rites_, _Dark Magic Veil_), the part which involve the grave will be not applicable by _Necrovalley_, but the other part won't be negated (_Preparation of Rites_ can search but can't recycle, _Dark Magic Veil_ can only summon from hand).
4. If them can't be negated (_Splendid Venus_, _Altergeist Protocol_), the effects type 1 won't be negated and won't be not applicable (_Altergeist Marionetter_ can summon from grave unless it sent _Altergeist Protocol_ to grave).
5. If them can't be negated, the effects type 2 will be not applicable? Nobody knows. (In YGOPro it won't be not applicable.)
6. If them can't be negated, the effects type 3 will still have the not applicable part (Even though _Subterror Final Battle_ activated the last effect, _Subterror Fiendess_ can't summon from grave). (In YGOPro it won't be not applicable, this ruling is not implemented.)

**The new ruling of _Necrovalley_:**
Types 1 2 3 6 are not changed.
Type 4 will still have the not applicable part (_Altergeist Marionetter_ can't summon from grave even through _Altergeist Protocol_ is in effect).
We can assume Type 5 should behave same as type 4.

**We need to:**
- Update `aux.NecroValleyFilter` to don't check whether the effect can't be negated.
- Update all scripts that rely on `c47355498.disop` to negate them (the location of OperationInfo is grave, or target is in grave), make sure the grave part will be not applicable.
- Update all scripts that use `aux.NecroValleyNegateCheck`.