### PR TITLE
Optimize way of choosing target on Effect1

### DIFF
--- a/c29301450.lua
+++ b/c29301450.lua
@@ -44,7 +44,13 @@ function s.srmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE+LOCATION_ONFIELD) and chkc:IsAbleToRemove() end
 	if chk==0 then return Duel.IsExistingTarget(Card.IsAbleToRemove,tp,LOCATION_GRAVE+LOCATION_ONFIELD,LOCATION_GRAVE+LOCATION_ONFIELD,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,LOCATION_GRAVE+LOCATION_ONFIELD,LOCATION_GRAVE+LOCATION_ONFIELD,1,1,nil)
+	local g1=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	local g2=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil)
+	if (g1:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1))) or g2:GetCount()==0 then
+		local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	else
+		local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil)
+	end
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
 end
 function s.srmop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Before choosing target, I added an yesno-select to ask player if you want to remove the card onfield (if not it will turn to choose the target in grave). Therefore it needs stringid in cdb. (text:Do you want to remove the card onfield?) 在选目标之前，我增加了一个是否选项，询问玩家是否要除外场上的卡（如果选否，则会转到选择墓地的卡）。因此，cdb需要一个文本。（文本：是否要除外场上的卡？）