### PR TITLE
fix Yado Karu, Magikey Mechmusket - Batosbuster

### DIFF
--- a/c19489718.lua
+++ b/c19489718.lua
@@ -70,7 +70,14 @@ function c19489718.disop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TODECK)
 	local g=Duel.SelectMatchingCard(p,Card.IsAbleToDeck,p,LOCATION_HAND,0,1,63,nil)
 	if g:GetCount()==0 then return end
-	if Duel.SendtoDeck(g,nil,SEQ_DECKBOTTOM,REASON_EFFECT)~=0 and tc and tc:IsRelateToBattle() and tc:IsControler(1-tp)
+	local ct=Duel.SendtoDeck(g,nil,SEQ_DECKTOP,REASON_EFFECT)
+	if ct==0 then return end
+	Duel.SortDecktop(p,p,ct)
+	for i=1,ct do
+		local mg=Duel.GetDecktopGroup(p,1)
+		Duel.MoveSequence(mg:GetFirst(),SEQ_DECKBOTTOM)
+	end
+	if tc and tc:IsRelateToBattle() and tc:IsControler(1-tp)
 		and not tc:IsDisabled() and not tc:IsImmuneToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -81,6 +88,6 @@ function c19489718.disop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_DISABLE_EFFECT)
 		tc:RegisterEffect(e2)
 		Duel.BreakEffect()
-		Duel.Draw(p,g:GetCount(),REASON_EFFECT)
+		Duel.Draw(p,ct,REASON_EFFECT)
 	end
 end

--- a/c29380133.lua
+++ b/c29380133.lua
@@ -21,5 +21,11 @@ end
 function c29380133.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToDeck,tp,LOCATION_HAND,0,1,99,nil)
-	Duel.SendtoDeck(g,nil,SEQ_DECKBOTTOM,REASON_EFFECT)
+	local ct=Duel.SendtoDeck(g,nil,SEQ_DECKTOP,REASON_EFFECT)
+	if ct==0 then return end
+	Duel.SortDecktop(tp,tp,ct)
+	for i=1,ct do
+		local mg=Duel.GetDecktopGroup(tp,1)
+		Duel.MoveSequence(mg:GetFirst(),SEQ_DECKBOTTOM)
+	end
 end


### PR DESCRIPTION
> mail:
> Q.
> 「魔鍵銃－バトスバスター」の②の効果で自分の手札を任意の数だけデッキの一番下に戻す際に、好きな順番で戻せますか？
> A.
> ご質問の場合、好きな順番で戻します。