### PR TITLE
Fix 無限泡影 via Add owner-check

### DIFF
--- a/c10045474.lua
+++ b/c10045474.lua
@@ -75,9 +75,12 @@ end
 function c10045474.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tseq=e:GetLabel()
 	local loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
-	if loc&LOCATION_SZONE~=0 and seq<=4 and re:IsActiveType(TYPE_SPELL+TYPE_TRAP)
-		and ((rp==tp and seq==tseq) or (rp==1-tp and seq==4-tseq)) then
-		Duel.NegateEffect(ev)
+	if loc&LOCATION_SZONE~=0 and seq<=4 and re:IsActiveType(TYPE_SPELL+TYPE_TRAP) then
+		local ts=false
+		local co=re:GetHandler():GetOwner()
+		if co==tp then ts=(rp==tp and seq==tseq) or (rp==1-tp and seq==tseq)
+		else ts=(rp==tp and seq==4-tseq) or (rp==1-tp and seq==4-tseq) end
+		if ts then Duel.NegateEffect(ev) end
 	end
 end
 function c10045474.handcon(e)


### PR DESCRIPTION
Fix: this card will wrongly disable effect-sloving from cards  those were set on playerA's field but were used by the opposite.
Until now, this error only occur on **王宮の弾圧 Royal Oppression**
****
修复：发动后的无效同纵列魔法/陷阱效果会将 对方发动的，我方场上的[王宫的弹压] 的效果无效化的错误。