### PR TITLE
fix 速攻の黒い忍者

### DIFF
--- a/c41006930.lua
+++ b/c41006930.lua
@@ -41,5 +41,7 @@ function c41006930.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c41006930.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(41006930) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制速攻的黑衣忍者效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题