### PR TITLE
fix 巌征竜－レドックス

### DIFF
--- a/c90411554.lua
+++ b/c90411554.lua
@@ -100,11 +100,15 @@ function c90411554.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and Duel.IsExistingTarget(c90411554.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectTarget(tp,c90411554.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	if g:GetFirst()==e:GetHandler() then
+		e:GetHandler():ReleaseEffectRelation(e)
+	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function c90411554.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	local c=e:GetHandler()
+	if tc:IsRelateToChain() or (tc==c and c:IsLocation(LOCATION_GRAVE) and c:IsPreviousLocation(LOCATION_HAND) and c:GetReasonEffect()==e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
If "巌征竜－レドックス" activating its 2nd effect, discard self to the GY and target self, "召喚獣メルカバー" cannot banish it from GY.