### PR TITLE
Modify トライアングル－O

### DIFF
--- a/c11489642.lua
+++ b/c11489642.lua
@@ -40,7 +40,6 @@ function s.destarget(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,aux.ExceptThisCard(e))
-	Duel.Destroy(g,REASON_EFFECT)
 	local c=e:GetHandler()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -50,6 +49,7 @@ function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(s.val)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+	Duel.Destroy(g,REASON_EFFECT)
 end
 function s.val(e,re,ev,r,rp,rc)
 	return bit.band(r,REASON_EFFECT)~=0


### PR DESCRIPTION
From: [2023/9/1](https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id188)
我方发动「[三角阵-O](https://ygocdb.com/card/name/%E4%B8%89%E8%A7%92%E9%98%B5-O)」，破坏了我方「[白之衣](https://ygocdb.com/card/name/%E7%99%BD%E4%B9%8B%E8%A1%A3)」的场合，「[白之衣](https://ygocdb.com/card/name/%E7%99%BD%E4%B9%8B%E8%A1%A3)」的④效果处理时，「[三角阵-O](https://ygocdb.com/card/name/%E4%B8%89%E8%A7%92%E9%98%B5-O)」的『这个回合，自己受到的效果伤害由对方代受』适用，对方受到3000伤害。
****
Change the sequence of _destroy-card_ and _reflect-damage_