### PR TITLE
fix Scareclaw Light-Heart

### DIFF
--- a/c53776969.lua
+++ b/c53776969.lua
@@ -27,7 +27,7 @@ function c53776969.initial_effect(c)
 end
 function c53776969.mfilter(c)
 	return (c:IsLinkSetCard(0x17a) or c:IsLinkCode(56099748))
-		and (c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5 or not c:IsLocation(LOCATION_MZONE))
+		and c:IsLocation(LOCATION_MZONE) and c:GetSequence()<5
 end
 function c53776969.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23957&keyword=&tag=-1
> Question
> 自分のモンスターゾーンにモンスターが存在しない状況で「[Into the VRAINS！](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17262)」を発動し、手札から特殊召喚した「スケアクロー」モンスターまたは「[ヴィサス＝スタフロスト](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17120)」のみを素材として「[スケアクロー・ライトハート](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17452)」をリンク召喚できますか？
> Answer
> できません。