### PR TITLE
fix Ruins of the Divine Dragon Lords

### DIFF
--- a/c69868555.lua
+++ b/c69868555.lua
@@ -39,7 +39,7 @@ function c69868555.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c69868555.cfilter(c)
-	return not c:IsSummonLocation(LOCATION_GRAVE)
+	return not c:IsSummonLocation(LOCATION_GRAVE) or (c:GetOriginalType()&TYPE_TRAP~=0)
 end
 function c69868555.dfilter(c,eg)
 	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and c:IsLevel(7,8) and not eg:IsContains(c)
@@ -55,7 +55,7 @@ function c69868555.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,g:GetCount(),0,0)
 end
 function c69868555.filter(c,e)
-	return c:IsFaceup() and c:IsType(TYPE_EFFECT) and not c:IsPreviousLocation(LOCATION_GRAVE) and c:IsRelateToEffect(e)
+	return c:IsFaceup() and c:IsType(TYPE_EFFECT) and c69868555.cfilter(c) and c:IsRelateToEffect(e)
 end
 function c69868555.disop(e,tp,eg,ep,ev,re,r,rp)
 	local g=eg:Filter(c69868555.filter,nil,e)

--- a/c73082255.lua
+++ b/c73082255.lua
@@ -43,8 +43,8 @@ end
 function c73082255.eval(e,re,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
-	return re:IsActiveType(TYPE_MONSTER) and not rc:IsSummonLocation(LOCATION_GRAVE) and rc:IsSummonType(SUMMON_TYPE_SPECIAL)
-		and re:GetActivateLocation()==LOCATION_MZONE
+	return re:IsActiveType(TYPE_MONSTER) and re:GetActivateLocation()==LOCATION_MZONE and rc:IsSummonType(SUMMON_TYPE_SPECIAL)
+		and (not rc:IsSummonLocation(LOCATION_GRAVE) or (rc:GetOriginalType()&TYPE_TRAP~=0))
 end
 function c73082255.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end


### PR DESCRIPTION
>「[幻影騎士団ダーク・ガントレット](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12268)」は墓地にて発動した自身の効果によって、モンスターゾーンに効果モンスター扱いとして特殊召喚される事になりますが、墓地では罠カードとしてしか扱われません。
したがって、墓地からモンスターが特殊召喚された扱いにはならず、……
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18430&keyword=&tag=-1&request_locale=ja

Trap monsters are always "monsters SS not from the GY"