### PR TITLE
Update 儚無みずき

### DIFF
--- a/c60643553.lua
+++ b/c60643553.lua
@@ -94,6 +94,7 @@ end
 function c60643553.lpop2(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ResetFlagEffect(tp,60643554)
 	local lg=e:GetLabelObject():GetLabelObject()
+	lg=lg:Filter(Card.IsLocation,nil,LOCATION_MZONE)
 	local rnum=lg:GetSum(Card.GetAttack)
 	local g=Group.CreateGroup()
 	g:KeepAlive()


### PR DESCRIPTION
[对手发动卡的效果，那张卡的效果处理全部结束的时点，特殊召唤的怪兽在怪兽区表侧表示存在的情况下，自己的生命点数恢复该怪兽的攻击力。](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23959&keyword=&tag=-1&request_locale=ja)
****
增加任意效果处理完成时，该效果特殊召唤的怪兽是否处于怪兽区的检查。