### PR TITLE
fix--賜炎の咎姫

### DIFF
--- a/c2772337.lua
+++ b/c2772337.lua
@@ -1,6 +1,8 @@
 --賜炎の咎姫
 local s,id,o=GetID()
 function s.initial_effect(c)
+	--same effect send this card to grave and summon another card check
+	local e0=aux.AddThisCardInGraveAlreadyCheck(c)
 	--link summon
 	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkType,TYPE_EFFECT),2)
 	c:EnableReviveLimit()
@@ -31,6 +33,7 @@ function s.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e3:SetRange(LOCATION_GRAVE)
 	e3:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
+	e3:SetLabelObject(e0)
 	e3:SetCountLimit(1,id+o)
 	e3:SetCondition(s.spcon2)
 	e3:SetTarget(s.sptg2)
@@ -56,8 +59,12 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end
+function s.spfilter2(c,tp,se)
+    return c:IsControler(tp) and (se==nil or c:GetReasonEffect()~=se)
+end
 function s.spcon2(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(Card.IsControler,1,nil,1-tp)
+	local se=e:GetLabelObject():GetLabelObject()
+	return eg:IsExists(s.spfilter2,1,nil,1-tp,se)
 end
 function s.descheck(c,tp)
 	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_FIRE) and Duel.GetMZoneCount(tp,c)>0


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=24040&keyword=&tag=-1&request_locale=ja
Question
相手の「賜炎の咎姫」の③の効果によって自分フィールドの「賜炎の咎姫」が破壊され墓地へ送られ、相手フィールドに「賜炎の咎姫」が特殊召喚されました。この一連のチェーン処理後に、自分はその破壊された「賜炎の咎姫」の③の効果を発動できますか？
Answer
発動できません。
「賜炎の咎姫」の③の効果を発動するためには、相手フィールドにモンスターが特殊召喚された時点で、既にその「賜炎の咎姫」が墓地に存在する必要があります。「賜炎の咎姫」の③の効果による破壊と特殊召喚は同時に行われる扱いですので、相手の「賜炎の咎姫」が特殊召喚された時点では、自分の「賜炎の咎姫」は墓地に存在せず、発動の条件を満たしていません。
