### PR TITLE
Fix Evil★Twin and Swordsoul Auspice Chunjun

### DIFF
--- a/c29884951.lua
+++ b/c29884951.lua
@@ -56,7 +56,6 @@ function c29884951.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c29884951.spop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)

--- a/c36609518.lua
+++ b/c36609518.lua
@@ -11,7 +11,6 @@ function c36609518.initial_effect(c)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
 	e1:SetCountLimit(1,36609518)
-	e1:SetCondition(c36609518.descon)
 	e1:SetTarget(c36609518.destg)
 	e1:SetOperation(c36609518.desop)
 	c:RegisterEffect(e1)
@@ -34,9 +33,6 @@ function c36609518.lcheck(g,lc)
 end
 function c36609518.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x152)
-end
-function c36609518.descon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c36609518.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c36609518.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() end

--- a/c9205573.lua
+++ b/c9205573.lua
@@ -11,7 +11,6 @@ function c9205573.initial_effect(c)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetCountLimit(1,9205573)
-	e1:SetCondition(c9205573.drcon)
 	e1:SetTarget(c9205573.drtg)
 	e1:SetOperation(c9205573.drop)
 	c:RegisterEffect(e1)
@@ -34,9 +33,6 @@ function c9205573.lcheck(g,lc)
 end
 function c9205573.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x153)
-end
-function c9205573.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c9205573.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c9205573.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDraw(tp,1)


### PR DESCRIPTION
Fixed Evil★Twin monster existence check, which should be only in Target.
Removed Swordsoul Auspice Chunjun monster zone check in Operation.