### PR TITLE
fix c44710391 地縛地上絵

### DIFF
--- a/c44710391.lua
+++ b/c44710391.lua
@@ -20,7 +20,7 @@ function c44710391.initial_effect(c)
 	--double tribute
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD)
-	e4:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_SET_AVAILABLE)
+	e4:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
 	e4:SetCode(EFFECT_DOUBLE_TRIBUTE)
 	e4:SetRange(LOCATION_FZONE)
 	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14594&request_locale=ja

【②の効果について】
■モンスターに適用する効果です。（魔法カードの効果を受けないシンクロモンスター１体を２体分のリリースにはできません。）