### PR TITLE
fix Knightmare Goblin, Noble Knight Custennin and Simorgh, Bird of Beginning

### DIFF
--- a/c39064822.lua
+++ b/c39064822.lua
@@ -29,7 +29,7 @@ function c39064822.lcheck(g,lc)
 	return g:GetClassCount(Card.GetLinkCode)==g:GetCount()
 end
 function c39064822.sumcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK) and Duel.GetTurnPlayer()==tp
 end
 function c39064822.sumcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end

--- a/c42472002.lua
+++ b/c42472002.lua
@@ -54,7 +54,7 @@ function c42472002.effop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c42472002.sumcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFlagEffect(tp,42472002)==0
+	return Duel.GetFlagEffect(tp,42472002)==0 and Duel.GetTurnPlayer()==tp
 end
 function c42472002.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanSummon(tp) and Duel.IsPlayerCanAdditionalSummon(tp) end

--- a/c50820852.lua
+++ b/c50820852.lua
@@ -22,7 +22,8 @@ function c50820852.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c50820852.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanSummon(tp) and Duel.IsPlayerCanAdditionalSummon(tp) and Duel.GetFlagEffect(tp,50820852)==0 end
+	if chk==0 then return Duel.IsPlayerCanSummon(tp) and Duel.IsPlayerCanAdditionalSummon(tp)
+		and Duel.GetFlagEffect(tp,50820852)==0 and Duel.GetTurnPlayer()==tp end
 end
 function c50820852.sumop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetFlagEffect(tp,50820852)~=0 then return end


### PR DESCRIPTION
fix: these effects can activate during opponent turn.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21712&keyword=&tag=-1
> 「[トロイメア・ゴブリン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13598)」のモンスター効果は、自分のターンに行う通常召喚に加えて1度だけ、モンスターを召喚できるようになる効果となりますので、相手ターンに「[トロイメア・ゴブリン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13598)」のリンク召喚に成功したとしても、そのモンスター効果を発動する事はできません。