### PR TITLE
Fix 風の天翼ミラドーラ

### DIFF
--- a/c17063599.lua
+++ b/c17063599.lua
@@ -45,7 +45,7 @@ function c17063599.actcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_HAND)
 end
 function c17063599.filter(c)
-	return c:IsFaceup() and c:IsSummonLocation(LOCATION_EXTRA)
+	return c:IsFaceup() and c:IsSummonLocation(LOCATION_EXTRA) and c:GetType()&TYPE_EFFECT~=0
 end
 function c17063599.acttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c17063599.filter(chkc) end


### PR DESCRIPTION
https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2021.html#id105
wiki:
「[风之天翼 米拉多羽蛇](https://ygocdb.com/card/name/%E9%A3%8E%E4%B9%8B%E5%A4%A9%E7%BF%BC%20%E7%B1%B3%E6%8B%89%E5%A4%9A%E7%BE%BD%E8%9B%87)」的②效果不能对效果怪兽以外的怪兽发动。这个效果处理时，对象怪兽变成里侧表示的场合，这个效果仍然适用（对象怪兽反转后也不能发动效果）；这个效果处理后，对象怪兽变成里侧表示的场合，这个效果不再适用。[21/5/21](https://yugioh-wiki.net/index.php?%A1%D4%C9%F7%A4%CE%C5%B7%CD%E3%A5%DF%A5%E9%A5%C9%A1%BC%A5%E9%A1%D5#faq)
****
对象筛选部分增加效果怪兽检查<code>c:GetType()&TYPE_EFFECT~=0</code>