### PR TITLE
Fix 超雷龍－サンダー・ドラゴン

### DIFF
--- a/c15291624.lua
+++ b/c15291624.lua
@@ -44,7 +44,7 @@ function c15291624.chainfilter(re,tp,cid)
 end
 function c15291624.spfilter(c,fc,tp)
 	return c:IsRace(RACE_THUNDER) and c:IsFusionType(TYPE_EFFECT) and not c:IsFusionType(TYPE_FUSION)
-		and c:IsReleasable() and Duel.GetLocationCountFromEx(tp,tp,c,fc)>0 and c:IsCanBeFusionMaterial(fc,SUMMON_TYPE_SPECIAL)
+		and Duel.GetLocationCountFromEx(tp,tp,c,fc)>0 and c:IsCanBeFusionMaterial(fc,SUMMON_TYPE_SPECIAL)
 end
 function c15291624.spcon(e,c)
 	if c==nil then return true end


### PR DESCRIPTION
Card.IsReleasable now have default param ``REASON_COST``, which will be blocked by ``聖霊獣騎 レイラウタリ``.
I think ``CheckReleaseGroup`` is already enough to check whether it's able to release.