### PR TITLE
fix シューティング・セイヴァー・スター・ドラゴン

### DIFF
--- a/c40939228.lua
+++ b/c40939228.lua
@@ -133,5 +133,7 @@ function c40939228.retcon(e,tp,eg,ep,ev,re,r,rp)
 	else return true end
 end
 function c40939228.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(40939228) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制流天救世星龙效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题