### PR TITLE
fix destroy replace effect

### DIFF
--- a/c10002346.lua
+++ b/c10002346.lua
@@ -28,7 +28,8 @@ function c10002346.val(e,c)
 	return e:GetHandler():GetOverlayCount()*200
 end
 function c10002346.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+		and not e:GetHandler():IsReason(REASON_REPLACE) end
 	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
 end
 function c10002346.repop(e,tp,eg,ep,ev,re,r,rp)

--- a/c1281505.lua
+++ b/c1281505.lua
@@ -56,8 +56,10 @@ function c1281505.eqlimit(e,c)
 	return c:IsControler(tp)
 end
 function c1281505.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not c:GetEquipTarget():IsReason(REASON_REPLACE) end
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function c1281505.repop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)

--- a/c16259549.lua
+++ b/c16259549.lua
@@ -60,9 +60,11 @@ function c16259549.recop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Recover(p,d,REASON_EFFECT)
 end
 function c16259549.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT)
+	local c=e:GetHandler()
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		c:RemoveOverlayCard(tp,1,1,REASON_EFFECT)
 		return true
 	else return false end
 end

--- a/c176392.lua
+++ b/c176392.lua
@@ -25,12 +25,14 @@ function c176392.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_END
 end
 function c176392.rfilter(c)
-	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x1d)
+	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x1d) and not c:IsReason(REASON_REPLACE)
 end
 function c176392.destg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return eg:IsExists(c176392.rfilter,1,e:GetHandler()) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		Duel.Destroy(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
+	local c=e:GetHandler()
+	if chk==0 then return eg:IsExists(c176392.rfilter,1,c)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		Duel.Destroy(c,REASON_EFFECT+REASON_REPLACE)
 		return true
 	else return false end
 end

--- a/c19748583.lua
+++ b/c19748583.lua
@@ -73,7 +73,8 @@ function c19748583.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	local tc=c:GetEquipTarget()
 	if chk==0 then return bit.band(r,REASON_EFFECT)~=0 and tc and tc:IsAttribute(ATTRIBUTE_LIGHT)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED) end
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not tc:IsReason(REASON_REPLACE) end
 	return Duel.SelectEffectYesNo(e:GetOwnerPlayer(),c,96)
 end
 function c19748583.repop(e,tp,eg,ep,ev,re,r,rp)

--- a/c20457551.lua
+++ b/c20457551.lua
@@ -65,7 +65,8 @@ function c20457551.atkval(e,c)
 	return e:GetHandler():GetEquipTarget():GetLevel()*-100
 end
 function c20457551.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetCurrentPhase()==PHASE_END and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) end
+	if chk==0 then return Duel.GetCurrentPhase()==PHASE_END and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not e:GetHandler():GetEquipTarget():IsReason(REASON_REPLACE) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
 		return true

--- a/c23232295.lua
+++ b/c23232295.lua
@@ -24,6 +24,7 @@ function c23232295.initial_effect(c)
 end
 function c23232295.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x84)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function c23232295.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c23232295.repfilter,1,nil,tp) end

--- a/c23998625.lua
+++ b/c23998625.lua
@@ -51,9 +51,11 @@ function c23998625.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c23998625.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT)
+	local c=e:GetHandler()
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		c:RemoveOverlayCard(tp,1,1,REASON_EFFECT)
 		return true
 	else return false end
 end

--- a/c2525268.lua
+++ b/c2525268.lua
@@ -32,7 +32,7 @@ function c2525268.addc(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c2525268.dfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_SPELLCASTER)
+	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_SPELLCASTER) and not c:IsReason(REASON_REPLACE)
 end
 function c2525268.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c25853045.lua
+++ b/c25853045.lua
@@ -38,9 +38,11 @@ function c25853045.atkval(e,c)
 	return c:GetOverlayCount()*200
 end
 function c25853045.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		local g=e:GetHandler():GetOverlayGroup()
