### PR TITLE
fix ヴァリアンツB－バロン

### DIFF
--- a/c14418464.lua
+++ b/c14418464.lua
@@ -112,12 +112,13 @@ function c14418464.mvop(e,tp,eg,ep,ev,re,r,rp)
 	local nseq=0
 	if seq==0 then nseq=1 end
 	if seq==4 then nseq=3 end
-	Duel.MoveToField(tc,tp,tc:GetControler(),LOCATION_SZONE,POS_FACEUP,true,1<<nseq)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetCode(EFFECT_CHANGE_TYPE)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET)
-	e1:SetValue(TYPE_SPELL+TYPE_CONTINUOUS)
-	tc:RegisterEffect(e1)
+	if Duel.MoveToField(tc,tp,tc:GetControler(),LOCATION_SZONE,POS_FACEUP,true,1<<nseq) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetCode(EFFECT_CHANGE_TYPE)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET)
+		e1:SetValue(TYPE_SPELL+TYPE_CONTINUOUS)
+		tc:RegisterEffect(e1)
+	end
 end


### PR DESCRIPTION
fix: if targeted pendulum card sent to grave while player had no space in spell&trap zone, target card change continuous spell.
(need https://github.com/Fluorohydride/ygopro-core/pull/448)