### PR TITLE
Update-煉獄の氾爛

### DIFF
--- a/c34822850.lua
+++ b/c34822850.lua
@@ -65,7 +65,7 @@ function c34822850.filter(c,lv)
 	return c:IsFaceup() and c:IsSetCard(0xbb) and c:GetLevel()>lv
 end
 function c34822850.atlimit(e,c)
-	return c:IsFaceup() and c:IsSetCard(0xbb) and Duel.IsExistingMatchingCard(c34822850.filter,c:GetControler(),LOCATION_MZONE,0,1,nil,c:GetLevel())
+	return c:IsFaceup() and c:IsSetCard(0xbb) and (c:GetLevel()<1 or Duel.IsExistingMatchingCard(c34822850.filter,c:GetControler(),LOCATION_MZONE,0,1,nil,c:GetLevel()))
 end
 function c34822850.tglimit(e,c)
 	return c:IsSetCard(0xbb)


### PR DESCRIPTION
[ 我方场上存在「炼狱的泛烂」和不持有等级的「狱火机·洪水」时，无论我方场上是否存在其他「狱火机」怪兽，对方都不能把「狱火机·洪水」作为效果对象或攻击对象](https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html?highlight=%22%E7%82%BC%E7%8B%B1%E7%9A%84%E6%B3%9B%E7%83%82%22#id254)
****
增加对不持有等级的怪兽的保护
<code>return c:IsFaceup() and c:IsSetCard(0xbb) and Duel.IsExistingMatchingCard(c34822850.filter,c:GetControler(),LOCATION_MZONE,0,1,nil,c:GetLevel())</code>
↓
<code>... and c:IsSetCard(0xbb) and (c:GetLevel()<1 or ...)</code>