### PR TITLE
fix Prank-Kids Rocket Ride

### DIFF
--- a/c18514525.lua
+++ b/c18514525.lua
@@ -33,7 +33,7 @@ end
 function c18514525.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local atk=c:GetAttack()
-	if not c:IsRelateToEffect(e) or atk<1000 then return end
+	if c:IsFacedown() or not c:IsRelateToEffect(e) or atk<1000 then return end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_ATTACK)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=156&keyword=&tag=-1
> 質問の状況のように、**効果を発動した「[プランキッズ・ロケット](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14023)」自身が効果処理時に裏側守備表示になっている場合には、『攻撃力が１０００ダウンし』の処理を適用する事ができませんので、『さらに直接攻撃もできる』処理も適用されません**。
> （そのターンに「[太陽の書](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5431)」等の効果によって表側攻撃表示に戻ったとしても、直接攻撃が行えるようにはなりません。）