### PR TITLE
fix Morpheus, the Dream Mirror White Knight

### DIFF
--- a/c1872843.lua
+++ b/c1872843.lua
@@ -31,7 +31,7 @@ function c1872843.indcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c1872843.indop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsFaceup() and c:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)


### PR DESCRIPTION
fix: if _Morpheus, the Dream Mirror White Knight_ was face-down in resolved, _Morpheus, the Dream Mirror White Knight_'s effect don't apply.

> ref:
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19882&keyword=&tag=-1
> 「[Kozmo－ダーク・ローズ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12101)」のモンスター効果の処理時に、**「[Kozmo－ダーク・ローズ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12101)」自身が裏側守備表示になっている場合でも、『このターン、このカードは戦闘・効果では破壊されない』効果は通常通り適用されます**。