### PR TITLE
fix フェイバリット・コンタクト

### DIFF
--- a/c75047173.lua
+++ b/c75047173.lua
@@ -42,9 +42,6 @@ end
 function s.dfilter(c,tp)
 	return c:IsLocation(LOCATION_DECK) and c:IsControler(tp)
 end
-function s.exfilter(c,tp)
-	return c:IsLocation(LOCATION_DECK) and c:IsCode(89943723)
-end
 function s.fsop(e,tp,eg,ep,ev,re,r,rp)
 	local chkf=tp|0x200
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(s.fsfilter1),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED,0,nil,e)
@@ -60,6 +57,7 @@ function s.fsop(e,tp,eg,ep,ev,re,r,rp)
 		if cf:GetCount()>0 then
 			Duel.ConfirmCards(1-tp,cf)
 		end
+		local ng=mat:Filter(Card.IsCode,nil,89943723)
 		if #mat>0 and Duel.SendtoDeck(mat,nil,SEQ_DECKTOP,REASON_EFFECT)>0 then
 			local p=tp
 			for i=1,2 do
@@ -76,7 +74,7 @@ function s.fsop(e,tp,eg,ep,ev,re,r,rp)
 		end
 		Duel.BreakEffect()
 		Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)
-		if mat:IsExists(s.exfilter,1,nil) then
+		if ng:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetDescription(aux.Stringid(id,1))
 			e1:SetProperty(EFFECT_FLAG_CLIENT_HINT)


### PR DESCRIPTION
The neos is checked on field.
> Q.
「フェイバリット・コンタクト」の効果によって、「N・グラン・モール」と、カード名が「E・HERO ネオス」として扱われている、「E・HERO アナザー・ネオス」や「E・HERO プリズマー」や「ファントム・オブ・カオス」をデッキに戻し、「E・HERO グラン・ネオス」を特殊召喚した場合、『「E・HERO ネオス」をデッキに戻した場合、この効果で特殊召喚したモンスターをお互いにEXデッキに戻す事はできない』効果は適用されますか？
A.
適用されます。 
Q.
「フェイバリット・コンタクト」の効果によって、「N・グラン・モール」と、カード名が「E・HERO ネオス」として扱われている「覇王眷竜スターヴ・ヴェノム」をエクストラデッキに戻し、「E・HERO グラン・ネオス」を特殊召喚した場合、『「E・HERO ネオス」をデッキに戻した場合、この効果で特殊召喚したモンスターをお互いにEXデッキに戻す事はできない』効果は適用されますか？
A.
適用されません。