### PR TITLE
fix Wake Up Your E・HERO

### DIFF
--- a/c32828466.lua
+++ b/c32828466.lua
@@ -68,7 +68,7 @@ function c32828466.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_EXTRA_ATTACK_MONSTER)
-	e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+	e2:SetReset(RESET_EVENT+RESETS_STANDARD)
 	e2:SetValue(ct2-1)
 	c:RegisterEffect(e2)
 end


### PR DESCRIPTION
fix: if Wake Up Your E・HERO's effect is negated, Wake Up Your E・HERO's multi attack was reseted.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23570&keyword=&tag=-1
> その後、その「[Wake Up Your E・HERO](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17247)」の効果が無効化されていない状態に戻った場合でも、攻撃力をアップする効果が再度適用されることはありません。ただし、**効果が無効化されていない状態になった場合、モンスターに複数回攻撃できる効果については再度適用されます**。