### PR TITLE
partly fix 六花精ボタン

### DIFF
--- a/c71002019.lua
+++ b/c71002019.lua
@@ -63,5 +63,8 @@ function c71002019.thop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c71002019.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:IsActiveType(TYPE_MONSTER) and Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_RACE)&RACE_PLANT~=0
+	if not (re and re:IsActiveType(TYPE_MONSTER)) then return false end
+	local race=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_RACE)
+	if race==nil then race=re:GetHandler():GetOriginalRace() end
+	return race&RACE_PLANT~=0
 end


### PR DESCRIPTION
mail:
>Q.
自分が相手の「プティカの蟲惑魔」の②の効果で、スタンバイフェイズに「六花精ボタン」を特殊召喚した場合、「六花精ボタン」の②の効果は発動できますか？
A.
ご質問の場合、植物族モンスターの効果で特殊召喚された扱いになりますので、「六花精ボタン」の『②』の効果を発動することができます。
 
>Q.
自分が相手が「DNA改造手術」で戦士族になった「プティカの蟲惑魔」の②の効果で、スタンバイフェイズに「六花精ボタン」を特殊召喚した場合、「六花精ボタン」の②の効果は発動できますか？
A.
ご質問の場合、戦士族モンスターの効果で特殊召喚された扱いになりますので、「六花精ボタン」の『②』の効果を発動することはできません。

That should mean, if Pudica is plant when it activate effect, the special summon effect is treated as an effect of plant monster, but if Pudica is warrior when it activate, the effect won't be.

But in YGOPro, we can't get the race when the special summon effect resolve.