### PR TITLE
fix--再転

### DIFF
--- a/c96015976.lua
+++ b/c96015976.lua
@@ -20,7 +20,8 @@ end
 c96015976.toss_dice=true
 function c96015976.filter(c)
 	local lv=c:GetLevel()
-	return c:IsFaceup() and lv~=0 and lv~=c:GetOriginalLevel()
+	local olv=c:GetOriginalLevel()
+	return c:IsFaceup() and lv~=0 and lv~=olv and olv~=0
 end
 function c96015976.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c96015976.filter(chkc) end


### PR DESCRIPTION
fix 再転 can select token monster that don't have original level.（ such as ヴェンデット・リボーン）

修复再转可以以没有原本等级的衍生物怪兽为对象发动（如复仇死者的还魂再生）