### PR TITLE
fix Magikey Mechmusket - Batosbuster

### DIFF
--- a/c19489718.lua
+++ b/c19489718.lua
@@ -51,7 +51,7 @@ function c19489718.discon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=c:GetBattleTarget()
 	e:SetLabelObject(tc)
-	return tc and tc:IsFaceup() and tc:IsControler(1-tp) and tc:IsType(TYPE_MONSTER) and not tc:IsDisabled()
+	return tc and tc:IsControler(1-tp) and tc:IsType(TYPE_MONSTER) and aux.NegateMonsterFilter(tc)
 		and Duel.IsExistingMatchingCard(c19489718.cfilter,tp,LOCATION_GRAVE,0,1,nil,tc:GetAttribute())
 end
 function c19489718.distg(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
fix: if Magikey Mechmusket - Batosbuster attacked normal monster, Magikey Mechmusket - Batosbuster can activate effect.

> https://yugioh-wiki.net/index.php?%A1%D4%CB%E2%B8%B0%BD%C6%A1%DD%A5%D0%A5%C8%A5%B9%A5%D0%A5%B9%A5%BF%A1%BC%A1%D5#faq2
> Ｑ：《魔鍵銃－バトスバスター》の(2)の[効果](https://yugioh-wiki.net/index.php?%B8%FA%B2%CC)は[相手](https://yugioh-wiki.net/index.php?%C1%EA%BC%EA)[モンスター](https://yugioh-wiki.net/index.php?%A5%E2%A5%F3%A5%B9%A5%BF%A1%BC)が[通常モンスター](https://yugioh-wiki.net/index.php?%C4%CC%BE%EF%A5%E2%A5%F3%A5%B9%A5%BF%A1%BC)、または[効果](https://yugioh-wiki.net/index.php?%B8%FA%B2%CC)が[無効](https://yugioh-wiki.net/index.php?%CC%B5%B8%FA)になっている[モンスター](https://yugioh-wiki.net/index.php?%A5%E2%A5%F3%A5%B9%A5%BF%A1%BC)の場合に[発動](https://yugioh-wiki.net/index.php?%C8%AF%C6%B0)できますか？
> Ａ：《魔鍵銃－バトスバスター》の(2)の[効果](https://yugioh-wiki.net/index.php?%B8%FA%B2%CC)は『[相手](https://yugioh-wiki.net/index.php?%C1%EA%BC%EA)モンスターの効果をターン終了時まで無効にする』ですので、相手の[通常モンスター](https://yugioh-wiki.net/index.php?%C4%CC%BE%EF%A5%E2%A5%F3%A5%B9%A5%BF%A1%BC)が[攻撃宣言](https://yugioh-wiki.net/index.php?%B9%B6%B7%E2%C0%EB%B8%C0)した時には(2)の[効果](https://yugioh-wiki.net/index.php?%B8%FA%B2%CC)を[発動](https://yugioh-wiki.net/index.php?%C8%AF%C6%B0)できません。
> 　　また、[《禁じられた聖杯》](https://yugioh-wiki.net/index.php?%A1%D4%B6%D8%A4%B8%A4%E9%A4%EC%A4%BF%C0%BB%C7%D5%A1%D5)などの[効果](https://yugioh-wiki.net/index.php?%B8%FA%B2%CC)によって[無効](https://yugioh-wiki.net/index.php?%CC%B5%B8%FA)化されている[モンスター](https://yugioh-wiki.net/index.php?%A5%E2%A5%F3%A5%B9%A5%BF%A1%BC)が[攻撃宣言](https://yugioh-wiki.net/index.php?%B9%B6%B7%E2%C0%EB%B8%C0)を行った場合にも(2)の[効果](https://yugioh-wiki.net/index.php?%B8%FA%B2%CC)を[発動](https://yugioh-wiki.net/index.php?%C8%AF%C6%B0)できません。(21/05/21)