### PR TITLE
fix オノマト選択

### DIFF
--- a/c85119159.lua
+++ b/c85119159.lua
@@ -20,7 +20,7 @@ function c85119159.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c85119159.filter(c)
-	return c:IsAbleToHand() and (c:IsSetCard(0x13a) or c:IsCode(8512558)) and not c:IsCode(85119159)
+	return c:IsAbleToHand() and c:IsSetCard(0x13a) and not c:IsCode(85119159)
 end
 function c85119159.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c85119159.filter,tp,LOCATION_DECK,0,nil)


### PR DESCRIPTION
@mercury233 
Require https://github.com/Fluorohydride/ygopro-core/pull/541
Now ygopro can handle cards with 5+ setcodes.