### PR TITLE
fix シンクロキャンセル&マルチ・ピース・ゴーレム

### DIFF
--- a/c32441317.lua
+++ b/c32441317.lua
@@ -19,6 +19,7 @@ function c32441317.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 	local g=Duel.SelectTarget(tp,c32441317.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,nil,tp,LOCATION_GRAVE)
 end
 function c32441317.mgfilter(c,e,tp,sync)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_GRAVE)
@@ -32,8 +33,7 @@ function c32441317.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ct=mg:GetCount()
 	local sumtype=tc:GetSummonType()
 	if Duel.SendtoDeck(tc,nil,SEQ_DECKTOP,REASON_EFFECT)~=0 and sumtype==SUMMON_TYPE_SYNCHRO
-		and ct>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
-		and ct<=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		and tc:IsLocation(LOCATION_EXTRA) and ct>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133) and ct<=Duel.GetLocationCount(tp,LOCATION_MZONE)
 		and mg:FilterCount(aux.NecroValleyFilter(c32441317.mgfilter),nil,e,tp,tc)==ct
 		and Duel.SelectYesNo(tp,aux.Stringid(32441317,0)) then
 		Duel.BreakEffect()

--- a/c71628381.lua
+++ b/c71628381.lua
@@ -22,6 +22,7 @@ end
 function c71628381.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToDeck() end
 	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,e:GetHandler(),1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,nil,tp,LOCATION_GRAVE)
 end
 function c71628381.mgfilter(c,e,tp,fusc,mg)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_GRAVE)
@@ -35,7 +36,7 @@ function c71628381.spop(e,tp,eg,ep,ev,re,r,rp)
 	local mg=c:GetMaterial()
 	local ct=mg:GetCount()
 	local sumtype=c:GetSummonType()
-	if Duel.SendtoDeck(c,nil,SEQ_DECKTOP,REASON_EFFECT)~=0 and bit.band(sumtype,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
+	if Duel.SendtoDeck(c,nil,SEQ_DECKTOP,REASON_EFFECT)~=0 and bit.band(sumtype,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION and c:IsLocation(LOCATION_EXTRA)
 		and ct>0 and ct<=Duel.GetLocationCount(tp,LOCATION_MZONE)
 		and mg:FilterCount(aux.NecroValleyFilter(c71628381.mgfilter),nil,e,tp,c,mg)==ct
 		and not Duel.IsPlayerAffectedByEffect(tp,59822133)


### PR DESCRIPTION
修复同调解除和多块石人以下问题：
①不能被屋敷童、闭锁世界的冥神响应。
②作为效果对象的怪兽或自身被离场重定向导致未能回到额外卡组的场合，应该不能适用后续效果。