### PR TITLE
Fix 古代の機械要塞

### DIFF
--- a/c70147689.lua
+++ b/c70147689.lua
@@ -47,7 +47,9 @@ function c70147689.target(e,c)
 	return c:IsSetCard(0x7) and c:IsStatus(STATUS_SUMMON_TURN+STATUS_SPSUMMON_TURN)
 end
 function c70147689.chainop(e,tp,eg,ep,ev,re,r,rp)
-	if re:GetHandler():IsSetCard(0x7) then
+	local b1=re:GetHandler():IsSetCard(0x7)
+	local b2=re:GetActivateLocation()==LOCATION_MZONE and not re:GetHandler():IsLocation(LOCATION_MZONE) and ec:IsPreviousSetCard(0x7)
+	if b1 or b2 then
 		Duel.SetChainLimit(c70147689.chainlm)
 	end
 end

--- a/c70147689.lua
+++ b/c70147689.lua
@@ -47,8 +47,9 @@ function c70147689.target(e,c)
 	return c:IsSetCard(0x7) and c:IsStatus(STATUS_SUMMON_TURN+STATUS_SPSUMMON_TURN)
 end
 function c70147689.chainop(e,tp,eg,ep,ev,re,r,rp)
-	local b1=re:GetHandler():IsSetCard(0x7)
-	local b2=re:GetActivateLocation()==LOCATION_MZONE and not re:GetHandler():IsLocation(LOCATION_MZONE) and ec:IsPreviousSetCard(0x7)
+	local ec=re:GetHandler()
+	local b1=ec:IsSetCard(0x7)
+	local b2=re:GetActivateLocation()==LOCATION_MZONE and not ec:IsLocation(LOCATION_MZONE) and ec:IsPreviousSetCard(0x7)
 	if b1 or b2 then
 		Duel.SetChainLimit(c70147689.chainlm)
 	end


### PR DESCRIPTION
If a monster copy ``Ancient Gear``'s name, and activate effect costing itself, enemy will be able to activate effect in response to it.

获得``古代的机械``卡名的怪兽以自己为COST发动效果时，对方能够对应发动效果