### PR TITLE
update ThisCardInGraveAlreadyCheck & fix Assault Synchron

### DIFF
--- a/c77202120.lua
+++ b/c77202120.lua
@@ -57,16 +57,14 @@ end
 function c77202120.splimit(e,c)
 	return not c:IsType(TYPE_SYNCHRO) and c:IsLocation(LOCATION_EXTRA)
 end
-function c77202120.cfilter(c,e,tp,se,cre)
+function c77202120.cfilter(c,tp,se)
 	return c:IsControler(tp) and c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO)
 		and c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousControler(tp)
 		and (se==nil or c:GetReasonEffect()~=se)
-		and (c:GetReasonEffect()~=cre or cre and cre:IsActivated())
 end
 function c77202120.condition(e,tp,eg,ep,ev,re,r,rp)
 	local se=e:GetLabelObject():GetLabelObject()
-	local cre=e:GetHandler():GetReasonEffect()
-	return eg:IsExists(c77202120.cfilter,1,nil,e,tp,se,cre)
+	return eg:IsExists(c77202120.cfilter,1,nil,tp,se)
 end
 function c77202120.spfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO)

--- a/utility.lua
+++ b/utility.lua
@@ -2975,12 +2975,13 @@ function Auxiliary.AddThisCardInGraveAlreadyCheck(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(EVENT_TO_GRAVE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e1:SetOperation(Auxiliary.ThisCardInGraveAlreadyCheckOperation)
+	e1:SetCondition(Auxiliary.ThisCardInGraveAlreadyCheckReg)
 	c:RegisterEffect(e1)
 	return e1
 end
-function Auxiliary.ThisCardInGraveAlreadyCheckOperation(e,tp,eg,ep,ev,re,r,rp)
+function Auxiliary.ThisCardInGraveAlreadyCheckReg(e,tp,eg,ep,ev,re,r,rp)
+	--condition of continous effect will be checked before other effects
+	if e:GetLabelObject()~=nil then return false end
 	if (r&REASON_EFFECT)>0 then
 		e:SetLabelObject(re)
 		local e1=Effect.CreateEffect(e:GetHandler())
@@ -2996,7 +2997,22 @@ function Auxiliary.ThisCardInGraveAlreadyCheckOperation(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetReset(RESET_CHAIN)
 		e2:SetLabelObject(e1)
 		Duel.RegisterEffect(e2,tp)
+	elseif (r&REASON_MATERIAL)>0 then
+		e:SetLabelObject(re)
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_SUMMON)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetOperation(Auxiliary.ThisCardInGraveAlreadyReset1)
+		e1:SetLabelObject(e)
+		Duel.RegisterEffect(e1,tp)
+		local e2=e1:Clone()
+		e2:SetCode(EVENT_SPSUMMON)
+		e2:SetOperation(Auxiliary.ThisCardInGraveAlreadyReset2)
+		e2:SetLabelObject(e1)
+		Duel.RegisterEffect(e2,tp)
 	end
+	return false
 end
 function Auxiliary.ThisCardInGraveAlreadyReset1(e)
 	--this will run after EVENT_SPSUMMON_SUCCESS

--- a/utility.lua
+++ b/utility.lua
@@ -2997,7 +2997,7 @@ function Auxiliary.ThisCardInGraveAlreadyCheckReg(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetReset(RESET_CHAIN)
 		e2:SetLabelObject(e1)
 		Duel.RegisterEffect(e2,tp)
-	elseif (r&REASON_MATERIAL)>0 then
+	elseif (r&REASON_MATERIAL)>0 or re and not re:IsActivated() and (r&REASON_COST)>0 then
 		e:SetLabelObject(re)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)


### PR DESCRIPTION
There is a ruling that if _Assault Synchron_ and _Chaos Ruler, the Chaotic Magical Dragon_ (summoned by its 2nd effect) are used as synchro material, _Assault Synchron_ can't use its effect in grave because it is not in grave when Chaos Ruler is banished.

Formerly, `Auxiliary.AddThisCardInGraveAlreadyCheck` can't be used at this case because those `EVENT_REMOVE` and `EVENT_TO_GRAVE` events are checked together, so the operation of the ThisCardInGraveAlreadyCheck will be called after the condition of `EVENT_REMOVE`. We can move the operation to condition to fix this.

The problem of the formerly implement of that ruling in _Assault Synchron_ is, if it was used as material of a synchro monster, and the synchro monster was returned to extra deck, and the same synchro monster is summoned again using Chaos Ruler, it should be able to use effect, but `c:GetReasonEffect()` is same at this condition. So we had to reset this reg in ThisCardInGraveAlreadyCheck.