### PR TITLE
Fix 閉ザサレシ世界ノ冥神

### DIFF
--- a/c98127546.lua
+++ b/c98127546.lua
@@ -50,7 +50,14 @@ function c98127546.matfilter1(c,tp)
 	return c:GetFlagEffect(100200249)>0 and c:IsControler(tp)
 end
 function c98127546.exmatcheck(c,lc,tp)
-	return c:GetFlagEffect(100200249)==0 and c:IsControler(tp)
+	 if not c:IsControler(1-tp) then return false end
+	 local le={c:IsHasEffect(EFFECT_EXTRA_LINK_MATERIAL,tp)}
+	         for _,te in pairs(le) do	 
+	         local f=te:GetValue()
+	         local related,valid=f(te,lc,nil,c,tp)
+	 if related and not te:GetHandler():IsCode(98127546) then return false end
+	 end
+	 return true	 
 end
 function c98127546.matval(e,lc,mg,c,tp)
 	if e:GetHandler()~=lc then return false,nil end

--- a/c98127546.lua
+++ b/c98127546.lua
@@ -54,7 +54,7 @@ function c98127546.matfilter2(c,tp)
 end
 function c98127546.matval(e,lc,mg,c,tp)
 	if e:GetHandler()~=lc then return false,nil end
-	return true,not mg or (mg:IsExists(c98127546.matfilter1,1,nil,1-tp) and not mg:IsExists(c98127546.matfilter2,1,nil,1-tp)) or (not mg:IsExists(Card.IsControler,1,nil,1-tp))
+	return true,not mg or not mg:IsExists(c98127546.exmatcheck,1,nil,lc,tp)
 end
 function c98127546.discon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)

--- a/c98127546.lua
+++ b/c98127546.lua
@@ -48,7 +48,6 @@ function c98127546.initial_effect(c)
 end
 function c98127546.matfilter1(c,tp)
 	return c:GetFlagEffect(100200249)>0 and c:IsControler(tp)
-end
 function c98127546.exmatcheck(c,lc,tp)
 	 if not c:IsControler(1-tp) then return false end
 	 local le={c:IsHasEffect(EFFECT_EXTRA_LINK_MATERIAL,tp)}

--- a/c98127546.lua
+++ b/c98127546.lua
@@ -49,7 +49,7 @@ end
 function c98127546.matfilter1(c,tp)
 	return c:GetFlagEffect(100200249)>0 and c:IsControler(tp)
 end
-function c98127546.matfilter2(c,tp)
+function c98127546.exmatcheck(c,lc,tp)
 	return c:GetFlagEffect(100200249)==0 and c:IsControler(tp)
 end
 function c98127546.matval(e,lc,mg,c,tp)

--- a/c98127546.lua
+++ b/c98127546.lua
@@ -47,7 +47,6 @@ function c98127546.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c98127546.matfilter1(c,tp)
-	return c:GetFlagEffect(100200249)>0 and c:IsControler(tp)
 function c98127546.exmatcheck(c,lc,tp)
 	 if not c:IsControler(1-tp) then return false end
 	 local le={c:IsHasEffect(EFFECT_EXTRA_LINK_MATERIAL,tp)}

--- a/c98127546.lua
+++ b/c98127546.lua
@@ -46,7 +46,6 @@ function c98127546.initial_effect(c)
 	e4:SetOperation(c98127546.negop)
 	c:RegisterEffect(e4)
 end
-function c98127546.matfilter1(c,tp)
 function c98127546.exmatcheck(c,lc,tp)
 	 if not c:IsControler(1-tp) then return false end
 	 local le={c:IsHasEffect(EFFECT_EXTRA_LINK_MATERIAL,tp)}

--- a/c98127546.lua
+++ b/c98127546.lua
@@ -47,14 +47,14 @@ function c98127546.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c98127546.exmatcheck(c,lc,tp)
-	 if not c:IsControler(1-tp) then return false end
-	 local le={c:IsHasEffect(EFFECT_EXTRA_LINK_MATERIAL,tp)}
-	         for _,te in pairs(le) do	 
-	         local f=te:GetValue()
-	         local related,valid=f(te,lc,nil,c,tp)
-	 if related and not te:GetHandler():IsCode(98127546) then return false end
-	 end
-	 return true	 
+	if not c:IsControler(1-tp) then return false end
+	local le={c:IsHasEffect(EFFECT_EXTRA_LINK_MATERIAL,tp)}
+	for _,te in pairs(le) do	 
+		local f=te:GetValue()
+		local related,valid=f(te,lc,nil,c,tp)
+		if related and not te:GetHandler():IsCode(98127546) then return false end
+	end
+	return true	 
 end
 function c98127546.matval(e,lc,mg,c,tp)
 	if e:GetHandler()~=lc then return false,nil end

--- a/c98127546.lua
+++ b/c98127546.lua
@@ -46,9 +46,15 @@ function c98127546.initial_effect(c)
 	e4:SetOperation(c98127546.negop)
 	c:RegisterEffect(e4)
 end
+function c98127546.matfilter1(c,tp)
+	return c:GetFlagEffect(100200249)>0 and c:IsControler(tp)
+end
+function c98127546.matfilter2(c,tp)
+	return c:GetFlagEffect(100200249)==0 and c:IsControler(tp)
+end
 function c98127546.matval(e,lc,mg,c,tp)
 	if e:GetHandler()~=lc then return false,nil end
-	return true,not mg or not mg:IsExists(Card.IsControler,1,nil,1-tp)
+	return true,not mg or (mg:IsExists(c98127546.matfilter1,1,nil,1-tp) and not mg:IsExists(c98127546.matfilter2,1,nil,1-tp)) or (not mg:IsExists(Card.IsControler,1,nil,1-tp))
 end
 function c98127546.discon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)


### PR DESCRIPTION
The effect that provides an extra link material of 閉ザサレシ世界ノ冥神 is incorrect because of 閉ザサレシ天ノ月