### PR TITLE
Modify 沈黙狼－カルーポ

### DIFF
--- a/c15947754.lua
+++ b/c15947754.lua
@@ -33,7 +33,7 @@ function s.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetDecktopGroup(tp,1):GetFirst()
 	if c:IsFaceup() and c:IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and tc and tc:IsFacedown() then
+		and tc and tc:IsFacedown() and Duel.IsPlayerCanSSet(tp,tc) then
 		Duel.DisableShuffleCheck()
 		if tc:IsForbidden() then
 			Duel.SendtoGrave(tc,REASON_RULE)


### PR DESCRIPTION
(https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id241)
对方场上存在「[暗黑神鸟 斯摩夫](https://ygocdb.com/card/name/%E6%9A%97%E9%BB%91%E7%A5%9E%E9%B8%9F%20%E6%96%AF%E6%91%A9%E5%A4%AB)」的场合，「[沉默狼-卡鲁波狼犬](https://ygocdb.com/card/name/%E6%B2%89%E9%BB%98%E7%8B%BC-%E5%8D%A1%E9%B2%81%E6%B3%A2%E7%8B%BC%E7%8A%AC)」的①效果也会强制发动，但是不处理。
****
OP增加能否盖放的检查:<code>Duel.IsPlayerCanSSet(tp,tc)</code>