### PR TITLE
fix equip trap

### DIFF
--- a/c13235258.lua
+++ b/c13235258.lua
@@ -79,7 +79,7 @@ function c13235258.filter(c)
 end
 function c13235258.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c13235258.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c13235258.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c13235258.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -113,7 +113,8 @@ function c13235258.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c13235258.eqlimit(e,c)
-	return c:IsRace(RACE_INSECT) or e:GetHandler():GetEquipTarget()==c
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRace(RACE_INSECT)
 end
 function c13235258.atkcon1(e)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c13317419.lua
+++ b/c13317419.lua
@@ -57,7 +57,7 @@ function c13317419.filter(c)
 end
 function c13317419.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c13317419.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c13317419.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c13317419.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -82,12 +82,16 @@ function c13317419.operation(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetType(EFFECT_TYPE_SINGLE)
 		e2:SetCode(EFFECT_EQUIP_LIMIT)
 		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e2:SetValue(1)
+		e2:SetValue(c13317419.eqlimit)
 		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
 		c:RegisterEffect(e2)
 	else
 		c:CancelToGrave(false)
 	end
+end
+function c13317419.eqlimit(e,c)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsPosition(POS_FACEUP_ATTACK) and c:IsAttackAbove(800)
 end
 function c13317419.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetEquipTarget()

--- a/c15684835.lua
+++ b/c15684835.lua
@@ -41,7 +41,7 @@ function c15684835.filter(c,e,tp)
 end
 function c15684835.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return eg:IsContains(chkc) and c15684835.filter(chkc,e,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and eg:IsExists(c15684835.filter,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=eg:FilterSelect(tp,c15684835.filter,1,1,nil,e,tp)

--- a/c18096222.lua
+++ b/c18096222.lua
@@ -54,7 +54,7 @@ function c18096222.filter(c)
 end
 function c18096222.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c18096222.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c18096222.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c18096222.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -65,7 +65,7 @@ function c18096222.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsLocation(LOCATION_SZONE) then return end
 	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
 		Duel.Equip(tp,c,tc)
 		--Atkup
 		local e1=Effect.CreateEffect(c)
@@ -87,7 +87,8 @@ function c18096222.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c18096222.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer() and c:IsType(TYPE_DUAL)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsType(TYPE_DUAL)
 end
 function c18096222.dacon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c18446701.lua
+++ b/c18446701.lua
@@ -41,7 +41,7 @@ function c18446701.filter(c)
 end
 function c18446701.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c18446701.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c18446701.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c18446701.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -52,7 +52,7 @@ function c18446701.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsLocation(LOCATION_SZONE) then return end
 	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetControler()==c:GetControler() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) and tc:IsRace(RACE_SPELLCASTER) then
 		Duel.Equip(tp,c,tc)
 		--draw
 		local e1=Effect.CreateEffect(c)
@@ -75,5 +75,6 @@ function c18446701.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c18446701.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer() and c:IsRace(RACE_SPELLCASTER)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRace(RACE_SPELLCASTER)
 end

--- a/c21350571.lua
+++ b/c21350571.lua
@@ -43,7 +43,7 @@ function c21350571.filter(c)
 end
 function c21350571.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c21350571.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c21350571.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c21350571.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -89,7 +89,8 @@ function c21350571.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c21350571.eqlimit(e,c)
-	return c:IsRace(RACE_BEAST+RACE_BEASTWARRIOR)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRace(RACE_BEAST+RACE_BEASTWARRIOR)
 end
 function c21350571.drfilter(c,rc)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc

--- a/c23122036.lua
+++ b/c23122036.lua
@@ -41,7 +41,7 @@ function c23122036.filter(c)
 end
 function c23122036.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c23122036.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c23122036.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c23122036.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -74,7 +74,7 @@ function c23122036.operation(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetType(EFFECT_TYPE_SINGLE)
 		e3:SetCode(EFFECT_EQUIP_LIMIT)
 		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e3:SetValue(1)
+		e3:SetValue(c23122036.eqlimit)
 		e3:SetReset(RESET_EVENT+RESETS_STANDARD)
 		c:RegisterEffect(e3)
 	else
@@ -86,4 +86,7 @@ function c23122036.valcon(e,re,r,rp)
 end
 function c23122036.damcon(e)
 	return e:GetHandler():GetEquipTarget():GetControler()==e:GetHandlerPlayer()
+end
+function c23122036.eqlimit(e,c)
+	return e:GetHandler():GetEquipTarget()==c or c:IsControler(e:GetHandlerPlayer())
 end

--- a/c2542230.lua
+++ b/c2542230.lua
@@ -62,7 +62,7 @@ function c2542230.filter(c)
 end
 function c2542230.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c2542230.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c2542230.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c2542230.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -96,7 +96,8 @@ function c2542230.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c2542230.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO)
 end
 function c2542230.discon(e)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c259314.lua
+++ b/c259314.lua
@@ -43,7 +43,7 @@ function c259314.filter(c)
 end
 function c259314.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c259314.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c259314.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c259314.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -82,5 +82,6 @@ function c259314.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c259314.eqlimit(e,c)
-	return c:IsSetCard(0x56)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x56)
 end

--- a/c26647858.lua
+++ b/c26647858.lua
@@ -41,11 +41,11 @@ function c26647858.filter(c)
 	return c:IsFaceup() and c:IsAttackBelow(1500) and c:IsRace(RACE_WARRIOR)
 end
 function c26647858.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c26647858.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
-		and Duel.IsExistingTarget(c26647858.filter,tp,LOCATION_MZONE,0,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c26647858.filter(chkc) end
+	if chk==0 then return e:IsCostChecked()
+		and Duel.IsExistingTarget(c26647858.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	Duel.SelectTarget(tp,c26647858.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c26647858.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
 end
 function c26647858.operation(e,tp,eg,ep,ev,re,r,rp)
@@ -75,7 +75,8 @@ function c26647858.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c26647858.eqlimit(e,c)
-	return c:IsAttackBelow(1500) and c:IsRace(RACE_WARRIOR)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsAttackBelow(1500) and c:IsRace(RACE_WARRIOR)
 end
 function c26647858.atval(e,c)
 	return c:IsAttackAbove(1900) and not c:IsImmuneToEffect(e)

--- a/c29867611.lua
+++ b/c29867611.lua
@@ -67,7 +67,7 @@ function c29867611.filter(c,tp)
 end
 function c29867611.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c29867611.filter(chkc,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c29867611.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c29867611.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
@@ -93,7 +93,9 @@ function c29867611.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c29867611.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x15b)
+		or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c29867611.con(e)
 	return e:GetHandler():GetEquipTarget():IsControler(e:GetHandlerPlayer())

--- a/c30155789.lua
+++ b/c30155789.lua
@@ -38,7 +38,7 @@ function c30155789.tgop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c30155789.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
@@ -67,7 +67,6 @@ function c30155789.operation(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetCode(EFFECT_EQUIP_LIMIT)
 		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e3:SetValue(c30155789.eqlimit)
-		e3:SetLabelObject(tc)
 		e3:SetReset(RESET_EVENT+RESETS_STANDARD)
 		c:RegisterEffect(e3)
 	else
@@ -75,7 +74,7 @@ function c30155789.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c30155789.eqlimit(e,c)
-	return c==e:GetLabelObject()
+	return e:GetHandler():GetEquipTarget()==c or c:IsControler(e:GetHandlerPlayer())
 end
 function c30155789.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT)~=0 and ep~=tp and rp==tp

--- a/c36591747.lua
+++ b/c36591747.lua
@@ -66,7 +66,7 @@ function c36591747.filter(c,tp)
 end
 function c36591747.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c36591747.filter(chkc,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c36591747.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c36591747.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
@@ -92,7 +92,9 @@ function c36591747.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c36591747.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x15b)
+		or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c36591747.stcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c37390589.lua
+++ b/c37390589.lua
@@ -8,14 +8,9 @@ function c37390589.initial_effect(c)
 	e1:SetHintTiming(TIMING_DAMAGE_STEP)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetCondition(aux.dscon)
-	e1:SetCost(c37390589.cost)
 	e1:SetTarget(c37390589.target)
 	e1:SetOperation(c37390589.operation)
 	c:RegisterEffect(e1)
-end
-function c37390589.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	e:SetLabel(9)
 end
 function c37390589.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then
@@ -28,7 +23,7 @@ function c37390589.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local b1=Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetTurnPlayer()~=tp
 		and Duel.GetAttacker():IsLocation(LOCATION_MZONE) and Duel.GetAttacker():IsAttackPos()
 		and Duel.GetAttacker():IsCanChangePosition() and Duel.GetAttacker():IsCanBeEffectTarget(e)
-	local b2=e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	local b2=e:IsCostChecked()
 		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil)
 	if chk==0 then return b1 or b2 end
 	local opt=0
@@ -43,7 +38,7 @@ function c37390589.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		Duel.SetTargetCard(Duel.GetAttacker())
 	end
 	if opt==1 or opt==2 then
-		if e:GetLabel()==9 then
+		if e:IsCostChecked() then
 			local c=e:GetHandler()
 			local cid=Duel.GetChainInfo(0,CHAININFO_CHAIN_ID)
 			local e1=Effect.CreateEffect(c)
@@ -101,11 +96,14 @@ function c37390589.operation(e,tp,eg,ep,ev,re,r,rp)
 			e2:SetType(EFFECT_TYPE_SINGLE)
 			e2:SetCode(EFFECT_EQUIP_LIMIT)
 			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-			e2:SetValue(1)
+			e2:SetValue(c37390589.eqlimit)
 			e2:SetReset(RESET_EVENT+RESETS_STANDARD)
 			c:RegisterEffect(e2)
 		else
 			c:CancelToGrave(false)
 		end
 	end
+end
+function c37390589.eqlimit(e,c)
+	return e:GetHandler():GetEquipTarget()==c or c:IsControler(e:GetHandlerPlayer())
 end

--- a/c38643567.lua
+++ b/c38643567.lua
@@ -43,7 +43,7 @@ function c38643567.filter(c)
 end
 function c38643567.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c38643567.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c38643567.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c38643567.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -95,7 +95,8 @@ function c38643567.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c38643567.eqlimit(e,c)
-	return c:IsSetCard(0x56)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x56)
 end
 function c38643567.ngcon(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end

--- a/c43405287.lua
+++ b/c43405287.lua
@@ -55,7 +55,7 @@ function c43405287.filter(c)
 end
 function c43405287.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c43405287.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c43405287.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c43405287.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -66,7 +66,7 @@ function c43405287.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsLocation(LOCATION_SZONE) then return end
 	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
 		Duel.Equip(tp,c,tc)
 		--Atkup
 		local e2=Effect.CreateEffect(c)
@@ -88,7 +88,8 @@ function c43405287.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c43405287.eqlimit(e,c)
-	return c:IsSetCard(0xc008)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0xc008)
 end
 function c43405287.damfilter(c,rc)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc

--- a/c47819246.lua
+++ b/c47819246.lua
@@ -64,7 +64,7 @@ function c47819246.filter(c)
 end
 function c47819246.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c47819246.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c47819246.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c47819246.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -75,7 +75,7 @@ function c47819246.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsLocation(LOCATION_SZONE) then return end
 	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetControler()==c:GetControler() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Equip(tp,c,tc)
 		--Equip limit
 		local e1=Effect.CreateEffect(c)
@@ -90,7 +90,8 @@ function c47819246.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c47819246.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer() and c:IsSetCard(0xdc) and c:IsType(TYPE_XYZ)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0xdc) and c:IsType(TYPE_XYZ)
 end
 function c47819246.atkval(e,c)
 	return c:GetRank()*100

--- a/c49551909.lua
+++ b/c49551909.lua
@@ -42,7 +42,7 @@ function c49551909.filter(c)
 end
 function c49551909.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c49551909.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c49551909.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c49551909.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -86,7 +86,8 @@ function c49551909.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c49551909.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer() and c:IsSetCard(0x6f)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x6f)
 end
 function c49551909.descon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c51686645.lua
