### PR TITLE
Better Checks For Same & Different Attribute / Race

### DIFF
--- a/c11738489.lua
+++ b/c11738489.lua
@@ -3,7 +3,7 @@ function c11738489.initial_effect(c)
 	c:SetUniqueOnField(1,0,11738489)
 	--link summon
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,nil,3,6,c11738489.lcheck)
+	aux.AddLinkProcedure(c,nil,3,6,aux.DifferentLinkAttribute)
 	--base atk
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -28,9 +28,6 @@ function c11738489.initial_effect(c)
 	e3:SetTarget(c11738489.destg)
 	e3:SetOperation(c11738489.desop)
 	c:RegisterEffect(e3)
-end
-function c11738489.lcheck(g)
-	return g:GetClassCount(Card.GetLinkAttribute)==g:GetCount()
 end
 function c11738489.matcheck(e,c)
 	local ct=c:GetMaterialCount()

--- a/c21105106.lua
+++ b/c21105106.lua
@@ -34,6 +34,9 @@ end
 function c21105106.mat_filter(c,tp)
 	return c:IsLocation(LOCATION_MZONE) and c:IsControler(tp)
 end
+function c21105106.mat_group_check(g)
+	return #g==3 and aux.DifferentRace(g)
+end
 function c21105106.discon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1
 end
@@ -92,7 +95,4 @@ end
 function c21105106.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,aux.ExceptThisCard(e))
 	Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
-end
-function c21105106.mat_group_check(g)
-	return #g==3 and g:GetClassCount(Card.GetRace)==3
 end

--- a/c27069566.lua
+++ b/c27069566.lua
@@ -59,8 +59,7 @@ function c27069566.spfilter(c,e,tp)
 	return c:IsSetCard(0x14e) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c27069566.fselect(g)
-	return g:GetClassCount(Card.GetRace)==1
-		and g:GetClassCount(Card.GetAttribute)==1
+	return aux.SameRace(g) and aux.SameAttribute(g)
 end
 function c27069566.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c28617139.lua
+++ b/c28617139.lua
@@ -33,12 +33,11 @@ function c28617139.thfilter(c)
 end
 function c28617139.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c28617139.thfilter,tp,LOCATION_DECK,0,nil)
-	if chk==0 then return g:GetClassCount(Card.GetAttribute)>=2 end
+	if chk==0 then return g:CheckSubGroup(aux.dabcheck,2,2) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,2,tp,LOCATION_DECK)
 end
 function c28617139.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c28617139.thfilter,tp,LOCATION_DECK,0,nil)
-	if g:GetClassCount(Card.GetAttribute)<2 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local sg=g:SelectSubGroup(tp,aux.dabcheck,false,2,2)
 	Duel.SendtoHand(sg,nil,REASON_EFFECT)

--- a/c28776350.lua
+++ b/c28776350.lua
@@ -1,7 +1,7 @@
 --アカシック・マジシャン
 function c28776350.initial_effect(c)
 	--link summon
-	aux.AddLinkProcedure(c,aux.NOT(aux.FilterBoolFunction(Card.IsLinkType,TYPE_TOKEN)),2,2,c28776350.lcheck)
+	aux.AddLinkProcedure(c,aux.NOT(aux.FilterBoolFunction(Card.IsLinkType,TYPE_TOKEN)),2,2,aux.SameLinkRace)
 	c:EnableReviveLimit()
 	--splimit
 	local e1=Effect.CreateEffect(c)
@@ -31,9 +31,6 @@ function c28776350.initial_effect(c)
 	e3:SetTarget(c28776350.actg)
 	e3:SetOperation(c28776350.acop)
 	c:RegisterEffect(e3)
-end
-function c28776350.lcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==1
 end
 function c28776350.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_LINK)==SUMMON_TYPE_LINK

--- a/c29981935.lua
+++ b/c29981935.lua
@@ -35,7 +35,7 @@ function c29981935.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local g=Duel.GetMatchingGroup(c29981935.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
 		return Duel.GetMZoneCount(tp,e:GetHandler())>=2 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
-			and g:GetClassCount(Card.GetRace)>=2
+			and g:CheckSubGroup(aux.drccheck,2,2)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
 end

--- a/c30163008.lua
+++ b/c30163008.lua
@@ -1,7 +1,7 @@
 --Ra'ten, the Heavenly General
 function c30163008.initial_effect(c)
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,nil,2,nil,c30163008.lcheck)
+	aux.AddLinkProcedure(c,nil,2,nil,aux.SameLinkRace)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -24,9 +24,6 @@ function c30163008.initial_effect(c)
 	e2:SetTarget(c30163008.destg)
 	e2:SetOperation(c30163008.desop)
 	c:RegisterEffect(e2)
-end
-function c30163008.lcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==1
 end
 function c30163008.cfilter(c,e,tp,lg,zone)
 	return c:IsFaceup() and lg:IsContains(c)

