### PR TITLE
fix シンクロキャンセル

### DIFF
--- a/c32441317.lua
+++ b/c32441317.lua
@@ -32,8 +32,7 @@ function c32441317.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ct=mg:GetCount()
 	local sumtype=tc:GetSummonType()
 	if Duel.SendtoDeck(tc,nil,SEQ_DECKTOP,REASON_EFFECT)~=0 and sumtype==SUMMON_TYPE_SYNCHRO
-		and ct>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
-		and ct<=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		and tc:IsLocation(LOCATION_EXTRA) and ct>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133) and ct<=Duel.GetLocationCount(tp,LOCATION_MZONE)
 		and mg:FilterCount(aux.NecroValleyFilter(c32441317.mgfilter),nil,e,tp,tc)==ct
 		and Duel.SelectYesNo(tp,aux.Stringid(32441317,0)) then
 		Duel.BreakEffect()


### PR DESCRIPTION
修复同调解除以下问题：
①不能被屋敷童、闭锁世界的冥神响应。
②作为效果对象的怪兽被离场重定向导致未能回到额外卡组的场合，应该不能适用后续效果。