### PR TITLE
fix Icejade Gymir Aegirine

### DIFF
--- a/c86682165.lua
+++ b/c86682165.lua
@@ -74,7 +74,7 @@ function s.rmfilter(c,code)
 	return c:IsFaceupEx() and c:IsCode(code) and c:IsAbleToRemove()
 end
 function s.cfilter(c,tp)
-	return c:GetReasonPlayer()==1-tp and c:IsReason(REASON_EFFECT)
+	return c:GetReasonPlayer()==1-tp and c:IsReason(REASON_EFFECT) and not c:IsType(TYPE_TOKEN)
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.cfilter,1,nil,tp) and not eg:IsContains(e:GetHandler())


### PR DESCRIPTION
fix: if token(s) was banished, _Icejade Gymir Aegirine_ can activate special summon effect.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18183
> ■**モンスタートークンが除外された場合には発動できません**。