### PR TITLE
Fix 超接地展開

### DIFF
--- a/c96462121.lua
+++ b/c96462121.lua
@@ -49,7 +49,7 @@ end
 function c96462121.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsControler(tp) and tc:IsFaceup()
-		and aux.MustMaterialCheck(tc,tp,EFFECT_MUST_BE_XMATERIAL) then
+		and aux.MustMaterialCheck(tc,tp,EFFECT_MUST_BE_XMATERIAL) and not tc:IsImmuneToEffect(e) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c96462121.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc:GetRank()+2,tc)
 		local sc=g:GetFirst()


### PR DESCRIPTION
[「升阶魔法-异晶人的魔力」的对象怪兽处理时不受魔法卡的效果影响的场合，这个效果不适用。](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12796&request_locale=ja)

****
类似的升阶效果已检查，无此问题
70026064
23581825
35906693
36224040
39680372
41201386
45950291
47660516
48333324
58988903
67517351
71345905
92365601
94220427
3298689
4408198
33252803
43383478
43476205
47185546
47882565
86196216
88504133
10125011
93238626
96462121
46008667
10424147
32764863
61818176
82162616
82983267
49082032