### PR TITLE
fix TG グレイヴ・ブラスター

### DIFF
--- a/c68406755.lua
+++ b/c68406755.lua
@@ -68,6 +68,7 @@ function c68406755.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	c:SetStatus(STATUS_PROC_COMPLETE,true)
 end
 function c68406755.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0xe2)

--- a/c95973569.lua
+++ b/c95973569.lua
@@ -70,7 +70,7 @@ function s.matchk(e,c)
 end
 function s.sfilter(c,e,tp)
 	return c:IsFaceup() and c:IsCanBeEffectTarget(e)
-		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) and c:IsType(TYPE_MONSTER)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and c:IsType(TYPE_MONSTER) or c:IsStatus(STATUS_PROC_COMPLETE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=eg:Filter(s.sfilter,nil,e,tp)


### PR DESCRIPTION
修复科技属长柄刀爆破炮手能把未正规出场的龙辉巧怪兽、三形金字塔的斯芬克斯、魂食神龙吸灵龙等被除外的场合下特殊召唤的问题