### PR TITLE
fix Behemoth the King of All Animals

### DIFF
--- a/c22996376.lua
+++ b/c22996376.lua
@@ -57,7 +57,6 @@ function c22996376.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,ct,0,0)
 end
 function c22996376.thop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
+	local sg=Duel.GetTargetsRelateToChain():Filter(Card.IsRace,nil,RACE_BEAST)
 	Duel.SendtoHand(sg,nil,REASON_EFFECT)
 end


### PR DESCRIPTION
> https://twitter.com/YuGiOh_OCG_INFO/status/1638812834204356613
> ②：このカードがアドバンス召喚した時、このカードのアドバンス召喚のためにリリースしたモンスターの数だけ、自分の墓地の獣族モンスターを対象として発動できる。
> **その獣族モンスターを手札に加える**。