--- a/c32965616.lua
+++ b/c32965616.lua
@@ -44,11 +44,11 @@ function c32965616.spcon(e,c)
 	local tp=c:GetControler()
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then return end
 	local g=Duel.GetMatchingGroup(Card.IsType,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil,TYPE_MONSTER)
-	return g:GetClassCount(Card.GetAttribute)>=6
+	return g:GetBinClassCount(Card.GetAttribute)>=6
 end
 function c32965616.atkval(e,c)
 	local g=Duel.GetMatchingGroup(Card.IsType,e:GetHandlerPlayer(),LOCATION_GRAVE,LOCATION_GRAVE,nil,TYPE_MONSTER)
-	return g:GetClassCount(Card.GetAttribute)*500
+	return g:GetBinClassCount(Card.GetAttribute)*500
 end
 function c32965616.discon(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=ep and Duel.GetCurrentChain()==0

--- a/c33212663.lua
+++ b/c33212663.lua
@@ -34,7 +34,7 @@ function c33212663.sprfilter(c)
 	return (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE)) and c:IsAbleToRemoveAsCost() and c:IsType(TYPE_MONSTER)
 end
 function c33212663.fselect(g,tp)
-	return Duel.GetMZoneCount(tp,g)>0 and g:GetClassCount(Card.GetRace)==#g
+	return Duel.GetMZoneCount(tp,g)>0 and aux.DifferentRace(g)
 end
 function c33212663.sprcon(e,c)
 	if c==nil then return true end

--- a/c41659072.lua
+++ b/c41659072.lua
@@ -1,7 +1,7 @@
 --熾天龍 ジャッジメント
 function c41659072.initial_effect(c)
 	--synchro summon
-	aux.AddSynchroMixProcedure(c,aux.Tuner(nil),nil,nil,aux.NonTuner(nil),1,99,c41659072.syncheck)
+	aux.AddSynchroMixProcedure(c,aux.Tuner(nil),nil,nil,aux.NonTuner(nil),1,99,aux.SameAttribute)
 	c:EnableReviveLimit()
 	--spsummon condition
 	local e1=Effect.CreateEffect(c)
@@ -34,15 +34,6 @@ function c41659072.initial_effect(c)
 	e3:SetTarget(c41659072.target2)
 	e3:SetOperation(c41659072.operation2)
 	c:RegisterEffect(e3)
-end
-function c41659072.syncheck(g)
-	local sg=g:Clone()
-	local attr=ATTRIBUTE_ALL
-	for c in aux.Next(sg) do
-		attr=attr&c:GetAttribute()
-		if attr==0 then break end
-	end
-	return attr~=0
 end
 function c41659072.sumlimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_SYNCHRO)~=SUMMON_TYPE_SYNCHRO or not se

--- a/c43577607.lua
+++ b/c43577607.lua
@@ -70,7 +70,7 @@ function c43577607.confilter(c)
 end
 function c43577607.effcon(e)
 	local g=Duel.GetMatchingGroup(c43577607.confilter,e:GetHandlerPlayer(),LOCATION_GRAVE,0,nil)
-	return g:GetClassCount(Card.GetAttribute)>=e:GetLabel()
+	return g:GetBinClassCount(Card.GetAttribute)>=e:GetLabel()
 end
 function c43577607.atktg(e,c)
 	return c:IsSetCard(0x9e)

--- a/c45877457.lua
+++ b/c45877457.lua
@@ -51,7 +51,7 @@ function c45877457.initial_effect(c)
 end
 function c45877457.atkval(e,c)
 	local g=Duel.GetMatchingGroup(Card.IsType,c:GetControler(),LOCATION_GRAVE,0,nil,TYPE_MONSTER)
-	return g:GetClassCount(Card.GetAttribute)*300
+	return g:GetBinClassCount(Card.GetAttribute)*300
 end
 function c45877457.matcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_RITUAL) and e:GetLabel()==1
@@ -65,7 +65,7 @@ end
 function c45877457.valcheck(e,c)
 	local mg=c:GetMaterial()
 	local fg=mg:Filter(c45877457.attfilter,nil)
-	if fg:GetClassCount(Card.GetAttribute)>1 then
+	if fg:GetBinClassCount(Card.GetAttribute)>1 then
 		e:GetLabelObject():SetLabel(1)
 	else
 		e:GetLabelObject():SetLabel(0)

--- a/c46935289.lua
+++ b/c46935289.lua
@@ -31,7 +31,7 @@ function c46935289.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c46935289.lcheck(g,lc)
-	return g:GetClassCount(Card.GetLinkAttribute)==1 and g:GetClassCount(Card.GetLinkRace)==1
+	return aux.SameLinkAttribute(g) and aux.SameLinkRace(g)
 end
 function c46935289.discon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)

--- a/c49922726.lua
+++ b/c49922726.lua
@@ -27,7 +27,7 @@ end
 function c49922726.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetMatchingGroup(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)
