### PR TITLE
fix Double Payback, Kaiju Capture Mission, War Rock Ordeal

### DIFF
--- a/c5914184.lua
+++ b/c5914184.lua
@@ -14,7 +14,7 @@ function c5914184.actcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and 1-tp==rp and ev>=1000 and bit.band(r,REASON_EFFECT)~=0
 end
 function c5914184.acttg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsCanAddCounter(0x1a,math.floor(ev/1000)) end
+	if chk==0 then return Duel.IsCanAddCounter(tp,0x1a,math.floor(ev/1000),e:GetHandler()) end
 end
 function c5914184.actop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c71331215.lua
+++ b/c71331215.lua
@@ -1,6 +1,5 @@
 --ウォークライ・オーディール
 function c71331215.initial_effect(c)
-	Duel.EnableGlobalFlag(GLOBALFLAG_SELF_TOGRAVE)
 	c:EnableCounterPermit(0x5a,LOCATION_SZONE)
 	c:SetUniqueOnField(1,0,71331215)
 	--Activate
@@ -8,6 +7,7 @@ function c71331215.initial_effect(c)
 	e1:SetCategory(CATEGORY_COUNTER)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c71331215.target)
 	e1:SetOperation(c71331215.activate)
 	c:RegisterEffect(e1)
 	--draw
@@ -22,20 +22,11 @@ function c71331215.initial_effect(c)
 	e2:SetOperation(c71331215.drop)
 	c:RegisterEffect(e2)
 end
-function c71331215.activate(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	c:AddCounter(0x5a,3)
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e1:SetCode(EFFECT_SELF_TOGRAVE)
-	e1:SetRange(LOCATION_SZONE)
-	e1:SetCondition(c71331215.sdcon)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-	c:RegisterEffect(e1)
+function c71331215.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsCanAddCounter(tp,0x5a,3,e:GetHandler()) end
 end
-function c71331215.sdcon(e)
-	return e:GetHandler():GetCounter(0x5a)==0
+function c71331215.activate(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():AddCounter(0x5a,3)
 end
 function c71331215.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
@@ -50,8 +41,11 @@ function c71331215.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 end
 function c71331215.drop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetHandler():RemoveCounter(tp,0x5a,1,REASON_EFFECT) then
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and c:RemoveCounter(tp,0x5a,1,REASON_EFFECT) then
 		local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
-		Duel.Draw(p,d,REASON_EFFECT)
+		if Duel.Draw(p,d,REASON_EFFECT)~=0 and c:GetCounter(0x5a)==0 then
+			Duel.SendtoGrave(c,REASON_EFFECT)
+		end
 	end
 end

--- a/c81057455.lua
+++ b/c81057455.lua
@@ -41,7 +41,8 @@ function c81057455.filter(c)
 end
 function c81057455.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c81057455.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c81057455.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsCanAddCounter(tp,0x37,1,e:GetHandler())
+		and Duel.IsExistingTarget(c81057455.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	local g=Duel.SelectTarget(tp,c81057455.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,1,0,0)


### PR DESCRIPTION
fix 1: _Double Payback_ cannot activate.
fix 2: if _Gate Blocker_ has on the field, _Kaiju Capture Mission_, _War Rock Ordeal_ can activate.
fix 3: if Counter Cleaner activated, _War Rock Ordeal_ is sent to grave.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=15951
> ■ **『③』の効果の処理でカウンターを取り除いてドローしたのち、このカードのカウンターが全て取り除かれたのであれば**、このカードは墓地へ送られます。