### PR TITLE
fix 聖剣を巡る王姫アンジェリカ

### DIFF
--- a/c36320744.lua
+++ b/c36320744.lua
@@ -106,5 +106,7 @@ function s.retcon(e,tp,eg,ep,ev,re,r,rp)
 	else return true end
 end
 function s.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(36320744) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制围绕圣剑的王姬 安洁莉卡效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题