### PR TITLE
remove Card.IsReleasable, Card.IsReleasableByEffect

### DIFF
--- a/c10113611.lua
+++ b/c10113611.lua
@@ -62,7 +62,7 @@ function s.sscon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==1-tp and Duel.GetAttackTarget()==nil
 end
 function s.mfilter(c)
-	return not c:IsType(TYPE_TUNER) and c:IsFaceupEx() and c:IsReleasableByEffect() and c:GetLevel()>0
+	return not c:IsType(TYPE_TUNER) and c:IsFaceupEx() and c:GetLevel()>0
 end
 function s.spfilter(c,e,tp,g)
 	return c:IsSetCard(0xe) and c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c14644902.lua
+++ b/c14644902.lua
@@ -14,14 +14,14 @@ function c14644902.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c14644902.rfilter(c,e,tp)
-	return c:IsReleasableByEffect() and not c:IsImmuneToEffect(e)
+	return not c:IsImmuneToEffect(e)
 		and Duel.IsExistingMatchingCard(c14644902.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c)
 end
 function c14644902.filter(c,e,tp,mc)
 	return c:IsType(TYPE_FUSION) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCountFromEx(tp,tp,mc,c)>0
 end
 function c14644902.rfilter2(c,tp)
-	return c:IsReleasableByEffect() and Duel.GetLocationCountFromEx(tp,tp,c,TYPE_FUSION)>0
+	return Duel.GetLocationCountFromEx(tp,tp,c,TYPE_FUSION)>0
 end
 function c14644902.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c16719140.lua
+++ b/c16719140.lua
@@ -47,7 +47,7 @@ function c16719140.fselect(g,tp,lv,mc)
 	else return false end
 end
 function c16719140.relfilter(c)
-	return c:IsLevelAbove(1) and c:IsReleasableByEffect()
+	return c:IsLevelAbove(1)
 end
 function c16719140.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c16960351.lua
+++ b/c16960351.lua
@@ -19,7 +19,7 @@ function c16960351.initial_effect(c)
 end
 function c16960351.rfilter(c,e,tp,ft)
 	local lv=c:GetOriginalLevel()
-	return lv>0 and c:IsRace(RACE_DRAGON) and c:IsReleasable()
+	return lv>0 and c:IsRace(RACE_DRAGON)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5)) and (c:IsControler(tp) or c:IsFaceup())
 		and Duel.IsExistingMatchingCard(c16960351.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp,lv)
 end

--- a/c24361622.lua
+++ b/c24361622.lua
@@ -32,7 +32,7 @@ function c24361622.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetSequence()>4 and Duel.GetTurnPlayer()~=tp
 end
 function c24361622.thcfilter(c,tp)
-	return c:IsType(TYPE_MONSTER) and c:IsReleasable()
+	return c:IsType(TYPE_MONSTER)
 		and Duel.IsExistingMatchingCard(c24361622.thfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c)
 end
 function c24361622.thfilter(c)

--- a/c25811989.lua
+++ b/c25811989.lua
@@ -91,8 +91,8 @@ function c25811989.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SendtoGrave(sg,REASON_EFFECT)
 end
 function c25811989.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c25811989.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c25857246.lua
+++ b/c25857246.lua
@@ -53,12 +53,9 @@ function c25857246.atkop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end
-function c25857246.filter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsReleasableByEffect()
-end
 function c25857246.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDraw(tp,1)
