### PR TITLE
Fix The blazing MARS

### DIFF
--- a/c15033525.lua
+++ b/c15033525.lua
@@ -54,16 +54,16 @@ end
 function c15033525.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1
 end
-function c15033525.ncostfilter(c)
-	return not c:IsAbleToGraveAsCost()
+function c15033525.stfilter(c)
+	return c:GetOriginalType()&(TYPE_SPELL+TYPE_TRAP)==0
 end
 function c15033525.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,0)
 	g:RemoveCard(e:GetHandler())
-	if chk==0 then return g:GetCount()>0 and not g:IsExists(c15033525.ncostfilter,1,nil) end
+	local mg=g:Filter(c15033525.stfilter,nil)
+	if chk==0 then return #mg>0 and g:IsExists(Card.IsAbleToGraveAsCost,#g,nil) end
 	Duel.SendtoGrave(g,REASON_COST)
-	local ct=g:FilterCount(Card.IsLocation,nil,LOCATION_GRAVE)
-	e:SetLabel(ct)
+	e:SetLabel(mg:FilterCount(Card.IsLocation,nil,LOCATION_GRAVE))
 end
 function c15033525.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
[wiki: 自己怪兽区域只有「烈焰火星」和陷阱怪兽时，不能发动「烈焰火星」的②效果。](https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2021.html#id15)

[FAQ：在自己的怪兽区存在衍生物或灵摆怪兽的场合，「烈焰火星」的怪兽效果不能发动](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=19286&keyword=&tag=-1&request_locale=ja)

[FAQ：被送去墓地的陷阱怪兽不记入效果伤害数量](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7475&keyword=&tag=-1&request_locale=ja)
****
增加cost对怪兽原本类型（怪兽/魔法/陷阱）的检测，调整效果伤害计算方式