### PR TITLE
fix 表側表示で存在するこのカードを戦闘で破壊

### DIFF
--- a/c33537328.lua
+++ b/c33537328.lua
@@ -36,7 +36,7 @@ function c33537328.sdcon(e)
 end
 function c33537328.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsReason(REASON_BATTLE) and c:GetBattlePosition()~=POS_FACEUP_DEFENSE
+	if chk==0 then return c:IsReason(REASON_BATTLE)
 		and Duel.CheckReleaseGroup(tp,Card.IsReleasableByEffect,1,c) end
 	if Duel.SelectEffectYesNo(tp,c,96) then
 		local g=Duel.SelectReleaseGroup(tp,Card.IsReleasableByEffect,1,1,c)

--- a/c3370104.lua
+++ b/c3370104.lua
@@ -44,7 +44,7 @@ function c3370104.disop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c3370104.condition(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsPreviousPosition(POS_FACEUP)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE)
 end
 function c3370104.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end

--- a/c3972721.lua
+++ b/c3972721.lua
@@ -26,8 +26,7 @@ function c3972721.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local p2=false
 	while tc do
 		if tc:IsType(TYPE_SYNCHRO) and tc:IsPreviousLocation(LOCATION_MZONE)
-			and ((tc:IsReason(REASON_BATTLE) and bit.band(tc:GetBattlePosition(),POS_FACEUP)~=0)
-			or (not tc:IsReason(REASON_BATTLE) and tc:IsPreviousPosition(POS_FACEUP)))
+			and (tc:IsReason(REASON_BATTLE) or tc:IsReason(REASON_EFFECT) and tc:IsPreviousPosition(POS_FACEUP))
 			and tc:GetPreviousControler()~=tc:GetReasonPlayer() then
 			if tc:GetReasonPlayer()==0 then p1=true else p2=true end
 		end

--- a/c44364207.lua
+++ b/c44364207.lua
@@ -32,7 +32,7 @@ function c44364207.indesval(e,re)
 end
 function c44364207.condition(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsPreviousPosition(POS_FACEUP)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE)
 end
 function c44364207.filter(c)
 	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4) and c:IsAbleToHand()

--- a/c55762976.lua
+++ b/c55762976.lua
@@ -39,7 +39,7 @@ function c55762976.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c55762976.cfilter(c)
-	return c:IsPreviousPosition(POS_FACEUP) and bit.band(c:GetPreviousTypeOnField(),TYPE_LINK)~=0 and c:IsReason(REASON_BATTLE)
+	return bit.band(c:GetPreviousTypeOnField(),TYPE_LINK)~=0 and c:IsReason(REASON_BATTLE)
 end
 function c55762976.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c55762976.cfilter,1,nil) and not eg:IsContains(e:GetHandler())

--- a/c71782404.lua
+++ b/c71782404.lua
@@ -12,8 +12,10 @@ function c71782404.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c71782404.cfilter(c,e,tp)
-	return c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
-		and c:IsPreviousSetCard(0x3b) and c:GetBaseAttack()>0 and c:IsCanBeEffectTarget(e) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
+	return c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE)
+		and (c:IsReason(REASON_BATTLE) or c:IsReason(REASON_EFFECT) and c:IsPreviousPosition(POS_FACEUP))
+		and c:IsPreviousSetCard(0x3b) and c:GetBaseAttack()>0
+		and c:IsCanBeEffectTarget(e) and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED)
 end
 function c71782404.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return eg:IsContains(chkc) and c71782404.cfilter(chkc,e,tp) end

--- a/c83682209.lua
+++ b/c83682209.lua
@@ -16,8 +16,8 @@ function c83682209.initial_effect(c)
 end
 function c83682209.spfilter(c,tp)
 	return c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE)
-		and c:IsPreviousPosition(POS_FACEUP) and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsCode(83682209)
-		and (c:GetPreviousAttributeOnField()&ATTRIBUTE_WATER)>0
+		and (c:IsReason(REASON_BATTLE) or c:IsReason(REASON_EFFECT) and c:IsPreviousPosition(POS_FACEUP))
+		and not c:IsCode(83682209) and (c:GetPreviousAttributeOnField()&ATTRIBUTE_WATER)>0
 end
 function c83682209.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c83682209.spfilter,1,nil,tp) and not eg:IsContains(e:GetHandler())

--- a/c83982270.lua
+++ b/c83982270.lua
@@ -13,7 +13,7 @@ function c83982270.initial_effect(c)
 end
 function c83982270.condition(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsPreviousPosition(POS_FACEUP)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE)
 end
 function c83982270.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/c87340664.lua
+++ b/c87340664.lua
@@ -14,7 +14,7 @@ function c87340664.initial_effect(c)
 end
 function c87340664.condition(e,tp,eg,ep,ev,re,r,rp)
 	e:SetLabel(e:GetHandler():GetReasonPlayer())
-	return e:GetHandler():IsReason(REASON_BATTLE) and e:GetHandler():IsPreviousPosition(POS_FACEUP)
+	return e:GetHandler():IsReason(REASON_BATTLE)
 end
 function c87340664.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end

--- a/c88753985.lua
+++ b/c88753985.lua
@@ -17,7 +17,7 @@ function c88753985.initial_effect(c)
 end
 function c88753985.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsPreviousPosition(POS_FACEUP) then
+	if c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetDescription(aux.Stringid(88753985,0))
 		e1:SetCategory(CATEGORY_SPECIAL_SUMMON)


### PR DESCRIPTION
>■裏側守備表示の「原子ホタル」が戦闘によってリバースし、その戦闘で破壊される場合でも、「原子ホタル」のモンスター効果は発動します。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5966

>自分のモンスターゾーンに裏側守備表示で存在する「真紅眼の飛竜」が相手モンスターに攻撃された場合には、戦闘によってリバースした後に破壊され墓地へ送られる事になりますので、戦闘で破壊され墓地へ送られた際に「レッドアイズ・バーン」を発動する事ができます。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=15969&keyword=&tag=-1&request_locale=ja

>-FAQの通り[[裏側守備表示]]のこの[[カード]]が[[戦闘破壊]]されても[[ドロー]]できるので、[[ドロー]][[効果]]の「[[表側表示]]で存在する」という部分は蛇足になっている。
https://yugioh-wiki.net/index.php?cmd=backup&page=%A1%D4%A5%B5%A5%A4%A5%D0%A1%BC%A1%A6%A5%D5%A5%A7%A5%CB%A5%C3%A5%AF%A5%B9%A1%D5&age=105&action=diff

Those cards shouldn't require face-up battle position