### PR TITLE
fix Concours de Cuisine～菓冷なる料理対決～

### DIFF
--- a/c14283055.lua
+++ b/c14283055.lua
@@ -29,15 +29,15 @@ function s.filter(c)
 	return c:IsSetCard(0x196,0x19f) and c:IsType(TYPE_PENDULUM)
 end
 function s.sfilter1(c,e,tp,g)
-	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and (not c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-			or c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0)
+	return (c:IsCanBeSpecialSummoned(e,0,tp,false,false) 
+		and (c:IsLocation(LOCATION_DECK+LOCATION_HAND) or (c:IsLocation(LOCATION_EXTRA) and c:IsFacedown())) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		or (c:IsLocation(LOCATION_EXTRA) and c:IsFaceup()) and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0)	
 		and g:IsExists(s.sfilter2,1,c,e,tp,c)
 end
 function s.sfilter2(c,e,tp,oc)
-	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,1-tp)
-		and (not c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCount(1-tp,LOCATION_MZONE,tp)>0
-			or c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(1-tp,tp,nil,c)>0)
+	return (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,1-tp)
+		and (c:IsLocation(LOCATION_DECK+LOCATION_HAND) or (c:IsLocation(LOCATION_EXTRA) and c:IsFacedown())) and Duel.GetLocationCount(1-tp,LOCATION_MZONE,tp)>0
+		or (c:IsLocation(LOCATION_EXTRA) and c:IsFaceup()) and Duel.GetLocationCountFromEx(1-tp,tp,nil,c)>0)
 		and aux.gfcheck(Group.FromCards(c,oc),Card.IsSetCard,0x196,0x19f)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -46,6 +46,9 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		and g:IsExists(s.sfilter1,1,nil,e,tp,g) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,PLAYER_ALL,LOCATION_DECK+LOCATION_EXTRA+LOCATION_HAND)
 end
+function s.spfilter(c)
+	return c:GetSequence()>=5
+end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_HAND,0,nil)
 	if not Duel.IsPlayerAffectedByEffect(tp,59822133) and g:IsExists(s.sfilter1,1,nil,e,tp,g) then
@@ -53,9 +56,82 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		local sc=g:FilterSelect(tp,s.sfilter1,1,1,nil,e,tp,g):GetFirst()
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,3))
 		local oc=g:FilterSelect(tp,s.sfilter2,1,1,sc,e,tp,sc):GetFirst()
+		local mex=Duel.GetLinkedZone(1-tp)
+		local lex1=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x40)
+		local rex1=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x20)
+		if mex>0 or oc:IsLocation(LOCATION_DECK+LOCATION_HAND) or (oc:IsLocation(LOCATION_EXTRA) and oc:IsFacedown()) then
 		Duel.SpecialSummonStep(sc,0,tp,tp,false,false,POS_FACEUP)
-		Duel.SpecialSummonStep(oc,0,tp,1-tp,false,false,POS_FACEUP)
-		Duel.SpecialSummonComplete()
+			if oc:IsLocation(LOCATION_DECK+LOCATION_HAND) or
+			(oc:IsLocation(LOCATION_EXTRA) and (Duel.IsExistingMatchingCard(s.spfilter,tp,0,LOCATION_MZONE,1,nil) or Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_MZONE,LOCATION_MZONE,2,nil))) then
+			Duel.SpecialSummonStep(oc,0,tp,1-tp,false,false,POS_FACEUP,0x1f)
+			end
+			local lex2=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x40)
+			local rex2=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x20)
+			if oc:IsLocation(LOCATION_EXTRA) and lex2>0 and rex2>0 then
+				local exsp=aux.SelectFromOptions(tp,{true,aux.Stringid(id,4)},{true,aux.Stringid(id,5)}) 
+				if exsp==1 then Duel.SpecialSummonStep(oc,0,tp,1-tp,false,false,POS_FACEUP,0x1f)
+				else local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,6)},{true,aux.Stringid(id,7)},{true,aux.Stringid(id,8)},{true,aux.Stringid(id,9)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x40) end
+			   		if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x40) end
+			   		if op==3 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x20) end
+			  		if op==4 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x20) end
+				end
+			end
+			if oc:IsLocation(LOCATION_EXTRA) and lex2>0 and rex2==0 then
+				local exsp=aux.SelectFromOptions(tp,{true,aux.Stringid(id,4)},{true,aux.Stringid(id,5)}) 
+				if exsp==1 then Duel.SpecialSummonStep(oc,0,tp,1-tp,false,false,POS_FACEUP,0x1f)
+				else local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,6)},{true,aux.Stringid(id,7)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x40) end
+			 	  	if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x40) end
+				end
+			end
+			if oc:IsLocation(LOCATION_EXTRA) and lex2==0 and rex2>0 then
+				local exsp=aux.SelectFromOptions(tp,{true,aux.Stringid(id,4)},{true,aux.Stringid(id,5)}) 
+				if exsp==1 then Duel.SpecialSummonStep(oc,0,tp,1-tp,false,false,POS_FACEUP,0x1f)
+				else local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,8)},{true,aux.Stringid(id,9)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x20) end
+				   	if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x20) end
+				end
+			end
+		end
+		if mex==0 and oc:IsLocation(LOCATION_EXTRA) and oc:IsFaceup() then
+			if lex1>0 and rex1>0 then
+			Duel.SpecialSummonStep(sc,0,tp,tp,false,false,POS_FACEUP)
+			local lex2=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x40)
+			local rex2=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x20)
+				if lex2>0 and rex2>0 then
+					local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,6)},{true,aux.Stringid(id,7)},{true,aux.Stringid(id,8)},{true,aux.Stringid(id,9)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x40) end
+					if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x40) end
+					if op==3 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x20) end
+					if op==4 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x20) end
+				end
+				if lex2>0 and rex2==0 then
+					local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,6)},{true,aux.Stringid(id,7)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x40) end
+					if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x40) end
+				end
+				if lex2==0 and rex2>0 then
+					local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,8)},{true,aux.Stringid(id,9)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x20) end
+					if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x20) end
+				end
+			else Duel.SpecialSummonStep(sc,0,tp,tp,false,false,POS_FACEUP,0x1f)
+				local lex2=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x40)
+				local rex2=Duel.GetLocationCountFromEx(1-tp,tp,nil,oc,0x20)
+				if lex2>0 and rex2==0 then
+					local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,6)},{true,aux.Stringid(id,7)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x40) end
+					if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x40) end
+				end
+				if lex2==0 and rex2>0 then
+					local op=aux.SelectFromOptions(tp,{true,aux.Stringid(id,8)},{true,aux.Stringid(id,9)})
+					if op==1 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_ATTACK,0x20) end
+					if op==2 then Duel.SpecialSummonStep(oc,0,1-tp,1-tp,false,false,POS_FACEUP_DEFENSE,0x20) end
+				end
+			end
+		end
+	Duel.SpecialSummonComplete()
 	end
 	local c=e:GetHandler()
 	local e1=Effect.CreateEffect(c)


### PR DESCRIPTION
修复糕冷的料理对决不能把需要特殊召唤到对方场上的怪兽选择特殊召唤到额外怪兽区的问题（数据库上从第五行开始依次添加“在主要怪兽区特殊召唤”、“在额外怪兽区特殊召唤”、“在左侧额外怪兽区攻击表示特殊召唤”、“在左侧额外怪兽区守备表示特殊召唤”、“在右侧额外怪兽区攻击表示特殊召唤”、“在右侧额外怪兽区守备表示特殊召唤”的提示语句）