### PR TITLE
fix ～が破壊される場合、代わり～

### DIFF
--- a/c23790299.lua
+++ b/c23790299.lua
@@ -84,7 +84,7 @@ end
 function c23790299.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		return not c:IsReason(REASON_REPLACE) and Duel.IsExistingMatchingCard(c23790299.repfilter,tp,LOCATION_GRAVE,0,1,nil)
+		return c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE) and Duel.IsExistingMatchingCard(c23790299.repfilter,tp,LOCATION_GRAVE,0,1,nil)
 	end
 	if Duel.SelectEffectYesNo(tp,c,96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)

--- a/c2403771.lua
+++ b/c2403771.lua
@@ -49,7 +49,7 @@ function c2403771.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
 		local g=c:GetEquipGroup()
-		return not c:IsReason(REASON_REPLACE) and g:IsExists(c2403771.repfilter,1,nil)
+		return c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE) and g:IsExists(c2403771.repfilter,1,nil)
 	end
 	if Duel.SelectEffectYesNo(tp,c,96) then
 		local g=c:GetEquipGroup()

--- a/c25165047.lua
+++ b/c25165047.lua
@@ -55,7 +55,7 @@ function c25165047.repfilter(c)
 end
 function c25165047.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not c:IsReason(REASON_REPLACE)
+	if chk==0 then return c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 		and Duel.IsExistingMatchingCard(c25165047.repfilter,tp,LOCATION_GRAVE,0,1,nil) end
 	if Duel.SelectEffectYesNo(tp,c,96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)

--- a/c2525268.lua
+++ b/c2525268.lua
@@ -32,7 +32,8 @@ function c2525268.addc(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c2525268.dfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_SPELLCASTER) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
+	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_SPELLCASTER)
+		and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function c2525268.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c2525268.lua
+++ b/c2525268.lua
@@ -32,7 +32,7 @@ function c2525268.addc(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c2525268.dfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_SPELLCASTER) and not c:IsReason(REASON_REPLACE)
+	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_SPELLCASTER) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function c2525268.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c39910367.lua
+++ b/c39910367.lua
@@ -54,8 +54,9 @@ function c39910367.rop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetHandler():RemoveCounter(ep,0x1,ev,REASON_EFFECT)
 end
 function c39910367.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not e:GetHandler():IsReason(REASON_RULE+REASON_REPLACE)
-		and e:GetHandler():IsCanRemoveCounter(tp,0x1,1,REASON_EFFECT) end
+	local c=e:GetHandler()
+	if chk==0 then return c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
+		and c:IsCanRemoveCounter(tp,0x1,1,REASON_EFFECT) end
 	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
 end
 function c39910367.desrepop(e,tp,eg,ep,ev,re,r,rp)

--- a/c63881033.lua
+++ b/c63881033.lua
@@ -73,7 +73,7 @@ function c63881033.lvop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c63881033.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
-		and c:IsType(TYPE_XYZ) and c:IsRace(RACE_MACHINE) and not c:IsReason(REASON_REPLACE)
+		and c:IsType(TYPE_XYZ) and c:IsRace(RACE_MACHINE) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function c63881033.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED)

--- a/c72497366.lua
+++ b/c72497366.lua
@@ -36,7 +36,7 @@ function c72497366.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=eg:GetFirst()
 	if chk==0 then return eg:GetCount()==1 and tc:IsFaceup() and tc:IsLocation(LOCATION_MZONE)
 		and tc:IsRace(RACE_FIEND) and tc:IsLevelAbove(5) and tc:IsSummonType(SUMMON_TYPE_NORMAL)
-		and not tc:IsReason(REASON_REPLACE) end
+		and tc:IsReason(REASON_EFFECT+REASON_BATTLE) and not tc:IsReason(REASON_REPLACE) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
 		return true

--- a/c74580251.lua
+++ b/c74580251.lua
@@ -36,7 +36,7 @@ function c74580251.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c74580251.repfilter(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0xc4) and c:IsOnField()
-		and c:IsControler(tp) and not c:IsReason(REASON_REPLACE)
+		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function c74580251.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemove() and aux.exccon(e) and eg:IsExists(c74580251.repfilter,1,nil,tp) end

--- a/c75775867.lua
+++ b/c75775867.lua
@@ -15,8 +15,10 @@ function c75775867.initial_effect(c)
 	c:RegisterEffect(e1)
 	--Destroy replace
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
 	e2:SetTarget(c75775867.reptg)
 	e2:SetOperation(c75775867.repop)
 	c:RegisterEffect(e2)
@@ -51,7 +53,7 @@ function c75775867.repfilter(c,e)
 end
 function c75775867.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not c:IsReason(REASON_REPLACE) and c:IsOnField() and c:IsFaceup() and c:IsDefensePos()
+	if chk==0 then return c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE) and c:IsDefensePos()
 		and Duel.IsExistingMatchingCard(c75775867.repfilter,tp,LOCATION_MZONE,0,1,c,e) end
 	if Duel.SelectEffectYesNo(tp,c,96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)

--- a/c98986900.lua
+++ b/c98986900.lua
@@ -50,7 +50,8 @@ function s.ctop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.dreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:CheckRemoveOverlayCard(tp,1,REASON_EFFECT) and not c:IsReason(REASON_REPLACE) end
+	if chk==0 then return c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
+		and c:CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.drepop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12975&request_locale=ja
セフィラの神意
②：自分フィールドの「セフィラ」カードが破壊される場合、代わりに墓地のこのカードを除外できる。この効果はこのカードが墓地へ送られたターンには使用できない。 
■『②：自分フィールドの「セフィラ」カードが破壊される場合、代わりに墓地のこのカードを除外できる。この効果はこのカードが墓地へ送られたターンには使用できない』効果はチェーンブロックの作られない効果です。（ダメージステップでも適用する事ができます。自分フィールドの表側表示の「セフィラ」カードが、戦闘または効果で破壊される場合に適用できます。）

Only destroyed by battle or effect can be replaced by this kind of effect.



