### PR TITLE
fix プロモーション

### DIFF
--- a/c88617904.lua
+++ b/c88617904.lua
@@ -12,7 +12,7 @@ function c88617904.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c88617904.tgfilter(c,tp)
-	return c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsLevelBelow(3)
+	return c:IsFaceup() and c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsLevelBelow(3)
 		and c:IsAbleToGrave() and Duel.GetMZoneCount(tp,c)>0
 end
 function c88617904.spfilter(c,e,tp)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6716
> ■自分フィールドのレベル３以下の**表側表示の**戦士族・地属性モンスター１体を対象に取る効果です。