### PR TITLE
fix-カオス・アンヘル-混沌の双翼(Re Pr

### DIFF
--- a/c22850702.lua
+++ b/c22850702.lua
@@ -92,6 +92,6 @@ function c22850702.regop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c22850702.efilter(e,re)
-	return re:GetOwnerPlayer()~=e:GetOwnerPlayer() and re:IsActivated()
+	return re:GetHandlerPlayer()~=e:GetHandlerPlayer() and re:IsActivated()
 		and re:IsActiveType(TYPE_MONSTER)
 end


### PR DESCRIPTION
fix: Effect-protect may couldn't work after any monsters' controller was changed.
修复：效果抗性在场上的怪兽发生控制权转移后错误适用的问题。