-	local val=g:GetClassCount(Card.GetRace)*100
+	local val=g:GetClassBinCount(Card.GetRace)*100
 	if c:IsFaceup() and c:IsRelateToEffect(e) and val>0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c49922726.lua
+++ b/c49922726.lua
@@ -27,7 +27,7 @@ end
 function c49922726.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetMatchingGroup(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)
-	local val=g:GetClassBinCount(Card.GetRace)*100
+	local val=g:GetBinClassCount(Card.GetRace)*100
 	if c:IsFaceup() and c:IsRelateToEffect(e) and val>0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c52331012.lua
+++ b/c52331012.lua
@@ -91,7 +91,7 @@ function c52331012.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c52331012.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetMatchingGroup(c52331012.atkfilter,tp,LOCATION_MZONE,0,nil)
-	local ct=tg:GetClassCount(Card.GetRace)
+	local ct=tg:GetBinClassCount(Card.GetRace)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
 	local tc=g:GetFirst()
 	while tc do

--- a/c55553602.lua
+++ b/c55553602.lua
@@ -29,7 +29,7 @@ function c55553602.atkfilter(c)
 end
 function c55553602.atkvalue(e,c)
 	local g=Duel.GetMatchingGroup(c55553602.atkfilter,c:GetControler(),LOCATION_MZONE,0,nil)
-	local ct=g:GetClassCount(Card.GetRace)
+	local ct=g:GetBinClassCount(Card.GetRace)
 	return ct*200
 end
 function c55553602.confilter(c)
@@ -37,7 +37,7 @@ function c55553602.confilter(c)
 end
 function c55553602.condition(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c55553602.confilter,tp,LOCATION_MZONE,0,nil)
-	local ct=g:GetClassCount(Card.GetRace)
+	local ct=g:GetBinClassCount(Card.GetRace)
 	return ct==4
 end
 function c55553602.spfilter(c,e,sp)

--- a/c5611760.lua
+++ b/c5611760.lua
@@ -28,7 +28,7 @@ function c5611760.filter(c)
 end
 function c5611760.condition(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c5611760.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	return Duel.GetFlagEffect(tp,5611760)==0 and g:GetClassCount(Card.GetRace)>=2
+	return Duel.GetFlagEffect(tp,5611760)==0 and g:CheckSubGroup(aux.DifferentRace,2,2)
 end
 function c5611760.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c57282724.lua
+++ b/c57282724.lua
@@ -66,7 +66,7 @@ function c57282724.imfilter(e,te)
 end
 function c57282724.valcheck(e,c)
 	local g=c:GetMaterial()
-	if #g==3 and g:GetClassCount(Card.GetRace)==3 and g:GetClassCount(Card.GetAttribute)==3 then
+	if #g==3 and aux.DifferentLinkRace(g) and aux.DifferentLinkAttribute(g) then
 		e:GetLabelObject():SetLabel(1)
 	else
 		e:GetLabelObject():SetLabel(0)

--- a/c58116537.lua
+++ b/c58116537.lua
@@ -40,7 +40,7 @@ end
 function c58116537.actcon(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,0)
 	local sg=g:Filter(c58116537.cfilter,nil)
-	return sg and sg:GetClassCount(Card.GetAttribute)>=2
+	return sg and sg:GetBinClassCount(Card.GetAttribute)>=2
 end
 function c58116537.acttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)

--- a/c61245672.lua
+++ b/c61245672.lua
@@ -2,7 +2,7 @@
 function c61245672.initial_effect(c)
 	--link summon
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkRace,RACE_CYBERSE),2,3,c61245672.lcheck)
+	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkRace,RACE_CYBERSE),2,3,aux.DifferentLinkAttribute)
 	--atk
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -24,9 +24,6 @@ function c61245672.initial_effect(c)
 	e2:SetTarget(c61245672.drtg)
 	e2:SetOperation(c61245672.drop)
 	c:RegisterEffect(e2)
-end
-function c61245672.lcheck(g)
-	return g:GetClassCount(Card.GetLinkAttribute)==g:GetCount()
 end
 function c61245672.atkval(e,c)
 	return c:GetLinkedGroupCount()*500

--- a/c61557074.lua
+++ b/c61557074.lua
@@ -38,7 +38,7 @@ function c61557074.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c61557074.atkval(e,c)
-	return Duel.GetMatchingGroup(Card.IsType,e:GetHandlerPlayer(),LOCATION_GRAVE,0,nil,TYPE_MONSTER):GetClassCount(Card.GetAttribute)*200
+	return Duel.GetMatchingGroup(Card.IsType,e:GetHandlerPlayer(),LOCATION_GRAVE,0,nil,TYPE_MONSTER):GetBinClassCount(Card.GetAttribute)*200
 end
 function c61557074.thfilter(c)
 	return c:IsSetCard(0x400d) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()

