### PR TITLE
fix Invoked Elysium

### DIFF
--- a/c11270236.lua
+++ b/c11270236.lua
@@ -39,9 +39,7 @@ function c11270236.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or aux.fuslimit(e,se,sp,st)
 end
 function c11270236.rmfilter1(c,tp)
-	local att=c:GetAttribute()
-	return c:IsSetCard(0xf4) and c:IsType(TYPE_MONSTER) and (c:IsLocation(LOCATION_GRAVE) or c:IsFaceup()) and c:IsAbleToRemove()
-		and Duel.IsExistingMatchingCard(c11270236.rmfilter2,tp,0,LOCATION_MZONE,1,nil,att)
+	return c:IsSetCard(0xf4) and c:IsType(TYPE_MONSTER) and c:IsFaceupEx() and c:IsAbleToRemove()
 end
 function c11270236.rmfilter2(c,att)
 	return c:IsFaceup() and c:IsAttribute(att) and c:IsAbleToRemove()

--- a/c11270236.lua
+++ b/c11270236.lua
@@ -38,17 +38,17 @@ end
 function c11270236.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or aux.fuslimit(e,se,sp,st)
 end
-function c11270236.rmfilter1(c,tp)
+function c11270236.rmfilter1(c)
 	return c:IsSetCard(0xf4) and c:IsType(TYPE_MONSTER) and c:IsFaceupEx() and c:IsAbleToRemove()
 end
 function c11270236.rmfilter2(c,att)
 	return c:IsFaceup() and c:IsAttribute(att) and c:IsAbleToRemove()
 end
 function c11270236.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE+LOCATION_GRAVE) and chkc:IsControler(tp) and c11270236.rmfilter1(chkc,tp) end
-	if chk==0 then return Duel.IsExistingTarget(c11270236.rmfilter1,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil,tp) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE+LOCATION_GRAVE) and chkc:IsControler(tp) and c11270236.rmfilter1(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c11270236.rmfilter1,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g1=Duel.SelectTarget(tp,c11270236.rmfilter1,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,nil,tp)
+	local g1=Duel.SelectTarget(tp,c11270236.rmfilter1,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,nil)
 	local g2=Duel.GetMatchingGroup(c11270236.rmfilter2,tp,0,LOCATION_MZONE,nil,g1:GetFirst():GetAttribute())
 	local gr=false
 	if g1:GetFirst():IsLocation(LOCATION_GRAVE) then gr=true end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20235&keyword=&tag=-1
> Question
> 「[召喚獣エリュシオン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12850)」の『②：１ターンに１度、自分のフィールド・墓地の「召喚獣」モンスター１体を対象として発動できる。そのモンスター及びそのモンスターと同じ属性を持つ相手フィールドのモンスターを全て除外する。この効果は相手ターンでも発動できる』モンスター効果は、相手のモンスターゾーンに表側表示モンスターが存在しない場合に発動する事はできますか？
> Answer
> **発動できます**。
> 
> 処理時に、対象のモンスターと同じ属性のモンスターが相手フィールドに表側表示で存在しない場合、対象のモンスターだけ除外されます。