+++ b/c51686645.lua
@@ -51,7 +51,7 @@ function c51686645.tgop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c51686645.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsFaceup() end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
@@ -86,7 +86,7 @@ function c51686645.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c51686645.eqlimit(e,c)
-	return c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c51686645.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsReason(REASON_LOST_TARGET)

--- a/c53656677.lua
+++ b/c53656677.lua
@@ -41,7 +41,7 @@ function c53656677.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local a=Duel.GetAttacker()
 	local d=Duel.GetAttackTarget()
 	if chk==0 then return d and d:IsControler(tp) and d:IsFaceup() and d:IsCanBeEffectTarget(e)
-		and d:GetAttack()<a:GetAttack() end
+		and d:GetAttack()<a:GetAttack() and e:IsCostChecked() end
 	Duel.SetTargetCard(d)
 end
 function c53656677.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c54451023.lua
+++ b/c54451023.lua
@@ -54,7 +54,7 @@ function c54451023.filter(c)
 end
 function c54451023.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c54451023.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c54451023.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c54451023.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -87,7 +87,8 @@ function c54451023.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c54451023.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer() and c:IsRace(RACE_PLANT)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRace(RACE_PLANT)
 end
 function c54451023.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(e:GetHandler():GetReason(),REASON_EFFECT+REASON_DESTROY)==REASON_EFFECT+REASON_DESTROY

