### PR TITLE
Fix-真エクゾディア

### DIFF
--- a/c37984331.lua
+++ b/c37984331.lua
@@ -25,4 +25,5 @@ end
 function c37984331.operation(e,tp,eg,ep,ev,re,r,rp)
 	local WIN_REASON_TRUE_EXODIA = 0x20
 	Duel.Win(1-tp,WIN_REASON_TRUE_EXODIA)
+	if Duel.GetCurrentChain()==0 then Duel.Readjust() end
 end


### PR DESCRIPTION
为不入连锁的 召唤 /特殊召唤 /一时除外返场 手动刷新状态以及时完成<code>Duel.Win()</code>