### PR TITLE
fix EMユニ

### DIFF
--- a/c7714344.lua
+++ b/c7714344.lua
@@ -59,7 +59,7 @@ function c7714344.cfilter(c)
 	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost() and not c:IsCode(7714344)
 end
 function c7714344.damcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp and aux.bpcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp and aux.bpcon()
 end
 function c7714344.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost()
@@ -72,9 +72,18 @@ end
 function c7714344.damop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)
+	e1:SetCode(EFFECT_CHANGE_DAMAGE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetTargetRange(1,0)
-	e1:SetReset(RESET_PHASE+PHASE_DAMAGE_CAL+PHASE_END)
+	e1:SetValue(c7714344.damval)
+	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+end
+function c7714344.damval(e,re,val,r,rp,rc)
+	local c=e:GetHandler()
+	if bit.band(r,REASON_BATTLE)~=0 and c:GetFlagEffect(7714344)==0 then
+		c:RegisterFlagEffect(7714344,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
+		return 0
+	end
+	return val
 end


### PR DESCRIPTION
修复娱乐伙伴小独防止战斗伤害的效果发动后如果己方先对对方造成战斗伤害，则该效果会失效的问题