### PR TITLE
fix Heat Wave and Tyrant's Throes

### DIFF
--- a/c45141013.lua
+++ b/c45141013.lua
@@ -25,5 +25,5 @@ function c45141013.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e2,tp)
 end
 function c45141013.sumlimit(e,c,sump,sumtype,sumpos,targetp)
-	return c:IsType(TYPE_EFFECT)
+	return c:GetOriginalType()&TYPE_EFFECT>0 and sumtype~=SUMMON_TYPE_DUAL
 end

--- a/c55271628.lua
+++ b/c55271628.lua
@@ -28,5 +28,5 @@ function c55271628.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(rg,REASON_COST)
 end
 function c55271628.sumlimit(e,c,sump,sumtype,sumpos,targetp)
-	return c:IsLocation(LOCATION_MZONE) or c:IsType(TYPE_EFFECT)
+	return c:GetOriginalType()&TYPE_EFFECT>0 and sumtype~=SUMMON_TYPE_DUAL
 end


### PR DESCRIPTION
Fix1: If those cards are in effect, pendulum monster can summon from P zone

Fix2: Those cards shouldn't affect dual summon.
> 手札のデュアルモンスターは効果モンスターの扱いですので、「[大熱波](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9139)」の効果適用中に召喚する事はできません。
また、モンスターゾーンに表側表示で存在するデュアルモンスターは通常モンスターの状態の時、もう1度召喚を行う事ができるモンスターです。
「[大熱波](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9139)」の効果適用中に、モンスターゾーンに通常モンスター扱いで存在する表側表示のデュアルモンスターをもう1度召喚する事はできます。（もう1度召喚されたそのデュアルモンスターは効果モンスターの扱いとなります。）
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10210&keyword=&tag=-1&request_locale=ja