### PR TITLE
fix--S：Pリトルナイト

### DIFF
--- a/c29301450.lua
+++ b/c29301450.lua
@@ -109,7 +109,7 @@ function s.retfilter(c,fid)
 	return c:GetFlagEffectLabel(id)==fid
 end
 function s.retfilter1(c,tp,fid)
-	return c:GetFlagEffectLabel(id)==fid and c:IsControler(tp)
+	return c:GetFlagEffectLabel(id)==fid and c:IsPreviousControler(tp)
 end
 function s.retcon(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetLabelObject():IsExists(s.retfilter,1,nil,e:GetLabel()) then


### PR DESCRIPTION
fix S：Pリトルナイト ② effect remove 2 monsters that original controller is opposing, and they will not return to field correctly。

修复 S：Pリトルナイト的②效果除外2张原本控制权为对方的怪兽时，在结束阶段回到场上处理不正确的bug 