### PR TITLE
fix Qliphort Genius

### DIFF
--- a/c22423493.lua
+++ b/c22423493.lua
@@ -53,7 +53,7 @@ function c22423493.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c22423493.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	local g=Duel.GetTargetsRelateToChain():Filter(aux.NegateAnyFilter,nil)
 	if g:GetCount()~=2 then return end
 	for tc in aux.Next(g) do
 		Duel.NegateRelatedChain(tc,RESET_TURN_SET)


### PR DESCRIPTION
fix: if one side of _Qliphort Genius_'s target card was negated, one the other card is negated.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13380&keyword=&tag=-1
> 質問の状況の場合、「[クリフォート・ゲニウス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13502)」のモンスター効果の対象となった2枚の表側表示のカードの内、1枚のカードの効果が既に無効化され、**その効果を無効にする事ができませんので、効果処理は適用されません**。
> （この場合、もう1体の対象である「[クリフォート・ツール](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11353)」の効果が無効化される事もありません。）
> 
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21619&keyword=&tag=-1
> 質問の状況の場合、「[クリフォート・ゲニウス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13502)」のモンスター効果の対象となった2枚の表側表示のカードの内、1枚が裏側守備表示になり、**その効果を無効にする事ができませんので、効果処理は適用されません**。
> （この場合、もう1体の対象である「[クリフォート・ツール](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11353)」の効果が無効化される事もありません。）

> ref:
> mail:
> Q.
> 相手のモンスターゾーンの「ヴェルズ・タナトス」1体と自分のペンデュラムゾーンの「クリフォート・ツール」1枚を対象として自分が「クリフォート・ゲニウス」の②の効果し、チェーンして相手が「ヴェルズ・タナトス」の効果を発動した場合、「ヴェルズ・タナトス」は「クリフォート・ゲニウス」の効果を受けなくなりますが、「クリフォート・ツール」の効果は無効になりますか？
> A.
> ご質問の場合、「クリフォート・ツール」の効果は無効となります。