+	local c=e:GetHandler()
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		local g=c:GetOverlayGroup()
 		Duel.SendtoGrave(g,REASON_EFFECT)
 		return true
 	else return false end

--- a/c30794966.lua
+++ b/c30794966.lua
@@ -45,7 +45,8 @@ function c30794966.repfilter(c)
 end
 function c30794966.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return Duel.CheckReleaseGroup(tp,c30794966.repfilter,1,c) end
+	if chk==0 then return not c:IsReason(REASON_REPLACE)
+		and Duel.CheckReleaseGroup(tp,c30794966.repfilter,1,c) end
 	if Duel.SelectEffectYesNo(tp,c,96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
 		local g=Duel.SelectReleaseGroup(tp,c30794966.repfilter,1,1,c)

--- a/c31766317.lua
+++ b/c31766317.lua
@@ -26,7 +26,7 @@ end
 function c31766317.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local dc=eg:GetFirst()
 	if chk==0 then return eg:GetCount()==1 and dc~=e:GetHandler() and dc:IsFaceup() and dc:IsLocation(LOCATION_MZONE)
-		and dc:IsRace(RACE_FIEND) and dc:IsAttribute(ATTRIBUTE_DARK)
+		and dc:IsRace(RACE_FIEND) and dc:IsAttribute(ATTRIBUTE_DARK) and not dc:IsReason(REASON_REPLACE)
 		and Duel.IsExistingMatchingCard(c31766317.rfilter,tp,LOCATION_GRAVE,0,1,nil) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)

--- a/c33438666.lua
+++ b/c33438666.lua
@@ -30,6 +30,7 @@ end
 function c33438666.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
 		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp))
+		and not c:IsReason(REASON_REPLACE)
 end
 function c33438666.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=eg:FilterCount(c33438666.repfilter,nil,tp)

--- a/c39373426.lua
+++ b/c39373426.lua
@@ -113,7 +113,7 @@ function c39373426.cnop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c39373426.repfilter(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0xee) and c:IsLocation(LOCATION_MZONE)
-		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
+		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function c39373426.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(c39373426.repfilter,1,nil,tp) end

--- a/c39910367.lua
+++ b/c39910367.lua
@@ -54,12 +54,12 @@ function c39910367.rop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetHandler():RemoveCounter(ep,0x1,ev,REASON_EFFECT)
 end
 function c39910367.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not e:GetHandler():IsReason(REASON_RULE)
-		and e:GetHandler():GetCounter(0x1)>0 end
+	if chk==0 then return not e:GetHandler():IsReason(REASON_RULE+REASON_REPLACE)
+		and e:GetHandler():IsCanRemoveCounter(tp,0x1,1,REASON_EFFECT) end
 	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
 end
 function c39910367.desrepop(e,tp,eg,ep,ev,re,r,rp)
-	e:GetHandler():RemoveCounter(ep,0x1,1,REASON_EFFECT)
+	e:GetHandler():RemoveCounter(tp,0x1,1,REASON_EFFECT)
 end
 function c39910367.addop2(e,tp,eg,ep,ev,re,r,rp)
 	local count=0

--- a/c4252828.lua
+++ b/c4252828.lua
@@ -69,7 +69,8 @@ function c4252828.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	local ec=e:GetLabelObject():GetLabelObject()
 	if chk==0 then return ec and ec:IsHasCardTarget(c) and ec:GetFlagEffect(4252828)~=0
-		and ec:IsDestructable(e) and not ec:IsStatus(STATUS_DESTROY_CONFIRMED) end
+		and ec:IsDestructable(e) and not ec:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not c:IsReason(REASON_REPLACE) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function c4252828.desrepop(e,tp,eg,ep,ev,re,r,rp)

--- a/c49678559.lua
+++ b/c49678559.lua
@@ -63,11 +63,13 @@ function c49678559.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c49678559.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		local g=e:GetHandler():GetOverlayGroup()
+	local c=e:GetHandler()
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		local g=c:GetOverlayGroup()
 		Duel.SendtoGrave(g,REASON_EFFECT)
