### PR TITLE
fix スプリガンズ・シップ エクスブロウラー

### DIFF
--- a/c62941499.lua
+++ b/c62941499.lua
@@ -106,5 +106,7 @@ function c62941499.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c62941499.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(62941499) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制护宝炮妖船 喧闹探险者号效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题