-		and Duel.CheckReleaseGroupEx(REASON_EFFECT,tp,c25857246.filter,1,nil) end
+		and Duel.CheckReleaseGroupEx(REASON_EFFECT,tp,nil,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
 end
 function c25857246.operation(e,tp,eg,ep,ev,re,r,rp)
@@ -66,7 +63,7 @@ function c25857246.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ct=Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 	if ct==0 then ct=1 end
 	if ct>2 then ct=2 end
-	local g=Duel.SelectReleaseGroupEx(REASON_EFFECT,tp,c25857246.filter,1,ct,nil)
+	local g=Duel.SelectReleaseGroupEx(REASON_EFFECT,tp,nil,1,ct,nil)
 	if g:GetCount()>0 then
 		Duel.HintSelection(g)
 		local rct=Duel.Release(g,REASON_EFFECT)

--- a/c26034577.lua
+++ b/c26034577.lua
@@ -103,8 +103,8 @@ function c26034577.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp
 end
 function c26034577.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c26034577.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c28553439.lua
+++ b/c28553439.lua
@@ -22,7 +22,7 @@ function c28553439.filter(c,e,tp)
 	return c:IsRace(RACE_SPELLCASTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c28553439.rfilter(c,e,tp,ft)
-	return c:IsReleasableByEffect() and c:IsCanBeEffectTarget(e)
+	return c:IsCanBeEffectTarget(e)
 		and (ft>0 or (c:IsControler(tp) and c:GetSequence()<5))
 end
 function c28553439.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c296499.lua
+++ b/c296499.lua
@@ -40,8 +40,8 @@ function c296499.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end
 function c296499.mtop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.CheckReleaseGroup(REASON_MAINTENANCE,tp,Card.IsReleasable,1,nil) and Duel.SelectYesNo(tp,aux.Stringid(296499,0)) then
-		local g=Duel.SelectReleaseGroup(REASON_MAINTENANCE,tp,Card.IsReleasable,1,1,nil)
+	if Duel.CheckReleaseGroup(REASON_MAINTENANCE,tp,nil,1,nil) and Duel.SelectYesNo(tp,aux.Stringid(296499,0)) then
+		local g=Duel.SelectReleaseGroup(REASON_MAINTENANCE,tp,nil,1,1,nil)
 		Duel.Release(g,REASON_MAINTENANCE)
 	else
 		Duel.Destroy(e:GetHandler(),REASON_COST)

--- a/c33537328.lua
+++ b/c33537328.lua
@@ -37,9 +37,9 @@ end
 function c33537328.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return c:IsReason(REASON_BATTLE) and c:GetBattlePosition()~=POS_FACEUP_DEFENSE
-		and Duel.CheckReleaseGroup(REASON_EFFECT,tp,Card.IsReleasableByEffect,1,c) end
+		and Duel.CheckReleaseGroup(REASON_EFFECT,tp,nil,1,c) end
 	if Duel.SelectEffectYesNo(tp,c,96) then
-		local g=Duel.SelectReleaseGroup(REASON_EFFECT,tp,Card.IsReleasableByEffect,1,1,c)
+		local g=Duel.SelectReleaseGroup(REASON_EFFECT,tp,nil,1,1,c)
 		Duel.Release(g,REASON_EFFECT)
 		Duel.SetLP(1-tp,math.ceil(Duel.GetLP(1-tp)/2))
 		return true

--- a/c39468724.lua
+++ b/c39468724.lua
@@ -43,7 +43,7 @@ function c39468724.tgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(c,REASON_COST+REASON_DISCARD)
 end
 function c39468724.filter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0xb4) and c:IsReleasableByEffect()
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0xb4)
 end
 function c39468724.tgfilter(c)
 	return c:IsSetCard(0xb4) and c:IsAbleToGrave()
@@ -68,13 +68,10 @@ end
 function c39468724.negcon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev) and re:IsActiveType(TYPE_MONSTER)
 end
-function c39468724.negfilter(c,tp)
-	return c:IsType(TYPE_MONSTER) and c:IsReleasable()
-end
 function c39468724.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroupEx(REASON_COST,tp,c39468724.negfilter,1,nil,tp) end
