### PR TITLE
fix Emダメージ・ジャグラー

### DIFF
--- a/c68819554.lua
+++ b/c68819554.lua
@@ -60,11 +60,20 @@ end
 function c68819554.damop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)
+	e1:SetCode(EFFECT_CHANGE_DAMAGE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetTargetRange(1,0)
-	e1:SetReset(RESET_PHASE+PHASE_DAMAGE_CAL+PHASE_END)
+	e1:SetValue(c68819554.damval)
+	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+end
+function c68819554.damval(e,re,val,r,rp,rc)
+	local c=e:GetHandler()
+	if bit.band(r,REASON_BATTLE)~=0 and c:GetFlagEffect(68819554)==0 then
+		c:RegisterFlagEffect(68819554,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
+		return 0
+	end
+	return val
 end
 function c68819554.thfilter(c)
 	return c:IsSetCard(0xc6) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand() and not c:IsCode(68819554)


### PR DESCRIPTION
修复娱乐法师伤害杂耍人防止战斗伤害的效果发动后如果己方先对对方造成战斗伤害，则该效果会失效的问题