--- a/c61641818.lua
+++ b/c61641818.lua
@@ -31,7 +31,7 @@ function c61641818.mfilter(c,xyzc)
 	return c:IsXyzType(TYPE_MONSTER) and c:IsXyzLevel(xyzc,3)
 end
 function c61641818.xyzcheck(g)
-	return g:GetClassCount(Card.GetRace)==1 and g:GetClassCount(Card.GetAttribute)==1
+	return aux.SameRace(g) and aux.SameAttribute(g)
 end
 function c61641818.etcon(e)
 	return e:GetHandler():GetOverlayCount()~=0

--- a/c61641818.lua
+++ b/c61641818.lua
@@ -1,7 +1,7 @@
 --電脳堺龍－龍々
 function c61641818.initial_effect(c)
 	--xyz summon
-	aux.AddXyzProcedureLevelFree(c,c61641818.mfilter,c61641818.xyzcheck,2,99)
+	aux.AddXyzProcedureLevelFree(c,c61641818.mfilter,aux.AND(aux.SameRace,aux.SameAttribute),2,99)
 	c:EnableReviveLimit()
 	--cannot be effect target
 	local e1=Effect.CreateEffect(c)
@@ -29,9 +29,6 @@ function c61641818.initial_effect(c)
 end
 function c61641818.mfilter(c,xyzc)
 	return c:IsXyzType(TYPE_MONSTER) and c:IsXyzLevel(xyzc,3)
-end
-function c61641818.xyzcheck(g)
-	return aux.SameRace(g) and aux.SameAttribute(g)
 end
 function c61641818.etcon(e)
 	return e:GetHandler():GetOverlayCount()~=0

--- a/c61665245.lua
+++ b/c61665245.lua
@@ -1,7 +1,7 @@
 --サモン・ソーサレス
 function c61665245.initial_effect(c)
 	--link summon
-	aux.AddLinkProcedure(c,aux.NOT(aux.FilterBoolFunction(Card.IsLinkType,TYPE_TOKEN)),2,99,c61665245.lcheck)
+	aux.AddLinkProcedure(c,aux.NOT(aux.FilterBoolFunction(Card.IsLinkType,TYPE_TOKEN)),2,99,aux.SameLinkRace)
 	c:EnableReviveLimit()
 	--special summon
 	local e1=Effect.CreateEffect(c)
@@ -25,9 +25,6 @@ function c61665245.initial_effect(c)
 	e2:SetTarget(c61665245.sptg2)
 	e2:SetOperation(c61665245.spop2)
 	c:RegisterEffect(e2)
-end
-function c61665245.lcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==1
 end
 function c61665245.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)

--- a/c6357341.lua
+++ b/c6357341.lua
@@ -14,7 +14,7 @@ function c6357341.filter(c)
 end
 function c6357341.condition(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c6357341.filter,tp,LOCATION_MZONE,0,nil)
-	return g:GetClassCount(Card.GetAttribute)==6
+	return #g==6 and aux.DifferentAttribute(g)
 end
 function c6357341.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(1-tp,EFFECT_SKIP_TURN) end

--- a/c66023650.lua
+++ b/c66023650.lua
@@ -2,7 +2,7 @@
 function c66023650.initial_effect(c)
 	--link summon
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,nil,3,3,c66023650.lcheck)
+	aux.AddLinkProcedure(c,nil,3,3,aux.DifferentLinkRace)
 	--cannot link material
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -41,9 +41,6 @@ function c66023650.initial_effect(c)
 	e4:SetTarget(c66023650.drtg)
 	e4:SetOperation(c66023650.drop)
 	c:RegisterEffect(e4)
-end
-function c66023650.lcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==g:GetCount()
 end
 function c66023650.valcheck(e,c)
 	local g=c:GetMaterial()

--- a/c6728559.lua
+++ b/c6728559.lua
@@ -34,7 +34,7 @@ function c6728559.sprfilter(c)
 	return (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE)) and c:IsAbleToRemoveAsCost() and c:IsType(TYPE_MONSTER)
 end
 function c6728559.fselect(g,tp)
-	return Duel.GetMZoneCount(tp,g)>0 and g:GetClassCount(Card.GetAttribute)==#g
+	return Duel.GetMZoneCount(tp,g)>0 and aux.DifferentAttribute(g)
 end
 function c6728559.sprcon(e,c)
 	if c==nil then return true end

--- a/c69522668.lua
+++ b/c69522668.lua
@@ -64,7 +64,7 @@ end
 function c69522668.valcheck(e,c)
 	local mg=c:GetMaterial()
 	local fg=mg:Filter(c69522668.attfilter,nil,c)
-	if fg:GetClassCount(Card.GetAttribute)>=2 then
+	if fg:GetBinClassCount(Card.GetAttribute)>=2 then
 		e:GetLabelObject():SetLabel(1)
 	else
 		e:GetLabelObject():SetLabel(0)

