### PR TITLE
Fix オーバーレイ・イーター，エクシーズ・リベンジ，rum－バリアンズ・フォース

### DIFF
--- a/c10275411.lua
+++ b/c10275411.lua
@@ -41,5 +41,6 @@ function c10275411.activate(e,tp,eg,ep,ev,re,r,rp)
 		local oc=mg:GetFirst():GetOverlayTarget()
 		Duel.Overlay(tc,mg)
 		Duel.RaiseSingleEvent(oc,EVENT_DETACH_MATERIAL,e,0,0,0,0)
+		Duel.RaiseEvent(oc,EVENT_DETACH_MATERIAL,e,0,0,0,0)
 	end
 end

--- a/c47660516.lua
+++ b/c47660516.lua
@@ -52,6 +52,7 @@ function c47660516.activate(e,tp,eg,ep,ev,re,r,rp)
 			local oc=mg2:GetFirst():GetOverlayTarget()
 			Duel.Overlay(sc,mg2)
 			Duel.RaiseSingleEvent(oc,EVENT_DETACH_MATERIAL,e,0,0,0,0)
+			Duel.RaiseEvent(oc,EVENT_DETACH_MATERIAL,e,0,0,0,0)
 		end
 	end
 end

--- a/c81816475.lua
+++ b/c81816475.lua
@@ -28,4 +28,5 @@ function c81816475.operation(e,tp,eg,ep,ev,re,r,rp)
 	local oc=mg:GetFirst():GetOverlayTarget()
 	Duel.Overlay(tc,mg)
 	Duel.RaiseSingleEvent(oc,EVENT_DETACH_MATERIAL,e,0,0,0,0)
+	Duel.RaiseEvent(oc,EVENT_DETACH_MATERIAL,e,0,0,0,0)
 end


### PR DESCRIPTION
修复上述卡使超量素材转移的效果无法诱发巨大喷流“冠军”尾宿五②效果的问题