### PR TITLE
Revert "fix Frozen Rose"

### DIFF
--- a/c53503015.lua
+++ b/c53503015.lua
@@ -24,7 +24,6 @@ function c53503015.thfilter(c)
 end
 function c53503015.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local chk1=Duel.IsExistingMatchingCard(c53503015.cfilter,tp,LOCATION_MZONE,0,1,nil,0,true)
-		and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>1
 	local chk2=Duel.IsExistingMatchingCard(c53503015.cfilter,tp,LOCATION_MZONE,0,1,nil,0,false)
 		and Duel.IsExistingMatchingCard(c53503015.thfilter,tp,LOCATION_DECK,0,1,nil)
 	if chk==0 then


### PR DESCRIPTION
Reverts Fluorohydride/ygopro-scripts#1738. (Frozen Rose's ruling was changed.)

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23814&keyword=&tag=-1
> Question
> 自分のデッキが１枚以下の状況や、相手の「[神殿を守る者](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6027)」の『相手プレイヤーはドローフェイズ以外ではカードをドローする事ができない』効果が適用されている状況で、自分は「[冷薔薇の抱香](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14178)」の『●植物族：このターンのエンドフェイズに、自分はデッキから２枚ドローし、その後手札を１枚選んで捨てる』効果を発動できますか？
> Answer
> **発動できます**。そのチェーンブロックの処理時に、自分は『このターンのエンドフェイズに、自分はデッキから２枚ドローし、その後手札を１枚選んで捨てる』状態になります。
> 
> エンドフェイズにこの処理を行う際に、自分のデッキが１枚以下である場合、自分はドローできずに敗北します。
> 
> エンドフェイズにこの処理を行う際に、相手の「[神殿を守る者](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6027)」の効果が適用されている場合、ドローすることも手札を捨てることもありません。