### PR TITLE
Fix 鉄騎の雷鎚

### DIFF
--- a/c12682213.lua
+++ b/c12682213.lua
@@ -40,7 +40,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local rc=re:GetHandler():GetColumnGroup()
+	local rc=re:GetHandler():GetColumnGroup():Filter(aux.TRUE,e:GetHandler())
 	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re)
 	and Duel.Destroy(eg,REASON_EFFECT)~=0 and rc:GetCount()>0 then
 		Duel.BreakEffect()

--- a/c12682213.lua
+++ b/c12682213.lua
@@ -40,10 +40,13 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local rc=re:GetHandler():GetColumnGroup():Filter(aux.TRUE,e:GetHandler())
-	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re)
-	and Duel.Destroy(eg,REASON_EFFECT)~=0 and rc:GetCount()>0 then
+	local rc=re:GetHandler()
+	local dg=rc:GetColumnGroup()
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then dg:RemoveCard(c) end
+	if Duel.NegateActivation(ev) and rc:IsRelateToEffect(re)
+		and Duel.Destroy(eg,REASON_EFFECT)~=0 and dg:GetCount()>0 then
 		Duel.BreakEffect()
-		Duel.Destroy(rc,REASON_EFFECT)
+		Duel.Destroy(dg,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
『それらのカードを全て破壊する』効果によって、発動したこのカードは破壊されません。