### PR TITLE
Fix ライトロード・ドミニオン キュリオス LSummonCheck

### DIFF
--- a/c98095162.lua
+++ b/c98095162.lua
@@ -39,8 +39,17 @@ function c98095162.initial_effect(c)
 	e3:SetOperation(c98095162.thop)
 	c:RegisterEffect(e3)
 end
+function c98095162.attfilter(c,att)
+	return c:GetLinkAttribute()&att==0
+end
 function c98095162.lcheck(g)
-	return g:GetClassCount(Card.GetLinkAttribute)==1 and g:GetClassCount(Card.GetLinkRace)==g:GetCount()
+	local tc=g:GetFirst()
+	local baseatt=tc:GetLinkAttribute()
+	while tc do
+		if tc:GetLinkAttribute()<baseatt then baseatt=tc:GetLinkAttribute() end
+		tc=g:GetNext()
+	end
+	return not g:IsExists(c98095162.attfilter,1,nil,baseatt) and g:GetClassCount(Card.GetLinkRace)==#g
 end
 function c98095162.tgcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)

--- a/c98095162.lua
+++ b/c98095162.lua
@@ -44,12 +44,7 @@ function c98095162.attfilter(c,att)
 end
 function c98095162.lcheck(g)
 	local tc=g:GetFirst()
-	local baseatt=tc:GetLinkAttribute()
-	while tc do
-		if tc:GetLinkAttribute()<baseatt then baseatt=tc:GetLinkAttribute() end
-		tc=g:GetNext()
-	end
-	return not g:IsExists(c98095162.attfilter,1,nil,baseatt) and g:GetClassCount(Card.GetLinkRace)==#g
+	return not g:IsExists(c98095162.attfilter,1,tc,tc:GetLinkAttribute()) and g:GetClassCount(Card.GetLinkRace)==#g
 end
 function c98095162.tgcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)


### PR DESCRIPTION
问题：不能使用**包含同时持有多个属性的怪兽与持有单一属性的怪兽**为连接素材连接召唤。

改动：素材组检查方法改为→素材组中有无：自身属性**与其他怪兽任意属性都不同**的怪兽。
即<code>not g:IsExists(c98095162.attfilter,1,nil,baseatt)</code>