### PR TITLE
fix The Great Double Casted Caster

### DIFF
--- a/c83340560.lua
+++ b/c83340560.lua
@@ -36,13 +36,13 @@ function s.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function s.noeff(c)
-	return not c:IsType(TYPE_EFFECT)
+	return not c:IsFusionType(TYPE_EFFECT)
 end
 function s.atkcalc(e,c)
 	local g=c:GetMaterial()
 	local atk=0
 	for tc in aux.Next(g) do
-		if tc:IsType(TYPE_RITUAL+TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK) then
+		if tc:IsFusionType(TYPE_RITUAL+TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_LINK) then
 			atk=atk+tc:GetBaseAttack()
 		end
 	end


### PR DESCRIPTION
> mail:
> Q.
> 「ペンデュラム・フュージョン」の効果で「偉大なるダブルキャスター」を融合召喚する際に、ペンデュラムゾーンに置かれている「降竜の魔術師」は魔法カードとして扱われていますが融合素材に使用できますか？
> A.
> **「降竜の魔術師」は効果モンスターですので、ご質問のように「偉大なるダブルキャスター」の融合素材にすることはできません**。