### PR TITLE
fix Contact with Gusto

### DIFF
--- a/c83544697.lua
+++ b/c83544697.lua
@@ -24,12 +24,16 @@ function c83544697.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,g1,2,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g2,1,0,0)
 end
+function c83544697.filter2(c,tp)
+	return c:IsOnField() and c:IsControler(tp)
+end
 function c83544697.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ex,g1=Duel.GetOperationInfo(0,CATEGORY_TODECK)
-	local ex,g2=Duel.GetOperationInfo(0,CATEGORY_DESTROY)
-	if g1:GetFirst():IsRelateToEffect(e) and g1:GetNext():IsRelateToEffect(e) then
-		Duel.SendtoDeck(g1,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
-		if g2:GetFirst():IsRelateToEffect(e) then
+	local g=Duel.GetTargetsRelateToChain()
+	local g1=g:Filter(Card.IsLocation,nil,LOCATION_GRAVE)
+	local g2=g:Filter(c83544697.filter2,nil,1-tp)
+	if g1:GetCount()==2 and Duel.SendtoDeck(g1,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)==2 then
+		local ct=Duel.GetOperatedGroup():FilterCount(Card.IsLocation,nil,LOCATION_DECK+LOCATION_EXTRA)
+		if ct==2 and g2:GetCount()>0 then
 			Duel.BreakEffect()
 			Duel.Destroy(g2,REASON_EFFECT)
 		end


### PR DESCRIPTION
fix 1: if _Contact with Gusto_'s target cards in grave was banished, _Contact with Gusto_'s target cards on the field is destroyed.
> mail:
> Q.
> 「ガスタの交信」の対象となった自分の墓地の「ガスタ」と名のついたモンスター２体が、「ガスタの交信」の効果処理時に「転生断絶」の効果でデッキに戻らずに除外された場合、「ガスタの交信」の対象となった相手フィールド上のカード１枚は破壊されますか？
> A.
> ご質問の場合、**対象とした相手フィールド上のカードを破壊する処理は行われません**。

fix 2: if _Contact with Gusto_'s target cards controller on the field was changed, _Contact with Gusto_'s target cards on the field is destroyed.
> mail:
> Q.
> 自分の墓地の「ガスタの巫女 ウィンダ」と「ダイガスタ・ガルドス」と相手フィールドの「TG ハイパー・ライブラリアン」を対象として「ガスタの交信」を発動し、チェーンして相手が対象となった「TG ハイパー・ライブラリアン」と自分フィールドの「ダイガスタ・スフィアード」を対象として「TG1－EM1」を発動した場合、「ガスタの交信」の効果の対象となった「TG ハイパー・ライブラリアン」は「ガスタの交信」の効果処理時に自分フィールドにコントロールが移ってますが、「ガスタの交信」はどのようになりますか？
> A.
> ご質問の場合、「ガスタの巫女 ウィンダ」がデッキに戻り、「ダイガスタ・ガルドス」がエクストラデッキに戻り、完了とします。
> **「TG ハイパー・ライブラリアン」は破壊されません**。