### PR TITLE
Fix  真炎王 ポニクス  聖炎王 ガルドニクス

### DIFF
--- a/c66431519.lua
+++ b/c66431519.lua
@@ -33,7 +33,7 @@ function s.initial_effect(c)
 end
 function s.cfilter(c,tp,se)
 	return c:IsPreviousControler(tp) and not c:IsPreviousLocation(LOCATION_SZONE) and c:GetOriginalAttribute()==ATTRIBUTE_FIRE
-		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and (se==nil or c:GetReasonEffect()~=se)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and (se==nil or c:GetReasonEffect()~=se) and (c:IsPreviousLocation(LOCATION_MZONE) or c:GetOriginalType()&TYPE_MONSTER~=0)
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c90681088.lua
+++ b/c90681088.lua
@@ -50,7 +50,7 @@ function s.initial_effect(c)
 end
 function s.cfilter(c,tp)
 	return c:IsPreviousControler(tp) and not c:IsPreviousLocation(LOCATION_SZONE) and c:GetOriginalAttribute()==ATTRIBUTE_FIRE
-		and c:IsReason(REASON_BATTLE+REASON_EFFECT)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and (c:IsPreviousLocation(LOCATION_MZONE) or c:GetOriginalType()&TYPE_MONSTER~=0)
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.cfilter,1,nil,tp)


### PR DESCRIPTION
fix 真炎王 ポニクス and 聖炎王 ガルドニクス will active their ① effect when 調星のドラッグスター in player's hand was destroyed by 闇のデッキ破壊ウイルス's effect