--- a/c71159974.lua
+++ b/c71159974.lua
@@ -68,7 +68,7 @@ end
 function c71159974.valcheck(e,c)
 	local mg=c:GetMaterial()
 	local fg=mg:Filter(c71159974.attfilter,nil,c)
-	if fg:GetClassCount(Card.GetAttribute)==2 then
+	if fg:GetBinClassCount(Card.GetAttribute)==2 then
 		e:GetLabelObject():SetLabel(1)
 	else
 		e:GetLabelObject():SetLabel(0)

--- a/c72218246.lua
+++ b/c72218246.lua
@@ -2,7 +2,7 @@
 function c72218246.initial_effect(c)
 	--link summon
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,nil,2,2,c72218246.lcheck)
+	aux.AddLinkProcedure(c,nil,2,2,aux.DifferentLinkRace)
 	--spsummon1
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(72218246,0))
@@ -31,9 +31,6 @@ function c72218246.initial_effect(c)
 	e2:SetTarget(c72218246.sptg2)
 	e2:SetOperation(c72218246.spop2)
 	c:RegisterEffect(e2)
-end
-function c72218246.lcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==g:GetCount()
 end
 function c72218246.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2

--- a/c74689476.lua
+++ b/c74689476.lua
@@ -2,7 +2,7 @@
 function c74689476.initial_effect(c)
 	--xyz summon
 	c:EnableReviveLimit()
-	aux.AddXyzProcedureLevelFree(c,c74689476.mfilter,c74689476.xyzcheck,2,2)
+	aux.AddXyzProcedureLevelFree(c,c74689476.mfilter,aux.DifferentAttribute,2,2)
 	--special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(74689476,0))
@@ -29,9 +29,6 @@ function c74689476.initial_effect(c)
 end
 function c74689476.mfilter(c,xyzc)
 	return c:IsXyzType(TYPE_MONSTER) and c:IsXyzLevel(xyzc,4) and c:IsRace(RACE_SPELLCASTER)
-end
-function c74689476.xyzcheck(g)
-	return g:GetClassCount(Card.GetAttribute)==#g
 end
 function c74689476.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/c77610772.lua
+++ b/c77610772.lua
@@ -41,7 +41,7 @@ function c77610772.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c77610772.lcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==g:GetCount() and g:GetClassCount(Card.GetLinkAttribute)==g:GetCount()
+	return aux.DifferentLinkRace(g) and aux.DifferentLinkAttribute(g)
 end
 function c77610772.incon(e)
 	return e:GetHandler():IsLinkState()

--- a/c78348934.lua
+++ b/c78348934.lua
@@ -26,9 +26,6 @@ end
 function c78348934.filter1(c,e)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemove() and c:IsCanBeEffectTarget(e)
 end
-function c78348934.fselect(g)
-	return g:GetClassCount(Card.GetRace)==1
-end
 function c78348934.filter3(c)
 	return c:IsFaceup() and c:IsSetCard(0xd6,0xd7)
 end
@@ -38,7 +35,7 @@ function c78348934.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and Duel.IsExistingMatchingCard(c78348934.filter3,tp,LOCATION_MZONE,0,1,nil) end
 	local g=Duel.GetMatchingGroup(c78348934.filter1,tp,0,LOCATION_GRAVE,nil,e)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local sg=g:SelectSubGroup(tp,c78348934.fselect,false,1,3)
+	local sg=g:SelectSubGroup(tp,aux.SameRace,false,1,3)
 	Duel.SetTargetCard(sg)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,sg,#sg,0,0)
 end

--- a/c79266769.lua
+++ b/c79266769.lua
@@ -16,8 +16,7 @@ function c79266769.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c79266769.spcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==1
-		and g:GetClassCount(Card.GetLinkAttribute)==1
+	return aux.SameLinkRace(g) and aux.SameLinkAttribute(g)
 end
 function c79266769.filter(c,e,tp,zone)
 	return (c:IsFaceup() or not c:IsLocation(LOCATION_REMOVED)) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE,tp,zone)

--- a/c82386016.lua
+++ b/c82386016.lua
@@ -42,7 +42,7 @@ function c82386016.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c82386016.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c82386016.filter,tp,LOCATION_MZONE,0,nil)
-	local ct=g:GetClassCount(Card.GetRace)
+	local ct=g:GetBinClassCount(Card.GetRace)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	Duel.Draw(p,ct,REASON_EFFECT)
 end

--- a/c82386016.lua
+++ b/c82386016.lua
@@ -29,20 +29,25 @@ end
 function c82386016.aclimit(e,re,tp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP)
 end
