### PR TITLE
fix `Infernal Flame Banshee`

### DIFF
--- a/c29423048.lua
+++ b/c29423048.lua
@@ -23,7 +23,6 @@ function s.initial_effect(c)
 	e2:SetCode(EVENT_REMOVE)
 	e2:SetCountLimit(1,id+o)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
-	e2:SetCondition(s.spcon)
 	e2:SetTarget(s.sptg)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
@@ -52,13 +51,11 @@ end
 function s.cfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_PYRO)
 end
-function s.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
-end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
 function s.afilter(c)


### PR DESCRIPTION
② effect did not activate if a Pyro monster is placed on its owner's field during the same Chain Link she was banished while her owner did not already control a Pyro monster

Source: [Evil★Twin Lil-la](https://github.com/Fluorohydride/ygopro-scripts/blob/master/c36609518.lua)