### PR TITLE
fix 電脳増幅器

### DIFF
--- a/c303660.lua
+++ b/c303660.lua
@@ -17,15 +17,10 @@ function c303660.initial_effect(c)
 	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetValue(c303660.eqlimit)
 	c:RegisterEffect(e2)
-	--immune
+	--change effect
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetCode(EFFECT_IMMUNE_EFFECT)
-	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
-	e3:SetRange(LOCATION_SZONE)
-	e3:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)
-	e3:SetTarget(c303660.etarget)
-	e3:SetValue(c303660.efilter)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetCode(303660)
 	c:RegisterEffect(e3)
 	--leave
 	local e4=Effect.CreateEffect(c)
@@ -37,6 +32,7 @@ function c303660.initial_effect(c)
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE)
 	e5:SetCode(EFFECT_CANNOT_DISABLE)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	c:RegisterEffect(e5)
 end
 function c303660.eqlimit(e,c)
@@ -57,13 +53,6 @@ function c303660.operation(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Equip(tp,e:GetHandler(),tc)
 	end
-end
-function c303660.etarget(e,c)
-	local ec=e:GetHandler():GetEquipTarget()
-	return c:IsType(TYPE_TRAP) and ec and c:GetControler()==ec:GetControler()
-end
-function c303660.efilter(e,re)
-	return re:GetHandler()==e:GetHandler():GetEquipTarget()
 end
 function c303660.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetHandler():GetFirstCardTarget()

--- a/c77585513.lua
+++ b/c77585513.lua
@@ -1,12 +1,13 @@
 --人造人間－サイコ・ショッカー
 function c77585513.initial_effect(c)
-	--cannot trigger
+	--cannot trigger, normal version
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_TRIGGER)
 	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetTargetRange(LOCATION_HAND+LOCATION_SZONE,LOCATION_HAND+LOCATION_SZONE)
+	e1:SetCondition(c77585513.condition1)
 	e1:SetTarget(c77585513.distg)
 	c:RegisterEffect(e1)
 	--disable
@@ -15,6 +16,7 @@ function c77585513.initial_effect(c)
 	e2:SetCode(EFFECT_DISABLE)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e2:SetCondition(c77585513.condition1)
 	e2:SetTarget(c77585513.distg)
 	c:RegisterEffect(e2)
 	--disable effect
@@ -22,7 +24,8 @@ function c77585513.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e3:SetCode(EVENT_CHAIN_SOLVING)
 	e3:SetRange(LOCATION_MZONE)
-	e3:SetOperation(c77585513.disop)
+	e3:SetCondition(c77585513.discon1)
+	e3:SetOperation(c77585513.disop1)
 	c:RegisterEffect(e3)
 	--disable trap monster
 	local e4=Effect.CreateEffect(c)
@@ -30,15 +33,54 @@ function c77585513.initial_effect(c)
 	e4:SetCode(EFFECT_DISABLE_TRAPMONSTER)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e4:SetCondition(c77585513.condition1)
 	e4:SetTarget(c77585513.distg)
 	c:RegisterEffect(e4)
+	--Amplifier version
+	local e5=e1:Clone()
+	e5:SetTargetRange(0,LOCATION_HAND+LOCATION_SZONE)
+	e5:SetCondition(c77585513.condition2)
+	c:RegisterEffect(e5)
+	--
+	local e6=e2:Clone()
+	e6:SetTargetRange(0,LOCATION_SZONE)
+	e6:SetCondition(c77585513.condition2)
+	c:RegisterEffect(e6)
+	--
+	local e7=e3:Clone()
+	e7:SetCondition(c77585513.discon2)
+	e7:SetOperation(c77585513.disop2)
+	c:RegisterEffect(e7)
+	--
+	local e8=e4:Clone()
+	e8:SetTargetRange(0,LOCATION_MZONE)
+	e8:SetCondition(c77585513.condition2)
+	c:RegisterEffect(e8)
+end
+function c77585513.condition1(e)
+	return not e:GetHandler():IsHasEffect(303660)
 end
 function c77585513.distg(e,c)
 	return c:IsType(TYPE_TRAP)
 end
-function c77585513.disop(e,tp,eg,ep,ev,re,r,rp)
+function c77585513.discon1(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetHandler():IsHasEffect(303660)
+end
+function c77585513.disop1(e,tp,eg,ep,ev,re,r,rp)
 	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
 	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) then
+		Duel.NegateEffect(ev)
+	end
+end
+function c77585513.condition2(e)
+	return e:GetHandler():IsHasEffect(303660)
+end
+function c77585513.discon2(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsHasEffect(303660)
+end
+function c77585513.disop2(e,tp,eg,ep,ev,re,r,rp)
+	local p,tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_PLAYER,CHAININFO_TRIGGERING_LOCATION)
+	if p==1-e:GetHandlerPlayer() and tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) then
 		Duel.NegateEffect(ev)
 	end
 end


### PR DESCRIPTION
# Problem
https://github.com/Fluorohydride/ygopro/issues/2444

電脳増幅器
「人造人間－サイコ・ショッカー」にのみ装備可能。このカードの発動と効果は無効化されない。①：装備モンスターの持つ、「お互いにフィールドの罠カードの効果を発動できず、フィールドの罠カードの効果は無効化される」効果は、「相手はフィールドの罠カードの効果を発動できず、相手フィールドの罠カードの効果は無効化される」として適用される。②：このカードがフィールドから離れた時に装備モンスターは破壊される。 

It changes the effect of Jinzo.
The script should not use EFFECT_IMMUNE_EFFECT.

# Solution
Now the effect of Jinzo has 2 version.

# Reference
https://yugioh-wiki.net/index.php?%A1%D4%A3%D3%A3%E9%A3%EE%20%A3%D4%A3%E5%A3%F2%A3%F2%A3%E9%A3%F4%A3%EF%A3%F2%A3%F9%A1%D5
Ｑ：《Ｓｉｎ スターダスト・ドラゴン》とそれ以外のＳｉｎが存在する状況で《Ｓｉｎ スターダスト・ドラゴン》が《禁じられた聖槍》の効果を受けました。
この場合、どのＳｉｎモンスターがフィールドに残りますか？
Ａ：フィールドに出た順番に関わらず、《Ｓｉｎ Ｔｅｒｒｉｔｏｒｙ》の効果を受けられなくなった《Ｓｉｎ スターダスト・ドラゴン》のみが破壊されます。(19/02/09)

"Changing continuous effects" affects the monsters.
