### PR TITLE
workaround fix for Kaiser Colosseum vs Nibiru

### DIFF
--- a/c35059553.lua
+++ b/c35059553.lua
@@ -23,6 +23,16 @@ function c35059553.initial_effect(c)
 	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_IMMUNE)
 	e3:SetValue(c35059553.sumlimit)
 	c:RegisterEffect(e3)
+	--workaround for nibiru
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetTargetRange(0,1)
+	e4:SetCondition(c35059553.nibirucon)
+	e4:SetValue(c35059553.nibirulimit)
+	c:RegisterEffect(e4)
 end
 function c35059553.value(e,fp,rp,r)
 	if rp==e:GetHandlerPlayer() or r~=LOCATION_REASON_TOFIELD then return 7 end
@@ -42,4 +52,17 @@ function c35059553.sumlimit(e,c)
 	else
 		return false
 	end
+end
+function c35059553.nibirufilter(c)
+	return not c:IsReleasableByEffect()
+end
+function c35059553.nibirucon(e)
+	local tp=e:GetHandlerPlayer()
+	if Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 then return false end
+	local c1=Duel.GetMatchingGroupCount(c35059553.nibirufilter,tp,LOCATION_MZONE,0,nil)
+	local c2=Duel.GetMatchingGroupCount(c35059553.nibirufilter,tp,0,LOCATION_MZONE,nil)
+	return c1 <= c2
+end
+function c35059553.nibirulimit(e,re,tp)
+	return re:GetHandler():IsOriginalCodeRule(27204311)
 end


### PR DESCRIPTION
**This fix is not done by me**, personally I **DON'T AGREE** to merge this.

-----

> Question
相手のモンスターゾーンにモンスターが1体存在し、自分のモンスターゾーンには2体のモンスターが表側表示で存在している状況で、相手が「[カイザーコロシアム](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5605)」を発動した後、次の自分のターンを迎えました。
この状況で、自分は相手モンスターを対象として「[クロス･ソウル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5099)」発動し、アドバンス召喚を行う事はできますか？
Answer
質問の状況の場合でも、「[クロス･ソウル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5099)」を発動する事はできます。
ただし、相手の「[カイザーコロシアム](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5605)」の効果が適用されていますので、相手のモンスターの数を越えるように自分は新たなモンスターを出す事ができません。
この状況で、自分がアドバンス召喚を行う場合、「[クロス･ソウル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5099)」が適用された相手モンスターをリリースする事はできず、自分のモンスターのみをリリースしてアドバンス召喚を行う事になります。
この時、レベル5･6のモンスターなど、自分のモンスター1体のみをリリースして行うアドバンス召喚を行う事はできず、レベル7以上のモンスターなど、自分のモンスター2体のみをリリースして行うアドバンス召喚しか行う事はできません。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12157&keyword=&tag=-1&request_locale=ja

mail:
> Q.
相手の「カイザーコロシアム」が適用されており、自分フィールドに「青眼の白龍」1体、相手フィールドに「E・HERO エアーマン」「V・HERO ヴァイオン」「V・HERO インクリース」「V・HERO インクリース」4体のモンスターがいる場合、自分は「原始生命態ニビル」を発動できますか？（相手はこのターンに5回召喚している）
A.
ご質問の場合、自分は「原始生命態ニビル」の効果を発動することはできません。


Despite the card says __自分フィールドにモンスターが存在する限り__ or __If there is 1 or more monster(s) on the field of the controller of this card__, if there will be no monster on the field of the controller, the effect will still prevent the action to be performed.