### PR TITLE
Fix 蛇眼の炎龍

### DIFF
--- a/c48452496.lua
+++ b/c48452496.lua
@@ -98,7 +98,8 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_GRAVE)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 or Duel.IsPlayerAffectedByEffect(tp,59822133)
+		or Duel.GetMatchingGroupCount(s.ffilter,tp,LOCATION_GRAVE,0,null,e,tp)<2 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.ffilter,tp,LOCATION_GRAVE,0,2,2,nil,e,tp)
 	Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
If player have less than 2 monster that meets condition in GY when ③'s effect is resolved, it should not special summon.

③效果处理时，如果墓地少于2只符合条件的怪兽，不应该特殊召唤。