### PR TITLE
fix--増草剤

### DIFF
--- a/c44887817.lua
+++ b/c44887817.lua
@@ -41,6 +41,7 @@ function c44887817.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function c44887817.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetActivityCount(tp,ACTIVITY_NORMALSUMMON)~=0 then return end
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsRace(RACE_PLANT) then


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7671

■処理時に、このターンに自分が通常召喚を行っていない場合、対象のモンスターを特殊召喚します。この効果の発動からこの効果の処理時までの間に通常召喚を行った場合、この効果の処理は行われません。

fix 増草剤 can special summon monster when the active player summon monster between the effect's active and resolve.