### PR TITLE
end phase destroy workaround

### DIFF
--- a/c1845204.lua
+++ b/c1845204.lua
@@ -38,29 +38,18 @@ function c1845204.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1,true)
-		tc:RegisterFlagEffect(1845204,RESET_EVENT+RESETS_STANDARD,0,1)
-		tc:CompleteProcedure()
 		local e2=Effect.CreateEffect(e:GetHandler())
 		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e2:SetCode(EVENT_PHASE+PHASE_END)
 		e2:SetCountLimit(1)
+		e2:SetRange(LOCATION_MZONE)
 		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
-		e2:SetLabelObject(tc)
-		e2:SetCondition(c1845204.descon)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
 		e2:SetOperation(c1845204.desop)
-		Duel.RegisterEffect(e2,tp)
-	end
-end
-function c1845204.descon(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	if tc:GetFlagEffect(1845204)~=0 then
-		return true
-	else
-		e:Reset()
-		return false
+		tc:RegisterEffect(e2,true)
+		tc:CompleteProcedure()
 	end
 end
 function c1845204.desop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	Duel.Destroy(tc,REASON_EFFECT)
+	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
 end

--- a/c22993208.lua
+++ b/c22993208.lua
@@ -43,29 +43,18 @@ function c22993208.activate(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetValue(RESET_TURN_SET)
 		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e2,true)
-		tc:RegisterFlagEffect(22993208,RESET_EVENT+RESETS_STANDARD,0,1)
 		local e3=Effect.CreateEffect(e:GetHandler())
 		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		e3:SetCode(EVENT_PHASE+PHASE_END)
-		e3:SetCountLimit(1)
 		e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
-		e3:SetLabelObject(tc)
-		e3:SetCondition(c22993208.descon)
+		e3:SetRange(LOCATION_MZONE)
+		e3:SetCode(EVENT_PHASE+PHASE_END)
 		e3:SetOperation(c22993208.desop)
-		Duel.RegisterEffect(e3,tp)
+		e3:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e3:SetCountLimit(1)
+		tc:RegisterEffect(e3,true)
 	end
 	Duel.SpecialSummonComplete()
 end
-function c22993208.descon(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	if tc:GetFlagEffect(22993208)~=0 then
-		return true
-	else
-		e:Reset()
-		return false
-	end
-end
 function c22993208.desop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	Duel.Destroy(tc,REASON_EFFECT)
+	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
 end

--- a/c65450690.lua
+++ b/c65450690.lua
@@ -36,28 +36,17 @@ function c65450690.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_CANNOT_ATTACK)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1,true)
-		tc:RegisterFlagEffect(65450690,RESET_EVENT+RESETS_STANDARD,0,1)
 		local e2=Effect.CreateEffect(e:GetHandler())
 		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		e2:SetCode(EVENT_PHASE+PHASE_END)
-		e2:SetCountLimit(1)
 		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
-		e2:SetLabelObject(tc)
-		e2:SetCondition(c65450690.descon)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetCode(EVENT_PHASE+PHASE_END)
 		e2:SetOperation(c65450690.desop)
-		Duel.RegisterEffect(e2,tp)
-	end
-end
-function c65450690.descon(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	if tc:GetFlagEffect(65450690)~=0 then
-		return true
-	else
-		e:Reset()
-		return false
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e2:SetCountLimit(1)
+		tc:RegisterEffect(e2,true)
 	end
 end
 function c65450690.desop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	Duel.Destroy(tc,REASON_EFFECT)
+	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
 end


### PR DESCRIPTION
@mercury233 
# Problem
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6901&request_locale=ja
簡易融合
Instant Fusion
 このカード名のカードは１ターンに１枚しか発動できない。
①：１０００LPを払って発動できる。レベル５以下の融合モンスター１体を融合召喚扱いとしてEXデッキから特殊召喚する。この効果で特殊召喚したモンスターは攻撃できず、エンドフェイズに破壊される。 

■特殊召喚後、ただちにそのモンスターに『攻撃できず、エンドフェイズに破壊される』効果が適用されます。

[bug_instant.zip](https://github.com/Fluorohydride/ygopro-scripts/files/11592108/bug_instant.zip)
bug_instant.yrp
T2
A activates 簡易融合/Instant Fusion
Special Summon エルシャドール・ミドラーシ/El Shaddoll Winda

B activates 大捕り物/Crackdown
B gets the control of El Shaddoll Winda

End phase:
Now: El Shaddoll Winda will not be destroyed
Correct: El Shaddoll Winda will be destroyed

# Reason
I think the reason is the destruction of Instant Fusion is treated as "destroyed by A's effect".

# Solution
Revert Fluorohydride/ygopro@fc1a209 as a workaround.

This is done by:
- Reset ygopro to https://github.com/Fluorohydride/ygopro/commit/68c7985f1c4036883562db7d91e7557869c53122
- copy the current script file to script/
- git revert fc1a209

Now the destruction comes from the fusion monster itself, and El Shaddoll Winda will be destroyed.

# Reference
https://ocg-rule.readthedocs.io/zh_CN/latest/c06/2018.html#id148
18/12/1
「简易融合」来融合召唤的「神影依·米德拉什」之后控制权转移的场合，结束阶段仍然破坏。

https://ocg-rule.readthedocs.io/zh_CN/latest/c06/2019.html#id242
19/12/21
邮件：
自己用「简易融合」的效果融合召唤「神影依·米德拉什」后，发动「紫炎的间者」让「神影依·米德拉什」的控制权转移给对方的场合，结束阶段如果先让「紫炎的间者」的效果适用结束，那么「神影依·米德拉什」的控制权归还后因「简易融合」的效果被破坏。如果先处理「简易融合」的效果，那么「神影依·米德拉什」在对方场上被破坏。

El Shaddoll Winda will be destroyed after its control changes.
