### PR TITLE
Update Some_Target_Option

### DIFF
--- a/c16708652.lua
+++ b/c16708652.lua
@@ -28,17 +28,18 @@ end
 function c16708652.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return Duel.IsExistingTarget(c16708652.chkfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(16708652,0))
-	local g1=Duel.SelectTarget(tp,c16708652.filter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(16708652,1))
-	local g2=Duel.SelectTarget(tp,c16708652.filter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,g1:GetFirst())
-	e:SetLabelObject(g1:GetFirst())
+	local g=Duel.GetMatchingGroup(c16708652.chkfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
+	g=g:Filter(Card.IsCanBeEffectTarget,nil,e)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+	Duel.SetTargetCard(g:SelectSubGroup(tp,aux.TRUE,false,2,2))
 end
 function c16708652.activate(e,tp,eg,ep,ev,re,r,rp)
-	local tc1=e:GetLabelObject()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=Duel.GetTargetsRelateToChain()
+	if #g<2 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(16708652,0))
+	local tc1=g:Select(tp,1,1,nil):GetFirst()
 	local tc2=g:GetFirst()
-	if tc1==tc2 then tc2=g:GetNext() end
+	if tc2==tc1 then tc2=g:GetNext() end
 	if tc1:IsRelateToEffect(e) and tc1:IsPosition(POS_FACEUP_ATTACK) and tc2:IsRelateToEffect(e) then
 		Duel.ChangePosition(tc1,POS_FACEUP_DEFENSE)
 		local e1=Effect.CreateEffect(e:GetHandler())

--- a/c26864586.lua
+++ b/c26864586.lua
@@ -16,21 +16,23 @@ end
 function c26864586.filter2(c,rc,at,lv)
 	return not c:IsLevel(lv) and c:IsLevelAbove(1) and c:IsFaceup() and c:IsRace(rc) and c:IsAttribute(at)
 end
+function c26864586.fselect(g)
+	return g:GetClassCount(Card.GetAttribute)==1 and g:GetClassCount(Card.GetRace)==1
+end
 function c26864586.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return Duel.IsExistingTarget(c26864586.filter1,tp,LOCATION_MZONE,0,1,nil,tp) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g1=Duel.SelectTarget(tp,c26864586.filter1,tp,LOCATION_MZONE,0,1,1,nil,tp)
-	local tc1=g1:GetFirst()
-	e:SetLabelObject(tc1)
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(26864586,0))
-	local g2=Duel.SelectTarget(tp,c26864586.filter2,tp,LOCATION_MZONE,0,1,1,tc1,tc1:GetRace(),tc1:GetAttribute(),tc1:GetLevel())
+	local g=Duel.GetMatchingGroup(c26864586.filter1,tp,LOCATION_MZONE,0,nil,tp)
+	g=g:Filter(Card.IsCanBeEffectTarget,nil,e)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+	Duel.SetTargetCard(g:SelectSubGroup(tp,c26864586.fselect,false,2,2))
 end
 function c26864586.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local tc1=e:GetLabelObject()
-	local tc2=g:GetFirst()
-	if tc1==tc2 then tc2=g:GetNext() end
+	local g=Duel.GetTargetsRelateToChain()
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(26864586,0))
+	local tc2=g:Select(tp,1,1,nil):GetFirst()
+	local tc1=g:GetFirst()
+	if tc1==tc2 then tc1=g:GetNext() end
 	local lv=tc1:GetLevel()
 	if tc2:IsLevel(lv) then return end
 	if tc1:IsFaceup() and tc1:IsRelateToEffect(e) and tc2:IsFaceup() and tc2:IsRelateToEffect(e) then

--- a/c32671443.lua
+++ b/c32671443.lua
@@ -67,19 +67,22 @@ end
 function c32671443.atkfilter2(c,tc)
 	return c:IsFaceup() and c:IsSetCard(0xc008) and not c:IsAttack(tc:GetAttack())
 end
+function c32671443.fselect(g)
+	return g:GetClassCount(Card.GetAttack)==2
+end
 function c32671443.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return Duel.IsExistingTarget(c32671443.atkfilter1,tp,LOCATION_MZONE,0,1,nil,tp) end
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(32671443,2))
-	local g1=Duel.SelectTarget(tp,c32671443.atkfilter1,tp,LOCATION_MZONE,0,1,1,nil,tp)
-	local tc=g1:GetFirst()
-	e:SetLabelObject(tc)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,c32671443.atkfilter2,tp,LOCATION_MZONE,0,1,1,tc,tc)
+	local g=Duel.GetMatchingGroup(c32671443.atkfilter1,tp,LOCATION_MZONE,0,nil,tp)
+	g=g:Filter(Card.IsCanBeEffectTarget,nil,e)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+	Duel.SetTargetCard(g:SelectSubGroup(tp,c32671443.fselect,false,2,2))
 end
 function c32671443.atkop(e,tp,eg,ep,ev,re,r,rp)
