### PR TITLE
fix Galaxy-Eyes Photon Dragon

### DIFF
--- a/c93717133.lua
+++ b/c93717133.lua
@@ -64,7 +64,7 @@ end
 function c93717133.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or not tc:IsRelateToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or not tc:IsRelateToEffect(e) or tc:IsControler(tp) then return end
 	local g=Group.FromCards(c,tc)
 	local mcount=0
 	if tc:IsFaceup() then mcount=tc:GetOverlayCount() end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12529&keyword=&tag=-1
> 「[TG1－EM1](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9541)」の効果によって、「[銀河眼の光子竜](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9729)」の『その相手モンスターとフィールドのこのカードを除外する』効果処理時に相手モンスターのコントロールが自分に移った場合、「**[銀河眼の光子竜](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9729)」の効果は適用されず、「[銀河眼の光子竜](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9729)」自身、相手モンスター、どちらもゲームから除外されません**。
> 
> また、「[大捕り物](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14328)」の効果によって、「[銀河眼の光子竜](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9729)」の『その相手モンスターとフィールドのこのカードを除外する』効果処理時に、「[銀河眼の光子竜](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9729)」のみのコントロールが相手に移った場合、『その相手モンスターとフィールドのこのカードを除外する。この効果で除外したモンスターはバトルフェイズ終了時にフィールドに戻り、この効果でXモンスターを除外した場合、このカードの攻撃力は、そのXモンスターを除外した時のX素材の数×５００アップする』処理は通常通り行われ、バトルフェイズ終了時に相手フィールドに戻った「[銀河眼の光子竜](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9729)」は直ちに自分フィールドに戻ります。