### PR TITLE
fix Charmer and so on

### DIFF
--- a/c19327348.lua
+++ b/c19327348.lua
@@ -11,7 +11,7 @@ function c19327348.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c19327348.filter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToChangeControler()
 end
 function c19327348.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c19327348.filter(chkc) end

--- a/c31440542.lua
+++ b/c31440542.lua
@@ -11,7 +11,7 @@ function c31440542.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c31440542.filter(c)
-	return c:IsFaceup() and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsAbleToChangeControler()
 end
 function c31440542.ctltg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c31440542.filter(chkc) end

--- a/c37620434.lua
+++ b/c37620434.lua
@@ -11,7 +11,7 @@ function c37620434.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37620434.filter(c)
-	return c:IsFaceup() and c:IsRace(RACE_FIEND) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsRace(RACE_FIEND) and c:IsAbleToChangeControler()
 end
 function c37620434.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c37620434.filter(chkc) end

--- a/c37744402.lua
+++ b/c37744402.lua
@@ -11,7 +11,7 @@ function c37744402.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37744402.filter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_WIND) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_WIND) and c:IsAbleToChangeControler()
 end
 function c37744402.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c37744402.filter(chkc) end

--- a/c37970940.lua
+++ b/c37970940.lua
@@ -11,7 +11,7 @@ function c37970940.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37970940.filter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsAbleToChangeControler()
 end
 function c37970940.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c37970940.filter(chkc) end

--- a/c5257687.lua
+++ b/c5257687.lua
@@ -11,10 +11,10 @@ function c5257687.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c5257687.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsControlerCanBeChanged() end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsAbleToChangeControler() end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
-	local g=Duel.SelectTarget(tp,Card.IsControlerCanBeChanged,tp,0,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToChangeControler,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_CONTROL,g,1,0,0)
 end
 function c5257687.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c63018132.lua
+++ b/c63018132.lua
@@ -11,7 +11,7 @@ function c63018132.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c63018132.filter(c)
-	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and c:IsAbleToChangeControler()
 end
 function c63018132.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c63018132.filter(chkc) end

--- a/c73318863.lua
+++ b/c73318863.lua
@@ -11,7 +11,7 @@ function c73318863.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c73318863.filter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToChangeControler()
 end
 function c73318863.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c73318863.filter(chkc) end

--- a/c74364659.lua
+++ b/c74364659.lua
@@ -11,7 +11,7 @@ function c74364659.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c74364659.filter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_WATER) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToChangeControler()
 end
 function c74364659.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c74364659.filter(chkc) end

--- a/c759393.lua
+++ b/c759393.lua
@@ -11,7 +11,7 @@ function c759393.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c759393.filter(c)
-	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsAbleToChangeControler()
 end
 function c759393.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c759393.filter(chkc) end

--- a/c7914843.lua
+++ b/c7914843.lua
@@ -19,7 +19,7 @@ function c7914843.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c7914843.filter(c)
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsControlerCanBeChanged()
+	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAbleToChangeControler()
 end
 function c7914843.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c7914843.filter(chkc) end


### PR DESCRIPTION
> Q.
> 自分のモンスターゾーンに空きがない状態で「水霊使いエリア」がリバースした場合でも、相手フィールドに水属性モンスターがいる場合そのモンスターを必ず対象に取らなければならないのでしょうか？（例えば、自分のモンスターゾーンに空きがなく、相手フィールドに「水晶機巧－ハリファイバー」が存在する場合に「水霊使いエリア」がリバースした場合、相手フィールドの「水晶機巧－ハリファイバー」を必ず対象にしないといけませんか？）
> A.
> ご質問の場合でも、**「水晶機巧－ハリファイバー」を、「水霊使いエリア」の必ず発動する『①』の効果の対象に選ばなければなりません**。
>  
> したがって、効果処理の際には、メインモンスターゾーンに空きがないため、「水晶機巧－ハリファイバー」は破壊されます。