### PR TITLE
fix Shooting Majestic Star Dragon

### DIFF
--- a/c40939228.lua
+++ b/c40939228.lua
@@ -107,19 +107,30 @@ function c40939228.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c40939228.negop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	local fid=c:GetFieldID()
 	if c:IsRelateToEffect(e) and Duel.Remove(c,0,REASON_EFFECT+REASON_TEMPORARY)~=0 and c:IsLocation(LOCATION_REMOVED) then
+		c:RegisterFlagEffect(40939228,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1,fid)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_END)
 		e1:SetReset(RESET_PHASE+PHASE_END)
+		e1:SetLabel(fid)
 		e1:SetLabelObject(c)
 		e1:SetCountLimit(1)
+		e1:SetCondition(c40939228.retcon)
 		e1:SetOperation(c40939228.retop)
 		Duel.RegisterEffect(e1,tp)
 		if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
 			Duel.Remove(eg,POS_FACEUP,REASON_EFFECT)
 		end
 	end
+end
+function c40939228.retcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:GetFlagEffectLabel(40939228)~=e:GetLabel() then
+		e:Reset()
+		return false
+	else return true end
 end
 function c40939228.retop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ReturnToField(e:GetLabelObject())


### PR DESCRIPTION
Fix: Activate its 3rd effect, summon it back with _Storm Dragon's Return_ or _Majestic Mirage_, activate its 3rd effect again, there will be 2 return effects in the end phase.