### PR TITLE
fix クロノダイバー・リダン

### DIFF
--- a/c55285840.lua
+++ b/c55285840.lua
@@ -103,5 +103,7 @@ function c55285840.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c55285840.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(55285840) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制时间潜行者·表盘修复师效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题