### PR TITLE
fix 竜輝巧－エルγ

### DIFF
--- a/c60037599.lua
+++ b/c60037599.lua
@@ -20,6 +20,8 @@ function c60037599.rbfilter(c,e,tp)
 	return c:IsSetCard(0x154) and c:IsAttack(2000) and not c:IsCode(60037599) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c60037599.extraop(e,tp)
+	local c=e:GetHandler()
+	c:SetStatus(STATUS_PROC_COMPLETE,true)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c60037599.rbfilter),tp,LOCATION_GRAVE,0,nil,e,tp)
 	if g:GetCount()>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.SelectYesNo(tp,aux.Stringid(60037599,1)) then


### PR DESCRIPTION
修复未正规出场的龙辉巧-天棓四γ被除外的场合下能被科技属长柄刀爆破炮手特殊召唤的问题