### PR TITLE
fix c75874514.lua

### DIFF
--- a/c75874514.lua
+++ b/c75874514.lua
@@ -61,7 +61,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummonComplete()
 		Duel.AdjustAll()
 		local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_EXTRA,0,nil,c)
-		if g:GetCount()>0 and c:IsControler(tp) and c:IsFaceup()
+		if g:GetCount()>0 and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsFaceup()
 			and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/c75874514.lua
+++ b/c75874514.lua
@@ -61,7 +61,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummonComplete()
 		Duel.AdjustAll()
 		local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_EXTRA,0,nil,c)
-		if g:GetCount()>0 and c:IsRelateToEffect(e) and c:IsControler(tp) and c:IsFaceup()
+		if g:GetCount()>0 and c:IsControler(tp) and c:IsFaceup()
 			and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
辉煌的星之龙特殊召唤后必定和发动的效果失去联系，不应该判断c:IsRelateToEffect(e)