### PR TITLE
Fix Nine Pillars of Yang Zing

### DIFF
--- a/c57831349.lua
+++ b/c57831349.lua
@@ -25,7 +25,7 @@ function c57831349.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c57831349.desfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x9e)
+	return c:IsFaceup() and c:IsSetCard(0x9e) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c57831349.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()


### PR DESCRIPTION
fixed an issue that Nine Pillars could destory Yang Zing monsters already destoryed by battle.