### PR TITLE
fix PSY-Frame Circuit, Dragunity Whirlwind, Gold Pride - Leon, Stand Up Centur-Ion!

### DIFF
--- a/c23512906.lua
+++ b/c23512906.lua
@@ -84,12 +84,12 @@ function s.scon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
 end
 function s.stg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local g=Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_MZONE,0,nil,0x192)
+	local g=Duel.GetSynchroMaterial(tp):Filter(Card.IsSetCard,nil,0x192)
 	if chk==0 then return #g>0 and Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,nil,g) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function s.sop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_MZONE,0,nil,0x192)
+	local g=Duel.GetSynchroMaterial(tp):Filter(Card.IsSetCard,nil,0x192)
 	if #g==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sc=Duel.SelectMatchingCard(tp,Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,1,nil,nil,g):GetFirst()

--- a/c575512.lua
+++ b/c575512.lua
@@ -38,13 +38,13 @@ function c575512.sccon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c575512.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local mg=Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_MZONE,0,nil,0xc1)
+		local mg=Duel.GetSynchroMaterial(tp):Filter(Card.IsSetCard,nil,0xc1)
 		return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,nil,mg)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c575512.scop(e,tp,eg,ep,ev,re,r,rp)
-	local mg=Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_MZONE,0,nil,0xc1)
+	local mg=Duel.GetSynchroMaterial(tp):Filter(Card.IsSetCard,nil,0xc1)
 	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,nil,mg)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/c89450409.lua
+++ b/c89450409.lua
@@ -31,9 +31,6 @@ end
 function c89450409.cfilter(c)
 	return c:IsSummonLocation(LOCATION_EXTRA)
 end
-function c89450409.matfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x29)
-end
 function c89450409.scfilter(c,mg)
 	return c:IsRace(RACE_DRAGON) and c:IsSynchroSummonable(nil,mg)
 end
@@ -76,7 +73,7 @@ function c89450409.activate(e,tp,eg,ep,ev,re,r,rp)
 		cb:RegisterEffect(e4)
 	end
 	Duel.SpecialSummonComplete()
-	local mg=Duel.GetMatchingGroup(c89450409.matfilter,tp,LOCATION_MZONE,0,nil)
+	local mg=Duel.GetSynchroMaterial(tp):Filter(Card.IsSetCard,nil,0x29)
 	if success and Duel.IsExistingMatchingCard(c89450409.cfilter,tp,0,LOCATION_MZONE,1,nil)
 		and Duel.IsExistingMatchingCard(c89450409.scfilter,tp,LOCATION_EXTRA,0,1,nil,mg)
 		and Duel.SelectYesNo(tp,aux.Stringid(89450409,1)) then


### PR DESCRIPTION
_Stand Up Centur-Ion!_:
fix for https://github.com/Fluorohydride/ygopro-scripts/commit/896bc750acda6c5e72c1323aaa6f794a16cb9c46.

_PSY-Frame Circuit_, _Dragunity Whirlwind_, _Gold Pride - Leon_:

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16785&keyword=&tag=-1
> 質問の状況の場合、**「[シンクロ・マテリアル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9241)」の効果が適用されている相手モンスターが「PSYフレーム」と名のついたモンスターだったのであれば、シンクロ召喚の素材に含める事ができます**。
> 
> なお、「[シンクロ・マテリアル](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9241)」の効果が適用されている相手モンスターが「PSYフレーム」と名のついたモンスターでないのであれば、シンクロ召喚の素材に含める事はできません。