### PR TITLE
fix--聖霊獣騎 ガイアペライオ

### DIFF
--- a/c56655675.lua
+++ b/c56655675.lua
@@ -40,7 +40,7 @@ function c56655675.operation(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCost(c56655675.discost)
 	e1:SetTarget(c56655675.distg)
 	e1:SetOperation(c56655675.disop)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_LEAVE-RESET_TEMP_REMOVE)
 	e:GetHandler():RegisterEffect(e1)
 end
 function c56655675.discon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id257
通过自身记述的召唤方法特殊召唤的「圣灵兽骑 地火狮」被一时除外的场合，回到场上后仍然是得到『●』效果的状态。

fix 聖霊獣騎 ガイアペライオ will lose effect (●During either player's turn, when a Spell/Trap Card, or monster effect, is activated: You can banish 1 "Ritual Beast" card from your hand; negate the activation, and if you do, destroy it.) when it return to field by temp removed.

but maybe have some problem because RESET_LEAVE was removed.
@salix5 @mercury233 