### PR TITLE
fix IsSSetable

### DIFF
--- a/c10333641.lua
+++ b/c10333641.lua
@@ -36,14 +36,15 @@ function c10333641.setcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return c:IsReleasable() end
 	Duel.Release(c,REASON_COST)
 end
-function c10333641.setfilter(c)
-	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable()
+function c10333641.setfilter(c,ft)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable(true) and (c:IsType(TYPE_FIELD) or ft>0)
 end
 function c10333641.settg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_GRAVE) and c10333641.setfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c10333641.setfilter,tp,0,LOCATION_GRAVE,1,nil) end
+	local ft=Duel.GetLocationCount(tp,LOCATION_SZONE)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_GRAVE) and c10333641.setfilter(chkc,ft) end
+	if chk==0 then return Duel.IsExistingTarget(c10333641.setfilter,tp,0,LOCATION_GRAVE,1,nil,ft) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
-	local g=Duel.SelectTarget(tp,c10333641.setfilter,tp,0,LOCATION_GRAVE,1,1,nil)
+	local g=Duel.SelectTarget(tp,c10333641.setfilter,tp,0,LOCATION_GRAVE,1,1,nil,ft)
 	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
 end
 function c10333641.setop(e,tp,eg,ep,ev,re,r,rp)

--- a/c24413299.lua
+++ b/c24413299.lua
@@ -57,7 +57,7 @@ function c24413299.operation(e,tp,eg,ep,ev,re,r,rp)
 					if Duel.Destroy(g,REASON_EFFECT)~=0
 						and (tc:IsType(TYPE_FIELD) or Duel.GetLocationCount(tp,LOCATION_SZONE)>0)
 						and not tc:IsLocation(LOCATION_HAND+LOCATION_DECK)
-						and tc:IsType(TYPE_SPELL+TYPE_TRAP) and tc:IsSSetable()
+						and tc:IsType(TYPE_SPELL+TYPE_TRAP) and tc:IsSSetable(true)
 						and Duel.SelectYesNo(tp,aux.Stringid(24413299,3)) then
 						Duel.BreakEffect()
 						Duel.SSet(tp,tc)

--- a/c45935145.lua
+++ b/c45935145.lua
@@ -74,9 +74,11 @@ function s.sptcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	c:RemoveOverlayCard(tp,2,2,REASON_COST)
 end
 function s.sptfilter(c,e,tp)
-	return c:IsType(TYPE_MONSTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	local res1=c:IsType(TYPE_MONSTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP+POS_FACEDOWN_DEFENSE)
-		or not c:IsType(TYPE_MONSTER) and c:IsSSetable()
+	local res2=not c:IsType(TYPE_MONSTER) and c:IsSSetable(true)
+		and (c:IsType(TYPE_FIELD) or Duel.GetLocationCount(tp,LOCATION_SZONE)>0)
+	return res1 or res2
 end
 function s.spttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and s.sptfilter(chkc,e,tp) end

--- a/c90809975.lua
+++ b/c90809975.lua
@@ -100,7 +100,7 @@ function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.SpecialSummon(rc,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
 			Duel.ConfirmCards(1-tp,rc)
 		elseif (rc:IsType(TYPE_FIELD) or Duel.GetLocationCount(tp,LOCATION_SZONE)>0)
-			and rc:IsSSetable() and Duel.SelectYesNo(tp,aux.Stringid(90809975,4)) then
+			and rc:IsSSetable(true) and Duel.SelectYesNo(tp,aux.Stringid(90809975,4)) then
 			Duel.BreakEffect()
 			Duel.SSet(tp,rc)
 		end


### PR DESCRIPTION
When checking `Card.IsSSetable`, it will always use current controler
https://github.com/Fluorohydride/ygopro-core/blob/a42373cd9f56ff97e43916f9fbdaae3f823f3b95/card.cpp#L3425

If the opponent have 5 cards in S&T zone, `Card.IsSSetable` will return false for _超重武者オン－３２_ etc.