### PR TITLE
fix PSYフレームロード・Ω

### DIFF
--- a/c74586817.lua
+++ b/c74586817.lua
@@ -107,13 +107,16 @@ function c74586817.retcon(e,tp,eg,ep,ev,re,r,rp)
 	else return true end
 end
 function c74586817.retop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
 	local g=e:GetLabelObject()
 	local sg=g:Filter(c74586817.retfilter,nil,e:GetLabel())
 	g:DeleteGroup()
 	local tc=sg:GetFirst()
 	while tc do
-		if tc==e:GetHandler() then
+		if tc==c and c:IsCode(74586817) then
 			Duel.ReturnToField(tc)
+		elseif tc==c and not c:IsCode(74586817) then 
+			Duel.Remove(tc,POS_FACEUP,nil)
 		else
 			Duel.SendtoHand(tc,tc:GetPreviousControler(),REASON_EFFECT)
 		end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制PSY骨架王·Ω效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题