### PR TITLE
fix for TERMINAL WORLD

### DIFF
--- a/c17760003.lua
+++ b/c17760003.lua
@@ -127,8 +127,7 @@ function c17760003.target3(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c17760003.operation3(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
-		Duel.Destroy(tc,REASON_EFFECT)
+	if tc:IsRelateToEffect(e) and c17760003.filter3(tc) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end
 end

--- a/c27827903.lua
+++ b/c27827903.lua
@@ -27,7 +27,7 @@ function c27827903.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c27827903.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
 		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end

--- a/c38049541.lua
+++ b/c38049541.lua
@@ -23,15 +23,15 @@ end
 function c38049541.costg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
 	if chk==0 then return Duel.IsExistingTarget(c38049541.filter,tp,LOCATION_MZONE,0,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATTRIBUTE)
-	local att=Duel.AnnounceAttribute(tp,1,ATTRIBUTE_ALL)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c38049541.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	local g=Duel.SelectTarget(tp,c38049541.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATTRIBUTE)
+	local att=Duel.AnnounceAttribute(tp,1,ATTRIBUTE_ALL-g:GetFirst():GetAttribute())
 	e:SetLabel(att)
 end
 function c38049541.cosop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) and tc:IsControler(tp) and c38049541.filter(tc) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_ATTRIBUTE)

--- a/c38528901.lua
+++ b/c38528901.lua
@@ -33,7 +33,7 @@ function c38528901.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c38528901.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+	if tc:IsRelateToEffect(e) and c38528901.desfilter(tc) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local g=Duel.SelectMatchingCard(tp,c38528901.sfilter,tp,LOCATION_DECK,0,1,1,nil)
 		if g:GetCount()>0 then

--- a/c44877690.lua
+++ b/c44877690.lua
@@ -74,7 +74,7 @@ function c44877690.rettg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c44877690.retop2(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
+	if tc and tc:IsControler(1-tp) and tc:IsRelateToEffect(e) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end

--- a/c52709508.lua
+++ b/c52709508.lua
@@ -116,8 +116,7 @@ function c52709508.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c52709508.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsAttribute(ATTRIBUTE_LIGHT) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
-		Duel.ConfirmCards(1-tp,tc)
 	end
 end

--- a/c53944920.lua
+++ b/c53944920.lua
@@ -15,5 +15,5 @@ end
 function c53944920.ntcon(e,c,minc)
 	if c==nil then return true end
 	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c53944920.ntfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(c53944920.ntfilter,c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end

--- a/c56511382.lua
+++ b/c56511382.lua
@@ -30,11 +30,13 @@ function c56511382.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,1,1-tp,g:GetFirst():GetLevel()*400)
 end
+function c56511382.desfilter(c,tp)
+	return c:IsFaceup() and c:IsControler(tp)
+end
 function c56511382.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local lv=tc:GetLevel()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
-		Duel.Destroy(tc,REASON_EFFECT)
+	if tc:IsRelateToEffect(e) and c56511382.desfilter(tc,tp) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		Duel.Damage(1-tp,lv*400,REASON_EFFECT)
 	end
 end

--- a/c59546528.lua
+++ b/c59546528.lua
@@ -43,7 +43,7 @@ function c59546528.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
 function c59546528.operation(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	local g=Duel.GetTargetsRelateToChain():Filter(Card.IsFacedown,nil)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 	end

--- a/c64990807.lua
+++ b/c64990807.lua
@@ -37,7 +37,7 @@ function c64990807.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c64990807.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+	if tc:IsRelateToEffect(e) and tc:IsControler(1-tp) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c64990807.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)

--- a/c66165755.lua
+++ b/c66165755.lua
@@ -34,7 +34,7 @@ end
 function c66165755.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) or Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-		or not tc:IsCanBeSpecialSummoned(e,0,tp,false,false) then return end
+		or not tc:IsRace(RACE_MACHINE) or not tc:IsCanBeSpecialSummoned(e,0,tp,false,false) then return end
 	if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
 		local atk=tc:GetBaseAttack()
 		local e1=Effect.CreateEffect(e:GetHandler())

--- a/c70583986.lua
+++ b/c70583986.lua
@@ -25,10 +25,14 @@ function c70583986.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.SelectTarget(tp,c70583986.filter,tp,LOCATION_ONFIELD,0,1,12,e:GetHandler())
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
 end
+function c70583986.thfilter(c,tp)
+	return c:IsFaceup() and c:IsControler(tp)
+end
 function c70583986.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local rg=tg:Filter(Card.IsRelateToEffect,nil,e)
