### PR TITLE
fix エクソシスター・マルファ

### DIFF
--- a/c37343995.lua
+++ b/c37343995.lua
@@ -63,16 +63,16 @@ function c37343995.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
 function c37343995.spop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.IsPlayerAffectedByEffect(tp,59822133) or Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) or not c:IsCanBeSpecialSummoned(e,0,tp,false,false) then return end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c37343995.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
-	if g:GetCount()>0 then
-		Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP)
-		Duel.SpecialSummonStep(g:GetFirst(),0,tp,tp,false,false,POS_FACEUP)
-		Duel.SpecialSummonComplete()
+	if not c:IsRelateToEffect(e) or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectMatchingCard(tp,c37343995.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		if g:GetCount()>0 then
+			Duel.SpecialSummonStep(g:GetFirst(),0,tp,tp,false,false,POS_FACEUP)
+		end
 	end
+	Duel.SpecialSummonComplete()
 end
 function c37343995.xyzfilter(c,e,tp,mc)
 	return c:IsSetCard(0x172) and c:IsType(TYPE_XYZ) and mc:IsCanBeXyzMaterial(c)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23802&keyword=&tag=-1
> Question
> 「[エクソシスター・マルファ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17427)」の①の効果の処理時に、使用可能な自分のメインモンスターゾーンが１つだけになった場合、『手札のこのカードを特殊召喚し、デッキから「[エクソシスター・エリス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16736)」１体を特殊召喚する』処理はどうなりますか？
> Answer
> 『**手札のこのカードを特殊召喚』の処理を行って効果処理を完了します**。（『デッキから「[エクソシスター・エリス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16736)」１体を特殊召喚する』処理は行われず、「[エクソシスター・エリス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16736)」はデッキに残ります。）