### PR TITLE
fix Traptrix Trap Hole Nightmare etc.

### DIFF
--- a/c15613529.lua
+++ b/c15613529.lua
@@ -31,7 +31,7 @@ function c15613529.cfilter(c)
 	return c:IsType(TYPE_NORMAL) and c:IsLevelAbove(5) and c:IsFaceup()
 end
 function c15613529.spcon1(e,tp,eg,ep,ev,re,r,rp)
-	local loc=Duel.GetChainInfo(0,CHAININFO_TRIGGERING_LOCATION)
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
 	local tc=re:GetHandler()
 	return tc:IsControler(1-tp) and loc==LOCATION_MZONE and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainDisablable(ev)
 		and Duel.IsExistingMatchingCard(c15613529.cfilter,tp,LOCATION_MZONE,0,1,nil)

--- a/c27918365.lua
+++ b/c27918365.lua
@@ -48,7 +48,7 @@ function c27918365.spval(e,c)
 	return 0,Duel.GetLinkedZone(c:GetControler())
 end
 function c27918365.negcon(e,tp,eg,ep,ev,re,r,rp)
-	local loc=Duel.GetChainInfo(0,CHAININFO_TRIGGERING_LOCATION)
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
 	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSummonLocation(LOCATION_EXTRA) and loc==LOCATION_MZONE
 		and Duel.IsChainNegatable(ev)
 end

--- a/c29616929.lua
+++ b/c29616929.lua
@@ -11,9 +11,9 @@ function c29616929.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c29616929.condition(e,tp,eg,ep,ev,re,r,rp)
-	local loc=Duel.GetChainInfo(0,CHAININFO_TRIGGERING_LOCATION)
+	local tgp,loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION)
 	local tc=re:GetHandler()
-	return tc:IsControler(1-tp) and loc==LOCATION_MZONE and tc:IsStatus(STATUS_SPSUMMON_TURN) and Duel.IsChainDisablable(ev)
+	return tgp==1-tp and loc==LOCATION_MZONE and tc:IsStatus(STATUS_SPSUMMON_TURN) and Duel.IsChainDisablable(ev)
 end
 function c29616929.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
Fix1: 
0 in `Duel.GetChainInfo` means current chain, which is usually last chain when checking activate condition.
But if _Traptrix Trap Hole Nightmare_ will be copied by _Traptrix Rafflesia_, while selecting trap card, the last chain is Rafflesia, and using 0 in `Duel.GetChainInfo` will return wrong value.

Fix2:
Original controller != activate controller