### PR TITLE
fix トラミッド・スフィンクス

### DIFF
--- a/c68406755.lua
+++ b/c68406755.lua
@@ -68,6 +68,7 @@ function c68406755.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	c:SetStatus(STATUS_PROC_COMPLETE,true)
 end
 function c68406755.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0xe2)


### PR DESCRIPTION
修复未正规出场的三形金字塔的斯芬克斯被除外的场合下能被科技属长柄刀爆破炮手特殊召唤的问题