### PR TITLE
fix-	現世離レ

### DIFF
--- a/c63086455.lua
+++ b/c63086455.lua
@@ -39,7 +39,7 @@ function c63086455.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c63086455.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local tc1=tg:Filter(Card.IsLocation,nil,LOCATION_ONFIELD):GetFirst()
+	local tc1=tg:Filter(c63086455.tgopfilter,nil,e):GetFirst()
 	local tc2=tg:Filter(Card.IsLocation,nil,LOCATION_GRAVE):GetFirst()
 	if tc1 and tc1:IsRelateToEffect(e) and Duel.SendtoGrave(tc1,REASON_EFFECT)~=0 and tc1:IsLocation(LOCATION_GRAVE)
 		and tc2 and tc2:IsRelateToEffect(e) then
@@ -49,4 +49,7 @@ function c63086455.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.SSet(tp,tc2,1-tp)
 		end
 	end
+end
+function c63086455.tgopfilter(c,e)
+	return  c:IsRelateToEffect(e) and c:IsLocation(LOCATION_MZONE)
 end

--- a/c63086455.lua
+++ b/c63086455.lua
@@ -51,5 +51,5 @@ function c63086455.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c63086455.tgopfilter(c,e)
-	return  c:IsRelateToEffect(e) and c:IsLocation(LOCATION_MZONE)
+	return  c:IsRelateToEffect(e) and c:IsLocation(LOCATION_ONFIELD)
 end


### PR DESCRIPTION
Fix the bug ：mix the target on field when the other target were spsummoned or placed on field by following chain effects like [閃刀機-シャークキャノン] and [天龍雪獄]
修复问题：当后续连锁效果([闪刀机-虎鲨加农炮]、[天龙雪狱])将作为墓地对象的卡特召或放置到场上，效果适用时会将那些卡片视作作为场上对象的卡。