### PR TITLE
Fix-竜剣士イグニスP

### DIFF
--- a/c56347375.lua
+++ b/c56347375.lua
@@ -63,7 +63,8 @@ function c56347375.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc=Duel.SelectMatchingCard(tp,c56347375.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp):GetFirst()
-	if tc and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+	if tc then
+		Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_ADD_TYPE)
@@ -71,5 +72,6 @@ function c56347375.spop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetValue(TYPE_TUNER)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1)
+		Duel.SpecialSummonComplete()
 	end
 end


### PR DESCRIPTION
将怪兽效果②的特召方法更换为<code>Duel.SpecialSummonStep()</code>+<code>Duel.SpecialSummonComplete()</code>
以避免错误如：特殊召唤通常怪兽，而场上有[天威无崩之地](https://yugioh-wiki.net/index.php?%A1%D4%C5%B7%B0%D2%CC%B5%CA%F8%A4%CE%C3%CF%A1%D5)适用中的场合，那只怪兽不能适用变成调整的效果。