+	if chk==0 then return Duel.CheckReleaseGroupEx(REASON_COST,tp,nil,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-	local g=Duel.SelectReleaseGroupEx(REASON_COST,tp,c39468724.negfilter,1,1,nil,tp)
+	local g=Duel.SelectReleaseGroupEx(REASON_COST,tp,nil,1,1,nil,tp)
 	Duel.Release(g,REASON_COST)
 end
 function c39468724.negop(e,tp,eg,ep,ev,re,r,rp)

--- a/c49154689.lua
+++ b/c49154689.lua
@@ -16,7 +16,7 @@ end
 function c49154689.cfilter(c,e,tp)
 	local race=c:GetOriginalRace()
 	local attr=c:GetOriginalAttribute()
-	return bit.band(c:GetOriginalType(),TYPE_MONSTER)~=0 and c:IsReleasable()
+	return bit.band(c:GetOriginalType(),TYPE_MONSTER)~=0
 		and Duel.GetMZoneCount(tp,c,tp)>0
 		and Duel.IsExistingMatchingCard(c49154689.spfilter,tp,0,LOCATION_GRAVE,1,nil,race,attr,e,tp)
 end

--- a/c51316684.lua
+++ b/c51316684.lua
@@ -96,8 +96,8 @@ function c51316684.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c51316684.rmcost2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c51316684.rmtg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c52038272.lua
+++ b/c52038272.lua
@@ -111,8 +111,8 @@ function c52038272.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp
 end
 function c52038272.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c52038272.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c60551528.lua
+++ b/c60551528.lua
@@ -107,8 +107,8 @@ function c60551528.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp
 end
 function c60551528.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c60551528.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c61292243.lua
+++ b/c61292243.lua
@@ -31,7 +31,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function s.rfilter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsReleasableByEffect() and c:IsSetCard(0x18b)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x18b)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/c6284176.lua
+++ b/c6284176.lua
@@ -77,7 +77,7 @@ function c6284176.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_PLANT) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function c6284176.rfilter(c)
-	return c:IsReleasableByEffect() and c:IsRace(RACE_PLANT) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+	return c:IsRace(RACE_PLANT) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
 end
 function c6284176.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c6284176.repfilter,1,nil,tp)