--- a/c55262310.lua
+++ b/c55262310.lua
@@ -69,7 +69,7 @@ function c55262310.filter(c,tp)
 end
 function c55262310.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c55262310.filter(chkc,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c55262310.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c55262310.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
@@ -95,7 +95,9 @@ function c55262310.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c55262310.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x15b)
+		or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c55262310.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c57135971.lua
+++ b/c57135971.lua
@@ -54,7 +54,7 @@ function c57135971.filter(c)
 end
 function c57135971.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return c57135971.filter(chkc) and chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c57135971.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c57135971.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -86,7 +86,8 @@ function c57135971.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c57135971.eqlimit(e,c)
-	return c:IsSetCard(0x3b)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x3b)
 end
 function c57135971.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetEquipTarget() and aux.dscon()

--- a/c57470761.lua
+++ b/c57470761.lua
@@ -43,7 +43,7 @@ function c57470761.filter(c)
 end
 function c57470761.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c57470761.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c57470761.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c57470761.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
@@ -108,7 +108,8 @@ function c57470761.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c57470761.eqlimit(e,c)
-	return c:IsRace(RACE_DRAGON)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRace(RACE_DRAGON)
 end
 function c57470761.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c58272005.lua
+++ b/c58272005.lua
@@ -43,7 +43,7 @@ function c58272005.filter(c)
 end
 function c58272005.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c58272005.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c58272005.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c58272005.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -54,7 +54,7 @@ function c58272005.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsLocation(LOCATION_SZONE) then return end
 	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) and tc:IsRace(RACE_DINOSAUR) then
 		Duel.Equip(tp,c,tc)
 		--Atkup
 		local e1=Effect.CreateEffect(c)
