### PR TITLE
fix Performapal Recasting, Igknight Reload

### DIFF
--- a/c71705144.lua
+++ b/c71705144.lua
@@ -15,7 +15,7 @@ function c71705144.filter(c)
 	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck() and not c:IsPublic()
 end
 function c71705144.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1)
 		and Duel.IsExistingMatchingCard(c71705144.filter,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,nil,1,tp,LOCATION_HAND)

--- a/c76751255.lua
+++ b/c76751255.lua
@@ -15,7 +15,7 @@ function c76751255.filter(c)
 	return c:IsType(TYPE_PENDULUM) and c:IsAbleToDeck() and not c:IsPublic()
 end
 function c76751255.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1)
 		and Duel.IsExistingMatchingCard(c76751255.filter,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,nil,1,tp,LOCATION_HAND)


### PR DESCRIPTION
fix: if player has no card in deck, Performapal Recasting and Igknight Reload can activate.
> mail:
> Q.
> 自分のデッキが0枚の時に自分は「EMキャスト・チェンジ」を発動できますか？
> A.
> ご質問の場合、「EMキャスト・チェンジ」は発動できません。