### PR TITLE
fix for Barrel Behind the Door

### DIFF
--- a/c31571902.lua
+++ b/c31571902.lua
@@ -38,6 +38,7 @@ end
 function c31571902.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,e:GetHandler(),1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,tp,e:GetHandler():GetBaseAttack())
 end
 function c31571902.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c45115956.lua
+++ b/c45115956.lua
@@ -36,6 +36,7 @@ function c45115956.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c45115956.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,tp,0)
 end
 function c45115956.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/c51208877.lua
+++ b/c51208877.lua
@@ -31,10 +31,7 @@ function c51208877.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
 	local tg=g:GetMaxGroup(Card.GetAttack)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
-	local dam=0
-	for tc in aux.Next(tg) do
-		if dam<tc:GetBaseAttack() then dam=tc:GetBaseAttack() end
-	end
+	local _,dam=tg:GetMaxGroup(Card.GetBaseAttack)
 	if dam>0 then
 		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
 	end

--- a/c51208877.lua
+++ b/c51208877.lua
@@ -31,6 +31,13 @@ function c51208877.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
 	local tg=g:GetMaxGroup(Card.GetAttack)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,tg,1,0,0)
+	local dam=0
+	for tc in aux.Next(tg) do
+		if dam<tc:GetBaseAttack() then dam=tc:GetBaseAttack() end
+	end
+	if dam>0 then
+		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+	end
 end
 function c51208877.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)

--- a/c57823578.lua
+++ b/c57823578.lua
@@ -72,6 +72,7 @@ function c57823578.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local g=Duel.GetMatchingGroup(Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,PLAYER_ALL,0)
 end
 function c57823578.thop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsAbleToHand,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)

--- a/c75249652.lua
+++ b/c75249652.lua
@@ -20,7 +20,7 @@ function c75249652.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c75249652.filter,tp,0,LOCATION_MZONE,1,nil) end
 	local g=Duel.GetMatchingGroup(c75249652.filter,tp,0,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,PLAYER_ALL,0)
 end
 function c75249652.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c75249652.filter,tp,0,LOCATION_MZONE,nil)

--- a/c82052602.lua
+++ b/c82052602.lua
@@ -50,6 +50,7 @@ function c82052602.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c82052602.filter,tp,LOCATION_GRAVE,0,1,nil,Duel.GetTurnCount(),e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,tp,0)
 	Duel.RegisterFlagEffect(tp,82052602,RESET_PHASE+PHASE_END,0,1)
 end
 function c82052602.activate(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
fix 1: if some card(運命の抱く爆弾, Gagagaback, D-Boyz and so on)'s effect was activated, Barrel Behind the Door cannot activate.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23671&keyword=&tag=-1
> Question
> 「[運命の抱く爆弾](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17609)」の発動にチェーンして「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動できますか？
> Answer
> **『相手フィールドの攻撃力が一番高いモンスター』の元々の攻撃力（この場合はカードに記載されている攻撃力）が０や？ではないのであれば、発動できます**。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14022&keyword=&tag=-1
> **自分の「[Dボーイズ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9867)」の効果の発動にチェーンして、自分が「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動する事はできます**。
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11706&keyword=&tag=-1
> **「[ガガガバック](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9855)」の発動にチェーンして、自分が「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動する事はできます**。
> また、「[ガガガバック](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9855)」にチェーンして「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動した場合、「[ガガガバック](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9855)」の効果によって特殊召喚したモンスター1体につき600ポイントのダメージは、相手が受ける事になります。

fix 2: if player activated Blazing Mirror Force's effect, Blazing Mirror Force's activated player cannot activate Barrel Behind the Door.

> ref:
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14812&keyword=&tag=-1
> Question
> 攻撃力１０００の「[ジャイアントウィルス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4921)」を対象として、自分が「[破壊輪](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5005)」を発動しました。
> 
> その発動にチェーンして、自分は「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動する事はできますか？
> 
> また、自分の発動した「[破壊輪](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5005)」の発動にチェーンして、相手が「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動する事はできますか？
> Answer
> **「[破壊輪](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5005)」の発動にチェーンして、「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動する事はできます**。
> 
> 質問の状況で、自分が「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動した場合には、『その表側表示モンスターを破壊し、自分はそのモンスターの元々の攻撃力分のダメージを受ける』処理にて受ける１０００のダメージを相手が受ける事になります。
> その場合、自分はダメージを受けていませんので、『その後、自分が受けたダメージと同じ数値分のダメージを相手に与える』処理は適用されません。
> 
> また、質問の状況で、相手が「[地獄の扉越し銃](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5543)」を発動した場合には、『その表側表示モンスターを破壊し、自分はそのモンスターの元々の攻撃力分のダメージを受ける』処理にて受ける１０００のダメージは通常通り自分が受けます。
> 『その後、自分が受けたダメージと同じ数値分のダメージを相手に与える』処理によって相手が受ける１０００のダメージは自分が受ける事になります。
> （この場合、「[破壊輪](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5005)」を発動したプレイヤーがそれぞれの処理で１０００ダメージを受け、合計２０００のダメージを受ける事になります。）