+	local tg=Duel.GetTargetsRelateToChain()
+	local rg=tg:Filter(c70583986.thfilter,nil,tp)
 	Duel.SendtoHand(rg,nil,REASON_EFFECT)
 	if c:IsRelateToEffect(e) and c:IsFaceup() then
 		Duel.BreakEffect()

--- a/c82263578.lua
+++ b/c82263578.lua
@@ -26,7 +26,7 @@ function c82263578.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c82263578.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsAttribute(ATTRIBUTE_WATER+ATTRIBUTE_WIND) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,tc)
 	end

--- a/c93211836.lua
+++ b/c93211836.lua
@@ -40,7 +40,7 @@ function c93211836.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c93211836.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
 		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8250
> ①：このカードをリリースし、フィールドの水属性モンスター１体を対象として発動できる。**その水属性モンスターを破壊し**、デッキから「氷結界」モンスター１体を手札に加える。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8572
> ●このカードが召喚・リバースしたターンのエンドフェイズに、相手フィールドのモンスター１体を対象として発動する。**その相手モンスターを手札に戻す**。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=9110
> ①：１ターンに１度、自分フィールドに他の「氷結界」モンスターが存在する場合、手札の「氷結界」モンスターを任意の数だけ相手に見せ、その数だけ相手フィールドの裏側表示の魔法・罠カードを対象として発動できる。**その裏側表示カードを手札に戻す**。 

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=7970
> ①：自分フィールドの他の表側表示カードを任意の数だけ対象として発動できる。**その自分の表側表示カードを手札に戻す**。このカードの攻撃力はターン終了時まで、この効果で手札に戻ったカードの数×５００アップする。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8832
> ①：カード名が異なる手札の「氷結界」モンスター３体を相手に見せ、相手フィールドのカード１枚を対象として発動できる。**その相手のカードを破壊し**、手札から「氷結界」モンスター１体を特殊召喚する。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=10425
> ①：お互いのフィールドに他のカードが存在しない場合、自分の墓地の水・風属性モンスター１体を対象として発動できる。**その水・風属性モンスターを手札に加える**。

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7948
> ■自分フィールド（**魔法＆罠ゾーンを含む**）に「[ジェネクス・コントローラー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7807)」が表側表示で存在している場合、リリースなしで召喚できます。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8106
> ①：このカードが「ジェネクス」モンスターをリリースしてアドバンス召喚した時、相手フィールドのカード１枚を対象として発動できる。**その相手のカードを破壊する**。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8552
> ①：１ターンに１度、自分フィールドの表側表示の炎属性の「ジェネクス」モンスター１体を墓地へ送り、相手フィールドの表側表示モンスター１体を対象として発動できる。**その相手の表側表示モンスターを破壊し**、そのレベル×４００ダメージを相手に与える。
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8552
> ■処理時に『その相手の表側表示モンスターを破壊し』の処理を行い、**破壊に成功した場合、『そのレベル×４００ダメージを相手に与える』処理を行います**。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8708
> ①：自分・相手ターンに、このカードを手札から捨て、**自分フィールドの「ジェネクス」モンスター１体を対象とし、属性を１つ宣言して発動できる**。**その自分の「ジェネクス」モンスターは宣言した属性になる**。
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8708
> ■この効果を発動する際に、**対象のモンスターが持っていない属性を１つ宣言します**。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8711
> ①：１ターンに１度、このカードと同じ属性を持つモンスターが自分フィールドに召喚された時、相手フィールドのカード１枚を対象として発動できる。**その相手のカードを破壊する**。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8574
> ●闇：フィールドの光属性モンスター１体を対象として発動できる。**その光属性モンスターを破壊し**、自分は１枚ドローする。
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8574
> ■処理時に『その光属性モンスターを破壊し』の処理を行い、**破壊に成功した場合、『自分は１枚ドローする』処理を行います**。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8729
> ●光：１ターンに１度、自分の墓地の光属性モンスター１体を対象として発動できる。**その光属性モンスターを裏側守備表示で特殊召喚する**。

> https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=8763
> ①：１ターンに１度、手札を１枚捨て、自分の墓地のレベル４以下の機械族モンスター１体を対象として発動できる。**その機械族モンスターを特殊召喚する**。この効果で特殊召喚したモンスターは、攻撃力がターン終了時まで倍になり、相手に直接攻撃できず、自分エンドフェイズに除外される。