### PR TITLE
fix--リィラップ

### DIFF
--- a/c72233469.lua
+++ b/c72233469.lua
@@ -20,7 +20,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.filter(c,tp)
-	return c:IsSummonLocation(LOCATION_GRAVE) and c:IsSummonPlayer(tp)
+	return c:IsSummonLocation(LOCATION_GRAVE) and c:IsSummonPlayer(tp) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function s.lpcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.filter,1,nil,tp)


### PR DESCRIPTION
fix リィラップ can activate when trap monster special summon from grave（バージェストマ）

修复璃拉说唱可以在陷阱怪兽从墓地特招的场合发动（伯吉斯异兽）

作为陷阱怪兽的「伯吉斯异兽·高足杯虫」通过②效果从墓地特殊召唤到场上变成怪兽的场合，不是从墓地把怪兽特殊召唤，不能发动「璃拉说唱」的①效果。22/11/5

https://yugioh-wiki.net/index.php?%A1%D4%A5%EA%A5%A3%A5%E9%A5%C3%A5%D7%A1%D5
Ｑ：罠モンスターの《バージェストマ・ディノミスクス》が自身の(2)の効果で墓地から特殊召喚された場合、《リィラップ》の効果は発動できますか？
Ａ：その場合、《リィラップ》の効果は発動できません。(22/11/05)