### PR TITLE
fix Auxiliary.RegisterMergedDelayedEvent

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1411,6 +1411,10 @@ function Auxiliary.RegisterMergedDelayedEvent(c,code,event,g)
 	ge2:SetCode(EVENT_CHAIN_END)
 	ge2:SetOperation(Auxiliary.MergedDelayEventCheck2)
 	Duel.RegisterEffect(ge2,0)
+	local ge3=ge1:Clone()
+	ge3:SetCode(EVENT_CHAIN_SOLVING)
+	ge3:SetOperation(Auxiliary.MergedDelayEventCheck3)
+	Duel.RegisterEffect(ge3,0)
 end
 function Auxiliary.MergedDelayEventCheck1(e,tp,eg,ep,ev,re,r,rp)
 	local g=e:GetLabelObject()
@@ -1424,6 +1428,14 @@ end
 function Auxiliary.MergedDelayEventCheck2(e,tp,eg,ep,ev,re,r,rp)
 	local g=e:GetLabelObject()
 	if #g>0 then
+		local _eg=g:Clone()
+		Duel.RaiseEvent(_eg,EVENT_CUSTOM+e:GetLabel(),re,r,rp,ep,ev)
+		g:Clear()
+	end
+end
+function Auxiliary.MergedDelayEventCheck3(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetLabelObject()
+	if #g>0 and Duel.GetCurrentChain()==1 then
 		local _eg=g:Clone()
 		Duel.RaiseEvent(_eg,EVENT_CUSTOM+e:GetLabel(),re,r,rp,ep,ev)
 		g:Clear()


### PR DESCRIPTION
修复使用Auxiliary.RegisterMergedDelayedEvent的效果在以下情况时无法正确唤起时点
（以復烙印为例子）
c1发动I：Pマスカレーナ的①效果
c2发动手卡的深淵の獣マグナムート的①效果
（此时用I：Pマスカレーナ的①效果连接召唤S：Pリトルナイト）
在上述连锁结束后，S：Pリトルナイト连接召唤成功的场合
无法发动復烙印的效果（S：Pリトルナイト可以发动）
