### PR TITLE
fix Senet Switch, Rampaging Rhynos, Alien Infiltrator and Storm Shooter

### DIFF
--- a/c3784434.lua
+++ b/c3784434.lua
@@ -7,6 +7,7 @@ function c3784434.initial_effect(c)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)
 	e1:SetCondition(c3784434.seqcon)
+	e1:SetTarget(c3784434.seqtg)
 	e1:SetOperation(c3784434.seqop)
 	c:RegisterEffect(e1)
 	--
@@ -25,19 +26,23 @@ function c3784434.seqcon(e,tp,eg,ep,ev,re,r,rp)
 	return (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1))
 end
-function c3784434.seqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) then return end
-	local seq=c:GetSequence()
-	if seq>4 then return end
+function c3784434.seqtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local seq=e:GetHandler():GetSequence()
 	local flag=0
 	if seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1) then flag=flag|(1<<(seq-1)) end
 	if seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1) then flag=flag|(1<<(seq+1)) end
-	if flag==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOZONE)
 	local s=Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,~flag)
 	local nseq=math.log(s,2)
-	Duel.MoveSequence(c,nseq)
+	e:SetLabel(nseq)
+	Duel.Hint(HINT_ZONE,tp,s)
+end
+function c3784434.seqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local seq=e:GetLabel()
+	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) or c:GetSequence()>4 or not Duel.CheckLocation(tp,LOCATION_MZONE,seq) then return end
+	Duel.MoveSequence(c,seq)
 end
 function c3784434.atkcon(e)
 	local ph=Duel.GetCurrentPhase()

--- a/c39188539.lua
+++ b/c39188539.lua
@@ -8,6 +8,7 @@ function c39188539.initial_effect(c)
 	e1:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
 	e1:SetCondition(c39188539.seqcon)
 	e1:SetCost(c39188539.cost)
+	e1:SetTarget(c39188539.seqtg)
 	e1:SetOperation(c39188539.seqop)
 	c:RegisterEffect(e1)
 	--
@@ -33,19 +34,23 @@ function c39188539.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
 end
-function c39188539.seqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) then return end
-	local seq=c:GetSequence()
-	if seq>4 then return end
+function c39188539.seqtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local seq=e:GetHandler():GetSequence()
 	local flag=0
 	if seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1) then flag=flag|(1<<(seq-1)) end
 	if seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1) then flag=flag|(1<<(seq+1)) end
-	if flag==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOZONE)
 	local s=Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,~flag)
 	local nseq=math.log(s,2)
-	Duel.MoveSequence(c,nseq)
+	e:SetLabel(nseq)
+	Duel.Hint(HINT_ZONE,tp,s)
+end
+function c39188539.seqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local seq=e:GetLabel()
+	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) or c:GetSequence()>4 or not Duel.CheckLocation(tp,LOCATION_MZONE,seq) then return end
+	Duel.MoveSequence(c,seq)
 end
 function c39188539.filter(c,g)
 	return g:IsContains(c) and c:IsAbleToHand()

--- a/c63394872.lua
+++ b/c63394872.lua
@@ -26,19 +26,20 @@ function c63394872.seqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c63394872.filter(chkc,tp) end
 	if chk==0 then return Duel.IsExistingTarget(c63394872.filter,tp,LOCATION_MZONE,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(63394872,1))
-	Duel.SelectTarget(tp,c63394872.filter,tp,LOCATION_MZONE,0,1,1,nil,tp)
-end
-function c63394872.seqop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) then return end
-	local seq=tc:GetSequence()
-	if seq>4 then return end
+	local g=Duel.SelectTarget(tp,c63394872.filter,tp,LOCATION_MZONE,0,1,1,nil,tp)
+	local seq=g:GetFirst():GetSequence()
 	local flag=0
 	if seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1) then flag=flag|(1<<(seq-1)) end
 	if seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1) then flag=flag|(1<<(seq+1)) end
-	if flag==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOZONE)
 	local s=Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,~flag)
 	local nseq=math.log(s,2)
-	Duel.MoveSequence(tc,nseq)
+	e:SetLabel(nseq)
+	Duel.Hint(HINT_ZONE,tp,s)
+end
+function c63394872.seqop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	local seq=e:GetLabel()
+	if not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:GetSequence()>4 or not Duel.CheckLocation(tp,LOCATION_MZONE,seq) then return end
+	Duel.MoveSequence(tc,seq)
 end

--- a/c76573247.lua
+++ b/c76573247.lua
@@ -7,6 +7,7 @@ function c76573247.initial_effect(c)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)
 	e1:SetCondition(c76573247.seqcon)
+	e1:SetTarget(c76573247.seqtg)
 	e1:SetOperation(c76573247.seqop)
 	c:RegisterEffect(e1)
 	--direct attack
@@ -22,19 +23,23 @@ function c76573247.seqcon(e,tp,eg,ep,ev,re,r,rp)
 	return (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1))
 end
-function c76573247.seqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) then return end
-	local seq=c:GetSequence()
-	if seq>4 then return end
+function c76573247.seqtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local seq=e:GetHandler():GetSequence()
 	local flag=0
 	if seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1) then flag=flag|(1<<(seq-1)) end
 	if seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1) then flag=flag|(1<<(seq+1)) end
-	if flag==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOZONE)
 	local s=Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,~flag)
 	local nseq=math.log(s,2)
-	Duel.MoveSequence(c,nseq)
+	e:SetLabel(nseq)
+	Duel.Hint(HINT_ZONE,tp,s)
+end
+function c76573247.seqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local seq=e:GetLabel()
+	if not c:IsRelateToEffect(e) or c:IsControler(1-tp) or c:GetSequence()>4 or not Duel.CheckLocation(tp,LOCATION_MZONE,seq) then return end
+	Duel.MoveSequence(c,seq)
 end
 function c76573247.dircon(e)
 	return e:GetHandler():GetColumnGroup():FilterCount(Card.IsControler,nil,1-e:GetHandlerPlayer())==0


### PR DESCRIPTION
fix: these card effect select zone when effect was applied.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6909
> ■「ポジションチェンジ」の**効果を発動する際**に、対象として選択した自分のモンスターの左右いずれかの使用していないモンスターゾーン1カ所を指定します。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6895
> ■『自分フィールド上のこのカードをそのモンスターカードゾーンに移動する』**効果を発動する際**に、「突撃ライノス」自身の隣となる、使用していないモンスターゾーン1ヵ所を指定します。（対象を取る効果ではありません。）
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6897
> ■『使用していない隣のモンスターカードゾーンに移動する事ができる』**モンスター効果を発動する際**に、使用していない隣のモンスターゾーン1カ所を指定します。（対象を取る効果ではありません。）