### PR TITLE
fix Helshaddoll Hollow

### DIFF
--- a/c92079625.lua
+++ b/c92079625.lua
@@ -25,6 +25,7 @@ function c92079625.initial_effect(c)
 end
 function c92079625.cfilter(c,tp)
 	return c:IsFaceup() and Duel.IsExistingMatchingCard(c92079625.tgfilter,tp,LOCATION_EXTRA,0,1,nil,c:GetAttribute())
+		and c:IsAbleToRemove()
 end
 function c92079625.tgfilter(c,att)
 	return c:IsAbleToGrave() and c:IsAttribute(att) and c:IsSetCard(0x9d)

--- a/c92079625.lua
+++ b/c92079625.lua
@@ -24,8 +24,8 @@ function c92079625.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c92079625.cfilter(c,tp)
-	return c:IsFaceup() and Duel.IsExistingMatchingCard(c92079625.tgfilter,tp,LOCATION_EXTRA,0,1,nil,c:GetAttribute())
-		and c:IsAbleToRemove()
+	return c:IsFaceup() and c:IsAbleToRemove()
+		and Duel.IsExistingMatchingCard(c92079625.tgfilter,tp,LOCATION_EXTRA,0,1,nil,c:GetAttribute())
 end
 function c92079625.tgfilter(c,att)
 	return c:IsAbleToGrave() and c:IsAttribute(att) and c:IsSetCard(0x9d)


### PR DESCRIPTION
fix: if _Imperial Iron Wall_ has on the field, _Helshaddoll Hollow_ can activate flip effect.
> mail:
> Q.
> 相手の魔法＆罠ゾーンに「王宮の鉄壁」が表側表示で存在する場合、自分は「影依の炎核 ヴォイド」の①の効果を発動できますか？
> A.
> 「王宮の鉄壁」の効果が適用中ですと、**カードを除外することができませんので、ご質問の場合、「影依の炎核 ヴォイド」の『①』の効果は発動できません**。