### PR TITLE
fix コズミック・ブレイザー・ドラゴン

### DIFF
--- a/c21123811.lua
+++ b/c21123811.lua
@@ -107,5 +107,7 @@ function c21123811.negop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c21123811.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(21123811) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制宇宙耀变龙效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题