### PR TITLE
fix 王神鳥シムルグ

### DIFF
--- a/c72330894.lua
+++ b/c72330894.lua
@@ -71,17 +71,11 @@ end
 function c72330894.spfilter(c,e,tp,lv)
 	return c:IsRace(RACE_WINDBEAST) and c:IsLevelBelow(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
-function c72330894.seqfilter(c,seq)
-	return c:GetSequence()==seq
+function c72330894.seqfilter(c)
+	return c:GetSequence()<5
 end
 function c72330894.getct()
-	local ct=10
-	for p=0,1 do
-		for i=0,4 do
-			if Duel.IsExistingMatchingCard(c72330894.seqfilter,p,LOCATION_SZONE,0,1,nil,i) then ct=ct-1 end
-		end
-	end
-	return ct
+	return 5*2-Duel.GetMatchingGroupCount(c72330894.seqfilter,0,LOCATION_SZONE,LOCATION_SZONE,nil)
 end
 function c72330894.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c72330894.lua
+++ b/c72330894.lua
@@ -71,15 +71,29 @@ end
 function c72330894.spfilter(c,e,tp,lv)
 	return c:IsRace(RACE_WINDBEAST) and c:IsLevelBelow(lv) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
+function c72330894.seqfilter(c,seq)
+	return c:GetSequence()==seq
+end
+function c72330894.getct()
+	local ct=10
+	for p=0,1 do
+		for i=0,4 do
+			if Duel.IsExistingMatchingCard(c72330894.seqfilter,p,LOCATION_SZONE,0,1,nil,i) then ct=ct-1 end
+		end
+	end
+	return ct
+end
 function c72330894.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ct=Duel.GetLocationCount(tp,LOCATION_SZONE,PLAYER_NONE,0)+Duel.GetLocationCount(1-tp,LOCATION_SZONE,PLAYER_NONE,0)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c72330894.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp,ct) end
+	if chk==0 then
+		local ct=c72330894.getct()
+		return ct>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+			and Duel.IsExistingMatchingCard(c72330894.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp,ct)
+	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK)
 end
 function c72330894.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
-	local ct=Duel.GetLocationCount(tp,LOCATION_SZONE,PLAYER_NONE,0)+Duel.GetLocationCount(1-tp,LOCATION_SZONE,PLAYER_NONE,0)
+	local ct=c72330894.getct()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c72330894.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp,ct)
 	if g:GetCount()>0 then


### PR DESCRIPTION
>Q.
自分の魔法＆罠ゾーンに「閃光の宝札」2枚、相手の魔法＆罠ゾーンにカードは1枚も存在しない場合、エンドフェイズの「王神鳥シムルグ」のモンスター効果で、どのレベルの鳥獣族モンスターを特殊召喚できますか？
A.
ご質問の場合、レベル８以下の鳥獣族モンスター１体を特殊召喚できます。

Currently `Duel.GetLocationCount` will always count disabled zones, so it can't be used.