### PR TITLE
fix Ghostrick or Treat

### DIFF
--- a/c27170599.lua
+++ b/c27170599.lua
@@ -35,7 +35,7 @@ function c27170599.operation(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) and tc:IsLocation(LOCATION_MZONE) and tc:IsFaceup() then
 		local sel=1
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(27170599,0))
-		if Duel.CheckLPCost(1-tp,2000) then
+		if c:IsRelateToEffect(e) and c:IsCanTurnSet() and Duel.CheckLPCost(1-tp,2000) then
 			sel=Duel.SelectOption(1-tp,1213,1214)
 		end
 		if sel==0 then


### PR DESCRIPTION
fix: if Dark Simorgh has on opponent field, opponent can pay LP.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23384&keyword=&tag=-1
> Question
> 相手の「[ダーク・シムルグ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7770)」の『④』の『このカードがモンスターゾーンに存在する限り、相手はカードをセットできない』効果が適用されているターンや、自分が「[左腕の代償](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5637)」を発動して魔法・罠カードをセットできないターンに、自分は「[ゴーストリック・オア・トリート](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16881)」を発動できますか？
> Answer
> できます。
> 
> その場合、**相手はその処理時に２０００LPを払うことができません。『払わなかった場合』の処理を行うことになります**。