### PR TITLE
Fix 妖眼の相剣師

### DIFF
--- a/c62849088.lua
+++ b/c62849088.lua
@@ -49,17 +49,17 @@ end
 function c62849088.descon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(Card.IsSummonPlayer,1,nil,1-tp)
 end
-function c62849088.spfilter(c,loc)
-	return c:GetOriginalType()&TYPE_MONSTER~=0 and c:IsSummonLocation(loc)
+function c62849088.spfilter(c,loc,tp)
+	return c:GetOriginalType()&TYPE_MONSTER~=0 and c:IsSummonLocation(loc) and c:IsSummonPlayer(1-tp)
 end
 function c62849088.desfilter(c,tp)
 	return c:IsSummonPlayer(1-tp) and c:IsSummonLocation(LOCATION_EXTRA) and c:IsLocation(LOCATION_MZONE)
 end
 function c62849088.destg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local b1=eg:IsExists(c62849088.spfilter,1,nil,LOCATION_HAND) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	local b1=eg:IsExists(c62849088.spfilter,1,nil,LOCATION_HAND,tp) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(Card.IsCanBeSpecialSummoned,tp,LOCATION_HAND,0,1,nil,e,0,tp,false,false)
-	local b2=eg:IsExists(c62849088.spfilter,1,nil,LOCATION_DECK) and Duel.IsPlayerCanDraw(tp,2)
-	local b3=eg:IsExists(c62849088.spfilter,1,nil,LOCATION_EXTRA)
+	local b2=eg:IsExists(c62849088.spfilter,1,nil,LOCATION_DECK,tp) and Duel.IsPlayerCanDraw(tp,2)
+	local b3=eg:IsExists(c62849088.spfilter,1,nil,LOCATION_EXTRA,tp)
 	if chk==0 then return b1 or b2 or b3 end
 	local off=1
 	local ops={}


### PR DESCRIPTION
问题：我方场上有[妖眼的相剑师](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=16198&request_locale=ja)在一次对方有特殊召唤怪兽的连锁中，如果包含了由我方特殊召唤的，来自手卡/卡组/额外卡组的怪兽，[妖眼的相剑师](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=16198&request_locale=ja)可以触发对应那些位置的②效果。

原因：<code>c62849088.spfilter(c,loc)</code>不检查怪兽的召唤玩家

解法：<code>c62849088.spfilter(c,loc,tp)</code>增加检查怪兽的召唤玩家