### PR TITLE
Update オスティナート

### DIFF
--- a/c9113513.lua
+++ b/c9113513.lua
@@ -43,6 +43,7 @@ function c9113513.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,0,tp,LOCATION_GRAVE)
 end
 function c9113513.filter0(c,e)
 	return c:IsCanBeFusionMaterial() and not c:IsImmuneToEffect(e)


### PR DESCRIPTION
①：自己场上没有怪兽存在的场合才能发动。从自己的手卡·卡组把「幻奏」融合怪兽卡决定的2只融合素材怪兽送去墓地，把那1只融合怪兽从额外卡组融合召唤。这个回合的结束阶段，这个效果融合召唤的怪兽破坏，若那一组融合素材怪兽在自己墓地齐集，可以把那一组特殊召唤。
****
[2018/8/25](https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2018.html#id99)
发动「[固定音型](https://ygocdb.com/card/name/%E5%9B%BA%E5%AE%9A%E9%9F%B3%E5%9E%8B)」时，可以连锁发动「[屋敷童](https://ygocdb.com/card/name/%E5%B1%8B%E6%95%B7%E7%AB%A5)」的效果。