### PR TITLE
fix ジャック・ア・ボーラン

### DIFF
--- a/c36016907.lua
+++ b/c36016907.lua
@@ -91,5 +91,7 @@ function c36016907.spop2(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c36016907.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(36016907) then
 	Duel.ReturnToField(e:GetHandler())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制硼素死神 杰克南瓜效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题