### PR TITLE
Fix-BM－４ボムスパイダー

### DIFF
--- a/c40634253.lua
+++ b/c40634253.lua
@@ -53,11 +53,11 @@ end
 function c40634253.damcon1(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
 	local bc=tc:GetBattleTarget()
-	return tc:IsPreviousControler(1-tp) and tc:IsLocation(LOCATION_GRAVE)
+	return tc:IsPreviousControler(1-tp) and tc:IsLocation(LOCATION_GRAVE) and tc:GetBaseAttack()>0
 		and bc:IsControler(tp) and bc:GetOriginalAttribute()==ATTRIBUTE_DARK and bc:GetOriginalRace()==RACE_MACHINE and bc:IsType(TYPE_MONSTER)
 end
 function c40634253.damfilter1(c,tp)
-	return c:IsReason(REASON_EFFECT) and c:IsType(TYPE_MONSTER) and c:IsReason(REASON_DESTROY) and c:IsLocation(LOCATION_GRAVE) and c:IsPreviousControler(1-tp)
+	return c:IsReason(REASON_EFFECT) and c:IsType(TYPE_MONSTER) and c:IsReason(REASON_DESTROY) and c:IsLocation(LOCATION_GRAVE) and c:IsPreviousControler(1-tp) and c:GetBaseAttack()>0
 end
 function c40634253.damcon2(e,tp,eg,ep,ev,re,r,rp)
 	if not re then return false end


### PR DESCRIPTION
(https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id245)
由于被破坏的「[于贝尔精灵](https://ygocdb.com/card/name/%E4%BA%8E%E8%B4%9D%E5%B0%94%E7%B2%BE%E7%81%B5)」的原本攻击力是0，不能发动「[BM-4炸弹蜘蛛](https://ygocdb.com/card/name/BM-4%E7%82%B8%E5%BC%B9%E8%9C%98%E8%9B%9B)」的②效果。
****
增加破坏的怪兽的原本攻击力的检查