### PR TITLE
fix 死のマジック・ボックス

### DIFF
--- a/c25774450.lua
+++ b/c25774450.lua
@@ -32,7 +32,7 @@ function c25774450.activate(e,tp,eg,ep,ev,re,r,rp)
 	if dc:IsRelateToEffect(e) and Duel.Destroy(dc,REASON_EFFECT)~=0 then
         if cc:IsRelateToEffect(e) then
             Duel.BreakEffect()
-		    Duel.GetControl(cc,1-tp)
+			Duel.GetControl(cc,1-tp)
         end
 	end
 end

--- a/c25774450.lua
+++ b/c25774450.lua
@@ -29,8 +29,10 @@ function c25774450.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ex2,cg=Duel.GetOperationInfo(0,CATEGORY_CONTROL)
 	local dc=dg:GetFirst()
 	local cc=cg:GetFirst()
-	if dc:IsRelateToEffect(e) and cc:IsRelateToEffect(e) and Duel.Destroy(dc,REASON_EFFECT)~=0 then
-		Duel.BreakEffect()
-		Duel.GetControl(cc,1-tp)
+	if dc:IsRelateToEffect(e) and Duel.Destroy(dc,REASON_EFFECT)~=0 then
+        if cc:IsRelateToEffect(e) then
+            Duel.BreakEffect()
+		    Duel.GetControl(cc,1-tp)
+        end
 	end
 end

--- a/c25774450.lua
+++ b/c25774450.lua
@@ -30,9 +30,9 @@ function c25774450.activate(e,tp,eg,ep,ev,re,r,rp)
 	local dc=dg:GetFirst()
 	local cc=cg:GetFirst()
 	if dc:IsRelateToEffect(e) and Duel.Destroy(dc,REASON_EFFECT)~=0 then
-        if cc:IsRelateToEffect(e) then
-            Duel.BreakEffect()
+		if cc:IsRelateToEffect(e) then
+			Duel.BreakEffect()
 			Duel.GetControl(cc,1-tp)
-        end
+		end
 	end
 end


### PR DESCRIPTION
详情在[这里](https://ygobbs.com/t/%E6%AD%BB%E4%B9%8B%E9%AD%94%E6%9C%AF%E7%AE%B1bug%EF%BC%88%E9%99%84%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88%E4%BB%A3%E7%A0%81%EF%BC%89/446305)有讨论，根据官方裁定，当控制权转移的对象消失时，破坏仍然处理，但是现有代码中因为cc:IsRelateToEffect(e)返回false，故不处理Duel.Destroy(dc, REASON_EFFECT)部分。

有关时点的处理同样参见上述链接中的讨论，若控制权转移效果未处理，则仍然是破坏时时点，故仅当cc:IsRelateToEffect(e)时才会BreakEffect，即为当前更改后的实现。

English version:
Fixed the problem that, if the target control of which to be got disappeared, the destroy effect does not work. According to discussion [here](https://ygobbs.com/t/%E6%AD%BB%E4%B9%8B%E9%AD%94%E6%9C%AF%E7%AE%B1bug%EF%BC%88%E9%99%84%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88%E4%BB%A3%E7%A0%81%EF%BC%89/446305), even if the monster targeted to be gotten control disappears, we should still destroy the monster targeted to be destroyed, but currently we don't since cc:IsRelateToEffect(e) == false, so this fix has been made.

Also, since if cc:IsRelateToEffect(e) == false, the timing is still "monster destroyed" after this effect, so BreakEffect only called if we need to deal with the GetControl effect. That's just how the fixed code is implemented.