### PR TITLE
Add Nightmare Throne

### DIFF
--- a/c93729896.lua
+++ b/c93729896.lua
@@ -1,0 +1,72 @@
+--ナイトメア・スローン
+local s,id,o=GetID()
+function s.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,id+EFFECT_COUNT_CODE_OATH)
+	e1:SetOperation(s.activate)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetRange(LOCATION_FZONE)
+	e2:SetCountLimit(1)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetCondition(s.spcon)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+end
+function s.thfilter(c)
+	return c:IsRace(RACE_FIEND) and c:IsAttack(0) and c:IsDefense(0)
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_DECK,0,nil)
+	if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_OPERATECARD)
+		local sg=g:Select(tp,1,1,nil)
+		local tc=sg:GetFirst()
+		if tc:IsAbleToHand() and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
+			Duel.SendtoHand(tc,nil,REASON_EFFECT)
+			Duel.ConfirmCards(1-tp,tc)
+		else
+			Duel.Destroy(tc,REASON_EFFECT)
+		end
+	end
+end
+function s.cfilter(c,tp)
+	return c:IsSetCard(0x1a5) and c:IsReason(REASON_EFFECT) and c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.cfilter,1,nil,tp)
+end
+function s.filter(c,lv,tp)
+	return s.cfilter(c,tp) and (c:IsLevel(lv-1) or c:IsLevel(lv+1))
+end
+function s.spfilter(c,e,tp,eg)
+	local lv=c:GetLevel()
+	return c:IsSetCard(0x1a5) and c:IsFaceupEx() and c:IsAbleToHand()
+		and eg:IsExists(s.filter,1,nil,lv,tp)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK+LOCATION_GRAVE+LOCATION_REMOVED,0,1,nil,e,tp,eg) end
+	e:SetLabelObject(eg)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK+LOCATION_GRAVE+LOCATION_REMOVED)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local sg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,LOCATION_DECK+LOCATION_GRAVE+LOCATION_REMOVED,0,1,1,nil,e,tp,e:GetLabelObject())
+	local tc=sg:GetFirst()
+	if tc and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
+		Duel.ConfirmCards(1-tp,tc)
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and tc:IsCanBeSpecialSummoned(e,0,tp,true,false) and Duel.SelectYesNo(tp,aux.Stringid(id,3)) then
+			Duel.BreakEffect()
+			Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)
+		end
+	end
+end
+


### PR DESCRIPTION
This commit introduces the Nightmare Throne card to the project. Previously, the card had a logical error in the `activate` function in another repository due to the inclusion of a 'not' operator, which has been removed to correct the behaviour.

This fix is derived from a bug-fix made in the duelists-unite/omega_scripts repository. For reference, see the original commit: [duelists-unite/omega_scripts e4ba83a92776289157eea8fe8cea3593b08d264f](https://gitlab.com/duelists-unite/omega_scripts/-/commit/e4ba83a92776289157eea8fe8cea3593b08d264f)
