### PR TITLE
fix--S：Pリトルナイト

### DIFF
--- a/c29301450.lua
+++ b/c29301450.lua
@@ -105,6 +105,9 @@ end
 function s.retfilter(c)
 	return c:GetFlagEffect(id)~=0
 end
+function s.retfilter1(c,tp)
+	return c:GetFlagEffect(id)~=0 and c:IsControler(tp)
+end
 function s.retcon(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetLabelObject():IsExists(s.retfilter,1,nil) then
 		e:GetLabelObject():DeleteGroup()
@@ -114,8 +117,25 @@ function s.retcon(e,tp,eg,ep,ev,re,r,rp)
 	return true
 end
 function s.retop(e,tp,eg,ep,ev,re,r,rp)
-	local g=e:GetLabelObject():Filter(s.retfilter,nil)
-	for tc in aux.Next(g) do
-		Duel.ReturnToField(tc)
+	local g1=e:GetLabelObject():Filter(s.retfilter1,nil,tp)
+	local g2=e:GetLabelObject():Filter(s.retfilter1,nil,1-tp)
+	local turnp=Duel.GetTurnPlayer()
+	if #g2==0 then
+		if #g1==1 then
+			Duel.ReturnToField(g1:GetFirst())
+		else
+			local tc=g1:Select(tp,1,1,nil):GetFirst()
+			Duel.ReturnToField(tc)
+			g1=g1-tc
+			Duel.ReturnToField(g1:GetFirst())
+		end
+	else
+		if turnp==tp then
+			Duel.ReturnToField(g1:GetFirst())
+			Duel.ReturnToField(g2:GetFirst())
+		else
+			Duel.ReturnToField(g2:GetFirst())
+			Duel.ReturnToField(g1:GetFirst())
+		end
 	end
 end

--- a/c29301450.lua
+++ b/c29301450.lua
@@ -131,11 +131,15 @@ function s.retop(e,tp,eg,ep,ev,re,r,rp)
 		end
 	else
 		if turnp==tp then
-			Duel.ReturnToField(g1:GetFirst())
+			if #g1>0 then
+				Duel.ReturnToField(g1:GetFirst())
+			end
 			Duel.ReturnToField(g2:GetFirst())
 		else
 			Duel.ReturnToField(g2:GetFirst())
-			Duel.ReturnToField(g1:GetFirst())
+			if #g1>0 then
+				Duel.ReturnToField(g1:GetFirst())
+			end
 		end
 	end
 end


### PR DESCRIPTION
https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id223 (10/20)
「[S：P小夜]」的②效果把对方的怪兽也一时除外的场合，回到场上的时点，如果是对方回合，对方怪兽先回到对方场上，确认对方放置的位置后，我方怪兽再回到场上，选择放置的位置；如果是我方回合，我方怪兽先回到场上，放置了位置对方确认后，对方怪兽再回到场上，选择放置的位置。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=24029&keyword=&tag=-1
自分が「[S：Pリトルナイト]の『②：相手の効果が発動した時、自分フィールドのモンスターを含むフィールドの表側表示モンスター２体を対象として発動できる。そのモンスター２体をエンドフェイズまで除外する』効果を発動し、自分のモンスターゾーンに存在する「[S：Pリトルナイト]」と自分のモンスターゾーンに存在する「[共命の翼ガルーラ]」を除外しました。
このターンのエンドフェイズに自分の使用できるモンスターゾーンが１ヵ所のみの場合、除外されている自分のモンスター２体はどうなりますか？
Answer
自分がモンスターゾーンに戻すモンスターを１体選び、そのモンスターをモンスターゾーンに戻し、選ばなかったモンスターは墓地に置かれます。

（「[共命の翼ガルーラ)」が選ばれずに墓地に置かれた場合、『墓地へ送られた』扱いになりませんので、『②：このカードが墓地へ送られた場合に発動できる。自分は１枚ドローする』効果は発動できません。）