@@ -86,7 +86,8 @@ function c58272005.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c58272005.eqlimit(e,c)
-	return c:IsRace(RACE_DINOSAUR)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRace(RACE_DINOSAUR)
 end
 function c58272005.atcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c59490397.lua
+++ b/c59490397.lua
@@ -53,14 +53,15 @@ function c59490397.filter(c)
 end
 function c59490397.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c59490397.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c59490397.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c59490397.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
 end
 function c59490397.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() and c:IsType(TYPE_LINK) and c:IsSetCard(0x10b)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsType(TYPE_LINK) and c:IsSetCard(0x10b)
 end
 function c59490397.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c6112401.lua
+++ b/c6112401.lua
@@ -47,7 +47,7 @@ function c6112401.tgop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c6112401.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and e:GetLabelObject():IsCanBeEffectTarget(e) end
 	Duel.SetTargetCard(e:GetLabelObject())
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
@@ -92,7 +92,10 @@ function c6112401.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c6112401.eqlimit(e,c)
-	return c:IsSetCard(0x100d)
+	if e:GetHandler():GetEquipTarget()==c then return true end
+	local g=Duel.GetFieldGroup(e:GetHandlerPlayer(),LOCATION_MZONE,0)
+	local tc=g:GetFirst()
+	return g:GetCount()==1 and tc==c and c:IsSetCard(0x100d)
 end
 function c6112401.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsContains(e:GetHandler():GetEquipTarget())

--- a/c62753201.lua
+++ b/c62753201.lua
@@ -46,14 +46,15 @@ function c62753201.filter(c)
 end
 function c62753201.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c62753201.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c62753201.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c62753201.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
 end
 function c62753201.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() and c:IsType(TYPE_LINK) and c:IsSetCard(0x10f)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsType(TYPE_LINK) and c:IsSetCard(0x10f)
 end
 function c62753201.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c62868900.lua
