### PR TITLE
Update アブソリュート・パワーフォース

### DIFF
--- a/c51779204.lua
+++ b/c51779204.lua
@@ -12,7 +12,7 @@ function c51779204.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c51779204.filter(c)
-	return c:IsFaceup() and c:IsCode(70902743) and c:GetFlagEffect(51779204)==0
+	return c:IsFaceup() and c:IsCode(70902743)
 end
 function c51779204.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c51779204.filter(chkc) end
@@ -24,15 +24,15 @@ function c51779204.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetCondition(c51779204.atkcon)
+		e1:SetValue(1000)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
 		if tc:GetFlagEffect(51779204)==0 then
 			tc:RegisterFlagEffect(51779204,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
-			local e1=Effect.CreateEffect(c)
-			e1:SetType(EFFECT_TYPE_SINGLE)
-			e1:SetCode(EFFECT_UPDATE_ATTACK)
-			e1:SetCondition(c51779204.atkcon)
-			e1:SetValue(1000)
-			e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-			tc:RegisterEffect(e1)
 			local e2=Effect.CreateEffect(c)
 			e2:SetType(EFFECT_TYPE_FIELD)
 			e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)


### PR DESCRIPTION
[Database: 23/6/24](https://yugioh-wiki.net/index.php?%A5%DA%A5%F3%A5%C7%A5%E5%A5%E9%A5%E0%A5%E2%A5%F3%A5%B9%A5%BF%A1%BC#b31f7c00)
可以取已经适用了「[绝对权力强要](https://ygocdb.com/card/name/%E7%BB%9D%E5%AF%B9%E6%9D%83%E5%8A%9B%E5%BC%BA%E8%A6%81)」①效果的「[红莲魔龙](https://ygocdb.com/card/name/%E7%BA%A2%E8%8E%B2%E9%AD%94%E9%BE%99)」为对象发动第2张「绝对权力强要」。这个场合只上升攻击力，其他效果处理全不适用
****
同步复数张「绝对权力强要」的发动和处理。