### PR TITLE
add "Horus the Black Flame Dragon" setcode

### DIFF
--- a/c9264485.lua
+++ b/c9264485.lua
@@ -7,7 +7,7 @@ function c9264485.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e1:SetTarget(aux.TargetBoolFunction(Card.IsCode,75830094,11224103,48229808))
+	e1:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0x119d))
 	e1:SetValue(aux.tgoval)
 	c:RegisterEffect(e1)
 end


### PR DESCRIPTION
```conf
!setname 0x19d Horus	ホルス
!setname 0x119d Horus the Black Flame Dragon	ホルスの黒炎竜
```

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6108
> ■「ホルスのしもべ」のモンスター効果が適用されている場合、相手プレイヤーは、自分及び相手のモンスターゾーンに表側表示で存在する **「ホルスの黒炎竜」と名のついたモンスター** を、魔法・罠・モンスターの効果の対象とする事ができなくなります。