### PR TITLE
fix TG グレイヴ・ブラスター

### DIFF
--- a/c95973569.lua
+++ b/c95973569.lua
@@ -70,7 +70,7 @@ function s.matchk(e,c)
 end
 function s.sfilter(c,e,tp)
 	return c:IsFaceup() and c:IsCanBeEffectTarget(e)
-		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) and c:IsType(TYPE_MONSTER)
+		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) and c:IsType(TYPE_MONSTER) and not c:IsType(TYPE_TOKEN)   
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=eg:Filter(s.sfilter,nil,e,tp)


### PR DESCRIPTION
修复被除外的卡片组内有衍生物时发动②效果导致客户端闪退的问题