### PR TITLE
errata 深淵の暗殺者

### DIFF
--- a/c16226786.lua
+++ b/c16226786.lua
@@ -30,7 +30,7 @@ function c16226786.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c16226786.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
 		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end
@@ -38,19 +38,18 @@ function c16226786.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_HAND)
 end
 function c16226786.thfilter(c)
-	return c:IsType(TYPE_FLIP) and c:IsAbleToHand()
+	return c:IsType(TYPE_FLIP) and c:IsAbleToHand() and not c:IsCode(16226786)
 end
 function c16226786.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c16226786.thfilter(chkc) end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectTarget(tp,c16226786.thfilter,tp,LOCATION_GRAVE,0,1,1,e:GetHandler())
+	local g=Duel.SelectTarget(tp,c16226786.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
 function c16226786.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
-		Duel.ConfirmCards(1-tp,tc)
 	end
 end


### PR DESCRIPTION
>①：このカードがリバースした場合、相手フィールドのモンスター１体を対象として発動する。その相手モンスターを破壊する。②：このカードが手札から墓地へ送られた場合、「深淵の暗殺者」以外の自分の墓地のリバースモンスター１体を対象として発動する。そのモンスターを手札に加える。
※2022年4月29日発売「デュエルロワイヤル デッキセットEX ROUND2」収録時のテキスト

https://www.yugioh-card.com/japan/notice/revision/