### PR TITLE
Fix カノプスの守護者

### DIFF
--- a/c1490690.lua
+++ b/c1490690.lua
@@ -59,7 +59,7 @@ function c1490690.op(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c1490690.splimit(e,c,sump,sumtype,sumpos,targetp,se)
-	return e:GetHandler()==se:GetHandler() and c:IsOriginalCodeRule(e:GetLabel())
+	return se:GetHandler():IsCode(1490690) and c:IsOriginalCodeRule(e:GetLabel())
 end
 function c1490690.stcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_HAND+LOCATION_ONFIELD)


### PR DESCRIPTION
所有的「[卡诺匹斯的守护者](https://ygocdb.com/?search=%E5%8D%A1%E8%AF%BA%E5%8C%B9%E6%96%AF%E7%9A%84%E5%AE%88%E6%8A%A4%E8%80%85)」应共享特召限制。