### PR TITLE
fix 神碑の鬣スレイプニル

### DIFF
--- a/c74659582.lua
+++ b/c74659582.lua
@@ -85,9 +85,18 @@ function s.retcon(e,tp,eg,ep,ev,re,r,rp)
 	return true
 end
 function s.retop(e,tp,eg,ep,ev,re,r,rp)
-	local g=e:GetLabelObject():Filter(s.retfilter,nil)
-	for tc in aux.Next(g) do
+	local c=e:GetHandler()
+	local g=e:GetLabelObject()
+	local sg=g:Filter(s.retfilter,nil,e:GetLabel())
+	g:DeleteGroup()
+	local tc=sg:GetFirst()
+	while tc do
+		if tc==c and not c:IsCode(74659582) then 
+		Duel.Remove(tc,POS_FACEUP,nil)
+		else
 		Duel.ReturnToField(tc)
+		end
+		tc=sg:GetNext()
 	end
 end
 function s.cfilter(c,tp)


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制神碑之鬣 史莱普尼尔效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题