### PR TITLE
partly fix Cupid Pitch

### DIFF
--- a/c21915012.lua
+++ b/c21915012.lua
@@ -44,6 +44,10 @@ function c21915012.valcheck(e,c)
 	local g=c:GetMaterial()
 	local mg=g:Filter(Card.IsType,nil,TYPE_TUNER)
 	local tc=mg:GetFirst()
+	if not tc then
+		e:GetLabelObject():SetLabel(0)
+		return
+	end
 	if #mg>1 then
 		local tg=g-(g:Filter(Card.IsNotTuner,nil,c))
 		if #tg>0 then
@@ -68,6 +72,7 @@ function c21915012.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
 	local ct=e:GetLabel()
+	if ct==0 then return end
 	local sel=nil
 	if c:IsLevel(1) then
 		sel=Duel.SelectOption(tp,aux.Stringid(21915012,1))

--- a/c21915012.lua
+++ b/c21915012.lua
@@ -43,19 +43,23 @@ end
 function c21915012.valcheck(e,c)
 	local g=c:GetMaterial()
 	local mg=g:Filter(Card.IsType,nil,TYPE_TUNER)
-	if #mg==1 then
-		local tc=mg:GetFirst()
-		local lv=tc:GetSynchroLevel(c)
-		local lv2=lv>>16
-		lv=lv&0xffff
-		if lv2>0 and not g:CheckWithSumEqual(Card.GetLevel,c:GetLevel(),#g,#g,c) then
-			lv=lv2
+	local tc=mg:GetFirst()
+	if #mg>1 then
+		local tg=g-(g:Filter(Card.IsNotTuner,nil,c))
+		if #tg>0 then
+			tc=tg:GetFirst()
 		end
-		if tc:IsHasEffect(89818984) and not g:CheckWithSumEqual(Card.GetSynchroLevel,c:GetLevel(),#g,#g,c) then
-			lv=2
-		end
-		e:GetLabelObject():SetLabel(lv)
 	end
+	local lv=tc:GetSynchroLevel(c)
+	local lv2=lv>>16
+	lv=lv&0xffff
+	if lv2>0 and not g:CheckWithSumEqual(Card.GetLevel,c:GetLevel(),#g,#g,c) then
+		lv=lv2
+	end
+	if tc:IsHasEffect(89818984) and not g:CheckWithSumEqual(Card.GetSynchroLevel,c:GetLevel(),#g,#g,c) then
+		lv=2
+	end
+	e:GetLabelObject():SetLabel(lv)
 end
 function c21915012.lvcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)


### PR DESCRIPTION
If the player use 1 tuner + _Phantom King Hydride_ to synchro summon this card, it wasn't able to change level.
But if the player use _Phantom King Hydride_ + _Baby Mudragon_, the level is still incorrect.