### PR TITLE
fix: end phase destroy

### DIFF
--- a/c1845204.lua
+++ b/c1845204.lua
@@ -47,7 +47,7 @@ function c1845204.activate(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 		e2:SetLabelObject(tc)
 		e2:SetCondition(c1845204.descon)
-		e2:SetOperation(c1845204.desop)
+		e2:SetOperation(aux.EPDestroyOperation)
 		Duel.RegisterEffect(e2,tp)
 	end
 end
@@ -59,8 +59,4 @@ function c1845204.descon(e,tp,eg,ep,ev,re,r,rp)
 		e:Reset()
 		return false
 	end
-end
-function c1845204.desop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	Duel.Destroy(tc,REASON_EFFECT)
 end

--- a/c22993208.lua
+++ b/c22993208.lua
@@ -51,7 +51,7 @@ function c22993208.activate(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 		e3:SetLabelObject(tc)
 		e3:SetCondition(c22993208.descon)
-		e3:SetOperation(c22993208.desop)
+		e3:SetOperation(aux.EPDestroyOperation)
 		Duel.RegisterEffect(e3,tp)
 	end
 	Duel.SpecialSummonComplete()
@@ -64,8 +64,4 @@ function c22993208.descon(e,tp,eg,ep,ev,re,r,rp)
 		e:Reset()
 		return false
 	end
-end
-function c22993208.desop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	Duel.Destroy(tc,REASON_EFFECT)
 end

--- a/c65450690.lua
+++ b/c65450690.lua
@@ -44,7 +44,7 @@ function c65450690.activate(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 		e2:SetLabelObject(tc)
 		e2:SetCondition(c65450690.descon)
-		e2:SetOperation(c65450690.desop)
+		e2:SetOperation(aux.EPDestroyOperation)
 		Duel.RegisterEffect(e2,tp)
 	end
 end
@@ -56,8 +56,4 @@ function c65450690.descon(e,tp,eg,ep,ev,re,r,rp)
 		e:Reset()
 		return false
 	end
-end
-function c65450690.desop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject()
-	Duel.Destroy(tc,REASON_EFFECT)
 end

--- a/utility.lua
+++ b/utility.lua
@@ -3169,3 +3169,8 @@ function Auxiliary.RemoveOperation(e,tp,eg,ep,ev,re,r,rp)
 		end
 	end
 end
+--The operation function of "destroy during End Phase"
+function Auxiliary.EPDestroyOperation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	Duel.Destroy(tc,REASON_EFFECT,LOCATION_GRAVE,tc:GetControler())
+end


### PR DESCRIPTION
# Problem
see
https://github.com/Fluorohydride/ygopro/issues/2404
#2088 

# Solution
Auxiliary.EPDestroyOperation()
The operation function of "destroy during End Phase"
