### PR TITLE
fix Nightmare's Steelcage, Swords of Revealing Light and Big Evolution Pill

### DIFF
--- a/c58775978.lua
+++ b/c58775978.lua
@@ -11,9 +11,10 @@ function c58775978.initial_effect(c)
 	--cannot attack
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e2:SetCode(EFFECT_CANNOT_ATTACK)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e2:SetCondition(c58775978.atkcon)
 	c:RegisterEffect(e2)
 	--remain field
 	local e3=Effect.CreateEffect(c)
@@ -52,4 +53,7 @@ function c58775978.desop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Destroy(c,REASON_RULE)
 		c:ResetFlagEffect(1082946)
 	end
+end
+function c58775978.atkcon(e)
+	return e:GetHandler():GetType()==TYPE_SPELL
 end

--- a/c72302403.lua
+++ b/c72302403.lua
@@ -14,6 +14,7 @@ function c72302403.initial_effect(c)
 	e2:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetTargetRange(0,LOCATION_MZONE)
+	e2:SetCondition(c72302403.atkcon)
 	c:RegisterEffect(e2)
 	--remain field
 	local e3=Effect.CreateEffect(c)
@@ -59,4 +60,7 @@ function c72302403.desop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Destroy(c,REASON_RULE)
 		c:ResetFlagEffect(1082946)
 	end
+end
+function c72302403.atkcon(e)
+	return e:GetHandler():GetType()==TYPE_SPELL
 end

--- a/c84808313.lua
+++ b/c84808313.lua
@@ -57,7 +57,8 @@ function c84808313.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c84808313.ntcon(e,c,minc)
 	if c==nil then return true end
-	return minc==0 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+	return e:GetHandler():GetType()==TYPE_SPELL
+		and minc==0 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c84808313.nttg(e,c)
 	return c:IsLevelAbove(5) and c:IsRace(RACE_DINOSAUR)


### PR DESCRIPTION
fix 1: _Nightmare's Steelcage_'s effect is "monsters cannot declare an attack".

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=5120
> ①：このカードが魔法＆罠ゾーンに存在する限り、**モンスターは攻撃できない**。

fix 2: these cards were equipped to a monster, these effect is applied.

> mail:
> Q.
> 「マジカルシルクハット」の効果でモンスターとなっている「悪夢の鉄檻」を「ゴッドフェニックス・ギア・フリード」の②の効果で装備カード扱いとしました。
> そのバトルフェイズ中、「悪夢の鉄檻」の①の「このカードが魔法＆罠ゾーンに存在する限り、モンスターは攻撃できない」効果は適用されますか？
> A.
> ご質問の場合、**「悪夢の鉄檻」の効果は適用されません**。