### PR TITLE
fix Witchcrafter Pittore

### DIFF
--- a/c95245544.lua
+++ b/c95245544.lua
@@ -65,7 +65,7 @@ function c95245544.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c95245544.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	if chk==0 then return Duel.IsPlayerCanRemove(tp) and Duel.IsPlayerCanDraw(tp,1) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(1)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
@@ -88,6 +88,9 @@ function c95245544.drop(e,tp,eg,ep,ev,re,r,rp)
 		end
 	else
 		local sg=Duel.GetFieldGroup(p,LOCATION_HAND,0)
-		Duel.Remove(sg,POS_FACEUP,REASON_EFFECT)
+		if Duel.Remove(sg,POS_FACEUP,REASON_EFFECT)==0 then
+			Duel.ConfirmCards(1-p,sg)
+			Duel.ShuffleHand(p)
+		end
 	end
 end


### PR DESCRIPTION
fix: if Imperial Iron Wall is activated while Witchcrafter Pittore's resolving, hand(s) don't confirm.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7752&keyword=&tag=-1
> 「[ウィッチクラフト・ピットレ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14405)」の②の効果の処理時に『カードを除外できない』効果が適用された場合、デッキから１枚ドローし、手札に「ウィッチクラフト」カードがあれば、そのうち１枚を墓地へ送ります。**なければ、手札を全て相手に確認させ、処理を完了します**。