-function c82386016.filter(c)
-	return c:IsFaceup() and c:IsRace(RACE_BEAST+RACE_BEASTWARRIOR+RACE_WINDBEAST)
+function c82386016.drct(tp)
+	local ct=0
+	if Duel.IsExistingMatchingCard(c82386016.filter,tp,LOCATION_MZONE,0,1,nil,RACE_BEAST) then ct=ct+1 end
+	if Duel.IsExistingMatchingCard(c82386016.filter,tp,LOCATION_MZONE,0,1,nil,RACE_BEASTWARRIOR) then ct=ct+1 end
+	if Duel.IsExistingMatchingCard(c82386016.filter,tp,LOCATION_MZONE,0,1,nil,RACE_WINDBEAST) then ct=ct+1 end
+	return ct
+end
+function c82386016.filter(c,race)
+	return c:IsFaceup() and c:IsRace(race)
 end
 function c82386016.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local g=Duel.GetMatchingGroup(c82386016.filter,tp,LOCATION_MZONE,0,nil)
-	local ct=g:GetClassCount(Card.GetRace)
+	local ct=c82386016.drct(tp)
 	if chk==0 then return ct>0 and Duel.IsPlayerCanDraw(tp,ct) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(ct)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,ct)
 end
 function c82386016.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c82386016.filter,tp,LOCATION_MZONE,0,nil)
-	local ct=g:GetBinClassCount(Card.GetRace)
+	local ct=c82386016.drct(tp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	Duel.Draw(p,ct,REASON_EFFECT)
 end

--- a/c8728498.lua
+++ b/c8728498.lua
@@ -3,7 +3,7 @@ local s,id,o=GetID()
 function s.initial_effect(c)
 	--link summon
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,nil,2,2,s.lcheck)
+	aux.AddLinkProcedure(c,nil,2,2,aux.DifferentLinkRace)
 	--destroy
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
@@ -26,9 +26,6 @@ function s.initial_effect(c)
 	e2:SetTarget(s.sptg)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
-end
-function s.lcheck(g,lc)
-	return g:GetClassCount(Card.GetLinkRace)==g:GetCount()
 end
 function s.desfilter(c)
 	return c:IsSetCard(0x114) and c:IsFaceup()

--- a/c90969892.lua
+++ b/c90969892.lua
@@ -14,21 +14,25 @@ function c90969892.filter(c,e,tp,race)
 	return c:IsType(TYPE_MONSTER) and (c:IsAbleToHand() or c:IsCanBeSpecialSummoned(e,0,tp,false,false)) and c:IsRace(race)
 end
 function c90969892.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local mg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
-	local ct1=mg:GetClassCount(Card.GetRace)
-	local mc=mg:GetFirst()
-	local mrc=0
-	while mc do
-		mrc=mrc|mc:GetRace()
-		mc=mg:GetNext()
+	if chk==0 then
+		local mg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
+		local ct1=mg:GetBinClassCount(Card.GetRace)
+		if ct1<3 then return false end
+		local mc=mg:GetFirst()
+		local mrc=0
+		while mc do
+			mrc=mrc|mc:GetRace()
+			mc=mg:GetNext()
+		end
+		local g=Duel.GetMatchingGroup(c90969892.filter,tp,LOCATION_DECK,0,nil,e,tp,mrc)
+		local ct2=g:GetBinClassCount(Card.GetRace)
+		return ct2>=3 and g:CheckSubGroup(aux.drccheck,3,3)
 	end
-	local g=Duel.GetMatchingGroup(c90969892.filter,tp,LOCATION_DECK,0,nil,e,tp,mrc)
-	local ct2=g:GetClassCount(Card.GetRace)
-	if chk==0 then return ct1>=3 and ct2>=3 and g:CheckSubGroup(aux.drccheck,3,3) end
 end
 function c90969892.operation(e,tp,eg,ep,ev,re,r,rp)
 	local mg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
-	local ct1=mg:GetClassCount(Card.GetRace)
+	local ct1=mg:GetBinClassCount(Card.GetRace)
+	if ct1<3 then return end
 	local mc=mg:GetFirst()
 	local mrc=0
 	while mc do
@@ -36,8 +40,8 @@ function c90969892.operation(e,tp,eg,ep,ev,re,r,rp)
 		mc=mg:GetNext()
 	end
 	local g=Duel.GetMatchingGroup(c90969892.filter,tp,LOCATION_DECK,0,nil,e,tp,mrc)
-	local ct2=g:GetClassCount(Card.GetRace)
-	if ct1<3 or ct2<3 then return end
+	local ct2=g:GetBinClassCount(Card.GetRace)
+	if ct2<3 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
 	local sg=g:SelectSubGroup(tp,aux.drccheck,false,3,3)
 	if sg then

--- a/c97973962.lua
+++ b/c97973962.lua
@@ -30,7 +30,7 @@ function c97973962.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c97973962.spcheck(g)
-	return g:GetClassCount(Card.GetLinkRace)==g:GetCount() and g:GetClassCount(Card.GetLinkAttribute)==g:GetCount()
+	return aux.DifferentLinkRace(g) and aux.DifferentLinkAttribute(g)
 end
 function c97973962.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(Card.IsSummonType,1,nil,SUMMON_TYPE_FUSION)

