### PR TITLE
fix Morphtronic Celfon and so on

### DIFF
--- a/c30531525.lua
+++ b/c30531525.lua
@@ -14,22 +14,27 @@ function c30531525.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,800) end
 	Duel.PayLPCost(tp,800)
 end
-function c30531525.filter(c,e,tp)
-	return c:IsType(TYPE_NORMAL) and c:IsLevelBelow(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+function c30531525.filter(c)
+	return c:IsType(TYPE_NORMAL) and c:IsLevelBelow(3)
 end
 function c30531525.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	if chk==0 then return Duel.IsPlayerCanSpecialSummon(tp)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
 		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>3
-		and Duel.IsExistingMatchingCard(c30531525.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+		and Duel.IsExistingMatchingCard(c30531525.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function c30531525.spfilter(c,e,tp)
+	return c:IsType(TYPE_NORMAL) and c:IsLevelBelow(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c30531525.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ConfirmDecktop(tp,4)
-	local g=Duel.GetDecktopGroup(tp,4):Filter(c30531525.filter,nil,e,tp)
+	local g=Duel.GetDecktopGroup(tp,4):Filter(c30531525.spfilter,nil,e,tp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	if g:GetCount()>0 then
 		if ft<=0 then
-			Duel.SendtoGrave(g,REASON_EFFECT)
+			Duel.SendtoGrave(g,REASON_RULE)
 		elseif ft>=g:GetCount() then
 			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 		else
@@ -37,7 +42,7 @@ function c30531525.activate(e,tp,eg,ep,ev,re,r,rp)
 			local sg=g:Select(tp,ft,ft,nil)
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			g:Sub(sg)
-			Duel.SendtoGrave(g,REASON_EFFECT)
+			Duel.SendtoGrave(g,REASON_RULE)
 		end
 	end
 	Duel.ShuffleDeck(tp)

--- a/c30531525.lua
+++ b/c30531525.lua
@@ -14,22 +14,18 @@ function c30531525.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,800) end
 	Duel.PayLPCost(tp,800)
 end
-function c30531525.filter(c)
-	return c:IsType(TYPE_NORMAL) and c:IsLevelBelow(3)
+function c30531525.filter(c,e,tp)
+	return c:IsType(TYPE_NORMAL) and c:IsLevelBelow(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c30531525.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanSpecialSummon(tp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
-		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>3
-		and Duel.IsExistingMatchingCard(c30531525.filter,tp,LOCATION_DECK,0,1,nil) end
-end
-function c30531525.spfilter(c,e,tp)
-	return c:IsType(TYPE_NORMAL) and c:IsLevelBelow(3) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>3 end
 end
 function c30531525.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ConfirmDecktop(tp,4)
-	local g=Duel.GetDecktopGroup(tp,4):Filter(c30531525.spfilter,nil,e,tp)
+	local g=Duel.GetDecktopGroup(tp,4):Filter(c30531525.filter,nil,e,tp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	if g:GetCount()>0 then

--- a/c31000575.lua
+++ b/c31000575.lua
@@ -10,7 +10,10 @@ function c31000575.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c31000575.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_DECK)~=0 end
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_DECK)~=0
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
+		and not Duel.IsPlayerAffectedByEffect(tp,97148796) end
 end
 function c31000575.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ConfirmDecktop(1-tp,1)

--- a/c66171432.lua
+++ b/c66171432.lua
@@ -21,24 +21,22 @@ function c66171432.initial_effect(c)
 	e2:SetOperation(c66171432.spop)
 	c:RegisterEffect(e2)
 end
-function c66171432.filter(c)
-	return c:IsSetCard(0xe6) and c:IsType(TYPE_MONSTER)
+function c66171432.filter(c,e,tp)
+	return c:IsSetCard(0xe6) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c66171432.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanRemove(tp)
+		and Duel.IsPlayerCanSpecialSummon(tp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
-		and Duel.IsExistingMatchingCard(c66171432.filter,tp,LOCATION_DECK,0,1,nil) end
-end
-function c66171432.spfilter(c,e,tp)
-	return c:IsSetCard(0xe6) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>2 end
 end
 function c66171432.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not Duel.IsPlayerCanRemove(tp) then return end
 	Duel.ConfirmDecktop(tp,3)
 	local g=Duel.GetDecktopGroup(tp,3)
-	local sg=g:Filter(c66171432.spfilter,nil,e,tp)
+	local sg=g:Filter(c66171432.filter,nil,e,tp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	if g:GetCount()>0 then

--- a/c66171432.lua
+++ b/c66171432.lua
@@ -21,20 +21,24 @@ function c66171432.initial_effect(c)
 	e2:SetOperation(c66171432.spop)
 	c:RegisterEffect(e2)
 end
-function c66171432.filter(c,e,tp)
-	return c:IsSetCard(0xe6) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+function c66171432.filter(c)
+	return c:IsSetCard(0xe6) and c:IsType(TYPE_MONSTER)
 end
 function c66171432.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanRemove(tp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c66171432.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
+		and Duel.IsExistingMatchingCard(c66171432.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function c66171432.spfilter(c,e,tp)
+	return c:IsSetCard(0xe6) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c66171432.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not Duel.IsPlayerCanRemove(tp) then return end
 	Duel.ConfirmDecktop(tp,3)
 	local g=Duel.GetDecktopGroup(tp,3)
-	local sg=g:Filter(c66171432.filter,nil,e,tp)
+	local sg=g:Filter(c66171432.spfilter,nil,e,tp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	if g:GetCount()>0 then

--- a/c74879881.lua
+++ b/c74879881.lua
@@ -14,6 +14,7 @@ end
 function c74879881.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanSpecialSummon(tp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
 		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
 end
 function c74879881.spop(e,tp,eg,ep,ev,re,r,rp)

--- a/c93542102.lua
+++ b/c93542102.lua
@@ -29,15 +29,11 @@ end
 function c93542102.cond(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsDisabled() and e:GetHandler():IsDefensePos()
 end
-function c93542102.cfilter(c)
-	return c:IsLevelBelow(4) and c:IsSetCard(0x26) and c:IsType(TYPE_MONSTER)
-end
 function c93542102.tga(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanSpecialSummon(tp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
-		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0
-		and Duel.IsExistingMatchingCard(c93542102.cfilter,tp,LOCATION_DECK,0,1,nil) end
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0 end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)
 end
 function c93542102.tgd(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c93542102.lua
+++ b/c93542102.lua
@@ -33,7 +33,10 @@ function c93542102.cfilter(c)
 	return c:IsLevelBelow(4) and c:IsSetCard(0x26) and c:IsType(TYPE_MONSTER)
 end
 function c93542102.tga(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0
+	if chk==0 then return Duel.IsPlayerCanSpecialSummon(tp)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and not Duel.IsPlayerAffectedByEffect(tp,63060238)
+		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>0
 		and Duel.IsExistingMatchingCard(c93542102.cfilter,tp,LOCATION_DECK,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)
 end


### PR DESCRIPTION
fix: if Knightmare Corruptor Iblee has on the field, Morphtronic Celfon can activate effect.

> mail:
> Q.
> 自分フィールドに「夢幻崩界イヴリース」が存在する場合、自分は「D・モバホン」の『●攻撃表示』の効果を発動できますか？
> A.
> 発動できません。