### PR TITLE
fix Token Collector

### DIFF
--- a/c43534808.lua
+++ b/c43534808.lua
@@ -1,5 +1,7 @@
 --トークンコレクター
 function c43534808.initial_effect(c)
+	--same effect send this card to grave and spsummon another card check
+	local e0=aux.AddThisCardInGraveAlreadyCheck(c)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(43534808,0))
@@ -9,6 +11,7 @@ function c43534808.initial_effect(c)
 	e1:SetRange(LOCATION_HAND+LOCATION_GRAVE)
 	e1:SetProperty(EFFECT_FLAG_DELAY)
 	e1:SetCountLimit(1,43534808)
+	e1:SetLabelObject(e0)
 	e1:SetCondition(c43534808.spcon)
 	e1:SetTarget(c43534808.sptg)
 	e1:SetOperation(c43534808.spop)
@@ -33,8 +36,12 @@ function c43534808.initial_effect(c)
 	e3:SetTarget(c43534808.sumlimit)
 	c:RegisterEffect(e3)
 end
+function c43534808.cfilter(c,se)
+	return c:IsType(TYPE_TOKEN) and (se==nil or c:GetReasonEffect()~=se)
+end
 function c43534808.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(Card.IsType,1,nil,TYPE_TOKEN)
+	local se=e:GetLabelObject():GetLabelObject()
+	return eg:IsExists(c43534808.cfilter,1,nil,se)
 end
 function c43534808.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
fix: if Token Collector destroyed by Ancient Gear Catapult's effect, that destroyed Token Collector can activate.

> mail:
> Q.
> 相手フィールドに「スキルドレイン」が存在する状態で、自分フィールドの「トークンコレクター」を対象に墓地の「古代の機械射出機」の②の効果を発動し、「トークンコレクター」を破壊して古代の歯車トークンを特殊召喚した場合、自分はその破壊された「トークンコレクター」の①の効果を発動できますか？
> A.
> **「古代の機械射出機」の『②』の効果による対象にしたカードの破壊と「古代の歯車トークン」の特殊召喚の処理は同時に行われるため、効果の処理後に破壊された「トークンコレクター」の『①』の効果を発動することはできません**。