### PR TITLE
fix Herald of Pure Light

### DIFF
--- a/c1249315.lua
+++ b/c1249315.lua
@@ -35,6 +35,9 @@ function c1249315.thop(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 		local g=Duel.GetFieldGroup(tp,LOCATION_HAND,0):Select(tp,1,1,nil)
-		Duel.SendtoDeck(g,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		if g:GetCount()>0 then
+			Duel.BreakEffect()
+			Duel.SendtoDeck(g,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		end
 	end
 end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10661
> ■『そのモンスターを手札に加える』の処理と、その後の『手札を１枚選んでデッキに戻す』処理は**同時に行われません**。