### PR TITLE
fix World Legacy Discovery

### DIFF
--- a/c61654098.lua
+++ b/c61654098.lua
@@ -20,6 +20,7 @@ function c61654098.initial_effect(c)
 	--special summon
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(61654098,0))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e4:SetCode(EVENT_LEAVE_FIELD)
 	e4:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)


### PR DESCRIPTION
fix: World Legacy Discovery's effect cannot negate by Royal Oppression.