### PR TITLE
fix Senet Switch

### DIFF
--- a/c63394872.lua
+++ b/c63394872.lua
@@ -22,8 +22,12 @@ function c63394872.filter(c,tp)
 	return (seq>0 and Duel.CheckLocation(tp,LOCATION_MZONE,seq-1))
 		or (seq<4 and Duel.CheckLocation(tp,LOCATION_MZONE,seq+1))
 end
+function c63394872.chkfilter(c,cseq)
+	local seq=c:GetSequence()
+	return seq<5 and math.abs(seq-cseq)==1
+end
 function c63394872.seqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c63394872.filter(chkc,tp) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c63394872.chkfilter(chkc,e:GetLabel()) end
 	if chk==0 then return Duel.IsExistingTarget(c63394872.filter,tp,LOCATION_MZONE,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(63394872,1))
 	local g=Duel.SelectTarget(tp,c63394872.filter,tp,LOCATION_MZONE,0,1,1,nil,tp)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23651&keyword=&tag=-1
> また、「[暗遷士 カンゴルゴーム](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11083)」の効果で対象を移し替える際、新しい対象の選び方は「[ポジションチェンジ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6909)」の対象の選び方として適切なものでなければなりません。**つまり、指定したゾーンの隣のモンスターゾーンのモンスターにしか対象を移し替えられません**。