### PR TITLE
fix スプリガンズ・メリーメイカー

### DIFF
--- a/c48285768.lua
+++ b/c48285768.lua
@@ -83,5 +83,7 @@ function c48285768.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c48285768.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(48285768) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制护宝炮妖欢乐制造机效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题