--- a/c98095162.lua
+++ b/c98095162.lua
@@ -40,7 +40,7 @@ function c98095162.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c98095162.lcheck(g)
-	return g:GetClassCount(Card.GetLinkAttribute)==1 and g:GetClassCount(Card.GetLinkRace)==g:GetCount()
+	return aux.SameLinkAttribute(g) and aux.DifferentLinkRace(g)
 end
 function c98095162.tgcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)

--- a/c98672567.lua
+++ b/c98672567.lua
@@ -33,7 +33,7 @@ function c98672567.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then
 		if not Duel.IsPlayerCanDraw(tp,2) then return false end
 		local g=Duel.GetMatchingGroup(c98672567.filter,tp,LOCATION_GRAVE,0,nil,e)
-		return g:GetClassCount(Card.GetRace)>=3
+		return g:CheckSubGroup(aux.drccheck,3,3)
 	end
 	local g=Duel.GetMatchingGroup(c98672567.filter,tp,LOCATION_GRAVE,0,nil,e)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)

--- a/utility.lua
+++ b/utility.lua
@@ -2705,7 +2705,7 @@ end
 function Auxiliary.DifferentLinkRace(g)
 	return Auxiliary.DifferentBin(g,Card.GetLinkRace)
 end
-function Auxiliary.drccheck=Auxiliary.DifferentRace
+Auxiliary.drccheck=Auxiliary.DifferentRace
 --check for group with 2 cards, each card match f with a1/a2 as argument
 function Auxiliary.gfcheck(g,f,a1,a2)
 	if #g~=2 then return false end

--- a/utility.lua
+++ b/utility.lua
@@ -2688,22 +2688,22 @@ end
 function Auxiliary.DifferentAttribute(g)
 	return Auxiliary.DifferentBin(g,Card.GetAttribute)
 end
-function Auxiliary.DifferentFusionAttribute(g,tp)
-	return Auxiliary.DifferentBin(g,Card.GetFusionAttribute,tp)
+function Auxiliary.DifferentFusionAttribute(g)
+	return Auxiliary.DifferentBin(g,Card.GetFusionAttribute)
 end
-function Auxiliary.DifferentLinkAttribute(g,tp)
-	return Auxiliary.DifferentBin(g,Card.GetLinkAttribute,tp)
+function Auxiliary.DifferentLinkAttribute(g)
+	return Auxiliary.DifferentBin(g,Card.GetLinkAttribute)
 end
 Auxiliary.dabcheck=Auxiliary.DifferentAttribute
 --check for cards with different races
 function Auxiliary.DifferentRace(g)
 	return Auxiliary.DifferentBin(g,Card.GetRace)
 end
-function Auxiliary.DifferentFusionRace(g,tp)
-	return Auxiliary.DifferentBin(g,Card.GetFusionRace,tp)
+function Auxiliary.DifferentFusionRace(g)
+	return Auxiliary.DifferentBin(g,Card.GetFusionRace)
 end
-function Auxiliary.DifferentLinkRace(g,tp)
-	return Auxiliary.DifferentBin(g,Card.GetLinkRace,tp)
+function Auxiliary.DifferentLinkRace(g)
+	return Auxiliary.DifferentBin(g,Card.GetLinkRace)
 end
 function Auxiliary.drccheck=Auxiliary.DifferentRace
 --check for group with 2 cards, each card match f with a1/a2 as argument

--- a/utility.lua
+++ b/utility.lua
@@ -2435,7 +2435,7 @@ function Auxiliary.qlifilter(e,te)
 	if te:IsActiveType(TYPE_MONSTER) and te:IsActivated() then
 		local lv=e:GetHandler():GetLevel()
 		local ec=te:GetOwner()
-		if ec:IsType(TYPE_LINK) then
+		if ec:IsStatus(STATUS_NO_LEVEL) or ec:IsType(TYPE_LINK) then
 			return false
 		elseif ec:IsType(TYPE_XYZ) then
 			return ec:GetOriginalRank()<lv
@@ -2656,14 +2656,56 @@ end
 function Auxiliary.dlkcheck(g)
 	return g:GetClassCount(Card.GetLink)==#g
 end
+--check for cards with different attribute or race
+function Auxiliary.DifferentBin(g,getter,...)
+	local value=getter(g:GetFirst(),...)
+	local tc=g:GetNext()
+	while tc do
+		local value2=getter(tc,...)
+		if value&value2>0 then
+			return false
+		end
+		value=value|value2
+		tc=g:GetNext()
+	end
+	return true
+end
+--check for cards with same attribute or race
+function Auxiliaty.SameBin(g,getter,...)
+	local value=getter(g:GetFirst(),...)
+	local tc=g:GetNext()
+	while tc do
+		local value2=getter(tc,...)
+		value=value&value2
+		if value==0 then
+			return false
+		end
+		tc=g:GetNext()
+	end
+	return true
+end
 --check for cards with different attributes
