### PR TITLE
fix Ancient City - Rainbow Ruins

### DIFF
--- a/c34487429.lua
+++ b/c34487429.lua
@@ -86,7 +86,6 @@ function c34487429.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c34487429.disop(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsExistingMatchingCard(c34487429.filter1,tp,LOCATION_SZONE,0,3,nil) then return end
 	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
@@ -101,7 +100,6 @@ function c34487429.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 end
 function c34487429.drop(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsExistingMatchingCard(c34487429.filter1,tp,LOCATION_SZONE,0,4,nil) then return end
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Draw(p,d,REASON_EFFECT)
 end
@@ -120,7 +118,6 @@ function c34487429.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function c34487429.spop(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsExistingMatchingCard(c34487429.filter1,tp,LOCATION_SZONE,0,5,nil) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6642&keyword=&tag=-1
> Question
> 「[虹の古代都市－レインボー・ルイン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7079)」の『●３枚以上』の効果の処理時に、自分の魔法＆罠ゾーンに存在する「宝玉獣」カードの数が２枚以下になっている場合、処理はどうなりますか？
> Answer
> **その場合でも発動した『●３枚以上』の効果の処理は行われます**。
> 
> 『●４枚以上』『●５枚』の効果についても同様に、**処理時に条件を満たさなくなった（「[虹の古代都市－レインボー・ルイン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7079)」が効果を得ていない状況になった）場合でも、処理は行われます**。