### PR TITLE
Fix Condition like 29942771 ナチュル・カメリア Effect③

### DIFF
--- a/c29942771.lua
+++ b/c29942771.lua
@@ -56,11 +56,8 @@ function c29942771.tgop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoGrave(g,REASON_EFFECT)
 	end
 end
-function c29942771.cfilter(c,tp)
-	return c:IsSummonPlayer(tp)
-end
 function c29942771.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c29942771.cfilter,1,nil,1-tp)
+	return eg:IsExists(Card.IsSummonPlayer,1,e:GetHandler(),1-tp)
 end
 function c29942771.spfilter(c,e,tp)
 	return c:IsSetCard(0x2a) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c53087962.lua
+++ b/c53087962.lua
@@ -75,7 +75,7 @@ function c53087962.distg(e,c)
 	return c:GetSummonLocation()==LOCATION_EXTRA and c:IsLevel(0)
 end
 function c53087962.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(Card.IsSummonPlayer,1,nil,1-tp)
+	return eg:IsExists(Card.IsSummonPlayer,1,e:GetHandler(),1-tp)
 end
 function c53087962.thfilter(c)
 	return c:IsSetCard(0x163) and c:IsAbleToHand()

--- a/c6556909.lua
+++ b/c6556909.lua
@@ -29,7 +29,7 @@ function c6556909.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c6556909.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(Card.IsSummonPlayer,1,nil,1-tp)
+	return eg:IsExists(Card.IsSummonPlayer,1,e:GetHandler(),1-tp)
 end
 function c6556909.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end


### PR DESCRIPTION
源：
[由于「被妨碍的坏兽安眠」的效果，在自己或者对方的怪兽区特殊召唤了「黏丝坏兽库莫古斯」的场合，那个怪兽效果可以发动？](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19911&keyword=&tag=-1&request_locale=ja)
[对方「[错误复活](https://ygocdb.com/card/name/%E9%94%99%E8%AF%AF%E5%A4%8D%E6%B4%BB)」的效果把我方墓地的「[自然山茶](https://ygocdb.com/card/name/%E8%87%AA%E7%84%B6%E5%B1%B1%E8%8C%B6)」特殊召唤到我方场上时，「[自然山茶](https://ygocdb.com/card/name/%E8%87%AA%E7%84%B6%E5%B1%B1%E8%8C%B6)」的③效果不能发动。](https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id255)
“③：对方对怪兽的召唤·特殊召唤成功的场合才能发动。”-检查这类**怪兽效果**的发动条件时，当这只怪兽本身是由对方特殊召唤到我方场上，如果：
①那次召唤仅包含那只怪兽：不能发动那个效果。
②那次召唤包含多只怪兽：可以发动那个效果。
改动：从检查的特召卡片组<code>eg</code>中忽略卡片本身<code>e:GetHandler()</code>。即：
<code>return eg:IsExists(c29942771.cfilter,1,nil,1-tp)</code>→<code>return eg:IsExists(Card.IsSummonPlayer,1,e:GetHandler(),1-tp)</code>