### PR TITLE
fix Periallis, Empress of Blossoms

### DIFF
--- a/c72924435.lua
+++ b/c72924435.lua
@@ -29,8 +29,8 @@ function c72924435.atkval(e,c)
 	return Duel.GetMatchingGroupCount(c72924435.atkfilter,c:GetControler(),LOCATION_MZONE,0,c)*400
 end
 function c72924435.filter(c,e,tp)
-	return c:IsRace(RACE_PLANT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
-		and c:IsLevelAbove(5)
+	return c:IsRace(RACE_PLANT) and c:IsLevelAbove(5) and not c:IsCode(72924435)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c72924435.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=15565
> ②：自分メインフェイズに発動できる。自分の手札・墓地から **「瓔珞帝華－ペリアリス」以外の**レベル５以上の植物族モンスター１体を選んで守備表示で特殊召喚する。