### PR TITLE
Fix ヴァルモニカ・ヴェルサーレ

### DIFF
--- a/c42193638.lua
+++ b/c42193638.lua
@@ -19,8 +19,9 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp,op)
 		op=aux.SelectFromOptions(p,{true,aux.Stringid(id,1)},{true,aux.Stringid(id,2)})
 	end
 	if op==1 then
-		if Duel.Recover(tp,500,REASON_EFFECT)<1 or not Duel.SelectYesNo(tp,aux.Stringid(id,3)) then return end
 		local g=Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_DECK,0,nil,0x1a3)
+		g=g:Filter(Card.IsAbleToHand,nil)
+		if Duel.Recover(tp,500,REASON_EFFECT)<1 or #g==0 or not Duel.SelectYesNo(tp,aux.Stringid(id,3)) then return end
 		local dct=Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 		local seq=-1
 		local hc


### PR DESCRIPTION
「[岔子](https://ygocdb.com/card/name/%E5%B2%94%E5%AD%90)」「[小丑与锁鸟](https://ygocdb.com/card/name/%E5%B0%8F%E4%B8%91%E4%B8%8E%E9%94%81%E9%B8%9F)」或「[雷王](https://ygocdb.com/card/name/%E9%9B%B7%E7%8E%8B)」的效果适用中，可以发动「[异响鸣的倒水](https://ygocdb.com/card/name/%E5%BC%82%E5%93%8D%E9%B8%A3%E7%9A%84%E5%80%92%E6%B0%B4)」并适用第1个『●』效果。
但只适用至回复生命部分。
****
修改：执行回复生命后，检查可否从卡组将目标加入手卡，以判断能否继续执行。