### PR TITLE
fix--アーマード・エクシーズ

### DIFF
--- a/c73046708.lua
+++ b/c73046708.lua
@@ -86,6 +86,6 @@ function s.catg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.caop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToBattle() then return end
+	if not tc:IsRelateToBattle() or tc:IsImmuneToEffect(e) then return end
 	Duel.ChainAttack()
 end


### PR DESCRIPTION
fix equip monster that unaffected by equip cards' effects can chain attack by アーマード・エクシーズ（●At the end of the Damage Step, if the equipped monster attacked: You can send this card to the GY; that attacking monster can make a second attack in a row.）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20878&keyword=&tag=-1&request_locale=ja
自分のモンスターゾーンに「禁じられた聖槍」の効果が適用されている「クラッキング・ドラゴン」と、「エアークラック・ストーム」を装備した「ジャック・ワイバーン」が表側攻撃表示で存在しています。

この状況で、「ジャック・ワイバーン」が相手モンスターを攻撃し戦闘で破壊した際に、装備している「エアークラック・ストーム」の『①：装備モンスターの攻撃で相手モンスターを破壊した時に発動できる。このバトルフェイズ中、装備モンスターはもう１度だけ攻撃できる。この効果を発動するターン、装備モンスター以外の自分のモンスターは攻撃できない』効果を発動し、もう1度攻撃が行える状態になりました。

このバトルフェイズに、自分は「クラッキング・ドラゴン」でも攻撃を行う事ができますか？

「エアークラック・ストーム」の効果を発動するターンには、「エアークラック・ストーム」の装備モンスター以外のモンスターは攻撃を行う事はできません。

『この効果を発動するターン、装備モンスター以外の自分のモンスターは攻撃できない』は、モンスターが受ける効果の扱いではありませんので、質問の状況の場合、「禁じられた聖槍」の効果が適用され魔法カードの効果を受けない「クラッキング・ドラゴン」であっても、そのバトルフェイズには攻撃を行う事はできません。