### PR TITLE
fix シューティング・セイヴァー・スター・ドラゴン

### DIFF
--- a/c40939228.lua
+++ b/c40939228.lua
@@ -3,7 +3,7 @@ function c40939228.initial_effect(c)
 	aux.AddMaterialCodeList(c,21159309)
 	aux.AddCodeList(c,44508094)
 	--synchro summon
-	aux.AddSynchroMixProcedure(c,c40939228.mfilter,nil,nil,aux.NonTuner(nil),1,99,c40939228.gfilter)
+	aux.AddSynchroMixProcedure(c,aux.Tuner(Card.IsCode,21159309),nil,nil,aux.NonTuner(nil),1,99,c40939228.gfilter)
 	c:EnableReviveLimit()
 	--special summon condition
 	local e1=Effect.CreateEffect(c)
@@ -46,14 +46,11 @@ function c40939228.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 c40939228.material_type=TYPE_SYNCHRO
-function c40939228.mfilter(c)
-	return c:IsCode(21159309) and c:IsSynchroType(TYPE_TUNER)
-end
 function c40939228.cfilter(c)
-	return c:IsRace(RACE_DRAGON) and c:IsSynchroType(TYPE_SYNCHRO)
+	return c:IsRace(RACE_DRAGON) and c:IsSynchroType(TYPE_SYNCHRO) and not c:IsSynchroType(TYPE_TUNER)
 end
-function c40939228.gfilter(g,syncard,c1)
-	return g:IsExists(c40939228.cfilter,1,c1)
+function c40939228.gfilter(g)
+	return g:IsExists(c40939228.cfilter,1,nil)
 end
 function c40939228.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.NegateEffectMonsterFilter,tp,0,LOCATION_MZONE,1,nil) end

--- a/c40939228.lua
+++ b/c40939228.lua
@@ -3,7 +3,7 @@ function c40939228.initial_effect(c)
 	aux.AddMaterialCodeList(c,21159309)
 	aux.AddCodeList(c,44508094)
 	--synchro summon
-	aux.AddSynchroMixProcedure(c,aux.Tuner(Card.IsCode,21159309),nil,nil,aux.NonTuner(nil),1,99,c40939228.gfilter)
+	aux.AddSynchroMixProcedure(c,aux.Tuner(Card.IsCode,21159309),nil,nil,aux.NonTuner(nil),1,99,c40939228.syncheck(c))
 	c:EnableReviveLimit()
 	--special summon condition
 	local e1=Effect.CreateEffect(c)
@@ -46,11 +46,13 @@ function c40939228.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 c40939228.material_type=TYPE_SYNCHRO
-function c40939228.cfilter(c)
-	return c:IsRace(RACE_DRAGON) and c:IsSynchroType(TYPE_SYNCHRO) and not c:IsSynchroType(TYPE_TUNER)
+function c40939228.cfilter(c,syncard)
+	return c:IsRace(RACE_DRAGON) and c:IsSynchroType(TYPE_SYNCHRO) and c:IsNotTuner(syncard)
 end
-function c40939228.gfilter(g)
-	return g:IsExists(c40939228.cfilter,1,nil)
+function c40939228.syncheck(syncard)
+	return	function(g)
+				return g:IsExists(c40939228.cfilter,1,nil,syncard)
+			end
 end
 function c40939228.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.NegateEffectMonsterFilter,tp,0,LOCATION_MZONE,1,nil) end


### PR DESCRIPTION
@mercury233 
https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=16228&request_locale=ja
「救世竜 セイヴァー・ドラゴン」＋ドラゴン族Sモンスターを含むチューナー以外のモンスター１体以上

The condition should be:
g contains at least 1 Dragon, Synchro, non-Tuner monster
