### PR TITLE
errata Laundry Trap

### DIFF
--- a/c79371769.lua
+++ b/c79371769.lua
@@ -13,6 +13,7 @@ function c79371769.initial_effect(c)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetCondition(c79371769.discon)
+	e2:SetCost(c79371769.discost)
 	e2:SetTarget(c79371769.distg)
 	e2:SetOperation(c79371769.disop)
 	c:RegisterEffect(e2)
@@ -34,6 +35,11 @@ function c79371769.initial_effect(c)
 end
 function c79371769.discon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(Card.IsControler,1,nil,tp)
+end
+function c79371769.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:GetFlagEffect(79371769)==0 end
+	c:RegisterFlagEffect(79371769,RESET_CHAIN,0,1)
 end
 function c79371769.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=16566
> ①：自分フィールドにモンスターが召喚・特殊召喚された場合に発動できる（**同一チェーン上では１度まで**）。自分のデッキの上からカードを１枚墓地へ送る。