### PR TITLE
fix&update E・HERO シャイニング・ネオス・ウィングマン, Link Party and so on

### DIFF
--- a/c22908820.lua
+++ b/c22908820.lua
@@ -67,18 +67,7 @@ function c22908820.atkfilter(c)
 end
 function c22908820.val(e,c)
 	local g=Duel.GetMatchingGroup(c22908820.atkfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,nil)
-	local att=0
-	local tc=g:GetFirst()
-	while tc do
-		att=bit.bor(att,tc:GetAttribute())
-		tc=g:GetNext()
-	end
-	local ct=0
-	while att~=0 do
-		if bit.band(att,0x1)~=0 then ct=ct+1 end
-		att=bit.rshift(att,1)
-	end
-	return ct*200
+	return aux.GetAttributeCount(g)*200
 end
 function c22908820.descon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c33609093.lua
+++ b/c33609093.lua
@@ -65,14 +65,8 @@ function c33609093.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x137)
 end
 function c33609093.tfcon(e,tp,eg,ep,ev,re,r,rp)
-	local att=0
 	local g=Duel.GetMatchingGroup(c33609093.cfilter,tp,LOCATION_MZONE,0,nil)
-	local tc=g:GetFirst()
-	while tc do
-		att=bit.bor(att,tc:GetAttribute())
-		tc=g:GetNext()
-	end
-	return bit.band(att,att-1)~=0
+	return aux.GetAttributeCount(g)>1
 end
 function c33609093.tffilter(c,tp)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsType(TYPE_CONTINUOUS) and c:IsSetCard(0x137) and not c:IsCode(33609093)

--- a/c56733747.lua
+++ b/c56733747.lua
@@ -65,7 +65,7 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local cg=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	local ct=cg:GetClassCount(Card.GetAttribute)
+	local ct=aux.GetAttributeCount(cg)
 	if ct==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectMatchingCard(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,ct,nil)

--- a/c58116537.lua
+++ b/c58116537.lua
@@ -44,16 +44,7 @@ function c58116537.actcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c58116537.acttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
-	if chk==0 then
-		if g:GetCount()==0 then return false end
-		local tc=g:GetFirst()
-		local att=0
-		while tc do
-			att=bit.bor(att,tc:GetAttribute())
-			tc=g:GetNext()
-		end
-		return att~=0
-	end
+	if chk==0 then return aux.GetAttributeCount(g)>1 end
 	local tc=g:GetFirst()
 	local att=0
 	while tc do

--- a/c62256492.lua
+++ b/c62256492.lua
@@ -42,18 +42,7 @@ function c62256492.atkfilter(c)
 end
 function c62256492.atkval(e,c)
 	local g=Duel.GetMatchingGroup(c62256492.atkfilter,c:GetControler(),LOCATION_MZONE,0,nil)
-	local att=0
-	local tc=g:GetFirst()
-	while tc do
-		att=bit.bor(att,tc:GetAttribute())
-		tc=g:GetNext()
-	end
-	local ct=0
-	while att~=0 do
-		if bit.band(att,0x1)~=0 then ct=ct+1 end
-		att=bit.rshift(att,1)
-	end
-	return ct*300
+	return aux.GetAttributeCount(g)*300
 end
 function c62256492.target(e,c)
 	return c:IsSetCard(0xbf,0x10c0)

--- a/c62312469.lua
+++ b/c62312469.lua
@@ -32,19 +32,8 @@ function c62312469.atktg(e,c)
 end
 function c62312469.value(e,c)
 	local tp=e:GetHandlerPlayer()
-	local att=0
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
-	local tc=g:GetFirst()
-	while tc do
-		att=bit.bor(att,tc:GetAttribute())
-		tc=g:GetNext()
-	end
-	local ct=0
-	while att~=0 do
-		if bit.band(att,0x1)~=0 then ct=ct+1 end
-		att=bit.rshift(att,1)
-	end
-	return ct*200
+	return aux.GetAttributeCount(g)*200
 end
 function c62312469.sttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAttribute,tp,LOCATION_DECK,0,1,nil,ATTRIBUTE_EARTH)

--- a/c65046521.lua
+++ b/c65046521.lua
@@ -42,7 +42,7 @@ function c65046521.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 	local mg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
-	if mg:GetClassCount(Card.GetAttribute)>=2 and g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(65046521,1)) then
+	if aux.GetAttributeCount(mg)>=2 and g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(65046521,1)) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 		local g=Duel.SelectMatchingCard(tp,Card.IsFaceup,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)

--- a/c68957925.lua
+++ b/c68957925.lua
@@ -14,7 +14,7 @@ function c68957925.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_LINK)
 end
 function c68957925.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ct=Duel.GetMatchingGroup(c68957925.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetAttribute)
+	local ct=Duel.GetMatchingGroup(c68957925.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetOriginalAttribute)
 	if chk==0 then return (ct==1 and Duel.IsExistingMatchingCard(c68957925.filter,tp,LOCATION_MZONE,0,1,nil))
 	 	or (ct==2 and Duel.IsExistingMatchingCard(c68957925.filter,tp,0,LOCATION_MZONE,1,nil))
 		or ct==3 or ct==4
@@ -38,7 +38,7 @@ function c68957925.desfilter(c)
 	return c:IsFaceup() and c:IsAttackBelow(3000)
 end
 function c68957925.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ct=Duel.GetMatchingGroup(c68957925.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetAttribute)
+	local ct=Duel.GetMatchingGroup(c68957925.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetOriginalAttribute)
 	local g1=Duel.GetMatchingGroup(c68957925.filter,tp,LOCATION_MZONE,0,nil)
 	if ct==1 and g1:GetCount()>0 then
 		local tc1=g1:GetFirst()

--- a/utility.lua
+++ b/utility.lua
@@ -2204,6 +2204,19 @@ end
 function Auxiliary.IsTypeInText(c,type)
 	return c.has_text_type and type&c.has_text_type==type
 end
+function Auxiliary.GetAttributeCount(g)
+	if #g==0 then return 0 end
+	local att=0
+	for tc in Auxiliary.Next(g) do
+		att=att|tc:GetAttribute()
+	end
+	local ct=0
+	while att~=0 do
+		if att&0x1~=0 then ct=ct+1 end
+		att=att>>1
+	end
+	return ct
+end
 function Auxiliary.IsInGroup(c,g)
 	return g:IsContains(c)
 end


### PR DESCRIPTION
fix 1: Link Party don't check original attribute.

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=13886
> ①：フィールドのリンクモンスターの**元々の属性**の種類の数によって以下を適用する。

fix 2: if Elemental HERO Electrum has on the field, player cannot destroy 5 cards by E・HERO シャイニング・ネオス・ウィングマン's effect.

> mail:
> Q.
> 自分フィールドに「E・HERO エリクシーラー」が存在する状態で、自分が「E・HERO シャイニング・ネオス・ウィングマン」を融合召喚し、その「E・HERO シャイニング・ネオス・ウィングマン」の①の効果を発動した場合、その効果処理時に相手フィールドのカードを最大何枚まで選んで破壊できますか？
> A.
> **最大５枚まで破壊することができます**。

update: add `aux.GetAttributeCount`.