### PR TITLE
fix `Sand Moth`

### DIFF
--- a/c73648243.lua
+++ b/c73648243.lua
@@ -17,8 +17,7 @@ function c73648243.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and c:IsPreviousPosition(POS_FACEDOWN_DEFENSE)
 end
 function c73648243.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c73648243.spop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Mandatory effect was not activating with the Special Summon requirements unfulfilled when it should.

Mandatory effects always activate, even if costs and other activation requirements are unfulfilled.