### PR TITLE
fix Number 45: Crumble Logos the Prophet of Demolition

### DIFF
--- a/c29208536.lua
+++ b/c29208536.lua
@@ -42,7 +42,7 @@ function c29208536.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e)
-		and not tc:IsImmuneToEffect(e) then
+		and tc:IsCanBeDisabledByEffect(e) then
 		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
> mail:
> Q.
> 自分が「魔力の泉」を発動しているターン中に、相手の魔法＆罠ゾーンの「王家の神殿」を対象として「No.45 滅亡の予言者 クランブル・ロゴス」の①の効果を発動しました。
> ・その「魔力の泉」を発動しているターン中、自分は「王家の神殿」を発動できますか？
> ・『次の相手ターンの終了時』を迎えた事で「魔力の泉」の効果が適用されなくなった際に、その「王家の神殿」は「No.45 滅亡の予言者 クランブル・ロゴス」の①の効果で無効になりますか？
> A.
> ご質問の場合、「No.45 滅亡の予言者 クランブル・ロゴス」の効果処理は何も行われません。
>  
> したがって、**「王家の神殿」を発動することもでき、次の相手ターンを終えた後からも無効になりません**。