### PR TITLE
fix 巨神竜フェルグラント

### DIFF
--- a/c60681103.lua
+++ b/c60681103.lua
@@ -25,7 +25,7 @@ function c60681103.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonLocation(LOCATION_GRAVE)
 end
 function c60681103.rmfilter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemove() and (c:IsLevelAbove(1) or c:IsRankAbove(1))
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
 end
 function c60681103.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE+LOCATION_GRAVE) and chkc:IsControler(1-tp) and c60681103.rmfilter(chkc) end
@@ -45,7 +45,7 @@ function c60681103.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local atk=0
 	if tc:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)~=0 then
 		if tc:IsType(TYPE_XYZ) then atk=tc:GetRank() else atk=tc:GetLevel() end
-		if c:IsFaceup() and c:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) and atk>0 then
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_UPDATE_ATTACK)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8791&keyword=&tag=-1
Question
「[巨神竜フェルグラント](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12360)」の『①』の『このカードが墓地からの特殊召喚に成功した場合、相手のフィールド・墓地のモンスター１体を対象として発動できる。そのモンスターを除外し、このカードの攻撃力・守備力は、除外したそのモンスターのレベルまたはランク×１００アップする』効果の対象として、リンクモンスターや裏側守備表示のモンスターを対象に選択できますか？
Answer
選択できます。

リンクモンスターを対象として発動した場合、処理時にそのモンスターを除外します。リンクモンスターはレベル・ランクを持ちませんので、攻撃力・守備力をアップする処理は適用されません。

裏側守備表示のモンスターを対象として発動した場合、処理時にそのモンスターを表側表示で除外します。そのモンスターのレベル・ランクによって、攻撃力・守備力をアップする処理も適用されます。