### PR TITLE
fix Duel.SendtoExtraP

### DIFF
--- a/c18210764.lua
+++ b/c18210764.lua
@@ -60,7 +60,7 @@ end
 function c18210764.teop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
-		Duel.SendtoExtraP(tc,tp,REASON_EFFECT)
+		Duel.SendtoExtraP(tc,nil,REASON_EFFECT)
 	end
 end
 function c18210764.spfilter(c,e,tp)

--- a/c24094258.lua
+++ b/c24094258.lua
@@ -53,7 +53,7 @@ function c24094258.teop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(24094258,3))
 	local g=Duel.SelectMatchingCard(tp,c24094258.tefilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
-		Duel.SendtoExtraP(g,tp,REASON_EFFECT)
+		Duel.SendtoExtraP(g,nil,REASON_EFFECT)
 	end
 end
 function c24094258.thfilter(c)

--- a/c26237713.lua
+++ b/c26237713.lua
@@ -21,6 +21,6 @@ function c26237713.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(26237713,0))
 	local g=Duel.SelectMatchingCard(tp,c26237713.filter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
-		Duel.SendtoExtraP(g,tp,REASON_EFFECT)
+		Duel.SendtoExtraP(g,nil,REASON_EFFECT)
 	end
 end

--- a/c27870337.lua
+++ b/c27870337.lua
@@ -82,7 +82,7 @@ function c27870337.activate(e,tp,eg,ep,ev,re,r,rp)
 	elseif sel==1 then
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(27870337,3))
 		local g=Duel.SelectMatchingCard(tp,c27870337.toexfilter,tp,LOCATION_HAND,0,1,1,nil)
-		if g:GetCount()>0 and Duel.SendtoExtraP(g,tp,REASON_EFFECT)~=0
+		if g:GetCount()>0 and Duel.SendtoExtraP(g,nil,REASON_EFFECT)~=0
 			and Duel.CheckLocation(tp,LOCATION_PZONE,0) and Duel.CheckLocation(tp,LOCATION_PZONE,1) then
 			local g1=Duel.GetMatchingGroup(c27870337.pendfilter1,tp,LOCATION_DECK,0,nil)
 			local g2=Duel.GetMatchingGroup(c27870337.pendfilter2,tp,LOCATION_DECK,0,nil)
@@ -106,7 +106,7 @@ function c27870337.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(27870337,3))
 		local g2=Duel.SelectMatchingCard(tp,c27870337.toexfilter2,tp,LOCATION_PZONE,0,1,1,nil)
 		g1:Merge(g2)
-		if Duel.SendtoExtraP(g1,tp,REASON_EFFECT)~=0 then
+		if Duel.SendtoExtraP(g1,nil,REASON_EFFECT)~=0 then
 			local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 			Duel.Draw(p,d,REASON_EFFECT)
 		end

--- a/c29432356.lua
+++ b/c29432356.lua
@@ -59,7 +59,7 @@ function c29432356.scop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(29432356,1))
 	local g=Duel.SelectMatchingCard(tp,c29432356.scfilter,tp,LOCATION_DECK,0,1,1,nil,c)
 	local tc=g:GetFirst()
-	if tc and Duel.SendtoExtraP(tc,tp,REASON_EFFECT)>0 then
+	if tc and Duel.SendtoExtraP(tc,nil,REASON_EFFECT)>0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LSCALE)

--- a/c37972500.lua
+++ b/c37972500.lua
@@ -62,7 +62,7 @@ function c37972500.teop(e,tp,eg,ep,ev,re,r,rp)
 		sg=g:Select(tp,1,1,nil)
 	end
 	local tc=sg:GetFirst()
-	if tc and Duel.SendtoExtraP(tc,tp,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_EXTRA) then
+	if tc and Duel.SendtoExtraP(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_EXTRA) then
 		local odevity=tc:GetCurrentScale()%2
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local g2=Duel.SelectMatchingCard(tp,c37972500.thfilter,tp,LOCATION_EXTRA,0,1,1,nil,odevity)

--- a/c4836680.lua
+++ b/c4836680.lua
@@ -94,6 +94,6 @@ function c4836680.tgop(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsAbleToGrave() and (not tc:IsAbleToExtra() or Duel.SelectOption(tp,aux.Stringid(4836680,0),1191)==1) then
 		Duel.SendtoGrave(tc,REASON_EFFECT)
 	else
-		Duel.SendtoExtraP(tc,tp,REASON_EFFECT)
+		Duel.SendtoExtraP(tc,nil,REASON_EFFECT)
 	end
 end

--- a/c54100561.lua
+++ b/c54100561.lua
@@ -44,7 +44,7 @@ function c54100561.teop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(54100561,1))
 	local g=Duel.SelectMatchingCard(tp,c54100561.tefilter,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
-		Duel.SendtoExtraP(g,tp,REASON_EFFECT)
+		Duel.SendtoExtraP(g,nil,REASON_EFFECT)
 	end
 end
 function c54100561.pfilter(c)

--- a/c56677752.lua
+++ b/c56677752.lua
@@ -48,7 +48,7 @@ function c56677752.negop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(56677752,0))
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c56677752.negfilter),tp,LOCATION_GRAVE,0,1,1,nil)
 	local tc=g:GetFirst()
-	if tc and Duel.SendtoExtraP(tc,tp,REASON_EFFECT) and tc:IsLocation(LOCATION_EXTRA) and Duel.NegateAttack()
+	if tc and Duel.SendtoExtraP(tc,nil,REASON_EFFECT) and tc:IsLocation(LOCATION_EXTRA) and Duel.NegateAttack()
 		and tc:GetAttack()>0 and Duel.SelectYesNo(tp,aux.Stringid(56677752,1)) then
 		Duel.BreakEffect()
 		Duel.Recover(tp,tc:GetAttack(),REASON_EFFECT)

--- a/c59057953.lua
+++ b/c59057953.lua
@@ -29,5 +29,5 @@ function c59057953.operation(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetClassCount(Card.GetCode)<2 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(59057953,0))
 	local tg1=g:SelectSubGroup(tp,aux.dncheck,false,2,2)
-	Duel.SendtoExtraP(tg1,tp,REASON_EFFECT)
+	Duel.SendtoExtraP(tg1,nil,REASON_EFFECT)
 end


### PR DESCRIPTION
> Q.
> 「ドレミコード・エレガンス」の２つ目の『●』の効果の処理時に、「プレゼント交換」で加わった、元々の持ち主が相手となる「レドレミコード・ドリーミア」を手札からエクストラデッキに表側表示で加える場合、どちらのプレイヤーに加えることになりますか？
> A.
> ご質問の場合、**元々の持ち主のエクストラデッキに表側表示で加わります**。