### PR TITLE
fix TG グレイヴ・ブラスター

### DIFF
--- a/c95973569.lua
+++ b/c95973569.lua
@@ -70,7 +70,7 @@ function s.matchk(e,c)
 end
 function s.sfilter(c,e,tp)
 	return c:IsFaceup() and c:IsCanBeEffectTarget(e)
-		and c:IsCanBeSpecialSummoned(e,0,tp,true,false) and c:IsType(TYPE_MONSTER)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and c:IsType(TYPE_MONSTER) or c:IsStatus(STATUS_PROC_COMPLETE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=eg:Filter(s.sfilter,nil,e,tp)


### PR DESCRIPTION
修复未正规出场的龙辉巧怪兽、三形金字塔的斯芬克斯、魂食神龙吸灵龙等被除外的场合下能被科技属长柄刀爆破炮手特殊召唤的问题