### PR TITLE
add Auxiliary.ndcon

### DIFF
--- a/c42444868.lua
+++ b/c42444868.lua
@@ -46,9 +46,9 @@ function c42444868.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,1000)
 end
 function c42444868.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return aux.ndcon(tp,re) end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
-	if re:GetHandler():IsAbleToDeck() and re:GetHandler():IsRelateToEffect(re) then
+	if re:GetHandler():IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_TODECK,eg,1,0,0)
 	end
 end

--- a/c57831349.lua
+++ b/c57831349.lua
@@ -18,7 +18,7 @@ function c57831349.condition(e,tp,eg,ep,ev,re,r,rp)
 		and (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
 end
 function c57831349.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return aux.ndcon(tp,re) end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 	if re:GetHandler():IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_TODECK,eg,1,0,0)

--- a/c59957503.lua
+++ b/c59957503.lua
@@ -30,7 +30,7 @@ function c59957503.condition(e,tp,eg,ep,ev,re,r,rp)
 		and (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
 end
 function c59957503.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return aux.ndcon(tp,re) end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 	if re:GetHandler():IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_TODECK,eg,1,0,0)

--- a/c8038143.lua
+++ b/c8038143.lua
@@ -38,7 +38,7 @@ function c8038143.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if tgp~=tp and (te:IsActiveType(TYPE_MONSTER) or te:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(i) then
 			local tc=te:GetHandler()
 			ng:AddCard(tc)
-			if tc:IsOnField() and tc:IsRelateToEffect(te) and not tc:IsHasEffect(EFFECT_CANNOT_TO_DECK) and Duel.IsPlayerCanSendtoDeck(tp,tc) then
+			if tc:IsOnField() and tc:IsRelateToEffect(te) and tc:IsAbleToDeck() then
 				dg:AddCard(tc)
 			end
 		end
@@ -53,7 +53,7 @@ function c8038143.activate(e,tp,eg,ep,ev,re,r,rp)
 		local te,tgp=Duel.GetChainInfo(i,CHAININFO_TRIGGERING_EFFECT,CHAININFO_TRIGGERING_PLAYER)
 		if tgp~=tp and (te:IsActiveType(TYPE_MONSTER) or te:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.NegateActivation(i) then
 			local tc=te:GetHandler()
-			if tc:IsRelateToEffect(e) and tc:IsRelateToEffect(te) and not tc:IsHasEffect(EFFECT_CANNOT_TO_DECK) and Duel.IsPlayerCanSendtoDeck(tp,tc) then
+			if tc:IsRelateToEffect(e) and tc:IsRelateToEffect(te) and tc:IsAbleToDeck() then
 				tc:CancelToGrave()
 				dg:AddCard(tc)
 			end

--- a/c86060749.lua
+++ b/c86060749.lua
@@ -24,7 +24,7 @@ function c86060749.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c86060749.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local rc=re:GetHandler()
-	if chk==0 then return Duel.IsPlayerCanSendtoDeck(tp) end
+	if chk==0 then return aux.ndcon(tp,re) end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
 	if rc:IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_TODECK,eg,1,0,0)

--- a/utility.lua
+++ b/utility.lua
@@ -2809,6 +2809,11 @@ function Auxiliary.nbcon(tp,re)
 	return Duel.IsPlayerCanRemove(tp)
 		and (not rc:IsRelateToEffect(re) or rc:IsAbleToRemove())
 end
+--condition of "negate activation and return to deck"
+function Auxiliary.ndcon(tp,re)
+	local rc=re:GetHandler()
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE) or not rc:IsRelateToEffect(re) or rc:IsAbleToDeck()
+end
 --send to deck of contact fusion
 function Auxiliary.tdcfop(c)
 	return	function(g)


### PR DESCRIPTION
If _G.B. Hunter_ is in effect, the player shouldn't be able to activate _Nine Pillars of Yang Zing_ against monster effect on field.
But for the activation of S&T, the negated card is not on field so it shouldn't be affected by _G.B. Hunter_ .

~~but I don't know the ruling of _Tachyon Transmigration_~~