### PR TITLE
fix Dragunity Arma Leyvaten, Endymion, the Master Magician and Majesty Hyperion

### DIFF
--- a/c40732515.lua
+++ b/c40732515.lua
@@ -40,6 +40,7 @@ function c40732515.spcfilter(c,tp)
 end
 function c40732515.spcon(e,c)
 	if c==nil then return true end
+	if c:IsHasEffect(EFFECT_NECRO_VALLEY) then return false end
 	local tp=c:GetControler()
 	local g=Duel.GetMatchingGroup(c40732515.spcfilter,tp,LOCATION_ONFIELD,0,nil,tp)
 	local ct=0

--- a/c63487632.lua
+++ b/c63487632.lua
@@ -47,6 +47,7 @@ function c63487632.spfilter(c,ft)
 end
 function c63487632.spcon(e,c)
 	if c==nil then return true end
+	if c:IsHasEffect(EFFECT_NECRO_VALLEY) then return false end
 	local tp=c:GetControler()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	return ft>-1 and Duel.IsExistingMatchingCard(c63487632.spfilter,tp,LOCATION_MZONE,0,1,nil,ft)

--- a/c91434602.lua
+++ b/c91434602.lua
@@ -38,6 +38,7 @@ function c91434602.spcfilter(c,tp)
 end
 function c91434602.hspcon(e,c)
 	if c==nil then return true end
+	if c:IsHasEffect(EFFECT_NECRO_VALLEY) then return false end
 	local tp=c:GetControler()
 	return Duel.IsExistingMatchingCard(c91434602.spcfilter,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,1,nil,tp)
 end


### PR DESCRIPTION
fix: _Necrovalley_ has on the field, these monster can special summon by itself.

> ref:
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20408&keyword=&tag=-1
> 「[暗黒界の龍神 グラファ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9712)」の自身を墓地から特殊召喚するモンスター効果は、『墓地のカードへ及ぶ効果』となりますので、その効果を適用する事はできません。
> （『「[暗黒界の龍神 グラファ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9712)」以外の自分フィールド上に表側表示で存在する「暗黒界」と名のついたモンスター１体を手札に戻し』を行う事もできません。）