### PR TITLE
fix Battle of the Elements

### DIFF
--- a/c60530944.lua
+++ b/c60530944.lua
@@ -44,5 +44,5 @@ function c60530944.operation(e,tp,eg,ep,ev,re,r,rp)
 	local r2=Duel.AnnounceAttribute(1-tp,1,c60530944.getattr(g2))
 	g2:Remove(c60530944.rmfilter,nil,r2)
 	g1:Merge(g2)
-	Duel.SendtoGrave(g1,REASON_EFFECT)
+	Duel.SendtoGrave(g1,REASON_RULE)
 end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8365
> ■これによりモンスターが墓地へ送られる場合でも、この効果がそのモンスターに適用されているわけではありません。**罠カードの効果を受けるかどうかにかかわらず、プレイヤーが選んだモンスターは墓地へ送られます**。また、**これにより墓地へ送られたモンスターは罠カードの効果で墓地へ送られたモンスターとして扱われません**。