### PR TITLE
fix Vendread Revolution

### DIFF
--- a/c2287848.lua
+++ b/c2287848.lua
@@ -67,12 +67,12 @@ function c2287848.drtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c2287848.drop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	if not tg or tg:FilterCount(Card.IsRelateToEffect,nil,e)~=5 then return end
+	if not tg or tg:FilterCount(Card.IsRelateToEffect,nil,e)<=0 then return end
 	Duel.SendtoDeck(tg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
 	local g=Duel.GetOperatedGroup()
 	if g:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then Duel.ShuffleDeck(tp) end
 	local ct=g:FilterCount(Card.IsLocation,nil,LOCATION_DECK+LOCATION_EXTRA)
-	if ct==5 then
+	if ct>0 then
 		Duel.BreakEffect()
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=13537
> ②：墓地のこのカードを除外し、除外されている自分のアンデット族モンスター５体を対象として発動できる。**そのモンスターをデッキに加えてシャッフルする**。その後、自分はデッキから１枚ドローする。