### PR TITLE
fix ビビット騎士

### DIFF
--- a/c52575195.lua
+++ b/c52575195.lua
@@ -14,8 +14,8 @@ function c52575195.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(52575195,0))
 	e2:SetCategory(CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_BE_BATTLE_TARGET)
 	e2:SetRange(LOCATION_HAND)
 	e2:SetCondition(c52575195.tgcon2)
 	e2:SetTarget(c52575195.tgtg)
@@ -40,6 +40,7 @@ end
 function c52575195.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=e:GetLabelObject()
 	if chk==0 then return tc:IsAbleToRemove() and Duel.GetLocationCount(tp,LOCATION_MZONE)>=0
+		and not e:GetHandler():IsStatus(STATUS_CHAINING)
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetTargetCard(tc)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,tc,1,0,0)


### PR DESCRIPTION
修复ビビット騎士的效果的诱发时机错误（从EVENT_ATTACK_ANNOUNCE改成EVENT_BE_BATTLE_TARGET），以及效果类型错误（EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O改为EFFECT_TYPE_QUICK_O）