### PR TITLE
Fix VS 裏螺旋流雪風

### DIFF
--- a/c60883493.lua
+++ b/c60883493.lua
@@ -47,7 +47,8 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 	if ct>1 then
 		Duel.BreakEffect()
-		if Duel.Damage(1-tp,600,REASON_EFFECT)>0 and Duel.GetLP(1-tp)>0 then
+		Duel.Damage(1-tp,600,REASON_EFFECT)
+		if Duel.GetLP(1-tp)>0 then
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_FIELD)
 			e1:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)


### PR DESCRIPTION
[【关于第2个●的效果】](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19220&request_locale=ja)

处理时，进行『给予对方600点伤害』处理。同时，处理时，适用『这个回合中，自己场的「征服斗魂」怪兽效果不被破坏』效果。

**给予对手伤害的处理和『效果不破坏』效果的适用同时进行。**
****
修改：去除需要成功造成伤害才能适用破坏抗性的限制。