### PR TITLE
fix Gradius' Option

### DIFF
--- a/c14291024.lua
+++ b/c14291024.lua
@@ -8,16 +8,21 @@ function c14291024.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCondition(c14291024.spcon)
-	e1:SetOperation(c14291024.spop)
 	c:RegisterEffect(e1)
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_SPSUMMON_COST)
+	e0:SetOperation(c14291024.spcost)
+	c:RegisterEffect(e0)
 	local g=Group.CreateGroup()
 	g:KeepAlive()
-	e1:SetLabelObject(g)
+	e0:SetLabelObject(g)
 	--spsummon con
 	local e2=Effect.CreateEffect(c)
 	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e2:SetValue(c14291024.splimit)
 	c:RegisterEffect(e2)
 	--set target
 	local e3=Effect.CreateEffect(c)
@@ -25,7 +30,7 @@ function c14291024.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 	e3:SetOperation(c14291024.tgop)
-	e3:SetLabelObject(e1)
+	e3:SetLabelObject(e0)
 	c:RegisterEffect(e3)
 	--atk.def
 	local e4=Effect.CreateEffect(c)
@@ -57,18 +62,25 @@ function c14291024.spcon(e,c)
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(c14291024.filter,c:GetControler(),LOCATION_MZONE,0,1,nil)
 end
-function c14291024.spop(e,tp,eg,ep,ev,re,r,rp,c)
+function c14291024.spcost(e,tp,eg,ep,ev,re,r,rp)
+	e:GetLabelObject():Clear()
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(14291024,0))
 	local g=Duel.SelectMatchingCard(tp,c14291024.filter,tp,LOCATION_MZONE,0,1,1,nil)
-	Duel.HintSelection(g)
-	e:GetLabelObject():Clear()
-	e:GetLabelObject():Merge(g)
+	if g:GetCount()>0 then
+		Duel.HintSelection(g)
+		e:GetLabelObject():Merge(g)
+	end
+end
+function c14291024.splimit(e,se,sp,st,pos,top)
+	return Duel.IsExistingMatchingCard(c14291024.filter,sp,LOCATION_MZONE,0,1,nil)
 end
 function c14291024.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=e:GetLabelObject():GetLabelObject()
-	c:SetCardTarget(g:GetFirst())
-	c:RegisterFlagEffect(14291024,RESET_EVENT+RESETS_STANDARD+RESET_DISABLE,0,1)
+	if g:GetCount()>0 then
+		c:SetCardTarget(g:GetFirst())
+		c:RegisterFlagEffect(14291024,RESET_EVENT+RESETS_STANDARD,0,1)
+	end
 end
 function c14291024.adcon(e)
 	return e:GetHandler():GetFirstCardTarget()~=nil


### PR DESCRIPTION
fix 1: cannot special summon _Gradius' Option_ that already special summoned.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5372
> ■テキストに記載された方法で手札から特殊召喚できます。また、**このカードがこの方法で特殊召喚されたのち墓地へ送られている、または表側表示で除外されているのであれば、このカードを他のカードの効果で特殊召喚することもできます**。ただし、いずれの場合でも自分のモンスターゾーンに表側表示の「[超時空戦闘機ビック・バイパー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5140)」が存在する必要があります。

fix 2: if _Gradius' Option_'s effect was negated, FlagEffect is reseted.

> mail:
> Q.
> 自分フィールドの表側表示の「超時空戦闘機ビック・バイパー」1体を指定して特殊召喚した「オプション」を対象として相手が「禁じられた聖杯」を発動し、その次のターンのスタンバイフェイズに、前のターンに効果が無効化されていた「オプション」が指定している「超時空戦闘機ビック・バイパー」1体を対象として相手が「サンダー・ブレイク」を発動した場合、前のターンに効果が無効化されていた「オプション」は破壊されますか？
> A.
> ご質問の場合、**「オプション」は破壊されます**。

> ref:
> Q.
> 自分の「オプション」が『自分フィールド上に「超時空戦闘機ビック・バイパー」が表側表示で存在する場合に特殊召喚する事ができる』の方法で特殊召喚されたのち墓地へ送られています。
> 自分フィールドに「超時空戦闘機ビック・バイパー」が表側表示で存在する場合に「取捨蘇生」の効果で、そのテキストに記載された方法で特殊召喚されている「オプション」を特殊召喚する場合、自分フィールドの「超時空戦闘機ビック・バイパー」１体を選択しなければならないのですか？
> 選択しなければならない場合、どのタイミングで選択する事になりますか？
> A.
> ご質問の場合、「取捨蘇生」の『相手は対象のモンスターの中から１体を選ぶ』処理をした直後に、「超時空戦闘機ビック・バイパー」を選択して特殊召喚します。
> Q.
> 自分フィールドにモンスターが存在しない状態で、自分が「青天の霹靂」の効果で「オプション」を特殊召喚した場合、特殊召喚した時点で「超時空戦闘機ビック・バイパー」が存在していませんが、その「オプション」は『選択したモンスターがフィールド上に表側表示で存在しなくなった時、このカードを破壊する』により破壊されますか？
> A.
> 破壊されません。
> Q.
> 自分の「オプション」が『自分フィールド上に「超時空戦闘機ビック・バイパー」が表側表示で存在する場合に特殊召喚する事ができる』の方法で特殊召喚されたのち墓地へ送られています。
> そのテキストに記載された方法で特殊召喚されている「オプション」を「ギブ＆テイク」の効果で相手フィールドに特殊召喚する場合、自分フィールドと相手フィールドのどちらに「超時空戦闘機ビック・バイパー」が存在している必要がありますか？
>  
> A.
> ご質問の状況ですと、「超時空戦闘機ビック・バイパー」は、自分フィールドに存在している必要があります。