### PR TITLE
fix Number 58: Burner Visor

### DIFF
--- a/c93108839.lua
+++ b/c93108839.lua
@@ -13,24 +13,33 @@ function c93108839.initial_effect(c)
 	e1:SetTarget(c93108839.eqtg)
 	e1:SetOperation(c93108839.eqop)
 	c:RegisterEffect(e1)
-	--direct
+	--unequip
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_EQUIP)
-	e2:SetCode(EFFECT_DIRECT_ATTACK)
+	e2:SetDescription(aux.Stringid(93108839,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetTarget(c93108839.sptg)
+	e2:SetOperation(c93108839.spop)
 	c:RegisterEffect(e2)
-	--damage
+	--direct
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(93108839,2))
-	e3:SetCategory(CATEGORY_DAMAGE)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e3:SetCode(EVENT_BATTLE_DAMAGE)
-	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-	e3:SetRange(LOCATION_SZONE)
-	e3:SetCondition(c93108839.damcon)
-	e3:SetCost(c93108839.damcost)
-	e3:SetTarget(c93108839.damtg)
-	e3:SetOperation(c93108839.damop)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetCode(EFFECT_DIRECT_ATTACK)
 	c:RegisterEffect(e3)
+	--damage
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(93108839,2))
+	e4:SetCategory(CATEGORY_DAMAGE)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_BATTLE_DAMAGE)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c93108839.damcon)
+	e4:SetCost(c93108839.damcost)
+	e4:SetTarget(c93108839.damtg)
+	e4:SetOperation(c93108839.damop)
+	c:RegisterEffect(e4)
 end
 aux.xyz_number[93108839]=58
 function c93108839.filter(c)
@@ -54,16 +63,6 @@ function c93108839.eqop(e,tp,eg,ep,ev,re,r,rp)
 		return
 	end
 	if not Duel.Equip(tp,c,tc,false) then return end
-	--unequip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(93108839,1))
-	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_SZONE)
-	e1:SetTarget(c93108839.sptg)
-	e1:SetOperation(c93108839.spop)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-	c:RegisterEffect(e1)
 	--eqlimit
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE)
@@ -78,15 +77,16 @@ function c93108839.eqlimit(e,c)
 	return c==e:GetLabelObject()
 end
 function c93108839.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetFlagEffect(93108839)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,false,POS_FACEUP_ATTACK) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
-	e:GetHandler():RegisterFlagEffect(93108839,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+	local c=e:GetHandler()
+	if chk==0 then return c:GetFlagEffect(93108839)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+	c:RegisterFlagEffect(93108839,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
 end
 function c93108839.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP_ATTACK)
 end
 function c93108839.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp and eg:GetFirst()==e:GetHandler():GetEquipTarget()


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23800&keyword=&tag=-1
> Question
> 自身の①の効果以外の方法によって、「[No.58 炎圧鬼バーナー・バイサー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11025)」が装備カードとして魔法＆罠ゾーンに存在している状況です。
> 
> その状況で、装備されている「[No.58 炎圧鬼バーナー・バイサー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11025)」の①の『●装備されているこのカードを攻撃表示で特殊召喚する』効果の発動・処理を行えますか？
> Answer
> **その「[No.58 炎圧鬼バーナー・バイサー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11025)」が一度エクシーズ召喚されたのち装備カードになっているのであれば、その効果を発動でき、処理も行えます**。