-		local e1=Effect.CreateEffect(e:GetHandler())
+		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_FIELD)
 		e1:SetCode(EFFECT_CHANGE_BATTLE_DAMAGE)
 		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)

--- a/c50186558.lua
+++ b/c50186558.lua
@@ -58,8 +58,8 @@ function c50186558.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c50186558.repfilter(c,tp)
-	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_DRAGON) and c:IsControler(tp) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
-		and not c:IsReason(REASON_REPLACE)
+	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_DRAGON) and c:IsControler(tp)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function c50186558.tgfilter(c)
 	return c:IsType(TYPE_NORMAL) and c:IsAbleToGrave()

--- a/c50186558.lua
+++ b/c50186558.lua
@@ -59,6 +59,7 @@ function c50186558.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c50186558.repfilter(c,tp)
 	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_DRAGON) and c:IsControler(tp) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
+		and not c:IsReason(REASON_REPLACE)
 end
 function c50186558.tgfilter(c)
 	return c:IsType(TYPE_NORMAL) and c:IsAbleToGrave()

--- a/c60181553.lua
+++ b/c60181553.lua
@@ -26,7 +26,8 @@ function c60181553.indtg(e,c)
 	return c:IsFaceup() and c:IsLevelBelow(4)
 end
 function c60181553.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+		and not e:GetHandler():IsReason(REASON_REPLACE) end
 	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
 end
 function c60181553.repop(e,tp,eg,ep,ev,re,r,rp)

--- a/c66835946.lua
+++ b/c66835946.lua
@@ -32,6 +32,7 @@ function c66835946.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local tc=eg:GetFirst()
 		return eg:GetCount()==1 and tc:IsLocation(LOCATION_MZONE) and tc:IsControler(tp) and tc:IsFaceup() and tc:IsRace(RACE_ZOMBIE)
+			and not tc:IsReason(REASON_REPLACE)
 	end
 	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
 end

--- a/c67173574.lua
+++ b/c67173574.lua
@@ -37,9 +37,11 @@ function c67173574.initial_effect(c)
 end
 aux.xyz_number[67173574]=102
 function c67173574.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,2,REASON_EFFECT) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		e:GetHandler():RemoveOverlayCard(tp,2,2,REASON_EFFECT)
+	local c=e:GetHandler()
+	if chk==0 then return c:CheckRemoveOverlayCard(tp,2,REASON_EFFECT)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		c:RemoveOverlayCard(tp,2,2,REASON_EFFECT)
 		return true
 	else return false end
 end

--- a/c675319.lua
+++ b/c675319.lua
@@ -44,7 +44,7 @@ function c675319.atlimit(e,c)
 end
 function c675319.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
-		and c:IsSetCard(0xf1) and c:IsReason(REASON_EFFECT) and c:GetFlagEffect(675319)==0
+		and c:IsSetCard(0xf1) and c:IsReason(REASON_EFFECT) and c:GetFlagEffect(675319)==0 and not c:IsReason(REASON_REPLACE)
 end
 function c675319.desfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE+LOCATION_HAND) and c:IsType(TYPE_MONSTER)

--- a/c72497366.lua
+++ b/c72497366.lua
@@ -35,7 +35,8 @@ end
 function c72497366.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=eg:GetFirst()
 	if chk==0 then return eg:GetCount()==1 and tc:IsFaceup() and tc:IsLocation(LOCATION_MZONE)
-		and tc:IsRace(RACE_FIEND) and tc:IsLevelAbove(5) and tc:IsSummonType(SUMMON_TYPE_NORMAL) end
+		and tc:IsRace(RACE_FIEND) and tc:IsLevelAbove(5) and tc:IsSummonType(SUMMON_TYPE_NORMAL)
+		and not tc:IsReason(REASON_REPLACE) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
 		return true

