### PR TITLE
fix Tearlaments' fusion effect

### DIFF
--- a/c37961969.lua
+++ b/c37961969.lua
@@ -69,12 +69,15 @@ function c37961969.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		end
 		return res
 	end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c37961969.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) then return end
+	local ph=Duel.GetCurrentPhase()
+	if ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL then return end
+	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) or not aux.NecroValleyFilter()(c) then return end
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c37961969.filter0),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
 	local sg1=Duel.GetMatchingGroup(c37961969.filter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
 	local mg2=nil

--- a/c37961969.lua
+++ b/c37961969.lua
@@ -56,7 +56,8 @@ end
 function c37961969.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=tp
-		local mg=Duel.GetMatchingGroup(c37961969.filter0,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
+		local mg=Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToDeck,nil)
+		mg:Merge(Duel.GetMatchingGroup(c74078255.filter0,tp,LOCATION_GRAVE,0,nil,e))
 		local res=Duel.IsExistingMatchingCard(c37961969.filter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -78,7 +79,8 @@ function c37961969.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	if ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL then return end
 	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) or not aux.NecroValleyFilter()(c) then return end
-	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c37961969.filter0),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
+	local mg=Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToDeck,nil)
+	mg:Merge(Duel.GetMatchingGroup(aux.NecroValleyFilter(c74078255.filter0),tp,LOCATION_GRAVE,0,nil,e))
 	local sg1=Duel.GetMatchingGroup(c37961969.filter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
 	local mg2=nil
 	local sg2=nil

--- a/c572850.lua
+++ b/c572850.lua
@@ -63,7 +63,8 @@ end
 function c572850.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=tp
-		local mg=Duel.GetMatchingGroup(c572850.filter0,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
+		local mg=Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToDeck,nil)
+		mg:Merge(Duel.GetMatchingGroup(c74078255.filter0,tp,LOCATION_GRAVE,0,nil,e))
 		local res=Duel.IsExistingMatchingCard(c572850.filter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -85,7 +86,8 @@ function c572850.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	if ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL then return end
 	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) or not aux.NecroValleyFilter()(c) then return end
-	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c572850.filter0),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
+	local mg=Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToDeck,nil)
+	mg:Merge(Duel.GetMatchingGroup(aux.NecroValleyFilter(c74078255.filter0),tp,LOCATION_GRAVE,0,nil,e))
 	local sg1=Duel.GetMatchingGroup(c572850.filter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
 	local mg2=nil
 	local sg2=nil

--- a/c572850.lua
+++ b/c572850.lua
@@ -76,12 +76,15 @@ function c572850.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		end
 		return res
 	end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c572850.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) then return end
+	local ph=Duel.GetCurrentPhase()
+	if ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL then return end
+	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) or not aux.NecroValleyFilter()(c) then return end
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c572850.filter0),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
 	local sg1=Duel.GetMatchingGroup(c572850.filter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
 	local mg2=nil

--- a/c74078255.lua
+++ b/c74078255.lua
@@ -63,12 +63,15 @@ function c74078255.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		end
 		return res
 	end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c74078255.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
-	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) then return end
+	local ph=Duel.GetCurrentPhase()
+	if ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL then return end
+	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) or not aux.NecroValleyFilter()(c) then return end
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c74078255.filter0),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
 	local sg1=Duel.GetMatchingGroup(c74078255.filter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
 	local mg2=nil

--- a/c74078255.lua
+++ b/c74078255.lua
@@ -50,7 +50,8 @@ end
 function c74078255.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=tp
-		local mg=Duel.GetMatchingGroup(c74078255.filter0,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
+		local mg=Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToDeck,nil)
+		mg:Merge(Duel.GetMatchingGroup(c74078255.filter0,tp,LOCATION_GRAVE,0,nil,e))
 		local res=Duel.IsExistingMatchingCard(c74078255.filter1,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
@@ -72,7 +73,8 @@ function c74078255.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	if ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL then return end
 	if not c:IsRelateToChain() or c:IsImmuneToEffect(e) or not aux.NecroValleyFilter()(c) then return end
-	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c74078255.filter0),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
+	local mg=Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToDeck,nil)
+	mg:Merge(Duel.GetMatchingGroup(aux.NecroValleyFilter(c74078255.filter0),tp,LOCATION_GRAVE,0,nil,e))
 	local sg1=Duel.GetMatchingGroup(c74078255.filter1,tp,LOCATION_EXTRA,0,nil,e,tp,mg,nil,chkf)
 	local mg2=nil
 	local sg2=nil


### PR DESCRIPTION
1. Can not be negated by `Necrovalley`.
2. Can resolve in damage step.
3. Can't use `Fullmetalfoes Alkahest`'s third effect as material.