### PR TITLE
fix 效果伤害与原本攻击力问题

### DIFF
--- a/c33776843.lua
+++ b/c33776843.lua
@@ -27,11 +27,14 @@ function c33776843.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	local tc=g:GetFirst()
+	if tc:IsLocation(LOCATION_MZONE) and math.max(0,tc:GetTextAttack())>0 then
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0) end
 end
 function c33776843.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 and tc:IsPreviousLocation(LOCATION_MZONE) then
-		local atk=tc:GetBaseAttack()
+		local atk=math.max(0,tc:GetTextAttack())
 		if atk>0 then
 			Duel.BreakEffect()
 			Duel.Damage(1-tp,atk,REASON_EFFECT)

--- a/c88120966.lua
+++ b/c88120966.lua
@@ -34,7 +34,8 @@ function c88120966.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,c88120966.filter,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	if g:GetFirst():IsType(TYPE_XYZ) then
+	local tc=g:GetFirst()
+	if tc:IsType(TYPE_XYZ) and math.max(0,tc:GetTextAttack())>0 then
 		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
 	end
 end


### PR DESCRIPTION
修复No.15 机关傀儡-巨人杀手 以原本攻击力为0的怪兽为对象，可以被废品栗子球连锁的问题
修复混沌No.15 机关傀儡-连环杀手 无法被废品栗子球连锁，以及破坏陷阱怪兽不造成伤害的问题