### PR TITLE
fix Eagle Shark, Panther Shark and Prominence Hand

### DIFF
--- a/c21414674.lua
+++ b/c21414674.lua
@@ -15,5 +15,5 @@ end
 function c21414674.spcon(e,c)
 	if c==nil then return true end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c21414674.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c21414674.filter,c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end

--- a/c70101178.lua
+++ b/c70101178.lua
@@ -29,5 +29,5 @@ end
 function c70101178.spcon(e,c)
 	if c==nil then return true end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c70101178.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c70101178.filter,c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end

--- a/c7500772.lua
+++ b/c7500772.lua
@@ -29,5 +29,5 @@ end
 function c7500772.spcon(e,c)
 	if c==nil then return true end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c7500772.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c7500772.filter,c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end


### PR DESCRIPTION
fix: if a specified monster(s) has on the spell&trap zone, these monster cannot special summon by itself.

> ref:
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14740&keyword=&tag=-1
> Question
> 自分フィールドに「[サクリファイス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4737)」の効果によって装備魔法カード扱いとなっている「[冥界騎士トリスタン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11646)」が表側表示で存在する場合、「[冥界の麗人イゾルデ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11647)」を『①：自分フィールドに「[冥界騎士トリスタン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11646)」が存在する場合、このカードは手札から特殊召喚できる』方法によって特殊召喚する事はできますか？
> Answer
> できます。