### PR TITLE
fix Auxiliary.ExceptThisCard

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -2690,7 +2690,7 @@ end
 --used for "except this card"
 function Auxiliary.ExceptThisCard(e)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then return c else return nil end
+	if c:IsRelateToChain() then return c else return nil end
 end
 --used for multi-linked zone(zone linked by two or more link monsters)
 function Auxiliary.GetMultiLinkedZone(tp)


### PR DESCRIPTION
fix:
1. _Gandora-X the Dragon of Demolition_ **normal summon**.
2. _Gandora-X the Dragon of Demolition_ activate effect.
3. _A Rival Appears!_ activate in response to _Gandora-X the Dragon of Demolition_ effect activation.
4. _Compulsory Evacuation Device_ activate to _A Rival Appears!_ activation, then _Gandora-X the Dragon of Demolition_ return to hand.
5. _Gandora-X the Dragon of Demolition_ special summon by activated _A Rival Appears!_'s effect.


these situation, _Gandora-X the Dragon of Demolition_ is destroyed(reason https://github.com/Fluorohydride/ygopro-scripts/pull/1031).
but,
1. _Gandora-X the Dragon of Demolition_ **special summon** by some effect(s).
2. _Gandora-X the Dragon of Demolition_ activate effect.
3. _A Rival Appears!_ activate in response to _Gandora-X the Dragon of Demolition_ effect activation.
4. _Compulsory Evacuation Device_ activate to _A Rival Appears!_ activation, then _Gandora-X the Dragon of Demolition_ return to hand.
5. _Gandora-X the Dragon of Demolition_ special summon by activated _A Rival Appears!_'s effect.

these situation, _Gandora-X the Dragon of Demolition_ isn't destroyed.