### PR TITLE
fix Lair of Darkness

### DIFF
--- a/c59160188.lua
+++ b/c59160188.lua
@@ -46,7 +46,7 @@ function c59160188.relval(e,re,r,rp)
 	return (c59160188.re_activated or re:IsActivated()) and bit.band(r,REASON_COST)~=0
 end
 function c59160188.regfilter(c)
-	return c:GetPreviousTypeOnField()&TYPE_MONSTER>0
+	return (c:IsPreviousLocation(LOCATION_ONFIELD) and c:GetPreviousTypeOnField() or c:GetType())&TYPE_MONSTER>0
 end
 function c59160188.regop(e,tp,eg,ep,ev,re,r,rp)
 	local mct=eg:FilterCount(c59160188.regfilter,nil)

--- a/c59160188.lua
+++ b/c59160188.lua
@@ -46,7 +46,8 @@ function c59160188.relval(e,re,r,rp)
 	return (c59160188.re_activated or re:IsActivated()) and bit.band(r,REASON_COST)~=0
 end
 function c59160188.regfilter(c)
-	return (c:IsPreviousLocation(LOCATION_ONFIELD) and c:GetPreviousTypeOnField() or c:GetType())&TYPE_MONSTER>0
+	local typ=c:IsPreviousLocation(LOCATION_ONFIELD) and c:GetPreviousTypeOnField() or c:GetType()
+	return typ&TYPE_MONSTER>0
 end
 function c59160188.regop(e,tp,eg,ep,ev,re,r,rp)
 	local mct=eg:FilterCount(c59160188.regfilter,nil)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8145&keyword=&tag=-1
> 「[闇黒世界－シャドウ・ディストピア－](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13686)」の「シャドウトークン」を特殊召喚する効果は、そのターン、「[闇黒世界－シャドウ・ディストピア－](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13686)」自身が表側表示で存在する間にリリースされたモンスターの数に応じてトークンが特殊召喚されます。
> 
> 質問の状況のように、儀式魔法カードの効果によって、**手札のモンスターをリリースして儀式召喚を行った場合でも、手札のモンスターがリリースされていますので、そのリリースされたモンスターの数に応じて「シャドウトークン」が特殊召喚される事になります**。