### PR TITLE
add aux.EnableNeosReturn()

### DIFF
--- a/c11502550.lua
+++ b/c11502550.lua
@@ -12,22 +12,7 @@ function c11502550.initial_effect(c)
 	e1:SetValue(c11502550.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(11502550,0))
-	e3:SetCategory(CATEGORY_TODECK)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c11502550.retcon1)
-	e3:SetTarget(c11502550.rettg)
-	e3:SetOperation(c11502550.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c11502550.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c11502550.retop)
 	--atkup
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE)
@@ -41,16 +26,6 @@ c11502550.material_setcode=0x8
 c11502550.neos_fusion=true
 function c11502550.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c11502550.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c11502550.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c11502550.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c11502550.retop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end

--- a/c17032740.lua
+++ b/c17032740.lua
@@ -12,22 +12,7 @@ function c17032740.initial_effect(c)
 	e1:SetValue(c17032740.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(17032740,0))
-	e3:SetCategory(CATEGORY_TODECK)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c17032740.retcon1)
-	e3:SetTarget(c17032740.rettg)
-	e3:SetOperation(c17032740.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c17032740.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c17032740.retop)
 	--coin
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(17032740,1))
@@ -44,16 +29,6 @@ c17032740.material_setcode=0x8
 c17032740.toss_coin=true
 function c17032740.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c17032740.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c17032740.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c17032740.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c17032740.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c28677304.lua
+++ b/c28677304.lua
@@ -12,22 +12,7 @@ function c28677304.initial_effect(c)
 	e1:SetValue(c28677304.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(28677304,0))
-	e3:SetCategory(CATEGORY_TOEXTRA)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c28677304.retcon1)
-	e3:SetTarget(c28677304.rettg)
-	e3:SetOperation(c28677304.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c28677304.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c28677304.retop)
 	--disable
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(28677304,1))
@@ -44,16 +29,6 @@ c28677304.material_setcode=0x8
 c28677304.neos_fusion=true
 function c28677304.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c28677304.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c28677304.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c28677304.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,e:GetHandler(),1,0,0)
 end
 function c28677304.retop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end

--- a/c40080312.lua
+++ b/c40080312.lua
@@ -12,22 +12,7 @@ function c40080312.initial_effect(c)
 	e1:SetValue(c40080312.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(40080312,0))
-	e3:SetCategory(CATEGORY_TODECK+CATEGORY_REMOVE)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c40080312.retcon1)
-	e3:SetTarget(c40080312.rettg)
-	e3:SetOperation(c40080312.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c40080312.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c40080312.retop)
 	--draw
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(40080312,1))
@@ -42,18 +27,6 @@ end
 c40080312.material_setcode=0x8
 function c40080312.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c40080312.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c40080312.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c40080312.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler(),tp,POS_FACEDOWN)
-	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,#g,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c40080312.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c48996569.lua
+++ b/c48996569.lua
@@ -12,22 +12,7 @@ function c48996569.initial_effect(c)
 	e1:SetValue(c48996569.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(48996569,0))
-	e3:SetCategory(CATEGORY_TOEXTRA)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c48996569.retcon1)
-	e3:SetTarget(c48996569.rettg)
-	e3:SetOperation(c48996569.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c48996569.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c40080312.retop)
 	--tohand
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(48996569,1))
@@ -44,16 +29,6 @@ c48996569.material_setcode=0x8
 c48996569.neos_fusion=true
 function c48996569.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c48996569.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c48996569.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c48996569.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,e:GetHandler(),1,0,0)
 end
 function c48996569.retop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end

--- a/c48996569.lua
+++ b/c48996569.lua
@@ -12,7 +12,7 @@ function c48996569.initial_effect(c)
 	e1:SetValue(c48996569.splimit)
 	c:RegisterEffect(e1)
 	--return
-	aux.EnableNeosReturn(c,c40080312.retop)
+	aux.EnableNeosReturn(c,c48996569.retop)
 	--tohand
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(48996569,1))

--- a/c49352945.lua
+++ b/c49352945.lua
@@ -12,22 +12,7 @@ function c49352945.initial_effect(c)
 	e1:SetValue(c49352945.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(49352945,0))
-	e3:SetCategory(CATEGORY_TOEXTRA)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c49352945.retcon1)
-	e3:SetTarget(c49352945.rettg)
-	e3:SetOperation(c49352945.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c49352945.retcon2)
-	c:RegisterEffect(e4)
+	local e3,e4=aux.EnableNeosReturn(c,c49352945.retop)
 	--destroy
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(49352945,1))
@@ -54,16 +39,6 @@ end
 c49352945.material_setcode=0x8
 function c49352945.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c49352945.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c49352945.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c49352945.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,e:GetHandler(),1,0,0)
 end
 function c49352945.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c55171412.lua
+++ b/c55171412.lua
@@ -12,22 +12,7 @@ function c55171412.initial_effect(c)
 	e1:SetValue(c55171412.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(55171412,0))
-	e3:SetCategory(CATEGORY_TOEXTRA)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c55171412.retcon1)
-	e3:SetTarget(c55171412.rettg)
-	e3:SetOperation(c55171412.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c55171412.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c55171412.retop)
 	--destroy
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(55171412,1))
@@ -44,16 +29,6 @@ c55171412.material_setcode=0x8
 c55171412.neos_fusion=true
 function c55171412.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c55171412.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c55171412.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c55171412.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,e:GetHandler(),1,0,0)
 end
 function c55171412.retop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end

--- a/c78512663.lua
+++ b/c78512663.lua
@@ -12,22 +12,7 @@ function c78512663.initial_effect(c)
 	e1:SetValue(c78512663.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(78512663,0))
