### PR TITLE
fix "then inflict damage" cards

### DIFF
--- a/c13166204.lua
+++ b/c13166204.lua
@@ -26,11 +26,12 @@ function c13166204.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c13166204.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) and Duel.Destroy(re:GetHandler(),REASON_EFFECT)~=0 then
-		Duel.BreakEffect()
 		local a=re:GetHandler():GetAttack()
 		local b=re:GetHandler():GetDefense()
 		if b>a then a=b end
-		if a<0 then a=0 end
-		if a>0 then Duel.Damage(1-tp,a,REASON_EFFECT) end
+		if a>0 then
+			Duel.BreakEffect()
+			Duel.Damage(1-tp,a,REASON_EFFECT)
+		end
 	end
 end

--- a/c32986898.lua
+++ b/c32986898.lua
@@ -73,10 +73,11 @@ function c32986898.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
 		if Duel.Destroy(tc,REASON_EFFECT)~=0 and e:GetHandler():GetFlagEffect(32986898)~=0 then
-			Duel.BreakEffect()
 			local atk=tc:GetBaseAttack()
-			if atk<0 then atk=0 end
-			Duel.Damage(1-tp,math.ceil(atk/2),REASON_EFFECT)
+			if atk>0 then
+				Duel.BreakEffect()
+				Duel.Damage(1-tp,math.ceil(atk/2),REASON_EFFECT)
+			end
 		end
 	end
 end

--- a/c33776843.lua
+++ b/c33776843.lua
@@ -31,9 +31,10 @@ end
 function c33776843.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 and tc:IsPreviousLocation(LOCATION_MZONE) then
-		local atk=tc:GetTextAttack()
-		if atk<0 then atk=0 end
-		Duel.BreakEffect()
-		Duel.Damage(1-tp,atk,REASON_EFFECT)
+		local atk=tc:GetBaseAttack()
+		if atk>0 then
+			Duel.BreakEffect()
+			Duel.Damage(1-tp,atk,REASON_EFFECT)
+		end
 	end
 end

--- a/c40522482.lua
+++ b/c40522482.lua
@@ -51,6 +51,9 @@ function c40522482.activate(e,tp,eg,ep,ev,re,r,rp)
 		else
 			g,dam=og:GetMaxGroup(Card.GetBaseAttack)
 		end
-		Duel.Damage(1-tp,dam,REASON_EFFECT)
+		if dam>0 then
+			Duel.BreakEffect()
+			Duel.Damage(1-tp,dam,REASON_EFFECT)
+		end
 	end
 end

--- a/c71344451.lua
+++ b/c71344451.lua
@@ -39,9 +39,11 @@ function c71344451.activate(e,tp,eg,ep,ev,re,r,rp)
 					Duel.Destroy(sg,REASON_EFFECT)
 					local tg=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_GRAVE)
 					if tg:GetCount()>0 then
-						Duel.BreakEffect()
 						local dam=tg:GetCount()*2000
-						Duel.Damage(1-tp,dam,REASON_EFFECT)
+						if dam>0 then
+							Duel.BreakEffect()
+							Duel.Damage(1-tp,dam,REASON_EFFECT)
+						end
 					end
 				end
 			else

--- a/c86750474.lua
+++ b/c86750474.lua
@@ -56,8 +56,10 @@ function c86750474.damop2(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c86750474.damfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp)
 	if g:GetCount()>0 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)~=0 then
-		Duel.BreakEffect()
 		local d=Duel.GetFieldGroupCount(1-tp,LOCATION_ONFIELD,0)*200
-		Duel.Damage(1-tp,d,REASON_EFFECT)
+		if d>0 then
+			Duel.BreakEffect()
+			Duel.Damage(1-tp,d,REASON_EFFECT)
+		end
 	end
 end

--- a/c88120966.lua
+++ b/c88120966.lua
@@ -40,11 +40,10 @@ function c88120966.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c88120966.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
-		if Duel.Destroy(tc,REASON_EFFECT)~=0 and tc:IsType(TYPE_XYZ) then
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 and tc:IsType(TYPE_XYZ) then
+		local atk=tc:GetBaseAttack()
+		if atk>0 then
 			Duel.BreakEffect()
-			local atk=tc:GetBaseAttack()
-			if atk<0 then atk=0 end
 			Duel.Damage(1-tp,atk,REASON_EFFECT)
 		end
 	end

--- a/c96700602.lua
+++ b/c96700602.lua
@@ -33,7 +33,8 @@ function c96700602.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local g=Duel.GetMatchingGroup(c96700602.filter,tp,0,LOCATION_MZONE,nil)
 	if Duel.ChangePosition(g,POS_FACEUP_DEFENSE,POS_FACEDOWN_DEFENSE,0,0)~=0 then
-		if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetDefense()>0 then
+			Duel.BreakEffect()
 			Duel.Damage(1-tp,tc:GetDefense(),REASON_EFFECT)
 		end
 	end

--- a/c98643358.lua
+++ b/c98643358.lua
@@ -25,8 +25,10 @@ end
 function c98643358.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c98643358.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	if Duel.Destroy(g,REASON_EFFECT)~=0 then
-		Duel.BreakEffect()
 		local ct=Duel.GetOperatedGroup():FilterCount(c98643358.ctfilter,nil)
-		Duel.Damage(1-tp,ct*500,REASON_EFFECT)
+		if ct>0 then
+			Duel.BreakEffect()
+			Duel.Damage(1-tp,ct*500,REASON_EFFECT)
+		end
 	end
 end


### PR DESCRIPTION
The damage step of those effects should not be performed if the damage is 0.

mail:
> Q.
「No.1 インフェクション・バアル・ゼブル」の②の効果で相手の「ユベル」を破壊した場合、「ユベル」のATKが0なので、この「ユベル」の④の効果はタイミングを逃すことがありますか？
A.
ご質問の場合、『さらにその攻撃力の半分のダメージを相手に与える』処理を行いませんので、一連のチェーン処理後に「ユベル」の『④』の効果を発動できます。