### PR TITLE
fix スカイオニヒトクイエイ

### DIFF
--- a/c47349310.lua
+++ b/c47349310.lua
@@ -55,5 +55,7 @@ function c47349310.retcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c47349310.retop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsCode(47349310) then
 	Duel.ReturnToField(e:GetLabelObject())
+	end
 end


### PR DESCRIPTION
修复霸王眷龙凶饿毒复制天鬼食人蝠鲼效果发动短暂除外后会回到回场上（裁定为不会回到场上）的问题