### PR TITLE
Update c6992184.lua

### DIFF
--- a/c6992184.lua
+++ b/c6992184.lua
@@ -79,7 +79,7 @@ function c6992184.activate(e,tp,eg,ep,ev,re,r,rp)
 	local sg=Group.CreateGroup()
 	local pop=aux.PendOperation()
 	pop(e,tp,eg,ep,ev,re,r,rp,lpz,sg,g)
-	Duel.SpecialSummon(sg,SUMMON_TYPE_PENDULUM,tp,tp,false,false,POS_FACEUP)
+	Duel.SpecialSummon(sg,SUMMON_TYPE_PENDULUM,tp,tp,true,true,POS_FACEUP)
 end
 function c6992184.retop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetFieldGroup(tp,LOCATION_PZONE,0)


### PR DESCRIPTION
Issue: May select pendulum ritual monsters from your hand, but nothing happens. They aren't pendulum summoned and they stay in your hand.

Workaround: Makes it ignore summon condition & ignore revive limit when it tries to actually special summon the monsters. You cannot still pendulum summon monsters you couldn't before, because they cannot be selected in aux.PendOperation().