### PR TITLE
Fix 天幻の龍輪

### DIFF
--- a/c51684157.lua
+++ b/c51684157.lua
@@ -3,7 +3,7 @@ function c51684157.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(51684157,0))
-	e1:SetCategory(CATEGORY_SEARCH+CATEGORY_SPECIAL_SUMMON+CATEGORY_DECKDES)
+	e1:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER+TIMING_END_PHASE)
@@ -54,7 +54,11 @@ function c51684157.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		return Duel.IsExistingMatchingCard(c51684157.thfilter,tp,LOCATION_DECK,0,1,nil,e,tp,check)
 	end
 	if l2==0 then
+		e:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)
 		Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+	else
+		e:SetCategory(CATEGORY_SEARCH+CATEGORY_SPECIAL_SUMMON+CATEGORY_DECKDES)
+		Duel.SetOperationInfo(0,CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON+CATEGORY_DECKDES,nil,1,tp,LOCATION_DECK)
 	end
 end
 function c51684157.activate(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
When activating ``天幻の龍輪`` by tributing Effect Monster, it should not have ``CATEGORY_SPECIAL_SUMMON`` category.

解放效果怪兽发动天幻之龙轮时，不应该带有CATEGORY_SPECIAL_SUMMON，从而被对应特殊召唤的效果连锁。