### PR TITLE
Modify Auxiliary.EPDestroyOperation in utility.lua

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1335,6 +1335,6 @@ end
 function Auxiliary.EPDestroyOperation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()
 	if Auxiliary.GetValueType(tc)=="Card" or Auxiliary.GetValueType(tc)=="Group" then
-		Duel.Destroy(tc,REASON_EFFECT,LOCATION_GRAVE,tc:GetControler())
+		Duel.Destroy(tc,REASON_EFFECT,LOCATION_GRAVE)
 	end
 end


### PR DESCRIPTION
**Delete the cover behavior** about the user of Destroy Effect in **function Auxiliary.EPDestroyOperation**.

The current function will **broadcast the parameter 'rp'** with the value of the monster's controller when checking protect-from-opposite's-destroy.
As the result, when you use any cards using this function(_【簡易融合Instant Fusion】、【炎王の急襲Onslaught of the Fire Kings】 and 【限定解除Ritual Foregone】_)  **special monsters and  change their controller,give them protect-from-opposite's-destroy-effect** (_ways like【エルシャドール・ミドラーシュEl Shaddoll Winda】、use【レッド・ガードナーRed Gardna】)_,**they won't be protected** cause the function had mixed the parameter'rp'.

**After modified**,when thoese  protect-from-opposite's-destroy-effect were used,**the value of 'rp' they receive will be the value who the destroy-effect was register to.** 
****
删除函数Auxiliary.EPDestroyOperation对效果使用者的覆盖行为。
当进行一些“不会被对方的效果破坏”的检测时，当前该函数会将对象怪兽的控制者作为参数'rp'传播.
这样一来,使用这个函数的卡(简易融合、炎王的急袭、限定解除)特殊召唤的怪兽被转移控制权并获得“不会被对方的效果破坏”的抗性后(如神影依 米德拉什，或使用红莲守护者)，不能免疫这些卡片的破坏效果，因为抗性部分函数接收到的'rp'值为当前控制者。
修改后，那些“不会被对方的效果破坏”的抗性效果适用时，接收到的'rp'值为破坏效果注册时所指定的玩家。