+++ b/c62868900.lua
@@ -43,7 +43,8 @@ function c62868900.tgop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c62868900.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc==eg:GetFirst() end
-	if chk==0 then return eg:GetFirst():IsCanBeEffectTarget(e) end
+	if chk==0 then return e:IsCostChecked()
+		and eg:GetFirst():IsCanBeEffectTarget(e) end
 	Duel.SetTargetCard(eg)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
 end

--- a/c63049052.lua
+++ b/c63049052.lua
@@ -43,7 +43,7 @@ function c63049052.filter(c)
 end
 function c63049052.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c63049052.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c63049052.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c63049052.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -90,7 +90,8 @@ function c63049052.atkval(e,c)
 	return c:GetOverlayCount()*300
 end
 function c63049052.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer() and c:IsType(TYPE_XYZ)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsRank(4)
 end
 function c63049052.mfilter(c)
 	return c:IsSetCard(0x88) and c:IsType(TYPE_MONSTER) and c:IsCanOverlay()

--- a/c6691855.lua
+++ b/c6691855.lua
@@ -43,7 +43,7 @@ function c6691855.filter(c)
 end
 function c6691855.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c6691855.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c6691855.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c6691855.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)

--- a/c66984907.lua
+++ b/c66984907.lua
@@ -69,7 +69,7 @@ function c66984907.filter(c,tp)
 end
 function c66984907.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c66984907.filter(chkc,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c66984907.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c66984907.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
@@ -95,7 +95,9 @@ function c66984907.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c66984907.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x15b)
+		or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c66984907.togcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c68054593.lua
+++ b/c68054593.lua
@@ -43,7 +43,7 @@ function c68054593.filter(c)
 end
 function c68054593.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c68054593.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c68054593.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c68054593.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -77,7 +77,7 @@ function c68054593.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c68054593.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer()
+	return e:GetHandler():GetEquipTarget()==c or c:IsControler(e:GetHandlerPlayer())
 end
 function c68054593.atkfilter(c)
 	return c:IsFaceup() and c:GetAttack()>c:GetBaseAttack()

--- a/c68540058.lua
+++ b/c68540058.lua
@@ -43,7 +43,7 @@ function c68540058.filter(c)
 end
 function c68540058.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c68540058.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c68540058.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c68540058.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)

--- a/c75987257.lua
+++ b/c75987257.lua
@@ -55,7 +55,7 @@ function c75987257.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tc=Duel.GetAttacker()
 	if chkc then return chkc==tc end
 	if chk==0 then return tc:IsLocation(LOCATION_MZONE) and tc:IsAttackPos()
-		and tc:IsCanChangePosition() and tc:IsCanBeEffectTarget(e) end
+		and tc:IsCanChangePosition() and tc:IsCanBeEffectTarget(e) and e:IsCostChecked() end
 	Duel.SetTargetCard(tc)
 end
 function c75987257.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c78586116.lua
+++ b/c78586116.lua
@@ -51,7 +51,7 @@ function c78586116.filter(c)
 end
 function c78586116.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c78586116.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c78586116.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c78586116.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -84,7 +84,8 @@ function c78586116.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c78586116.eqlimit(e,c)
-	return c:IsSetCard(0x26)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x26)
 end
 function c78586116.attg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local eq=e:GetHandler():GetEquipTarget()

