### PR TITLE
Fix todeck operation

### DIFF
--- a/c22610082.lua
+++ b/c22610082.lua
@@ -28,5 +28,8 @@ function c22610082.activate(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsRelateToEffect(e) then
 		c:CancelToGrave()
 		Duel.SendtoDeck(c,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		if c:IsLocation(LOCATION_ONFIELD) then
+			c:CancelToGrave(false)
+		end
 	end
 end

--- a/c7165085.lua
+++ b/c7165085.lua
@@ -26,6 +26,9 @@ function c7165085.activate(e,tp,eg,ep,ev,re,r,rp)
 		if c:IsRelateToEffect(e) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 			c:CancelToGrave()
 			Duel.SendtoDeck(c,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+			if c:IsLocation(LOCATION_ONFIELD) then
+				c:CancelToGrave(false)
+			end
 		end
 		return
 	end
@@ -76,5 +79,8 @@ function c7165085.activate(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsRelateToEffect(e) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		c:CancelToGrave()
 		Duel.SendtoDeck(c,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		if c:IsLocation(LOCATION_ONFIELD) then
+			c:CancelToGrave(false)
+		end
 	end
 end

--- a/c81171949.lua
+++ b/c81171949.lua
@@ -23,6 +23,9 @@ function c81171949.activate(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsRelateToEffect(e) then
 		c:CancelToGrave()
 		Duel.SendtoDeck(c,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		if c:IsLocation(LOCATION_ONFIELD) then
+			c:CancelToGrave(false)
+		end
 	end
 end
 function c81171949.rmcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fix when spells with effect like _Shuffle this card into the deck_ cannot send itself to deck, it will keeps remain on field.

修复将自身洗回卡组的魔法没有被送回卡组时，无意义留场的问题。