### PR TITLE
fix シューティング・クェーサー・ドラゴン

### DIFF
--- a/c35952884.lua
+++ b/c35952884.lua
@@ -11,17 +11,10 @@ function c35952884.initial_effect(c)
 	e1:SetValue(aux.synlimit)
 	c:RegisterEffect(e1)
 	--multi attack
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
-	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
-	e2:SetCondition(c35952884.mtcon)
-	e2:SetOperation(c35952884.mtop)
-	c:RegisterEffect(e2)
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_MATERIAL_CHECK)
 	e3:SetValue(c35952884.valcheck)
-	e3:SetLabelObject(e2)
 	c:RegisterEffect(e3)
 	--negate
 	local e3=Effect.CreateEffect(c)
@@ -50,20 +43,15 @@ function c35952884.initial_effect(c)
 end
 c35952884.material_type=TYPE_SYNCHRO
 function c35952884.valcheck(e,c)
-	e:GetLabelObject():SetLabel(c:GetMaterialCount()-1)
-end
-function c35952884.mtcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO) and e:GetLabel()>0
-end
-function c35952884.mtop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local ct=e:GetLabel()
-	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetCode(EFFECT_EXTRA_ATTACK)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
-	e1:SetValue(ct-1)
-	c:RegisterEffect(e1)
+	local ct=c:GetMaterialCount()-1
+	if ct>1 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EXTRA_ATTACK)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE-RESET_TOFIELD)
+		e1:SetValue(ct-1)
+		c:RegisterEffect(e1)
+	end
 end
 function c35952884.discon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)


### PR DESCRIPTION
If the monster will grant an effect according to the number or condition of material, we can add the effect in `EFFECT_MATERIAL_CHECK` directly.

Reason:
1. Effects which change the stat of a monster should be added before it enters the field.
2. Not using `e:SetLabel()` and `e:GetLabel()` will simplify the control flow of the script.

Test:
[test_material.zip](https://github.com/Fluorohydride/ygopro-scripts/files/11406640/test_material.zip)
test_material.lua
Single mode test script