### PR TITLE
fix アーク・リベリオン・エクシーズ・ドラゴン

### DIFF
--- a/c64276752.lua
+++ b/c64276752.lua
@@ -48,7 +48,7 @@ function c64276752.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetValue(atk)
 		c:RegisterEffect(e1)
 		local mg=c:GetOverlayGroup()
-		if mg:IsExists(c64276752.mgfilter,1,nil) then
+		if mg:IsExists(c64276752.mgfilter,1,nil) and atk>0 then
 			local g=Duel.GetMatchingGroup(aux.NegateMonsterFilter,tp,LOCATION_MZONE,LOCATION_MZONE,c)
 			if #g>0 then Duel.BreakEffect() end
 			for tc in aux.Next(g) do


### PR DESCRIPTION
修复弧叛逆超量龙②效果处理时，场上不存在其他怪兽，或者只存在原本攻击力是0的怪兽时，裁定为无效的处理也不适用，只适用『这个效果的发动后，直到回合结束时自己不用这张卡不能攻击宣言』的问题