--- a/c80143954.lua
+++ b/c80143954.lua
@@ -58,7 +58,7 @@ function c80143954.filter(c)
 end
 function c80143954.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c80143954.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c80143954.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c80143954.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -89,7 +89,8 @@ function c80143954.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c80143954.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x103)
 end
 function c80143954.negcon(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end

--- a/c87043568.lua
+++ b/c87043568.lua
@@ -38,7 +38,7 @@ function c87043568.tgop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c87043568.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
@@ -73,14 +73,13 @@ function c87043568.operation(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e2:SetValue(c87043568.eqlimit)
 		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
-		e2:SetLabelObject(tc)
 		c:RegisterEffect(e2)
 	else
 		c:CancelToGrave(false)
 	end
 end
 function c87043568.eqlimit(e,c)
-	return c==e:GetLabelObject()
+	return e:GetHandler():GetEquipTarget()==c or c:IsControler(e:GetHandlerPlayer())
 end
 function c87043568.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()

--- a/c879958.lua
+++ b/c879958.lua
@@ -53,14 +53,15 @@ function c879958.filter(c)
 end
 function c879958.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c879958.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c879958.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c879958.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
 end
 function c879958.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() and c:IsType(TYPE_LINK)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsType(TYPE_LINK)
 end
 function c879958.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c92650018.lua
+++ b/c92650018.lua
@@ -69,7 +69,7 @@ function c92650018.filter(c,tp)
 end
 function c92650018.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c92650018.filter(chkc,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c92650018.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c92650018.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
@@ -95,7 +95,9 @@ function c92650018.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c92650018.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x15b)
+		or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c92650018.discon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c93473606.lua
+++ b/c93473606.lua
@@ -69,7 +69,7 @@ function c93473606.filter(c,tp)
 end
 function c93473606.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c93473606.filter(chkc,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c93473606.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c93473606.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
@@ -95,7 +95,9 @@ function c93473606.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c93473606.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x15b)
+		or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c93473606.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c93655221.lua
+++ b/c93655221.lua
@@ -53,7 +53,8 @@ function c93655221.disfilter(c)
 end
 function c93655221.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
-	if chk==0 then return Duel.IsExistingTarget(c93655221.eqfilter,tp,LOCATION_MZONE,0,1,nil)
+	if chk==0 then return e:IsCostChecked()
+		and Duel.IsExistingTarget(c93655221.eqfilter,tp,LOCATION_MZONE,0,1,nil)
 		and Duel.IsExistingTarget(c93655221.disfilter,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELF)
 	Duel.SelectTarget(tp,c93655221.eqfilter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -106,5 +107,6 @@ function c93655221.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c93655221.eqlimit(e,c)
-	return c:GetControler()==e:GetHandlerPlayer() and c:IsType(TYPE_LINK)
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsType(TYPE_LINK)
 end

--- a/c97182396.lua
+++ b/c97182396.lua
@@ -65,7 +65,7 @@ function c97182396.filter(c,tp)
 end
 function c97182396.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c97182396.filter(chkc,tp) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c97182396.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c97182396.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
@@ -91,7 +91,9 @@ function c97182396.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c97182396.eqlimit(e,c)
-	return c:IsSetCard(0x15b) or c:IsControler(1-e:GetHandlerPlayer())
+	return e:GetHandler():GetEquipTarget()==c
+		or c:IsControler(e:GetHandlerPlayer()) and c:IsSetCard(0x15b)
+		or c:IsControler(1-e:GetHandlerPlayer())
 end
 function c97182396.nacon(e,tp,eg,ep,ev,re,r,rp)
 	local at=Duel.GetAttacker()

--- a/c98239899.lua
+++ b/c98239899.lua
@@ -54,7 +54,7 @@ function c98239899.filter(c)
 end
 function c98239899.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c98239899.filter(chkc) end
-	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+	if chk==0 then return e:IsCostChecked()
 		and Duel.IsExistingTarget(c98239899.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	Duel.SelectTarget(tp,c98239899.filter,tp,LOCATION_MZONE,0,1,1,nil)
@@ -65,7 +65,7 @@ function c98239899.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsLocation(LOCATION_SZONE) then return end
 	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
 		Duel.Equip(tp,c,tc)
 		--Atkup
 		local e1=Effect.CreateEffect(c)
@@ -87,7 +87,7 @@ function c98239899.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c98239899.eqlimit(e,c)
-	return c:GetControler()==e:GetOwnerPlayer()
+	return e:GetHandler():GetEquipTarget()==c or c:IsControler(e:GetHandlerPlayer())
 end
 function c98239899.descon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,0x41)==0x41 and e:GetHandler():GetEquipTarget()~=nil


### PR DESCRIPTION
(confirming _Amazement Family Faces_, _Altergeist Manifestation_, _Super Quantal Mech Sword - Magnaslayer_)

fix 1: _Tailor of the Fickle_ can target wrong monster.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9505&keyword=&tag=-1
> ただし、「[甲虫装機の宝珠](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9944)」は『自分フィールド上の「甲虫装機」と名のついたモンスター１体に装備する』カードとなりますので、**「[移り気な仕立屋](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4904)」を発動する際の対象となるモンスターは、自分のモンスターゾーンに表側表示で存在する「甲虫装機」と名のついたモンスターでなければなりません**。
> 
> したがって、相手のモンスターゾーンのモンスターや、「甲虫装機」と名のついたモンスター以外のモンスターに移し替える事はできません。

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8142&keyword=&tag=-1
> 「[スカーレッド・コクーン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12066)」の正しい対象となるモンスターは、自分のモンスターゾーンに表側表示で存在するドラゴン族のシンクロモンスターとなりますので、**「[スカーレッド・コクーン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12066)」を装備しているそのモンスター以外に、自分のモンスターゾーンに表側表示で存在するドラゴン族のシンクロモンスターが存在するのであれば、「[移り気な仕立屋](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4904)」を発動し、「[スカーレッド・コクーン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12066)」を移し替える事はできます**。
> 
> その場合でも、移し替えられた「[スカーレッド・コクーン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12066)」の『②：このカードの効果でこのカードを装備したモンスターが相手モンスターと戦闘を行う場合、そのダメージステップ終了時まで相手フィールドの全ての表側表示モンスターの効果は無効化される』効果は通常通り適用される事になります。

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9290&keyword=&tag=-1
> 「[身剣一体](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8369)」は『自分フィールド上のモンスターが、「X－セイバー」と名のついたモンスター１体のみの場合に発動できる』カードですので、「[移り気な仕立屋](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4904)」で移し替える場合も、同じ状態でなければなりません。
> 
> したがって、基本的に「[移り気な仕立屋](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4904)」を発動し、「[身剣一体](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8369)」を他のモンスターへと移し替える事はできませんが、**「[身剣一体](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8369)」の装備モンスターのコントロールが相手に移っている状態で、自分のモンスターゾーンに「X－セイバー」と名のついたモンスター1体のみが存在する場合であれば、「[移り気な仕立屋](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4904)」を発動し、「[身剣一体](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8369)」を自分フィールドのモンスターに移し替える事はできます**。

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8873&keyword=&tag=-1
> Question
> 『相手フィールド上にモンスターが特殊召喚された時に発動する事ができる。発動後このカードは攻撃力５００ポイントアップの装備カードとなり、そのモンスターに装備する』効果処理によって装備カード扱いとなっている「[イービル・ブラスト](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7495)」を、「[移り気な仕立屋](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4904)」の効果で他のモンスターに移し替える事はできますか？
> Answer
> できません。
> 
> **「[イービル・ブラスト](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7495)」の正しい対象となるモンスターは、「[イービル・ブラスト](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7495)」のカードを発動した際に対象として選択した、相手フィールドに特殊召喚されたモンスターのみです**。

---

fix 2: if equip monster was changed its status, equipped trap is destroyed.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16835&keyword=&tag=-1
> 「[スカーレッド・コクーン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12066)」の発動にチェーンして、対象のモンスターの種族がドラゴン族以外になっている場合でも、装備する処理は通常通り適用されます。
> 
> また、**「[スカーレッド・コクーン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12066)」を装備しているモンスターの種族がその後にドラゴン族以外になった場合でも、「[スカーレッド・コクーン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12066)」は対象のモンスターに装備されたままとなります**。

---

fix 3: if equipping effect was activated, _Labrynth Barrage_ can activate.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23607&keyword=&tag=-1
> Question
> 『このカードを攻撃力５００アップの装備カード扱いとして、その自分のモンスターに装備する』効果を持つ「[鎖付き爆弾](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5396)」などの通常罠カードを対象として、「[闇よりの罠](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6453)」を発動できますか？
> 
> また、「[鎖付き爆弾](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5396)」などの通常罠カードの発動にチェーンして「[ラビュリンス・バラージュ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17371)」を発動できますか？
> Answer
> 発動できません。

---

fix 4: _Hero Ring_ cannot target opponent monster.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6528
> ■モンスターゾーンに表側表示で存在す攻撃力1500以下の戦士族モンスター1体を対象に取る効果です。（自分のモンスターゾーンのモンスターだけでなく、**相手のモンスターゾーンのモンスターも対象とする事ができます**。）