### PR TITLE
Fix 氷水のエジル

### DIFF
--- a/c39354437.lua
+++ b/c39354437.lua
@@ -45,7 +45,7 @@ function c39354437.thop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c39354437.spcon1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetAttacker():IsControler(1-tp)
+	return eg:IsContains(e:GetHandler()) and Duel.GetAttacker():IsControler(1-tp)
 end
 function c39354437.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsContains(e:GetHandler()) and rp==1-tp


### PR DESCRIPTION
②：``このカード``が相手の効果の対象になった時、または相手モンスターの攻撃対象に選択された時に発動できる。

Fix when other monster become attack target, ``氷水のエジル`` can activate its effect.