-	local hc=e:GetLabelObject()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=Duel.GetTargetsRelateToChain()
+	if g:GetClassCount(Card.GetAttack,nil)<2 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(32671443,2))
+	local hc=g:Select(tp,1,1,nil):GetFirst()
 	local tc=g:GetFirst()
 	if tc==hc then tc=g:GetNext() end
 	if hc:IsFaceup() and hc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then

--- a/c34016756.lua
+++ b/c34016756.lua
@@ -10,18 +10,21 @@ function c34016756.initial_effect(c)
 	e1:SetOperation(c34016756.activate)
 	c:RegisterEffect(e1)
 end
+function c34016756.fselect(g)
+	return g:IsExists(Card.IsAttackAbove,1,nil,1)
+end
 function c34016756.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,2,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(34016756,0))
-	local g1=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	e:SetLabelObject(g1:GetFirst())
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(34016756,1))
-	local g2=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,g1:GetFirst())
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	g=g:Filter(Card.IsCanBeEffectTarget,nil,e)
+	if chk==0 then return g:CheckSubGroup(c34016756.fselect,2,2) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+	Duel.SetTargetCard(g:SelectSubGroup(tp,c34016756.fselect,false,2,2))
 end
 function c34016756.activate(e,tp,eg,ep,ev,re,r,rp)
-	local hc=e:GetLabelObject()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=Duel.GetTargetsRelateToChain()
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(34016756,0))
+	local hc=g:Filter(Card.IsAttackAbove,nil,1):Select(tp,1,1,nil):GetFirst()
 	local tc=g:GetFirst()
 	if tc==hc then tc=g:GetNext() end
 	if hc:IsFaceup() and hc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then

--- a/c43857222.lua
+++ b/c43857222.lua
@@ -24,29 +24,37 @@ function c43857222.lvfilter3(c,tp,lv)
 	return c:IsFaceup() and c:IsLevelAbove(lv+1)
 		and Duel.IsExistingTarget(c43857222.lvfilter2,tp,LOCATION_MZONE,0,1,c)
 end
+function c43857222.fselect(g,lv)
+	local hc=g:GetFirst()
+	local tc=g:GetNext()
+	local res1=hc:IsFaceup() and tc:IsFaceup() and hc:IsLevelAbove(lv+1) and tc:IsLevelAbove(1)
+	local res2=hc:IsFaceup() and tc:IsFaceup() and tc:IsLevelAbove(lv+1) and hc:IsLevelAbove(1)
+	return res1 or res2
+end
 function c43857222.lvtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return Duel.IsExistingTarget(c43857222.lvfilter1,tp,LOCATION_MZONE,0,1,nil,tp) end
 	local g=Duel.GetMatchingGroup(c43857222.lvfilter1,tp,LOCATION_MZONE,0,nil,tp)
+	g=g:Filter(Card.IsCanBeEffectTarget,nil,e)
 	local mg,lv=g:GetMaxGroup(Card.GetLevel)
 	local alv=0
 	if lv>2 then alv=Duel.AnnounceLevel(tp,1,math.min(lv-1,6))
 	else alv=Duel.AnnounceLevel(tp,1,1) end
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(43857222,1))
-	local g1=Duel.SelectTarget(tp,c43857222.lvfilter3,tp,LOCATION_MZONE,0,1,1,nil,tp,alv)
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(43857222,2))
-	Duel.SelectTarget(tp,c43857222.lvfilter2,tp,LOCATION_MZONE,0,1,1,g1:GetFirst())
-	e:SetLabelObject(g1:GetFirst())
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+	local tg=g:SelectSubGroup(tp,c43857222.fselect,false,2,2,alv)
+	Duel.SetTargetCard(tg)
 	e:SetLabel(alv)
 end
 function c43857222.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local hc=e:GetLabelObject()
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=Duel.GetTargetsRelateToChain()
+	if #g<2 or g:IsExists(Card.IsFacedown,1,nil) or g:FilterCount(Card.IsLevelAbove,nil,1)<2 then return end
+	local lv=e:GetLabel()
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(43857222,1))
+	local hc=g:Filter(Card.IsLevelAbove,nil,lv+1):Select(tp,1,1,nil):GetFirst()
 	local tc=g:GetFirst()
 	if tc==hc then tc=g:GetNext() end
-	local lv=e:GetLabel()
 	if hc:IsFaceup() and hc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c56535497.lua
