### PR TITLE
Fix エクシーズ・アーマー・トルピード

### DIFF
--- a/c94151981.lua
+++ b/c94151981.lua
@@ -70,7 +70,7 @@ function s.drawoperation(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.actcon(e)
 	local tc=e:GetHandler():GetEquipTarget()
-	return Duel.GetAttacker()==tc or Duel.GetAttackTarget()==tc
+	return tc~=nil and (Duel.GetAttacker()==tc or Duel.GetAttackTarget()==tc)
 end
 function s.disfilter(c)
 	return aux.NegateAnyFilter(c) and c:IsType(TYPE_MONSTER) and c:IsFaceup()


### PR DESCRIPTION
When ``Xyz Armor Torpedo`` is placed as Continuous Spell/Trap, it's ③ effect will make all opponent monster cannot activate effect.

当``超量铠甲·鱼雷式``被当作永续魔法/陷阱放置时，③效果会让对方的所有怪兽无法发动效果。