### PR TITLE
fix 御巫の水舞踏

### DIFF
--- a/c43527730.lua
+++ b/c43527730.lua
@@ -62,6 +62,7 @@ function c43527730.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c43527730.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp,ec:GetOriginalCodeRule())
 	local tc=g:GetFirst()
+	Duel.DisableSelfDestroyCheck()
 	if tc and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 and Duel.Equip(tp,c,tc) then
 		--Add Equip limit
 		local e1=Effect.CreateEffect(tc)
@@ -76,6 +77,7 @@ function c43527730.spop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.SendtoHand(ec,nil,REASON_EFFECT)
 		end
 	end
+	Duel.DisableSelfDestroyCheck(false)
 end
 function c43527730.eqlimit(e,c)
 	return e:GetOwner()==c


### PR DESCRIPTION
if equip to a burning abyss monster and activate its 2nd effect, the equipped will first be destroyed, then be returned to hand.