### PR TITLE
Temp Revert "Fix Nine Pillars of Yang Zing (#1922)"

### DIFF
--- a/c57831349.lua
+++ b/c57831349.lua
@@ -25,7 +25,7 @@ function c57831349.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c57831349.desfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x9e) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
+	return c:IsFaceup() and c:IsSetCard(0x9e)
 end
 function c57831349.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()


### PR DESCRIPTION
@mercury233 @Sonic714 
This reverts commit 50a70cd5dbeed8bd530b74717dd9b87b8e3a20e0.
Revert #1922 temporarily.

# Reason
There are some evidences that the original version might be correct.
(Ex. The situation in Master Duel, the mail in 7/23)

Therefore, I think we should revert to the original version until further confirmation.