-	e3:SetCategory(CATEGORY_TOEXTRA)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c78512663.retcon1)
-	e3:SetTarget(c78512663.rettg)
-	e3:SetOperation(c78512663.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c78512663.retcon2)
-	c:RegisterEffect(e4)
+	local e3,e4=aux.EnableNeosReturn(c,c78512663.retop)
 	--atkup
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE)
@@ -55,16 +40,6 @@ function c78512663.splimit(e,se,sp,st)
 end
 function c78512663.atkval(e,c)
 	return Duel.GetFieldGroupCount(0,LOCATION_ONFIELD,LOCATION_ONFIELD)*400
-end
-function c78512663.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c78512663.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c78512663.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,e:GetHandler(),1,0,0)
 end
 function c78512663.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c81566151.lua
+++ b/c81566151.lua
@@ -12,22 +12,7 @@ function c81566151.initial_effect(c)
 	e1:SetValue(c81566151.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(81566151,0))
-	e3:SetCategory(CATEGORY_TOEXTRA)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c81566151.retcon1)
-	e3:SetTarget(c81566151.rettg)
-	e3:SetOperation(c81566151.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c81566151.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c81566151.retop)
 	--atkup
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE)
@@ -41,16 +26,6 @@ c81566151.material_setcode=0x8
 c81566151.neos_fusion=true
 function c81566151.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c81566151.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c81566151.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c81566151.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,e:GetHandler(),1,0,0)
 end
 function c81566151.retop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end

--- a/c85507811.lua
+++ b/c85507811.lua
@@ -12,22 +12,7 @@ function c85507811.initial_effect(c)
 	e1:SetValue(c85507811.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(85507811,0))
-	e3:SetCategory(CATEGORY_TODECK)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c85507811.retcon1)
-	e3:SetTarget(c85507811.rettg)
-	e3:SetOperation(c85507811.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c85507811.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c85507811.retop)
 	--destroy
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(85507811,1))
@@ -45,16 +30,6 @@ c85507811.material_setcode=0x8
 c85507811.neos_fusion=true
 function c85507811.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c85507811.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c85507811.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c85507811.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToExtra() end
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c85507811.retop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) or e:GetHandler():IsFacedown() then return end

--- a/c90050480.lua
+++ b/c90050480.lua
@@ -12,22 +12,7 @@ function c90050480.initial_effect(c)
 	e1:SetValue(c90050480.splimit)
 	c:RegisterEffect(e1)
 	--return
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(90050480,0))
-	e3:SetCategory(CATEGORY_TODECK+CATEGORY_DESTROY)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e3:SetCode(EVENT_PHASE+PHASE_END)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1)
-	e3:SetCondition(c90050480.retcon1)
-	e3:SetTarget(c90050480.rettg)
-	e3:SetOperation(c90050480.retop)
-	c:RegisterEffect(e3)
-	local e4=e3:Clone()
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(0)
-	e4:SetCondition(c90050480.retcon2)
-	c:RegisterEffect(e4)
+	aux.EnableNeosReturn(c,c90050480.retop)
 	--act limit
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(90050480,1))
@@ -45,18 +30,6 @@ function c90050480.ffilter(c,fc,sub,mg,sg)
 end
 function c90050480.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
-end
-function c90050480.retcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not e:GetHandler():IsHasEffect(42015635)
-end
-function c90050480.retcon2(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsHasEffect(42015635)
-end
-function c90050480.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	local g=Duel.GetMatchingGroup(nil,tp,0,LOCATION_ONFIELD,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c90050480.retop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/utility.lua
+++ b/utility.lua
@@ -212,6 +212,40 @@ function Auxiliary.SpiritReturnOperation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end
+--
+function Auxiliary.EnableNeosReturn(c,operation)
+	--return
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription()
+	e1:SetCategory(CATEGORY_TODECK)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(Auxiliary.NeosReturnConditionForced)
+	e1:SetTarget(Auxiliary.NeosReturnTargetForced)
+	e1:SetOperation(operation)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCondition(Auxiliary.NeosReturnConditionOptional)
+	e2:SetTarget(Auxiliary.NeosReturnTargetOptional)
+	c:RegisterEffect(e2)
+end
+function Auxiliary.NeosReturnConditionForced(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetHandler():IsHasEffect(42015635)
+end
+function Auxiliary.NeosReturnTargetForced(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
+end
+function Auxiliary.NeosReturnConditionOptional(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsHasEffect(42015635)
+end
+function Auxiliary.NeosReturnTargetOptional(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToExtra() end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
+end
 function Auxiliary.IsUnionState(effect)
 	local c=effect:GetHandler()
 	return c:IsHasEffect(EFFECT_UNION_STATUS)

--- a/utility.lua
+++ b/utility.lua
@@ -212,11 +212,10 @@ function Auxiliary.SpiritReturnOperation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end
---
 function Auxiliary.EnableNeosReturn(c,operation)
 	--return
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription()
+	e1:SetDescription(1105)
 	e1:SetCategory(CATEGORY_TODECK)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e1:SetCode(EVENT_PHASE+PHASE_END)
@@ -231,6 +230,7 @@ function Auxiliary.EnableNeosReturn(c,operation)
 	e2:SetCondition(Auxiliary.NeosReturnConditionOptional)
 	e2:SetTarget(Auxiliary.NeosReturnTargetOptional)
 	c:RegisterEffect(e2)
+	return e1,e2
 end
 function Auxiliary.NeosReturnConditionForced(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsHasEffect(42015635)


### PR DESCRIPTION
# Problem
There are forced and optional version of the "return to Extra Deck" effects of Neos.
Their target functions are different.

# Solution
add aux.EnableNeosReturn()
Now they have different target functions.

