### PR TITLE
fix BF－銀盾のミストラル

### DIFF
--- a/c46710683.lua
+++ b/c46710683.lua
@@ -15,9 +15,18 @@ end
 function c46710683.operation(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)
+	e1:SetCode(EFFECT_CHANGE_DAMAGE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetTargetRange(1,0)
-	e1:SetReset(RESET_PHASE+PHASE_DAMAGE_CAL+PHASE_END)
+	e1:SetValue(c46710683.damval)
+	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+end
+function c46710683.damval(e,re,val,r,rp,rc)
+	local c=e:GetHandler()
+	if bit.band(r,REASON_BATTLE)~=0 and c:GetFlagEffect(46710683)==0 then
+		c:RegisterFlagEffect(46710683,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
+		return 0
+	end
+	return val
 end


### PR DESCRIPTION
修复黑羽-银盾之密史脱拉防止战斗伤害的效果发动后如果己方先对对方造成战斗伤害，则该效果会失效的问题