### PR TITLE
update modern union monsters

### DIFF
--- a/c19190082.lua
+++ b/c19190082.lua
@@ -1,25 +1,6 @@
 --戦乙女の戦車
 function c19190082.initial_effect(c)
-	aux.EnableUnionAttribute(c,c19190082.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(19190082,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c19190082.eqtg)
-	e1:SetOperation(c19190082.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(19190082,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c19190082.sptg)
-	e2:SetOperation(c19190082.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c19190082.filter)
 	--atk up
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(19190082,2))
@@ -32,44 +13,7 @@ function c19190082.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c19190082.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_FAIRY) and ct2==0
-end
-function c19190082.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c19190082.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(19190082)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c19190082.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c19190082.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(19190082,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c19190082.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c19190082.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c19190082.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(19190082)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(19190082,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c19190082.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
-end
-function c19190082.eqlimit(e,c)
-	return c:IsRace(RACE_FAIRY) or e:GetHandler():GetEquipTarget()==c
+	return c:IsRace(RACE_FAIRY)
 end
 function c19190082.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local ec=e:GetHandler():GetEquipTarget()

--- a/c23265594.lua
+++ b/c23265594.lua
@@ -1,25 +1,6 @@
 --強化支援メカ・ヘビーウェポン
 function c23265594.initial_effect(c)
-	aux.EnableUnionAttribute(c,c23265594.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(23265594,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c23265594.eqtg)
-	e1:SetOperation(c23265594.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(23265594,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c23265594.sptg)
-	e2:SetOperation(c23265594.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c23265594.filter)
 	--Atk up
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
@@ -33,42 +14,6 @@ function c23265594.initial_effect(c)
 	e4:SetValue(500)
 	c:RegisterEffect(e4)
 end
-function c23265594.eqlimit(e,c)
-	return c:IsRace(RACE_MACHINE) or e:GetHandler():GetEquipTarget()==c
-end
 function c23265594.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and ct2==0
-end
-function c23265594.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c23265594.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(23265594)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c23265594.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c23265594.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	e:GetHandler():RegisterFlagEffect(23265594,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c23265594.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c23265594.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c23265594.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(23265594)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(23265594,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c23265594.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_MACHINE)
 end

--- a/c30012506.lua
+++ b/c30012506.lua
@@ -1,25 +1,6 @@
 --A－アサルト・コア
 function c30012506.initial_effect(c)
-	aux.EnableUnionAttribute(c,c30012506.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(30012506,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c30012506.eqtg)
-	e1:SetOperation(c30012506.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(30012506,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c30012506.sptg)
-	e2:SetOperation(c30012506.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c30012506.filter)
 	--immune
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
@@ -38,41 +19,7 @@ function c30012506.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c30012506.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and ct2==0
-end
-function c30012506.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c30012506.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(30012506)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c30012506.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c30012506.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(30012506,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c30012506.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c30012506.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c30012506.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(30012506)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(30012506,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c30012506.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)
 end
 function c30012506.efilter(e,te)
 	return te:GetOwnerPlayer()~=e:GetHandlerPlayer() and te:GetOwner()~=e:GetOwner()
@@ -95,7 +42,4 @@ function c30012506.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
 	end
-end
-function c30012506.eqlimit(e,c)
-	return (c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)) or e:GetHandler():GetEquipTarget()==c
 end

--- a/c3405259.lua
+++ b/c3405259.lua
@@ -1,25 +1,6 @@
 --C－クラッシュ・ワイバーン
 function c3405259.initial_effect(c)
-	aux.EnableUnionAttribute(c,c3405259.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(3405259,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c3405259.eqtg)
-	e1:SetOperation(c3405259.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(3405259,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c3405259.sptg)
-	e2:SetOperation(c3405259.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c3405259.filter)
 	--immune
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
@@ -38,41 +19,7 @@ function c3405259.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c3405259.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and ct2==0
-end
-function c3405259.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c3405259.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(3405259)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c3405259.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c3405259.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(3405259,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c3405259.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c3405259.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c3405259.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(3405259)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(3405259,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c3405259.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)
 end
 function c3405259.efilter(e,te)
 	return te:GetOwnerPlayer()~=e:GetHandlerPlayer() and te:GetOwner()~=e:GetOwner()
@@ -96,7 +43,4 @@ function c3405259.spop2(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
-end
-function c3405259.eqlimit(e,c)
-	return (c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)) or e:GetHandler():GetEquipTarget()==c
 end

--- a/c38783169.lua
+++ b/c38783169.lua
@@ -1,7 +1,7 @@
 --チューン・ナイト
 function c38783169.initial_effect(c)
 	aux.EnableExtraDeckSummonCountLimit()
-	aux.EnableUnionAttribute(c,1)
+	aux.EnableUnionAttribute(c,aux.TRUE)
 	--tuner
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(38783169,0))
@@ -11,25 +11,6 @@ function c38783169.initial_effect(c)
 	e1:SetTarget(c38783169.tntg)
 	e1:SetOperation(c38783169.tnop)
 	c:RegisterEffect(e1)
-	--equip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(38783169,1))
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e2:SetCategory(CATEGORY_EQUIP)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetTarget(c38783169.eqtg)
-	e2:SetOperation(c38783169.eqop)
-	c:RegisterEffect(e2)
-	--unequip
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(38783169,2))
-	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e3:SetType(EFFECT_TYPE_IGNITION)
-	e3:SetRange(LOCATION_SZONE)
-	e3:SetTarget(c38783169.sptg)
-	e3:SetOperation(c38783169.spop)
-	c:RegisterEffect(e3)
 end
 function c38783169.tntg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not e:GetHandler():IsType(TYPE_TUNER) end
@@ -80,41 +61,4 @@ function c38783169.checkop(e,tp,eg,ep,ev,re,r,rp)
 	if eg:IsExists(c38783169.cfilter,1,nil,1-tp) then
 		aux.ExtraDeckSummonCountLimit[1-tp]=aux.ExtraDeckSummonCountLimit[1-tp]-1
 	end
-end
-function c38783169.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and ct2==0
-end
-function c38783169.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c38783169.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(38783169)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-	and Duel.IsExistingTarget(c38783169.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c38783169.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(38783169,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c38783169.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c38783169.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c38783169.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(38783169)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(38783169,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c38783169.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
 end

--- a/c39299733.lua
+++ b/c39299733.lua
@@ -1,25 +1,6 @@
 --運命の戦車
 function c39299733.initial_effect(c)
-	aux.EnableUnionAttribute(c,c39299733.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(39299733,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c39299733.eqtg)
-	e1:SetOperation(c39299733.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(39299733,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c39299733.sptg)
-	e2:SetOperation(c39299733.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c39299733.filter)
 	--direct attack
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_EQUIP)
@@ -34,48 +15,11 @@ function c39299733.initial_effect(c)
 	c:RegisterEffect(e6)
 end
 function c39299733.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_FAIRY) and ct2==0
-end
-function c39299733.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c39299733.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(39299733)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c39299733.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c39299733.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(39299733,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c39299733.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c39299733.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c39299733.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(39299733)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(39299733,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c39299733.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_FAIRY)
 end
 function c39299733.rdcon(e)
 	local c=e:GetHandler():GetEquipTarget()
 	local tp=e:GetHandlerPlayer()
 	return Duel.GetAttackTarget()==nil
 		and c:GetEffectCount(EFFECT_DIRECT_ATTACK)<2 and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0
-end
-function c39299733.eqlimit(e,c)
-	return c:IsRace(RACE_FAIRY) or e:GetHandler():GetEquipTarget()==c
 end

--- a/c39890958.lua
+++ b/c39890958.lua
@@ -1,25 +1,6 @@
 --強化支援メカ・ヘビーアーマー
 function c39890958.initial_effect(c)
-	aux.EnableUnionAttribute(c,c39890958.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(39890958,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c39890958.eqtg)
-	e1:SetOperation(c39890958.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(39890958,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c39890958.sptg)
-	e2:SetOperation(c39890958.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c39890958.filter)
 	--untargetable
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
@@ -39,41 +20,7 @@ function c39890958.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c39890958.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and ct2==0
-end
-function c39890958.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c39890958.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(39890958)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c39890958.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c39890958.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(39890958,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c39890958.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c39890958.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c39890958.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(39890958)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(39890958,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c39890958.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_MACHINE)
 end
 function c39890958.spfilter(c,e,tp)
 	return c:IsType(TYPE_UNION) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
@@ -91,7 +38,4 @@ function c39890958.sumop(e,tp,eg,ep,ev,re,r,rp)
 	if tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
-end
-function c39890958.eqlimit(e,c)
-	return c:IsRace(RACE_MACHINE) or e:GetHandler():GetEquipTarget()==c
 end

--- a/c42940404.lua
+++ b/c42940404.lua
@@ -1,25 +1,6 @@
 --マシンナーズ・ギアフレーム
 function c42940404.initial_effect(c)
-	aux.EnableUnionAttribute(c,c42940404.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(42940404,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c42940404.eqtg)
-	e1:SetOperation(c42940404.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(42940404,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c42940404.sptg)
-	e2:SetOperation(c42940404.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c42940404.filter)
 	--search
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(42940404,2))
@@ -30,44 +11,8 @@ function c42940404.initial_effect(c)
 	e5:SetOperation(c42940404.sop)
 	c:RegisterEffect(e5)
 end
-function c42940404.eqlimit(e,c)
-	return c:IsRace(RACE_MACHINE) or e:GetHandler():GetEquipTarget()==c
-end
 function c42940404.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and ct2==0
-end
-function c42940404.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c42940404.filter(chkc) and chkc~=e:GetHandler() end
-	if chk==0 then return e:GetHandler():GetFlagEffect(42940404)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c42940404.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c42940404.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	e:GetHandler():RegisterFlagEffect(42940404,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c42940404.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c42940404.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c42940404.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(42940404)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(42940404,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c42940404.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_MACHINE)
 end
 function c42940404.sfilter(c)
 	return c:IsSetCard(0x36) and not c:IsCode(42940404) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()

--- a/c64500000.lua
+++ b/c64500000.lua
@@ -1,25 +1,6 @@
 --Z－メタル・キャタピラー
 function c64500000.initial_effect(c)
-	aux.EnableUnionAttribute(c,c64500000.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(64500000,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c64500000.eqtg)
-	e1:SetOperation(c64500000.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(64500000,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c64500000.sptg)
-	e2:SetOperation(c64500000.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c64500000.filter)
 	--Atk up
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
@@ -33,42 +14,6 @@ function c64500000.initial_effect(c)
 	e4:SetValue(600)
 	c:RegisterEffect(e4)
 end
-function c64500000.eqlimit(e,c)
-	return c:IsCode(62651957,65622692) or e:GetHandler():GetEquipTarget()==c
-end
 function c64500000.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsCode(62651957,65622692) and ct2==0
-end
-function c64500000.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c64500000.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(64500000)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c64500000.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c64500000.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	e:GetHandler():RegisterFlagEffect(64500000,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c64500000.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c64500000.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c64500000.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(64500000)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(64500000,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c64500000.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsCode(62651957,65622692)
 end

--- a/c65622692.lua
+++ b/c65622692.lua
@@ -1,25 +1,6 @@
 --Y－ドラゴン・ヘッド
 function c65622692.initial_effect(c)
-	aux.EnableUnionAttribute(c,c65622692.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(65622692,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c65622692.eqtg)
-	e1:SetOperation(c65622692.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(65622692,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c65622692.sptg)
-	e2:SetOperation(c65622692.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c65622692.filter)
 	--Atk up
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
@@ -33,42 +14,6 @@ function c65622692.initial_effect(c)
 	e4:SetValue(400)
 	c:RegisterEffect(e4)
 end
-function c65622692.eqlimit(e,c)
-	return c:IsCode(62651957) or e:GetHandler():GetEquipTarget()==c
-end
 function c65622692.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsCode(62651957) and ct2==0
-end
-function c65622692.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c65622692.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(65622692)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c65622692.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c65622692.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	e:GetHandler():RegisterFlagEffect(65622692,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c65622692.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c65622692.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c65622692.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(65622692)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(65622692,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c65622692.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsCode(62651957)
 end

--- a/c67159705.lua
+++ b/c67159705.lua
@@ -1,25 +1,6 @@
 --アーマード・サイバーン
 function c67159705.initial_effect(c)
-	aux.EnableUnionAttribute(c,c67159705.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(67159705,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c67159705.eqtg)
-	e1:SetOperation(c67159705.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(67159705,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c67159705.sptg)
-	e2:SetOperation(c67159705.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c67159705.filter)
 	--destroy
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(67159705,2))
@@ -32,44 +13,8 @@ function c67159705.initial_effect(c)
 	e5:SetOperation(c67159705.desop)
 	c:RegisterEffect(e5)
 end
-function c67159705.eqlimit(e,c)
-	return c:IsCode(70095154) or c:IsType(TYPE_FUSION) and aux.IsMaterialListCode(c,70095154) or e:GetHandler():GetEquipTarget()==c
-end
 function c67159705.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and (c:IsCode(70095154) or c:IsType(TYPE_FUSION) and aux.IsMaterialListCode(c,70095154)) and ct2==0
-end
-function c67159705.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c67159705.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(67159705)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c67159705.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c67159705.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	e:GetHandler():RegisterFlagEffect(67159705,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c67159705.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c67159705.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c67159705.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(67159705)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(67159705,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c67159705.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+	return c:IsCode(70095154) or c:IsType(TYPE_FUSION) and aux.IsMaterialListCode(c,70095154)
 end
 function c67159705.desfilter(c)
 	return c:IsFaceup()

--- a/c70298454.lua
+++ b/c70298454.lua
@@ -1,25 +1,6 @@
 --比翼レンリン
 function c70298454.initial_effect(c)
-	aux.EnableUnionAttribute(c,1)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(70298454,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c70298454.eqtg)
-	e1:SetOperation(c70298454.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(70298454,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c70298454.sptg)
-	e2:SetOperation(c70298454.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,aux.TRUE)
 	--change atk
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
@@ -32,44 +13,4 @@ function c70298454.initial_effect(c)
 	e5:SetCode(EFFECT_EXTRA_ATTACK)
 	e5:SetValue(1)
 	c:RegisterEffect(e5)
-end
-function c70298454.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and ct2==0
-end
-function c70298454.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c70298454.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(70298454)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c70298454.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c70298454.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(70298454,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c70298454.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c70298454.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c70298454.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(70298454)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(70298454,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c70298454.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) then
-		Duel.SendtoGrave(c,REASON_RULE)
-	end
 end

--- a/c77411244.lua
+++ b/c77411244.lua
@@ -1,25 +1,6 @@
 --B－バスター・ドレイク
 function c77411244.initial_effect(c)
-	aux.EnableUnionAttribute(c,c77411244.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(77411244,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c77411244.eqtg)
-	e1:SetOperation(c77411244.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(77411244,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c77411244.sptg)
-	e2:SetOperation(c77411244.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c77411244.filter)
 	--immune
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
@@ -38,41 +19,7 @@ function c77411244.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c77411244.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and ct2==0
-end
-function c77411244.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c77411244.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(77411244)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c77411244.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c77411244.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(77411244,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c77411244.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c77411244.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c77411244.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(77411244)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(77411244,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c77411244.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)
 end
 function c77411244.efilter(e,te)
 	return te:GetOwnerPlayer()~=e:GetHandlerPlayer() and te:GetOwner()~=e:GetOwner()
@@ -95,7 +42,4 @@ function c77411244.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
 	end
-end
-function c77411244.eqlimit(e,c)
-	return (c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)) or e:GetHandler():GetEquipTarget()==c
 end

--- a/c78349103.lua
+++ b/c78349103.lua
@@ -1,25 +1,6 @@
 --マシンナーズ・ピースキーパー
 function c78349103.initial_effect(c)
-	aux.EnableUnionAttribute(c,c78349103.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(78349103,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c78349103.eqtg)
-	e1:SetOperation(c78349103.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(78349103,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c78349103.sptg)
-	e2:SetOperation(c78349103.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c78349103.filter)
 	--search
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(78349103,2))
@@ -32,44 +13,8 @@ function c78349103.initial_effect(c)
 	e5:SetOperation(c78349103.sop)
 	c:RegisterEffect(e5)
 end
-function c78349103.eqlimit(e,c)
-	return c:IsRace(RACE_MACHINE) or e:GetHandler():GetEquipTarget()==c
-end
 function c78349103.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and ct2==0
-end
-function c78349103.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c78349103.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(78349103)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c78349103.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c78349103.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	e:GetHandler():RegisterFlagEffect(78349103,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c78349103.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c78349103.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c78349103.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(78349103)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(78349103,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c78349103.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsRace(RACE_MACHINE)
 end
 function c78349103.sfilter(c)
 	return c:IsType(TYPE_UNION) and c:IsAbleToHand()

--- a/c79538761.lua
+++ b/c79538761.lua
@@ -1,25 +1,6 @@
 --トルクチューン・ギア
 function c79538761.initial_effect(c)
-	aux.EnableUnionAttribute(c,1)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(79538761,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c79538761.eqtg)
-	e1:SetOperation(c79538761.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(79538761,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c79538761.sptg)
-	e2:SetOperation(c79538761.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,aux.TRUE)
 	--add type
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_EQUIP)
@@ -38,41 +19,4 @@ function c79538761.initial_effect(c)
 	e6:SetCode(EFFECT_UPDATE_DEFENSE)
 	e6:SetValue(500)
 	c:RegisterEffect(e6)
-end
-function c79538761.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and ct2==0
-end
-function c79538761.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c79538761.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(79538761)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c79538761.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c79538761.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(79538761,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c79538761.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c79538761.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c79538761.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(79538761)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(79538761,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c79538761.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
 end

--- a/c81951640.lua
+++ b/c81951640.lua
@@ -1,25 +1,6 @@
 --奇動装置メイルファクター
 function c81951640.initial_effect(c)
-	aux.EnableUnionAttribute(c,1)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(81951640,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c81951640.eqtg)
-	e1:SetOperation(c81951640.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(81951640,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c81951640.sptg)
-	e2:SetOperation(c81951640.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,aux.TRUE)
 	--spsummon
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(81951640,2))
@@ -32,43 +13,6 @@ function c81951640.initial_effect(c)
 	e4:SetTarget(c81951640.tg)
 	e4:SetOperation(c81951640.op)
 	c:RegisterEffect(e4)
-end
-function c81951640.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and ct2==0
-end
-function c81951640.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c81951640.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(81951640)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c81951640.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c81951640.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(81951640,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c81951640.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c81951640.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c81951640.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(81951640)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(81951640,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c81951640.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
 end
 function c81951640.con(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c96300057.lua
+++ b/c96300057.lua
@@ -1,25 +1,6 @@
 --W－ウィング・カタパルト
 function c96300057.initial_effect(c)
-	aux.EnableUnionAttribute(c,c96300057.eqlimit)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(96300057,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c96300057.eqtg)
-	e1:SetOperation(c96300057.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(96300057,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c96300057.sptg)
-	e2:SetOperation(c96300057.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,c96300057.filter)
 	--Atk up
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_EQUIP)
@@ -33,42 +14,6 @@ function c96300057.initial_effect(c)
 	e4:SetValue(400)
 	c:RegisterEffect(e4)
 end
-function c96300057.eqlimit(e,c)
-	return c:IsCode(51638941) or e:GetHandler():GetEquipTarget()==c
-end
 function c96300057.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and c:IsCode(51638941) and ct2==0
-end
-function c96300057.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c96300057.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(96300057)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c96300057.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c96300057.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	e:GetHandler():RegisterFlagEffect(96300057,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c96300057.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c96300057.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c96300057.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(96300057)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(96300057,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c96300057.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
+	return c:IsCode(51638941)
 end

--- a/c99249638.lua
+++ b/c99249638.lua
@@ -1,25 +1,6 @@
 --ユニオン・ドライバー
 function c99249638.initial_effect(c)
-	aux.EnableUnionAttribute(c,1)
-	--equip
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(99249638,0))
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e1:SetTarget(c99249638.eqtg)
-	e1:SetOperation(c99249638.eqop)
-	c:RegisterEffect(e1)
-	--unequip
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(99249638,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTarget(c99249638.sptg)
-	e2:SetOperation(c99249638.spop)
-	c:RegisterEffect(e2)
+	aux.EnableUnionAttribute(c,aux.TRUE)
 	--reequip
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(99249638,2))
@@ -31,43 +12,6 @@ function c99249638.initial_effect(c)
 	e4:SetTarget(c99249638.retg)
 	e4:SetOperation(c99249638.reop)
 	c:RegisterEffect(e4)
-end
-function c99249638.filter(c)
-	local ct1,ct2=c:GetUnionCount()
-	return c:IsFaceup() and ct2==0
-end
-function c99249638.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c99249638.filter(chkc) end
-	if chk==0 then return e:GetHandler():GetFlagEffect(99249638)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingTarget(c99249638.filter,tp,LOCATION_MZONE,0,1,c) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	local g=Duel.SelectTarget(tp,c99249638.filter,tp,LOCATION_MZONE,0,1,1,c)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
-	c:RegisterFlagEffect(99249638,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c99249638.eqop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local tc=Duel.GetFirstTarget()
-	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	if not tc:IsRelateToEffect(e) or not c99249638.filter(tc) then
-		Duel.SendtoGrave(c,REASON_EFFECT)
-		return
-	end
-	if not Duel.Equip(tp,c,tc,false) then return end
-	aux.SetUnionState(c)
-end
-function c99249638.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:GetFlagEffect(99249638)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
-	c:RegisterFlagEffect(99249638,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
-end
-function c99249638.spop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
 end
 function c99249638.recost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=e:GetHandler():GetEquipTarget()

--- a/constant.lua
+++ b/constant.lua
@@ -864,4 +864,5 @@ CARD_MARINE_DOLPHIN		=78734254	--海洋海豚(double name)
 CARD_TWINKLE_MOSS		=13857930	--光輝苔蘚(double name)
 CARD_QUESTION		    =38723936	--谜题
 --Special flag effect id
-FLAG_ID_CHAINING    =1
+FLAG_ID_CHAINING	=1
+FLAG_ID_UNION		=2

--- a/utility.lua
+++ b/utility.lua
@@ -291,8 +291,11 @@ end
 function Auxiliary.UnionReplaceFilter(e,re,r,rp)
 	return r&(REASON_BATTLE+REASON_EFFECT)~=0
 end
---add effect to modern union monsters
-function Auxiliary.EnableUnionAttribute(c,f)
+---add effect to modern union monsters
+---@param c Card
+---@param filter function
+function Auxiliary.EnableUnionAttribute(c,filter)
+	local equip_limit=Auxiliary.UnionEquipLimit(filter)
 	--destroy sub
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_EQUIP)
@@ -305,8 +308,76 @@ function Auxiliary.EnableUnionAttribute(c,f)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_UNION_LIMIT)
 	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetValue(f)
+	e2:SetValue(equip_limit)
 	c:RegisterEffect(e2)
+	--equip
+	local equip_filter=Auxiliary.UnionEquipFilter(filter)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(1068)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetCategory(CATEGORY_EQUIP)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTarget(Auxiliary.UnionEquipTarget(equip_filter))
+	e3:SetOperation(Auxiliary.UnionEquipOperation(equip_filter))
+	c:RegisterEffect(e3)
+	--unequip
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(1152)
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetTarget(Auxiliary.UnionUnequipTarget)
+	e4:SetOperation(Auxiliary.UnionUnequipOperation)
+	c:RegisterEffect(e4)
+end
+function Auxiliary.UnionEquipFilter(filter)
+	return function(c,tp)
+		local ct1,ct2=c:GetUnionCount()
+		return c:IsFaceup() and ct2==0 and c:IsControler(tp) and filter(c)
+	end
+end
+function Auxiliary.UnionEquipLimit(filter)
+	return function(e,c)
+		return (c:IsControler(e:GetHandlerPlayer()) and filter(c)) or e:GetHandler():GetEquipTarget()==c	
+	end
+end
+function Auxiliary.UnionEquipTarget(equip_filter)
+	return function(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+		local c=e:GetHandler()
+		if chkc then return chkc:IsLocation(LOCATION_MZONE) and equip_filter(chkc,tp) end
+		if chk==0 then return c:GetFlagEffect(FLAG_ID_UNION)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+			and Duel.IsExistingTarget(equip_filter,tp,LOCATION_MZONE,0,1,c,tp) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+		local g=Duel.SelectTarget(tp,equip_filter,tp,LOCATION_MZONE,0,1,1,c,tp)
+		Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+		c:RegisterFlagEffect(FLAG_ID_UNION,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+	end
+end
+function Auxiliary.UnionEquipOperation(equip_filter)
+	return function(e,tp,eg,ep,ev,re,r,rp)
+		local c=e:GetHandler()
+		local tc=Duel.GetFirstTarget()
+		if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+		if not tc:IsRelateToEffect(e) or not equip_filter(tc,tp) then
+			Duel.SendtoGrave(c,REASON_RULE)
+			return
+		end
+		if not Duel.Equip(tp,c,tc,false) then return end
+		Auxiliary.SetUnionState(c)
+	end
+end
+function Auxiliary.UnionUnequipTarget(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:GetFlagEffect(FLAG_ID_UNION)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and c:GetEquipTarget() and c:IsCanBeSpecialSummoned(e,0,tp,true,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+	c:RegisterFlagEffect(FLAG_ID_UNION,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function Auxiliary.UnionUnequipOperation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)
 end
 function Auxiliary.EnableChangeCode(c,code,location,condition)
 	Auxiliary.AddCodeList(c,code)
@@ -596,7 +667,7 @@ end
 --flag effect for spell counter
 function Auxiliary.chainreg(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():GetFlagEffect(FLAG_ID_CHAINING)==0 then
-		e:GetHandler():RegisterFlagEffect(FLAG_ID_CHAINING,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+		e:GetHandler():RegisterFlagEffect(1,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
 	end
 end
 --default filter for EFFECT_CANNOT_BE_BATTLE_TARGET

--- a/utility.lua
+++ b/utility.lua
@@ -339,7 +339,7 @@ function Auxiliary.UnionEquipFilter(filter)
 end
 function Auxiliary.UnionEquipLimit(filter)
 	return function(e,c)
-		return (c:IsControler(e:GetHandlerPlayer()) and filter(c)) or e:GetHandler():GetEquipTarget()==c	
+		return (c:IsControler(e:GetHandlerPlayer()) and filter(c)) or e:GetHandler():GetEquipTarget()==c
 	end
 end
 function Auxiliary.UnionEquipTarget(equip_filter)

--- a/utility.lua
+++ b/utility.lua
@@ -667,7 +667,7 @@ end
 --flag effect for spell counter
 function Auxiliary.chainreg(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():GetFlagEffect(FLAG_ID_CHAINING)==0 then
-		e:GetHandler():RegisterFlagEffect(1,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+		e:GetHandler():RegisterFlagEffect(FLAG_ID_CHAINING,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
 	end
 end
 --default filter for EFFECT_CANNOT_BE_BATTLE_TARGET


### PR DESCRIPTION
```lua
function Auxiliary.EnableUnionAttribute(c,filter)
```
c: union monster
filter: union target filter (except controller)

Example:
https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=12584&request_locale=ja
C－クラッシュ・ワイバーン
●自分フィールドの機械族・光属性モンスター１体を対象とし、このカードを装備カード扱いとしてそのモンスターに装備する。
```lua
function c3405259.filter(c)
	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)
end
```

update:
- Add controller check to `equip_filter`
- Add controller check to `equip_limit`
- Equip fail will send it to grave with `REASON_RULE`