-function Auxiliary.dabcheck(g)
-	return g:GetClassCount(Card.GetAttribute)==#g
+function Auxiliary.DifferentAttribute(g)
+	return Auxiliary.DifferentBin(g,Card.GetAttribute)
 end
+function Auxiliary.DifferentFusionAttribute(g,tp)
+	return Auxiliary.DifferentBin(g,Card.GetFusionAttribute,tp)
+end
+function Auxiliary.DifferentLinkAttribute(g,tp)
+	return Auxiliary.DifferentBin(g,Card.GetLinkAttribute,tp)
+end
+Auxiliary.dabcheck=Auxiliary.DifferentAttribute
 --check for cards with different races
-function Auxiliary.drccheck(g)
-	return g:GetClassCount(Card.GetRace)==#g
+function Auxiliary.DifferentRace(g)
+	return Auxiliary.DifferentBin(g,Card.GetRace)
 end
+function Auxiliary.DifferentFusionRace(g,tp)
+	return Auxiliary.DifferentBin(g,Card.GetFusionRace,tp)
+end
+function Auxiliary.DifferentLinkRace(g,tp)
+	return Auxiliary.DifferentBin(g,Card.GetLinkRace,tp)
+end
+function Auxiliary.drccheck=Auxiliary.DifferentRace
 --check for group with 2 cards, each card match f with a1/a2 as argument
 function Auxiliary.gfcheck(g,f,a1,a2)
 	if #g~=2 then return false end

--- a/utility.lua
+++ b/utility.lua
@@ -2697,6 +2697,16 @@ function Auxiliary.DifferentLinkAttribute(g)
 	return Auxiliary.DifferentBin(g,Card.GetLinkAttribute)
 end
 Auxiliary.dabcheck=Auxiliary.DifferentAttribute
+--check for cards with same attribute
+function Auxiliary.SameAttribute(g)
+	return Auxiliary.SameBin(g,Card.GetAttribute)
+end
+function Auxiliary.SameFusionAttribute(g)
+	return Auxiliary.SameBin(g,Card.GetFusionAttribute)
+end
+function Auxiliary.SameLinkAttribute(g)
+	return Auxiliary.SameBin(g,Card.GetLinkAttribute)
+end
 --check for cards with different races
 function Auxiliary.DifferentRace(g)
 	return Auxiliary.DifferentBin(g,Card.GetRace)
@@ -2708,6 +2718,16 @@ function Auxiliary.DifferentLinkRace(g)
 	return Auxiliary.DifferentBin(g,Card.GetLinkRace)
 end
 Auxiliary.drccheck=Auxiliary.DifferentRace
+--check for cards with same race
+function Auxiliary.SameRace(g)
+	return Auxiliary.SameBin(g,Card.GetRace)
+end
+function Auxiliary.SameFusionRace(g)
+	return Auxiliary.SameBin(g,Card.GetFusionRace)
+end
+function Auxiliary.SameLinkRace(g)
+	return Auxiliary.SameBin(g,Card.GetLinkRace)
+end
 --check for group with 2 cards, each card match f with a1/a2 as argument
 function Auxiliary.gfcheck(g,f,a1,a2)
 	if #g~=2 then return false end

--- a/utility.lua
+++ b/utility.lua
@@ -2658,6 +2658,7 @@ function Auxiliary.dlkcheck(g)
 end
 --check for cards with different attribute or race
 function Auxiliary.DifferentBin(g,getter,...)
+	if #g<=1 then return true end
 	local value=getter(g:GetFirst(),...)
 	local tc=g:GetNext()
 	while tc do
@@ -2672,6 +2673,7 @@ function Auxiliary.DifferentBin(g,getter,...)
 end
 --check for cards with same attribute or race
 function Auxiliaty.SameBin(g,getter,...)
+	if #g<=1 then return true end
 	local value=getter(g:GetFirst(),...)
 	local tc=g:GetNext()
 	while tc do


### PR DESCRIPTION
### Before
A LIGHT+DARK monster and a LIGHT monster are:
- never considered to be different attributes for the purpose of fusion material.
- always considered to be same attribute for the purpose of fusion material.
- **always considered to be different attributes for the purpose of link material.**
- **never considered to be same attribute for the purpose of link material.**

### After
A LIGHT+DARK monster and a LIGHT monster are:
- never considered to be different attributes for the purpose of fusion material.
- always considered to be same attribute for the purpose of fusion material.
- never considered to be different attributes for the purpose of link material. It's now consistant with fusion.
- always considered to be same attribute for the purpose of link material. It's now consistant with fusion.

<hr>

### Before

- A LIGHT+DARK monster, a LIGHT monster, and a DARK monster are sometimes counted as **three different attributes**.
- A LIGHT+EARTH+WATER+FIRE+EARTH monster is sometimes counted as **one different attribute**.

### After

- A LIGHT+DARK monster, a LIGHT monster, and a DARK monster are always counted as two different attributes.
- A LIGHT+EARTH+WATER+FIRE+EARTH monster is always counted as five different attributes.
