### PR TITLE
Drytron monster: add revive limit

### DIFF
--- a/c22420202.lua
+++ b/c22420202.lua
@@ -1,5 +1,6 @@
 --竜輝巧－ルタδ
 function c22420202.initial_effect(c)
+	c:EnableReviveLimit()
 	--spsummon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c33543890.lua
+++ b/c33543890.lua
@@ -1,5 +1,6 @@
 --竜輝巧－ラスβ
 function c33543890.initial_effect(c)
+	c:EnableReviveLimit()
 	--spsummon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c60037599.lua
+++ b/c60037599.lua
@@ -1,5 +1,6 @@
 --竜輝巧－エルγ
 function c60037599.initial_effect(c)
+	c:EnableReviveLimit()
 	--spsummon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c94187078.lua
+++ b/c94187078.lua
@@ -38,7 +38,7 @@ function c94187078.splimit(e,c,sump,sumtype,sumpos,targetp,se)
 	return c:IsSummonableCard()
 end
 function c94187078.filter(c,e,tp)
-	return c:IsSetCard(0x154) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x154) and c:IsCanBeSpecialSummoned(e,0,tp,false,aux.DrytronSpSummonType(c))
 end
 function c94187078.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -50,7 +50,7 @@ function c94187078.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c94187078.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
-	if tc and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
+	if tc and Duel.SpecialSummonStep(tc,0,tp,tp,false,aux.DrytronSpSummonType(tc),POS_FACEUP) then
 		tc:RegisterFlagEffect(94187078,RESET_EVENT+RESETS_STANDARD,0,1)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -61,6 +61,9 @@ function c94187078.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCondition(c94187078.descon)
 		e1:SetOperation(c94187078.desop)
 		Duel.RegisterEffect(e1,tp)
+		if aux.DrytronSpSummonType(tc) then
+			tc:CompleteProcedure()
+		end
 	end
 	Duel.SpecialSummonComplete()
 end

--- a/c95209656.lua
+++ b/c95209656.lua
@@ -87,7 +87,8 @@ function c95209656.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsSummonType(SUMMON_TYPE_RITUAL)
 end
 function c95209656.spfilter(c,e,tp)
-	return c:IsSetCard(0x154) and c:IsAttackAbove(1) and not c:IsCode(95209656) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0x154) and c:IsAttackAbove(1) and not c:IsCode(95209656)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,aux.DrytronSpSummonType(c))
 end
 function c95209656.fselect(g)
 	return g:GetSum(Card.GetAttack)==4000
@@ -120,6 +121,11 @@ function c95209656.spop(e,tp,eg,ep,ev,re,r,rp)
 	local sg=g:SelectSubGroup(tp,c95209656.fselect,false,1,ct)
 	aux.GCheckAdditional=nil
 	if sg then
-		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		for tc in aux.Next(sg) do
+			if Duel.SpecialSummonStep(tc,0,tp,tp,false,aux.DrytronSpSummonType(tc),POS_FACEUP) and aux.DrytronSpSummonType(tc) then
+				tc:CompleteProcedure()
+			end
+		end
+		Duel.SpecialSummonComplete()
 	end
 end

--- a/c96026108.lua
+++ b/c96026108.lua
@@ -1,5 +1,6 @@
 --竜輝巧－アルζ
 function c96026108.initial_effect(c)
+	c:EnableReviveLimit()
 	--spsummon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c97148796.lua
+++ b/c97148796.lua
@@ -1,5 +1,6 @@
 --竜輝巧－バンα
 function c97148796.initial_effect(c)
+	c:EnableReviveLimit()
 	--spsummon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/utility.lua
+++ b/utility.lua
@@ -905,7 +905,7 @@ function Auxiliary.DrytronSpSummonTarget(e,tp,eg,ep,ev,re,r,rp,chk)
 	local res=e:GetLabel()==100 or Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 	if chk==0 then
 		e:SetLabel(0)
-		return res and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+		return res and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,true,POS_FACEUP_DEFENSE)
 	end
 	e:SetLabel(0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
@@ -914,8 +914,17 @@ function Auxiliary.DrytronSpSummonOperation(func)
 	return function(e,tp,eg,ep,ev,re,r,rp)
 		local c=e:GetHandler()
 		if not c:IsRelateToEffect(e) then return end
-		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP_DEFENSE)~=0 then func(e,tp) end
+		if Duel.SpecialSummon(c,0,tp,tp,false,true,POS_FACEUP_DEFENSE)~=0 then
+			c:CompleteProcedure()
+			func(e,tp)
+		end
 	end
+end
+---Return the type of `nolimit` in Duel.SpecialSummon()
+---@param c Card
+---@return boolean
+function Auxiliary.DrytronSpSummonType(c)
+	return c:IsType(TYPE_SPSUMMON)
 end
 --additional destroy effect for the Labrynth field
 function Auxiliary.LabrynthDestroyOp(e,tp,res)


### PR DESCRIPTION
@mercury233 
# Problem
Drytron monsters does not have revive limit.
龍輝巧怪獸缺少蘇生限制。

# Solution
https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=1&sess=1&rp=10&mode=&sort=1&keyword=%E3%83%89%E3%83%A9%E3%82%A4%E3%83%88%E3%83%AD%E3%83%B3&stype=1&ctype=&othercon=2&starfr=&starto=&pscalefr=&pscaleto=&linkmarkerfr=&linkmarkerto=&link_m=2&atkfr=&atkto=&deffr=&defto=
ドライトロン/Drytron Cards
Add `CompleteProcedure()` to every Special Summon effect of Drytron Cards.
每個可以特召的龍輝巧效果都加上`c:CompleteProcedure()`

function Auxiliary.DrytronSpSummonType(c)
Return the type of `nolimit` in Duel.SpecialSummon()
傳回Duel.SpecialSummon()的`nolimit`參數

TYPE_SPSUMMON Drytron monsters
TYPE_SPSUMMON的龍輝巧怪獸
極超的龍輝巧是正規特召
->true

Ritual monsters and others
儀式怪獸等
只有明確說明可以特召儀式怪獸的效果才能從手牌、牌組特召
->false


# Reference
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23954&keyword=&tag=-1&request_locale=ja
> 原則として、手札・デッキの儀式モンスターは儀式召喚でしか特殊召喚できませんが、例外的に、"召喚条件を無視して特殊召喚する効果"によって特殊召喚することができます。
また、儀式モンスター側に特殊召喚の方法を制限するテキストがない限り、"儀式モンスターを特殊召喚することが明記されている効果"によって特殊召喚することができます。

> （"儀式モンスターを特殊召喚することが明記されている効果"には、「限定解除」「儀水鏡の幻影術」「ブエリヤベース・ド・ヌーベルズ」「コンフィラス・ド・ヌーベルズ」「ポワレティス・ド・ヌーベルズ」「フォアグラシャ・ド・ヌーベルズ」「バラムニエル・ド・ヌーベルズ」「バグリエル・ド・ヌーベルズ」「粛声の竜賢聖サウラヴィス」の②の効果が該当します。）