### PR TITLE
fix Garbage Collector

### DIFF
--- a/c11801343.lua
+++ b/c11801343.lua
@@ -14,7 +14,7 @@ function c11801343.initial_effect(c)
 end
 function c11801343.thfilter(c,e,tp)
 	return c:IsFaceup() and c:IsRace(RACE_CYBERSE) and c:IsAbleToHand()
-		and Duel.GetMZoneCount(tp,c)>0
+		and Duel.GetMZoneCount(tp,c)>0 and c:GetOriginalType()&TYPE_MONSTER>0 and not c:IsType(TYPE_TOKEN)
 		and Duel.IsExistingMatchingCard(c11801343.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp,c)
 end
 function c11801343.spfilter(c,e,tp,tc)
@@ -32,7 +32,7 @@ function c11801343.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c11801343.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND)
+	if tc:IsRelateToChain() and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c11801343.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,tc)


### PR DESCRIPTION
fix 1: if target monster was left from field, target monster return to hand.
fix 2: Garbage Collector can target token or trap monster.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13089&keyword=&tag=-1
> モンスタートークンは手札に戻す事ができず、『手札に戻ったモンスターと同じレベルでカード名が異なるサイバース族モンスター１体をデッキから特殊召喚する』処理を適用する事ができません。
> 
> したがって、**「セキュリティトークン」を対象として、「[ガベージコレクター](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13519)」のモンスター効果を発動する事はできません**。

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7727&keyword=&tag=-1
> 「[量子猫](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11432)」は自身の効果が適用された場合、フィールドではモンスターカードとしても扱われますが、手札に戻った際には罠カードとしてしか扱われず、『手札に戻ったモンスターと同じレベルでカード名が異なるサイバース族モンスター１体をデッキから特殊召喚する』処理を適用する事ができません。
> 
> したがって、**サイバース族として扱われている「[量子猫](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11432)」を対象として、「[ガベージコレクター](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13519)」のモンスター効果を発動する事はできません**。