### PR TITLE
fix condition of negate effect

### DIFF
--- a/c10604644.lua
+++ b/c10604644.lua
@@ -86,7 +86,7 @@ function c10604644.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(g,REASON_COST)
 end
 function c10604644.distg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not re:GetHandler():IsDisabled() end
+	if chk==0 then return true end
 	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end

--- a/c14558127.lua
+++ b/c14558127.lua
@@ -29,7 +29,7 @@ function c14558127.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(c,REASON_COST+REASON_DISCARD)
 end
 function c14558127.distg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not re:GetHandler():IsDisabled() end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
 function c14558127.disop(e,tp,eg,ep,ev,re,r,rp)

--- a/c15613529.lua
+++ b/c15613529.lua
@@ -38,8 +38,7 @@ function c15613529.spcon1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c15613529.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and not re:GetHandler():IsDisabled() end
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end

--- a/c67750322.lua
+++ b/c67750322.lua
@@ -22,7 +22,7 @@ function c67750322.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
 end
 function c67750322.distg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not re:GetHandler():IsDisabled() end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
 function c67750322.disop(e,tp,eg,ep,ev,re,r,rp)

--- a/c90179822.lua
+++ b/c90179822.lua
@@ -40,7 +40,7 @@ function c90179822.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
 end
 function c90179822.distg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not re:GetHandler():IsDisabled() end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
 function c90179822.disop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Once upon a time, you can't chain _Ash Blossom & Joyous Spring_ against cards that is already negated, but the ruling is changed.

Mail:
>Q.
自分の「サイレント・ソードマン LV７」の効果が適用されている状況です，相手が「おろかな埋葬」をした時に、チェーンして自分は「緑光の宣告者」や「灰流うらら」の効果を発動できますか？
A.
ご質問の場合でも、「緑光の宣告者」や「灰流うらら」の効果を発動できます。
 
The link refereed in https://github.com/Fluorohydride/ygopro-scripts/commit/d4aff3a507e1eb6a04fb23b04775f68c3a1eeaea was linked to another ruling too.