### PR TITLE
workaround fix Sinful Spoils of Subversion - Snake-Eye

### DIFF
--- a/c24081957.lua
+++ b/c24081957.lua
@@ -17,7 +17,10 @@ function s.filter(c,tp,ft)
 	local p=c:GetOwner()
 	if p~=tp then ft=0 end
 	local r=LOCATION_REASON_TOFIELD
-	if not c:IsControler(p) then r=LOCATION_REASON_CONTROL end
+	if not c:IsControler(p) then
+		if not c:IsAbleToChangeControler() then return false end
+		r=LOCATION_REASON_CONTROL
+	end
 	return Duel.GetLocationCount(p,LOCATION_SZONE,tp,r)>ft
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)


### PR DESCRIPTION
fix: _Sinful Spoils of Subversion - Snake-Eye_ can target _Mataza the Zapper_ opponent controls that is owned by self.

> mail:
> Q.
> 自分フィールドの「E・HERO フェザーマン」1体と自分の墓地の「不意打ち又佐」1体を対象として「ギブ＆テイク」を発動し、自分の墓地の「不意打ち又佐」を相手フィールドに特殊召喚しました。
> 「不意打ち又佐」はコントロールを変更できない永続効果を持ちますが、相手フィールドに存在する元々の持ち主が自分の「不意打ち又佐」を対象として「反逆の罪宝－スネークアイ」を発動できますか？
> A.
> ご質問の場合、**「不意打ち又佐」を対象に「反逆の罪宝－スネークアイ」を発動することはできません**。

this bug may occur to Snake-Eyes Flamberge Dragon and so on.
so, might be better to add `Card.IsAbleToField`.