### PR TITLE
fix センサー万別

### DIFF
--- a/c24207889.lua
+++ b/c24207889.lua
@@ -6,13 +6,13 @@ function c24207889.initial_effect(c)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER)
 	c:RegisterEffect(e1)
-	--adjust
+	--only one
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
-	e2:SetCode(EVENT_ADJUST)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_RACE_ONLY_ONE)
 	e2:SetRange(LOCATION_SZONE)
-	e2:SetOperation(c24207889.adjustop)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetTargetRange(1,1)
 	c:RegisterEffect(e2)
 	--cannot summon,spsummon,flipsummon
 	local e4=Effect.CreateEffect(c)
@@ -31,6 +31,7 @@ function c24207889.initial_effect(c)
 	c:RegisterEffect(e6)
 	if not c24207889.global_check then
 		c24207889.global_check=true
+		c24207889.is_empty=true
 		c24207889[0]={}
 		c24207889[1]={}
 		local race=1
@@ -41,6 +42,13 @@ function c24207889.initial_effect(c)
 			c24207889[1][race]:KeepAlive()
 			race=race<<1
 		end
+		--adjust
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+		ge1:SetCode(EVENT_ADJUST)
+		ge1:SetOperation(c24207889.adjustop)
+		Duel.RegisterEffect(ge1,0)
 	end
 end
 function c24207889.rmfilter(c,rc)
@@ -54,6 +62,19 @@ function c24207889.sumlimit(e,c,sump,sumtype,sumpos,targetp)
 	return Duel.IsExistingMatchingCard(c24207889.rmfilter,tp,LOCATION_MZONE,0,1,nil,c:GetRace())
 end
 function c24207889.adjustop(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerAffectedByEffect(0,EFFECT_RACE_ONLY_ONE) then
+		if not c24207889.is_empty then
+			local race=1
+			while race<RACE_ALL do
+				c24207889[0][race]:Clear()
+				c24207889[1][race]:Clear()
+				race=race<<1
+			end
+			c24207889.is_empty=true
+		end
+		return
+	end
+	c24207889.is_empty=false
 	local phase=Duel.GetCurrentPhase()
 	if (phase==PHASE_DAMAGE and not Duel.IsDamageCalculated()) or phase==PHASE_DAMAGE_CAL then return end
 	local sg=Group.CreateGroup()

--- a/c24207889.lua
+++ b/c24207889.lua
@@ -9,7 +9,7 @@ function c24207889.initial_effect(c)
 	--only one
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_RACE_ONLY_ONE)
+	e2:SetCode(24207889)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e2:SetTargetRange(1,1)
@@ -62,7 +62,7 @@ function c24207889.sumlimit(e,c,sump,sumtype,sumpos,targetp)
 	return Duel.IsExistingMatchingCard(c24207889.rmfilter,tp,LOCATION_MZONE,0,1,nil,c:GetRace())
 end
 function c24207889.adjustop(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsPlayerAffectedByEffect(0,EFFECT_RACE_ONLY_ONE) then
+	if not Duel.IsPlayerAffectedByEffect(0,24207889) then
 		if not c24207889.is_empty then
 			local race=1
 			while race<RACE_ALL do

--- a/constant.lua
+++ b/constant.lua
@@ -579,7 +579,6 @@ EFFECT_CHANGE_GRAVE_ATTRIBUTE	=365	--墓地的卡将会改变属性（升级转�
 EFFECT_CHANGE_GRAVE_RACE		=366	--墓地的卡将会改变种族（升级转变）
 EFFECT_ACTIVATION_COUNT_LIMIT	=367	--reserve
 EFFECT_LIMIT_SPECIAL_SUMMON_POSITION	=368	--不能以特定表示形式特殊召唤
-EFFECT_RACE_ONLY_ONE			=369	--千查万别
 
 --下面是诱发效果的诱发事件、时点 （如果是TYPE_SINGLE则自己发生以下事件后触发，如果TYPE_FIELD则场上任何卡发生以下事件都触发）
 EVENT_STARTUP					=1000	--N/A

--- a/constant.lua
+++ b/constant.lua
@@ -579,6 +579,7 @@ EFFECT_CHANGE_GRAVE_ATTRIBUTE	=365	--墓地的卡将会改变属性（升级转�
 EFFECT_CHANGE_GRAVE_RACE		=366	--墓地的卡将会改变种族（升级转变）
 EFFECT_ACTIVATION_COUNT_LIMIT	=367	--reserve
 EFFECT_LIMIT_SPECIAL_SUMMON_POSITION	=368	--不能以特定表示形式特殊召唤
+EFFECT_RACE_ONLY_ONE			=369	--千查万别
 
 --下面是诱发效果的诱发事件、时点 （如果是TYPE_SINGLE则自己发生以下事件后触发，如果TYPE_FIELD则场上任何卡发生以下事件都触发）
 EVENT_STARTUP					=1000	--N/A


### PR DESCRIPTION
@mercury233 
# Problem
![unknown](https://user-images.githubusercontent.com/2851577/199762175-606c614c-abef-4fff-83a8-e9cfd0f8e31a.png)
[bug_only_one.zip](https://github.com/Fluorohydride/ygopro-scripts/files/9930567/bug_only_one.zip)
Turn 3
The first `There Can Be Only One` is destroyed, and then the second `There Can Be Only One` is activated.
When the effect resolves, the player cannot choose `Number 4: Stealth Kragen` in Main Monster Zone.

# Reason
The groups should be cleared when `There Can Be Only One` is not applied.

# Solution
EFFECT_RACE_ONLY_ONE:
the mark of the effects:
> Each player can only control 1 monster of each Type. 

Ex. `There Can Be Only One` 

If all EFFECT_RACE_ONLY_ONE are removed, the groups should be cleared.
