### PR TITLE
fix Paradox Fusion

### DIFF
--- a/c57355219.lua
+++ b/c57355219.lua
@@ -28,7 +28,6 @@ function c57355219.cfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_FUSION) and c:IsAbleToRemoveAsCost() and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c57355219.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	e:SetLabel(100)
 	if chk==0 then return Duel.IsExistingMatchingCard(c57355219.cfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(tp,c57355219.cfilter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -36,12 +35,7 @@ function c57355219.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabelObject(g:GetFirst())
 end
 function c57355219.target1(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then
-		if e:GetLabel()~=100 then return false end
-		e:SetLabel(0)
-		return true
-	end
-	e:SetLabel(0)
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE_SUMMON,eg,eg:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,eg:GetCount(),0,0)
 end
@@ -64,12 +58,7 @@ function c57355219.condition2(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
 end
 function c57355219.target2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then
-		if e:GetLabel()~=100 then return false end
-		e:SetLabel(0)
-		return true
-	end
-	e:SetLabel(0)
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)

--- a/c57355219.lua
+++ b/c57355219.lua
@@ -42,17 +42,7 @@ end
 function c57355219.activate1(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateSummon(eg)
 	Duel.Destroy(eg,REASON_EFFECT)
-	local tc=e:GetLabelObject()
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_PHASE+PHASE_END)
-	e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,2)
-	e1:SetLabelObject(tc)
-	e1:SetCountLimit(1)
-	e1:SetCondition(c57355219.retcon)
-	e1:SetOperation(c57355219.retop)
-	tc:SetTurnCounter(0)
-	Duel.RegisterEffect(e1,tp)
+	c57355219.retreg(e,tp)
 end
 function c57355219.condition2(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
@@ -68,7 +58,12 @@ function c57355219.activate2(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
+	c57355219.retreg(e,tp)
+end
+function c57355219.retreg(e,tp)
 	local tc=e:GetLabelObject()
+	e:SetLabelObject(nil)
+	if not tc then return end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(EVENT_PHASE+PHASE_END)


### PR DESCRIPTION
> Q.
自分の墓地から「パラドックス・フュージョン」を除外して「ダイノルフィア・リヴァージョン」を発動できますか？
A.
自分フィールドに「ダイノルフィア」と名のついた融合モンスターが存在するのであれば、LPを半分払い、自分の墓地から「パラドックス・フュージョン」を除外して「ダイノルフィア・リヴァージョン」を発動できます。
 その際、『自分フィールドの表側表示の融合モンスター１体を除外し』は行いません。