### PR TITLE
Fix chainreg related effect

### DIFF
--- a/c2645637.lua
+++ b/c2645637.lua
@@ -43,7 +43,7 @@ function c2645637.disop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c2645637.atkcon3(e,tp,eg,ep,ev,re,r,rp)
-	return re:IsActiveType(TYPE_MONSTER) and Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)==LOCATION_GRAVE and e:GetHandler():GetFlagEffect(1)>0
+	return re:IsActiveType(TYPE_MONSTER) and Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)==LOCATION_GRAVE
 end
 function c2645637.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetFlagEffect(1)>0

--- a/c55591586.lua
+++ b/c55591586.lua
@@ -73,7 +73,7 @@ function c55591586.spop(e,tp,eg,ep,ev,re,r,rp,c)
 end
 function c55591586.atkcon1(e,tp,eg,ep,ev,re,r,rp)
 	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
-	return re:IsActiveType(TYPE_MONSTER) and loc==LOCATION_HAND and e:GetHandler():GetFlagEffect(1)>0
+	return re:IsActiveType(TYPE_MONSTER) and loc==LOCATION_HAND
 end
 function c55591586.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetFlagEffect(1)>0


### PR DESCRIPTION
>雷劫龍－サンダー・ドラゴン
(1)：１ターンに１度、**モンスターの効果が手札で発動した**場合に発動する。このカードの攻撃力はターン終了時まで３００アップする。

>零氷の魔妖－雪女
(3)：墓地からモンスターが特殊召喚された場合、または**墓地のモンスターの効果が発動した**場合、このカード以外のフィールドの表側表示モンスター１体を対象として発動できる。そのモンスターの攻撃力を０にし、その効果を無効にする。

Fix these effects' condition