### PR TITLE
fix Synchro Material

### DIFF
--- a/c14507213.lua
+++ b/c14507213.lua
@@ -35,7 +35,12 @@ function c14507213.activate(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SYNCHRO_MATERIAL)
+		e1:SetOwnerPlayer(tp)
+		e1:SetCondition(c14507213.matcon)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1)
 	end
+end
+function c14507213.matcon(e)
+	return e:GetHandler():IsControler(1-e:GetOwnerPlayer())
 end


### PR DESCRIPTION
fix: if opponent activated _Synchro Material_(targeted self monster) and _Synchro Material_'s effect applying monster's control was changed, self player can use that changed monster as synchro material.

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=9241
> 相手フィールド上に表側表示で存在するモンスター１体を選択して発動する。このターン**自分がシンクロ召喚をする場合**、選択したモンスターをシンクロ素材にする事ができる。このカードを発動するターン、自分はバトルフェイズを行う事ができない。