### PR TITLE
fix aux.ThisCardInGraveAlreadyCheckReg

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1332,10 +1332,10 @@ function Auxiliary.ThisCardInGraveAlreadyCheckReg(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetReset(RESET_CHAIN)
 		e2:SetLabelObject(e1)
 		Duel.RegisterEffect(e2,tp)
-	elseif (r&REASON_MATERIAL)>0 or not re:IsActivated() and (r&REASON_COST)>0 then
+	elseif (r&REASON_MATERIAL+REASON_SUMMON+REASON_SPSUMMON)>0 then
 		e:SetLabelObject(re)
 		local reset_event=EVENT_SPSUMMON
-		if re:GetCode()~=EFFECT_SPSUMMON_PROC then reset_event=EVENT_SUMMON end
+		if (r&REASON_SUMMON)>0 then reset_event=EVENT_SUMMON end
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(reset_event)


### PR DESCRIPTION
(need https://github.com/Fluorohydride/ygopro-scripts/pull/2366)
special summon condition is used `REASON_SPSUMMON` (reason: https://github.com/Fluorohydride/ygopro-scripts/commit/d26089da49837c6b3e1817e177c78bf498ce4d6c ).
so _Assault Synchron_'s bug happen again.
https://github.com/Fluorohydride/ygopro-scripts/pull/2068