### PR TITLE
fix 閃刀起動－リンケージ

### DIFF
--- a/c9726840.lua
+++ b/c9726840.lua
@@ -39,25 +39,44 @@ end
 function c9726840.spfilter2(c,e,tp)
 	return c:IsSetCard(0x1115) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,0x60)
 end
+function c9726840.tgfilter3(c,tp)
+	return c:IsAbleToGrave() and Duel.GetLocationCountFromEx(tp,tp,c,nil,0x60)>0
+end
+function c9726840.tgfilter4(c)
+	return c:IsAbleToGrave()
+end
 function c9726840.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local tc=Duel.SelectMatchingCard(tp,c9726840.tgfilter2,tp,LOCATION_ONFIELD,0,1,1,c,e,tp):GetFirst()
-	if tc and Duel.SendtoGrave(tc,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_GRAVE) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sc=Duel.SelectMatchingCard(tp,c9726840.spfilter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp):GetFirst()
-		if sc then
-			Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP,0x60)
-			local fg=Duel.GetMatchingGroup(c9726840.atkfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
-			if fg:CheckSubGroup(aux.gfcheck,2,2,Card.IsAttribute,ATTRIBUTE_LIGHT,ATTRIBUTE_DARK) then
-				local e1=Effect.CreateEffect(c)
-				e1:SetType(EFFECT_TYPE_SINGLE)
-				e1:SetCode(EFFECT_UPDATE_ATTACK)
-				e1:SetValue(1000)
-				e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-				sc:RegisterEffect(e1)
+	local tg2=Duel.GetMatchingGroup(c9726840.tgfilter2,tp,LOCATION_ONFIELD,0,c,e,tp)
+	local tg3=(#tg2==0) and Duel.GetMatchingGroup(c9726840.tgfilter3,tp,LOCATION_ONFIELD,0,c,tp) or nil
+	local tg4=(tg3 and #tg3==0) and Duel.GetMatchingGroup(c9726840.tgfilter4,tp,LOCATION_ONFIELD,0,c) or nil
+	if #tg2>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local tc=tg2:Select(tp,1,1,c):GetFirst()
+		if Duel.SendtoGrave(tc,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_GRAVE) then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sc=Duel.SelectMatchingCard(tp,c9726840.spfilter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp):GetFirst()
+			if sc then
+				Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP,0x60)
+				local fg=Duel.GetMatchingGroup(c9726840.atkfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+				if fg:CheckSubGroup(aux.gfcheck,2,2,Card.IsAttribute,ATTRIBUTE_LIGHT,ATTRIBUTE_DARK) then
+					local e1=Effect.CreateEffect(c)
+					e1:SetType(EFFECT_TYPE_SINGLE)
+					e1:SetCode(EFFECT_UPDATE_ATTACK)
+					e1:SetValue(1000)
+					e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+					sc:RegisterEffect(e1)
+				end
 			end
 		end
+	elseif tg3 and #tg3>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local tc=tg3:Select(tp,1,1,c):GetFirst()
+		Duel.SendtoGrave(tc,REASON_EFFECT)
+	elseif tg4 and #tg4>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local tc=tg4:Select(tp,1,1,c):GetFirst()
+		Duel.SendtoGrave(tc,REASON_EFFECT)
 	end
 	if not e:IsHasType(EFFECT_TYPE_ACTIVATE) then return end
 	local e2=Effect.CreateEffect(c)

--- a/c9726840.lua
+++ b/c9726840.lua
@@ -31,8 +31,7 @@ function c9726840.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 --send to grave filter after activation
 function c9726840.tgfilter2(c,e,tp)
-	return c:IsAbleToGrave()
-		and (not Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_EXTRA,0,1,nil,0x1115) or Duel.IsExistingMatchingCard(c9726840.exfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c))
+	return c:IsAbleToGrave() and Duel.IsExistingMatchingCard(c9726840.exfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c)
 end
 function c9726840.exfilter(c,e,tp,mc)
 	return c:IsSetCard(0x1115) and Duel.GetLocationCountFromEx(tp,tp,mc,c,0x60)>0


### PR DESCRIPTION
@mercury233 @kiritosoft 
tgfilter1
Select c s.t. there is a sp summonable Sky Striker Ace after removing c.

Resolution:
tgfilter2
Select c s.t. the Extra Monster Zone is available for a Sky Striker Ace monster after removing c.

If no match found, try:
tgfilter3
Select c s.t. the Extra Monster Zone is available after removing c.

If no match found, try:
tgfilter4
Select any card.

目前改成
發動前
tgfilter1
是否存在c，使得去除c之後額外牌組有可以特召的閃刀姬怪獸？

處理時
tgfilter2
選擇c，使得去除c之後額外牌組有可以放在額外怪獸區的閃刀姬怪獸
(不考慮可否特召，只看額外怪獸區是否可用)

若無（例如：額外牌組沒有閃刀姬）
則使用tgfilter3
選擇c，使得去除c之後額外怪獸區可用

若無（例如：2個額外怪獸區都被對手佔用）
則使用tgfilter4
選擇任何一張卡