### PR TITLE
fix 竜輝巧－ラスβ

### DIFF
--- a/c33543890.lua
+++ b/c33543890.lua
@@ -20,6 +20,8 @@ function c33543890.tgfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x154) and c:IsType(TYPE_MONSTER)
 end
 function c33543890.extraop(e,tp)
+	local c=e:GetHandler()
+	c:SetStatus(STATUS_PROC_COMPLETE,true)
 	local g=Duel.GetMatchingGroup(c33543890.tgfilter,tp,LOCATION_REMOVED,0,nil)
 	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(33543890,1)) then
 		Duel.BreakEffect()


### PR DESCRIPTION
修复未正规出场的龙辉巧-天棓三β被除外的场合下能被科技属长柄刀爆破炮手特殊召唤的问题