--- a/c64332231.lua
+++ b/c64332231.lua
@@ -20,14 +20,14 @@ function c64332231.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c64332231.destg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroupEx(REASON_EFFECT,tp,Card.IsReleasableByEffect,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroupEx(REASON_EFFECT,tp,nil,1,nil)
 		and Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function c64332231.desop(e,tp,eg,ep,ev,re,r,rp)
 	local ct1=Duel.GetMatchingGroupCount(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
-	local rg=Duel.SelectReleaseGroupEx(REASON_EFFECT,tp,Card.IsReleasableByEffect,1,ct1,nil)
+	local rg=Duel.SelectReleaseGroupEx(REASON_EFFECT,tp,nil,1,ct1,nil)
 	local ct2=Duel.Release(rg,REASON_EFFECT)
 	if ct2==0 then return end
 	Duel.BreakEffect()

--- a/c64442155.lua
+++ b/c64442155.lua
@@ -13,7 +13,7 @@ function c64442155.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c64442155.costfilter(c)
-	return c:IsSetCard(0x2093) and c:GetType()&0x81==0x81 and c:IsReleasable()
+	return c:IsSetCard(0x2093) and c:GetType()&0x81==0x81
 end
 function c64442155.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroupEx(REASON_COST,tp,c64442155.costfilter,1,nil) end

--- a/c71607202.lua
+++ b/c71607202.lua
@@ -42,7 +42,7 @@ function s.repfilter(c,tp)
 		and not c:IsReason(REASON_REPLACE)
 end
 function s.rfilter(c)
-	return c:IsReleasableByEffect() and c:IsRace(RACE_FIEND)
+	return c:IsRace(RACE_FIEND)
 		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c78371393.lua
+++ b/c78371393.lua
@@ -73,8 +73,8 @@ end
 function c78371393.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
-	if Duel.CheckReleaseGroup(REASON_EFFECT,tp,Card.IsReleasableByEffect,1,c) and Duel.SelectYesNo(tp,aux.Stringid(78371393,2)) then
-		local g=Duel.SelectReleaseGroup(REASON_EFFECT,tp,Card.IsReleasableByEffect,1,1,c)
+	if Duel.CheckReleaseGroup(REASON_EFFECT,tp,nil,1,c) and Duel.SelectYesNo(tp,aux.Stringid(78371393,2)) then
+		local g=Duel.SelectReleaseGroup(REASON_EFFECT,tp,nil,1,1,c)
 		Duel.Release(g,REASON_EFFECT)
 	else
 		Duel.Destroy(c,REASON_EFFECT)

--- a/c80758812.lua
+++ b/c80758812.lua
@@ -53,7 +53,7 @@ function c80758812.spop1(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummonComplete()
 end
 function c80758812.relfilter(c,tp)
-	return c:IsType(TYPE_DUAL) and c:IsReleasableByEffect() and Duel.GetMZoneCount(tp,c)>0
+	return c:IsType(TYPE_DUAL) and Duel.GetMZoneCount(tp,c)>0
 end
 function c80758812.spfilter2(c,e,tp)
 	return c:IsRace(RACE_WARRIOR) and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c88301393.lua
+++ b/c88301393.lua
@@ -85,8 +85,8 @@ function c88301393.atop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ChainAttack()
 end
 function c88301393.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c88301393.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c89423971.lua
+++ b/c89423971.lua
@@ -114,8 +114,8 @@ function c89423971.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp
 end
 function c89423971.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c89423971.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c89776023.lua
+++ b/c89776023.lua
@@ -68,7 +68,7 @@ function s.desrepfilter(c,tp)
 		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.rfilter(c)
-	return c:IsReleasableByEffect() and c:IsRace(RACE_REPTILE+RACE_DINOSAUR)
+	return c:IsRace(RACE_REPTILE+RACE_DINOSAUR)
 		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c96055137.lua
+++ b/c96055137.lua
@@ -85,8 +85,8 @@ function c96055137.rmop1(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
 end
 function c96055137.rmcost2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,nil) end
-	local g=Duel.SelectReleaseGroup(REASON_COST,tp,Card.IsReleasable,1,1,nil)
+	if chk==0 then return Duel.CheckReleaseGroup(REASON_COST,tp,nil,1,nil) end
+	local g=Duel.SelectReleaseGroup(REASON_COST,tp,nil,1,1,nil)
 	Duel.Release(g,REASON_COST)
 end
 function c96055137.rmtg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/c97342942.lua
+++ b/c97342942.lua
@@ -27,7 +27,7 @@ function c97342942.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_RELEASE,nil,1,tp,LOCATION_MZONE)
 end
 function c97342942.rfilter(c,e)
-	return c:IsFaceup() and c:IsReleasableByEffect() and not c:IsImmuneToEffect(e)
+	return c:IsFaceup() and not c:IsImmuneToEffect(e)
 end
 function c97342942.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c99666430.lua
+++ b/c99666430.lua
@@ -64,7 +64,7 @@ function c99666430.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c99666430.confilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
 end
 function c99666430.rlfilter(c,tp)
-	return c:IsReleasableByEffect() and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c)
+	return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c)
 end
 function c99666430.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(REASON_EFFECT,tp,c99666430.rlfilter,1,nil,tp) end
@@ -75,7 +75,7 @@ function c99666430.desop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
 	local g=Duel.SelectReleaseGroup(REASON_EFFECT,tp,c99666430.rlfilter,1,1,nil,tp)
 	if g:GetCount()==0 then
-		g=Duel.SelectReleaseGroup(REASON_EFFECT,tp,Card.IsReleasableByEffect,1,1,nil)
+		g=Duel.SelectReleaseGroup(REASON_EFFECT,tp,nil,1,1,nil)
 	end
 	if g:GetCount()>0 then
 		Duel.HintSelection(g)


### PR DESCRIPTION
`Card.IsReleasable`, `Card.IsReleasableByEffect` is checked in `Duel.GetReleaseGroup`, `Duel.CheckReleaseGroup`, `Duel.SelectReleaseGroup` (reason: https://github.com/Fluorohydride/ygopro-core/commit/f0ea88c1b97cf6de4dac75fc1ed9975f43322931 ) .