### PR TITLE
Fix F.A.

### DIFF
--- a/c33158448.lua
+++ b/c33158448.lua
@@ -16,7 +16,7 @@ function c33158448.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c33158448.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c33158448.chainreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(33158448,0))
@@ -25,6 +25,7 @@ function c33158448.initial_effect(c)
 	e3:SetCode(EVENT_CHAIN_SOLVED)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCondition(c33158448.lvcon)
+	e3:SetTarget(c33158448.lvtg)
 	e3:SetOperation(c33158448.lvop)
 	c:RegisterEffect(e3)
 	--pierce
@@ -52,8 +53,17 @@ end
 function c33158448.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c33158448.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(33158448,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c33158448.lvcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(33158448))
+	return e:GetHandler():GetFlagEffect(33158448)>0
+end
+function c33158448.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
+	if chk==0 then return true end
+	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 end
 function c33158448.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c37414347.lua
+++ b/c37414347.lua
@@ -29,7 +29,7 @@ function c37414347.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c37414347.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c37414347.chainreg)
 	c:RegisterEffect(e0)
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(37414347,0))
@@ -66,11 +66,17 @@ end
 function c37414347.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c37414347.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(37414347,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c37414347.ctcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(37414347))
+	return e:GetHandler():GetFlagEffect(37414347)>0
 end
 function c37414347.cttg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
 	if chk==0 then return true end
+	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 	Duel.SetOperationInfo(0,CATEGORY_COUNTER,nil,1,0,0x4a)
 end
 function c37414347.ctop(e,tp,eg,ep,ev,re,r,rp)

--- a/c49655592.lua
+++ b/c49655592.lua
@@ -34,7 +34,7 @@ function c49655592.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c49655592.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c49655592.chainreg)
 	c:RegisterEffect(e0)
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(49655592,0))
@@ -43,6 +43,7 @@ function c49655592.initial_effect(c)
 	e4:SetCode(EVENT_CHAIN_SOLVED)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetCondition(c49655592.lvcon)
+	e4:SetTarget(c49655592.lvtg)
 	e4:SetOperation(c49655592.lvop)
 	c:RegisterEffect(e4)
 	--discard limit
@@ -70,8 +71,17 @@ end
 function c49655592.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c49655592.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(49655592,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c49655592.lvcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(49655592))
+	return e:GetHandler():GetFlagEffect(49655592)>0
+end
+function c49655592.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
+	if chk==0 then return true end
+	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 end
 function c49655592.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c67045745.lua
+++ b/c67045745.lua
@@ -21,7 +21,7 @@ function c67045745.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c67045745.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c67045745.chainreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(67045745,0))
@@ -30,6 +30,7 @@ function c67045745.initial_effect(c)
 	e3:SetCode(EVENT_CHAIN_SOLVED)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCondition(c67045745.lvcon)
+	e3:SetTarget(c67045745.lvtg)
 	e3:SetOperation(c67045745.lvop)
 	c:RegisterEffect(e3)
 	--attack twice
@@ -56,8 +57,17 @@ end
 function c67045745.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c67045745.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(67045745,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c67045745.lvcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(67045745))
+	return e:GetHandler():GetFlagEffect(67045745)>0
+end
+function c67045745.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
+	if chk==0 then return true end
+	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 end
 function c67045745.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c6764709.lua
+++ b/c6764709.lua
@@ -23,7 +23,7 @@ function c6764709.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c6764709.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c6764709.chainreg)
 	c:RegisterEffect(e0)
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(6764709,0))
@@ -32,6 +32,7 @@ function c6764709.initial_effect(c)
 	e4:SetCode(EVENT_CHAIN_SOLVED)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetCondition(c6764709.lvcon)
+	e4:SetTarget(c6764709.lvtg)
 	e4:SetOperation(c6764709.lvop)
 	c:RegisterEffect(e4)
 	--destroy
@@ -65,8 +66,17 @@ end
 function c6764709.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c6764709.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(6764709,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c6764709.lvcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(6764709))
+	return e:GetHandler():GetFlagEffect(6764709)>0
+end
+function c6764709.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
+	if chk==0 then return true end
+	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 end
 function c6764709.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c75059201.lua
+++ b/c75059201.lua
@@ -33,7 +33,7 @@ function c75059201.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c75059201.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c75059201.chainreg)
 	c:RegisterEffect(e0)
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(75059201,0))
@@ -42,6 +42,7 @@ function c75059201.initial_effect(c)
 	e4:SetCode(EVENT_CHAIN_SOLVED)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetCondition(c75059201.lvcon)
+	e4:SetTarget(c75059201.lvtg)
 	e4:SetOperation(c75059201.lvop)
 	c:RegisterEffect(e4)
 	--actlimit
@@ -85,8 +86,17 @@ end
 function c75059201.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c75059201.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(75059201,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c75059201.lvcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(75059201))
+	return e:GetHandler():GetFlagEffect(75059201)>0
+end
+function c75059201.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
+	if chk==0 then return true end
+	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 end
 function c75059201.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c75676192.lua
+++ b/c75676192.lua
@@ -17,7 +17,7 @@ function c75676192.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c75676192.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c75676192.chainreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(75676192,0))
@@ -26,6 +26,7 @@ function c75676192.initial_effect(c)
 	e3:SetCode(EVENT_CHAIN_SOLVED)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCondition(c75676192.lvcon)
+	e3:SetTarget(c75676192.lvtg)
 	e3:SetOperation(c75676192.lvop)
 	c:RegisterEffect(e3)
 	--indes
@@ -59,8 +60,17 @@ end
 function c75676192.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c75676192.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(75676192,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c75676192.lvcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(75676192))
+	return e:GetHandler():GetFlagEffect(75676192)>0
+end
+function c75676192.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
+    	if chk==0 then return true end
+    	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 end
 function c75676192.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c93449450.lua
+++ b/c93449450.lua
@@ -23,7 +23,7 @@ function c93449450.initial_effect(c)
 	e0:SetCode(EVENT_CHAINING)
 	e0:SetRange(LOCATION_MZONE)
 	e0:SetCondition(c93449450.spchk)
-	e0:SetOperation(aux.chainreg)
+	e0:SetOperation(c93449450.chainreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(93449450,0))
@@ -32,6 +32,7 @@ function c93449450.initial_effect(c)
 	e3:SetCode(EVENT_CHAIN_SOLVED)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCondition(c93449450.lvcon)
+	e3:SetTarget(c93449450.lvtg)
 	e3:SetOperation(c93449450.lvop)
 	c:RegisterEffect(e3)
 	--redirect
@@ -63,8 +64,17 @@ end
 function c93449450.spchk(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107)
 end
+function c93449450.chainreg(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(93449450,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_CHAIN,0,1)
+end
 function c93449450.lvcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(1)>0
+	e:SetLabel(e:GetHandler():GetFlagEffect(93449450))
+	return e:GetHandler():GetFlagEffect(93449450)>0
+end
+function c93449450.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local count=e:GetLabel()
+	if chk==0 then return true end
+	e:SetCountLimit(count,EFFECT_COUNT_CODE_CHAIN)
 end
 function c93449450.lvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
fix F.A. monsters Each time a "F.A." Spell/Trap Card or effect is activated: You can increase this card's Level by 1(include Each time a "F.A." Spell/Trap Card or effect is activated: Place 1 Athlete Counter on this card. by F.A. Shining Star GT). effect will have incorrect number of active.