### PR TITLE
fix Time Stream

### DIFF
--- a/c85808813.lua
+++ b/c85808813.lua
@@ -52,7 +52,6 @@ function c85808813.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sg=Duel.SelectMatchingCard(tp,c85808813.ffilter,tp,LOCATION_EXTRA,0,1,1,nil,lv,e,tp,nil)
 	if sg:GetCount()>0 then
-		Duel.BreakEffect()
 		sg:GetFirst():SetMaterial(nil)
 		Duel.SpecialSummon(sg,SUMMON_TYPE_FUSION,tp,tp,true,false,POS_FACEUP)
 		sg:GetFirst():CompleteProcedure()


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=15370
> ■『そのモンスターをリリースし』の処理と、『そのモンスターより元々のレベルが２つ高い「化石」融合モンスター１体を、「[化石融合－フォッシル・フュージョン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=15369)」による融合召喚扱いとしてEXデッキから特殊召喚する』処理は**同時に行われる扱いとなります**。