### PR TITLE
fix Psychic Feel Zone

### DIFF
--- a/c11047543.lua
+++ b/c11047543.lua
@@ -41,8 +41,8 @@ function c11047543.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc2=g:GetNext()
 	if not tc1:IsRelateToEffect(e) or not tc2:IsRelateToEffect(e) then return end
 	local sg=Duel.GetMatchingGroup(c11047543.spfilter,tp,LOCATION_EXTRA,0,nil,e,tp,tc1:GetLevel()+tc2:GetLevel())
-	if sg:GetCount()==0 then return end
-	Duel.SendtoGrave(g,REASON_EFFECT+REASON_RETURN)
+	if sg:GetCount()==0 or Duel.SendtoGrave(g,REASON_EFFECT+REASON_RETURN)==0 then return end
+	Duel.BreakEffect()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local ssg=sg:Select(tp,1,1,nil)
 	Duel.SpecialSummon(ssg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)

--- a/c11047543.lua
+++ b/c11047543.lua
@@ -36,12 +36,12 @@ function c11047543.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c11047543.operation(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=Duel.GetTargetsRelateToChain()
+	if g:GetCount()~=2 or Duel.SendtoGrave(g,REASON_EFFECT+REASON_RETURN)==0 then return end
 	local tc1=g:GetFirst()
 	local tc2=g:GetNext()
-	if not tc1:IsRelateToEffect(e) or not tc2:IsRelateToEffect(e) then return end
 	local sg=Duel.GetMatchingGroup(c11047543.spfilter,tp,LOCATION_EXTRA,0,nil,e,tp,tc1:GetLevel()+tc2:GetLevel())
-	if sg:GetCount()==0 or Duel.SendtoGrave(g,REASON_EFFECT+REASON_RETURN)==0 then return end
+	if sg:GetCount()==0 then return end
 	Duel.BreakEffect()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local ssg=sg:Select(tp,1,1,nil)

--- a/c11047543.lua
+++ b/c11047543.lua
@@ -37,7 +37,7 @@ function c11047543.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c11047543.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetTargetsRelateToChain()
-	if g:GetCount()~=2 or Duel.SendtoGrave(g,REASON_EFFECT+REASON_RETURN)==0 then return end
+	if g:GetCount()~=2 or Duel.SendtoGrave(g,REASON_EFFECT+REASON_RETURN)~=2 then return end
 	local tc1=g:GetFirst()
 	local tc2=g:GetNext()
 	local sg=Duel.GetMatchingGroup(c11047543.spfilter,tp,LOCATION_EXTRA,0,nil,e,tp,tc1:GetLevel()+tc2:GetLevel())


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9527
> ■『ゲームから除外されている自分のサイキック族のチューナー１体とチューナー以外のサイキック族モンスター１体を墓地に戻し』の処理と、『そのレベルの合計と同じレベルのサイキック族のシンクロモンスター１体をエクストラデッキから表側守備表示で特殊召喚する』処理は**同時に行われる扱いではありません**。