--- a/c74580251.lua
+++ b/c74580251.lua
@@ -36,7 +36,7 @@ function c74580251.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c74580251.repfilter(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0xc4) and c:IsOnField()
-		and c:IsControler(tp)
+		and c:IsControler(tp) and not c:IsReason(REASON_REPLACE)
 end
 function c74580251.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemove() and aux.exccon(e) and eg:IsExists(c74580251.repfilter,1,nil,tp) end

--- a/c76067258.lua
+++ b/c76067258.lua
@@ -58,10 +58,12 @@ function c76067258.repfilter(c,tp)
 	return c:IsControler(tp) and c:GetFlagEffect(76067258)~=0
 end
 function c76067258.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetCardTarget():IsExists(c76067258.repfilter,1,nil,tp) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
+	local c=e:GetHandler()
+	if chk==0 then return c:GetCardTarget():IsExists(c76067258.repfilter,1,nil,tp)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		local g=e:GetHandler():GetCardTarget():FilterSelect(tp,c76067258.repfilter,1,1,nil,tp)
+		local g=c:GetCardTarget():FilterSelect(tp,c76067258.repfilter,1,1,nil,tp)
 		Duel.SendtoGrave(g,REASON_EFFECT)
 		return true
 	else return false end

--- a/c78156759.lua
+++ b/c78156759.lua
@@ -26,7 +26,8 @@ function c78156759.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c78156759.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
+	if chk==0 then return not e:GetHandler():IsReason(REASON_REPLACE)
+		and e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT)
 		e:GetHandler():RegisterFlagEffect(78156759,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)

--- a/c8437145.lua
+++ b/c8437145.lua
@@ -46,7 +46,7 @@ function c8437145.efilter(e,re)
 end
 function c8437145.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
-		and c:IsSetCard(0xbb) and c:IsReason(REASON_EFFECT)
+		and c:IsSetCard(0xbb) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function c8437145.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(c8437145.repfilter,1,nil,tp) end

--- a/c94599451.lua
+++ b/c94599451.lua
@@ -86,9 +86,9 @@ function c94599451.thop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c94599451.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsReason(REASON_EFFECT) and c:GetCounter(0x1)>0 end
+	if chk==0 then return c:IsReason(REASON_EFFECT) and c:IsCanRemoveCounter(tp,0x1,1,REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function c94599451.repop(e,tp,eg,ep,ev,re,r,rp)
-	e:GetHandler():RemoveCounter(ep,0x1,1,REASON_EFFECT)
+	e:GetHandler():RemoveCounter(tp,0x1,1,REASON_EFFECT)
 end

--- a/c95395761.lua
+++ b/c95395761.lua
@@ -65,7 +65,8 @@ function c95395761.eqlimit(e,c)
 end
 function c95395761.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED) end
+	if chk==0 then return c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not c:GetEquipTarget():IsReason(REASON_REPLACE) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function c95395761.repop(e,tp,eg,ep,ev,re,r,rp)

--- a/c99469936.lua
+++ b/c99469936.lua
@@ -38,7 +38,8 @@ function c99469936.atkval(e,c)
 	return c:GetOverlayCount()*500
 end
 function c99469936.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
+	if chk==0 then return not e:GetHandler():IsReason(REASON_REPLACE)
+		and e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT)
 		return true


### PR DESCRIPTION
fix: if destroy replace effect(e.g. Proxy Dragon) would be use, another destroy replace effect can use for that effect.

> mail:
> Q.
> 相手の「青眼の白龍」の攻撃で自分の「プロキシー・ドラゴン」が戦闘破壊される際に、自身の①の効果を適用し、代わりに破壊するリンク先の自分のモンスターとして「デーモンの召喚」を選んだ場合、自分は自分フィールドの「ヘル・エンプレス・デーモン」の『このカード以外のフィールド上に表側表示で存在する悪魔族・闇属性モンスター１体が破壊される場合、代わりに自分の墓地に存在する悪魔族・闇属性モンスター１体をゲームから除外する事ができる』効果を適用できますか？
> A.
> ご質問の場合、**「ヘル・エンプレス・デーモン」の効果を適用することはできません**。