### PR TITLE
Fix コード・エクスポーター

### DIFF
--- a/c37119142.lua
+++ b/c37119142.lua
@@ -12,7 +12,7 @@ function c37119142.initial_effect(c)
 	--to hand
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(37119142,0))
-	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON)
+	e2:SetCategory(CATEGORY_TOHAND)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
 	e2:SetCode(EVENT_BE_MATERIAL)
@@ -55,7 +55,12 @@ function c37119142.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingTarget(c37119142.thfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,check) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectTarget(tp,c37119142.thfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,check)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+	if e:GetLabel()==0 then
+		Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+	else
+		e:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON)
+		Duel.SetOperationInfo(0,CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+	end
 end
 function c37119142.thop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
When ``Code Exporter`` is used for link summon in Hand, it should not have category ``CATEGORY_SPECIAL_SUMMON``.

代码导出员从手卡作为连接素材的场合，不应该带``CATEGORY_SPECIAL_SUMMON``标志，从而能被对应特殊召唤的效果连锁。