### PR TITLE
Fix ベアルクティ－ポーラ＝スター

### DIFF
--- a/c62714453.lua
+++ b/c62714453.lua
@@ -102,7 +102,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		local tc=g:GetFirst()
 		if Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)>0 then
 			local c=e:GetHandler()
-			local e1=Effect.CreateEffect(c)
+			local e1=Effect.CreateEffect(tc)
 			e1:SetType(EFFECT_TYPE_FIELD)
 			e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 			e1:SetCode(EFFECT_CANNOT_ACTIVATE)


### PR DESCRIPTION
[【●对手从EX卡组特殊召唤，不能发动等级怪兽的效果】是这张卡的①效果特殊召唤的怪兽得到的永续效果。](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18828&request_locale=ja)
****
更改该效果的持有者。