### PR TITLE
Modify ヴェルズ・コッペリアル

### DIFF
--- a/c77841719.lua
+++ b/c77841719.lua
@@ -20,7 +20,7 @@ function c77841719.initial_effect(c)
 end
 function c77841719.condition(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:IsPreviousControler(tp) and rp==1-tp
+	return c:IsPreviousControler(tp) and rp==1-tp and (not c:IsLocation(LOCATION_HAND) or c:IsPreviousPosition(POS_FACEUP))
 end
 function c77841719.filter(c)
 	return c:IsFaceup() and c:IsControlerCanBeChanged()


### PR DESCRIPTION
(https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id260)
里侧守备表示的「[入魔人偶 葛佩利亚](https://ygocdb.com/card/name/%E5%85%A5%E9%AD%94%E4%BA%BA%E5%81%B6%20%E8%91%9B%E4%BD%A9%E5%88%A9%E4%BA%9A)」回到手卡的场合，不会发动效果。不过，如果手卡是公开的场合，自身效果也会发动。
****
更新回到手卡的处理