### PR TITLE
Update c82257671.lua

### DIFF
--- a/c82257671.lua
+++ b/c82257671.lua
@@ -95,5 +95,5 @@ function c82257671.imop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c82257671.efilter(e,re)
-	return e:GetOwnerPlayer()~=re:GetOwnerPlayer()
+	return e:GetOwnerPlayer()~=re:GetOwnerPlayer() and e:GetHandler():GetControler()==e:GetOwnerPlayer()
 end


### PR DESCRIPTION
修复牢牢妖③效果适用的怪兽的控制权转移后效果不能正常适用的问题（2023裁定）
97行efilter增加持有者判断