### PR TITLE
Fix らくがきじゅう－てらの

### DIFF
--- a/c67725394.lua
+++ b/c67725394.lua
@@ -95,7 +95,6 @@ function c67725394.desop(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 then
 		Duel.HintSelection(g)
 		if Duel.Destroy(g,REASON_EFFECT)~=0 and e:GetLabel()==1 and c:IsRelateToEffect(e) and c:IsFaceup() then
-			Duel.BreakEffect()
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_UPDATE_ATTACK)


### PR DESCRIPTION
[②效果的破坏与攻击力上升应为同时处理。](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17649&request_locale=ja)
****
删除<code>Duel.BreakEffect()</code>