### PR TITLE
fix Relay Soul

### DIFF
--- a/c42776960.lua
+++ b/c42776960.lua
@@ -43,7 +43,7 @@ function c42776960.activate(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetCode(EVENT_LEAVE_FIELD)
 		e3:SetLabel(1-tp)
 		e3:SetOperation(c42776960.leaveop)
-		e3:SetReset(RESET_EVENT+0xc020000)
+		e3:SetReset(RESET_EVENT+RESET_TURN_SET+RESET_TOFIELD+RESET_OVERLAY)
 		tc:RegisterEffect(e3,true)
 		Duel.SpecialSummonComplete()
 	end


### PR DESCRIPTION
fix: If _Crystal Beast_ use its effect to place in the spell&trap zone, player don't lose by _Relay Soul_.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=94&keyword=&tag=-1
> 「[魂のリレー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11154)」の効果によって特殊召喚した、モンスターゾーンの「[宝玉獣 ルビー・カーバンクル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7074)」が破壊された時点で、**その「[宝玉獣 ルビー・カーバンクル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7074)」を魔法＆罠ゾーンに置けるかどうかにかかわらず、自分はデュエルに敗北します**。
> （「[宝玉獣 ルビー・カーバンクル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7074)」がフィールドから離れた状況として扱われます。）

ref: konami's answer, if a monster that special summoned by _Relay Soul_ was equipped to a monster, player don't lose by _Relay Soul_.

> mail:
> Q.
> 「魂のリレー」の効果で「焔聖騎士－オジエ」を特殊召喚しており、その「焔聖騎士－オジエ」を対象として自分は「焔聖騎士将－オリヴィエ」の②の効果を発動し、「焔聖騎士－オジエ」を装備カード扱いとして装備しました。
> ・「焔聖騎士－オジエ」が装備された際に「魂のリレー」の『そのモンスターがフィールドから離れた時に相手はデュエルに勝利する』によって、自分はデュエルに敗北しますか？
> ・「焔聖騎士－オリヴィエ」の①の効果を発動するために、「焔聖騎士将－オリヴィエ」に装備されている「焔聖騎士－オジエ」を墓地へ送った場合、「魂のリレー」の『そのモンスターがフィールドから離れた時に相手はデュエルに勝利する』によって、自分はデュエルに敗北しますか？
> A.
> いずれの場合でも、「魂のリレー」を発動したプレイヤーは敗北しません。