+++ b/c56535497.lua
@@ -27,21 +27,29 @@ function c56535497.condition(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetTurnPlayer()==tp then return ph==PHASE_MAIN1 or ph==PHASE_MAIN2
 	else return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE and aux.dscon(e,tp,eg,ep,ev,re,r,rp) end
 end
+function c56535497.fselect(g)
+	return g:GetSum(Card.GetAttack)>0
+end
 function c56535497.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
-	if chk==0 then return Duel.IsExistingTarget(c56535497.filter,tp,LOCATION_MZONE,LOCATION_MZONE,2,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(56535497,2))
-	local rg=Duel.SelectTarget(tp,c56535497.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	e:SetLabelObject(rg:GetFirst())
-	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(56535497,3))
-	Duel.SelectTarget(tp,c56535497.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,rg:GetFirst())
+	local g=Duel.GetMatchingGroup(c56535497.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	g=g:Filter(Card.IsCanBeEffectTarget,nil,e)
+	if chk==0 then return g:GetSum(Card.GetAttack)>0 end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+	Duel.SetTargetCard(g:SelectSubGroup(tp,c56535497.fselect,false,2,2))
 end
 function c56535497.operation(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local tc1=e:GetLabelObject()
-	if not tc1 then return end
+	local g=Duel.GetTargetsRelateToChain()
+	if #g<2 or g:GetSum(Card.GetAttack)==0 then return end
+	local tc1
+	if g:FilterCount(Card.IsAttackAbove,nil,1)>1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+		tc1=g:Select(tp,1,1,nil):GetFirst()
+	else
+		tc1=g:Filter(Card.IsAttackAbove,nil,1):GetFirst()
+	end
 	local tc2=g:GetFirst()
-	if tc1==tc2 then tc2=g:GetNext() end
+	if tc2==tc1 then tc2=g:GetNext() end
 	if tc1:IsFaceup() and tc1:IsRelateToEffect(e) and tc2:IsFaceup() and tc2:IsRelateToEffect(e) then
 		local atk=math.ceil(tc1:GetAttack()/2)
 		local e1=Effect.CreateEffect(e:GetHandler())

--- a/c64038662.lua
+++ b/c64038662.lua
@@ -41,11 +41,8 @@ function c64038662.eftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	e:SetLabel(op)
 	if op==1 then
 		e:SetCategory(CATEGORY_EQUIP)
-		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(64038662,4))
-		local g1=Duel.SelectTarget(tp,c64038662.filter1,tp,LOCATION_MZONE,0,1,1,nil)
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-		local g2=Duel.SelectTarget(tp,c64038662.filter1,tp,LOCATION_MZONE,0,1,1,g1:GetFirst())
-		e:SetLabelObject(g1:GetFirst())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+		Duel.SelectTarget(tp,c64038662.filter1,tp,LOCATION_MZONE,0,2,2,nil)
 	else
 		e:SetCategory(CATEGORY_SPECIAL_SUMMON)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
@@ -55,8 +52,10 @@ function c64038662.eftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c64038662.efop(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetLabel()==1 then
-		local tc1=e:GetLabelObject()
-		local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+		local g=Duel.GetTargetsRelateToChain()
+		if #g<2 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(64038662,4))
+		local tc1=g:Select(tp,1,1,nil):GetFirst()
 		local tc2=g:GetFirst()
 		if tc1==tc2 then tc2=g:GetNext() end
 		if tc1:IsFaceup() and tc2:IsFaceup() and tc1:IsRelateToEffect(e) and tc2:IsRelateToEffect(e) and Duel.Equip(tp,tc1,tc2,false) then

--- a/c99890852.lua
+++ b/c99890852.lua
@@ -16,22 +16,30 @@ function c99890852.filter(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0xfb)
 		and c:IsAbleToHand() and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,c)
 end
+function c99890852.fselect(g,tp)
+	return g:IsExists(c99890852.filter,1,nil,tp)
+end
 function c99890852.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	if chk==0 then return Duel.IsExistingTarget(c99890852.filter,tp,LOCATION_MZONE,0,1,nil,tp) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,c99890852.filter,tp,LOCATION_MZONE,0,1,1,nil,tp)
-	e:SetLabelObject(g:GetFirst())
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,g)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tp)
+	g=g:Filter(Card.IsCanBeEffectTarget,nil,e)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SELECT)
+	Duel.SetTargetCard(g:SelectSubGroup(tp,c99890852.fselect,false,2,2,tp))
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,0,0)
 end
 function c99890852.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
-	if g:GetCount()~=2 then return end
-	local hc=g:GetFirst()
-	local tc=g:GetNext()
-	if hc~=e:GetLabelObject() then tc,hc=hc,tc end
+	local g=Duel.GetTargetsRelateToChain()
+	if g:GetCount()<2 then return end
+	local hc,tc
+	if g:FilterCount(c99890852.filter,nil,tp)>1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+		hc=g:Select(tp,1,1,nil):GetFirst()
+	else
+		hc=g:Filter(c99890852.filter,nil,tp):GetFirst()
+	end
+	g=g-hc
+	tc=g:GetFirst()
 	if hc:IsFaceup() and tc:IsFaceup() and Duel.SendtoHand(hc,nil,REASON_EFFECT)~=0 then
 		local atk=hc:GetBaseAttack()
 		local e1=Effect.CreateEffect(e:GetHandler())


### PR DESCRIPTION
对“以2只怪兽为对象发动。作为对象的1只怪兽xxx，另1只怪兽yyy。”类效果处理规范化。
统一为：
发动动作：选取符合要求的对象卡片组
效果处理：根据选择的卡片组中的怪兽条件，由玩家选择可行的选项。

另：
修复原力可以减半攻击力为0的怪兽的问题
修复狂怒可以减半攻击力为0的怪兽的问题
****
附：改动的卡ydk、残局测试例
[Uploading Ydk&Singe.zip…]()
