### PR TITLE
Fix remove operation

### DIFF
--- a/c13735899.lua
+++ b/c13735899.lua
@@ -41,14 +41,14 @@ function c13735899.cfilter(c,e)
 	local sc=se:GetHandler()
 	return typ&TYPE_MONSTER~=0 and se:IsActivated()
 		and c:IsFaceup() and (c:GetOriginalRace()==sc:GetOriginalRace() or c==sc)
-		and c:IsCanBeEffectTarget(e) and c:IsAbleToRemove()
+		and c:IsCanBeEffectTarget(e) and Duel.IsExistingMatchingCard(c13735899.rmfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,c)
 end
 function c13735899.remcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c13735899.cfilter,1,nil,e)
 		and not eg:IsContains(e:GetHandler())
 end
 function c13735899.rmfilter(c,tc)
-	return c:IsFaceup() and c:GetOriginalRace()==tc:GetOriginalRace()
+	return c:IsFaceup() and c:GetOriginalRace()==tc:GetOriginalRace() and c:IsAbleToRemove()
 end
 function c13735899.remtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return eg:IsContains(chkc) and c13735899.cfilter(chkc,e) end

--- a/c16832845.lua
+++ b/c16832845.lua
@@ -42,17 +42,11 @@ end
 function c16832845.condition(e,tp,eg,ep,ev,re,r,rp)
 	return c16832845[0] and c16832845[1]
 end
-function c16832845.chkfilter(c)
-	return c:IsType(TYPE_MONSTER) and not c:IsAbleToRemove()
-end
 function c16832845.filter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
 end
 function c16832845.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then
-		return Duel.IsExistingMatchingCard(c16832845.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil) and
-			not Duel.IsExistingMatchingCard(c16832845.chkfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil)
-	end
+	if chk==0 then return Duel.IsExistingMatchingCard(c16832845.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil) end
 	local g=Duel.GetMatchingGroup(c16832845.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
 end

--- a/c17775525.lua
+++ b/c17775525.lua
@@ -54,17 +54,11 @@ function c17775525.operation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Destroy(rg,REASON_EFFECT)
 	end
 end
-function c17775525.chkfilter(c)
-	return c:IsType(TYPE_SPELL+TYPE_TRAP) and not c:IsAbleToRemove()
-end
 function c17775525.filter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToRemove()
 end
 function c17775525.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then
-		return Duel.IsExistingMatchingCard(c17775525.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil)
-			and not Duel.IsExistingMatchingCard(c17775525.chkfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil)
-	end
+	if chk==0 then return Duel.IsExistingMatchingCard(c17775525.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil) end
 	local g=Duel.GetMatchingGroup(c17775525.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,g:GetCount()*200)

--- a/c21105106.lua
+++ b/c21105106.lua
@@ -82,10 +82,7 @@ function c21105106.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.RegisterEffect(e3,tp)
 end
 function c21105106.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then
-		return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,1,e:GetHandler())
-			and not Duel.IsExistingMatchingCard(aux.NOT(Card.IsAbleToRemove),tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,1,e:GetHandler())
-	end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,1,e:GetHandler()) end
 	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,e:GetHandler())
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
 end

--- a/c2743001.lua
+++ b/c2743001.lua
@@ -30,17 +30,11 @@ c2743001.material_type=TYPE_SYNCHRO
 function c2743001.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
 end
-function c2743001.chkfilter(c)
-	return c:IsType(TYPE_SPELL+TYPE_TRAP) and not c:IsAbleToRemove()
-end
 function c2743001.rmfilter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToRemove()
 end
 function c2743001.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then
-		return Duel.IsExistingMatchingCard(c2743001.rmfilter,tp,0,LOCATION_GRAVE+LOCATION_ONFIELD,1,nil)
-			and not Duel.IsExistingMatchingCard(c2743001.chkfilter,tp,0,LOCATION_GRAVE+LOCATION_ONFIELD,1,nil)
-	end
+	if chk==0 then return Duel.IsExistingMatchingCard(c2743001.rmfilter,tp,0,LOCATION_GRAVE+LOCATION_ONFIELD,1,nil) end
 	local g=Duel.GetMatchingGroup(c2743001.rmfilter,tp,0,LOCATION_GRAVE+LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
 end

--- a/c58330108.lua
+++ b/c58330108.lua
@@ -70,9 +70,7 @@ function c58330108.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local b1=Duel.IsExistingMatchingCard(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c)
 		local b2=Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c)
-			and not Duel.IsExistingMatchingCard(aux.NOT(Card.IsAbleToRemove),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c)
 		local b3=Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,1,c)
-			and not Duel.IsExistingMatchingCard(aux.NOT(Card.IsAbleToRemove),tp,LOCATION_ONFIELD+LOCATION_GRAVE,LOCATION_ONFIELD+LOCATION_GRAVE,1,c)
 		return (gc==1 and b1) or (gc==2 and b2) or (gc>2 and b3)
 	end
 	if gc==1 then

--- a/c7030340.lua
+++ b/c7030340.lua
@@ -10,9 +10,6 @@ function c7030340.initial_effect(c)
 	e1:SetOperation(c7030340.activate)
 	c:RegisterEffect(e1)
 end
-function c7030340.chkfilter(c)
-	return c:IsSetCard(0x26) and c:IsType(TYPE_MONSTER) and not c:IsAbleToRemove()
-end
 function c7030340.filter1(c)
 	return c:IsSetCard(0x26) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
 end
@@ -23,7 +20,6 @@ function c7030340.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c7030340.filter2(chkc) end
 	if chk==0 then
 		return Duel.IsExistingMatchingCard(c7030340.filter1,tp,LOCATION_GRAVE,0,1,nil)
-			and not Duel.IsExistingMatchingCard(c7030340.chkfilter,tp,LOCATION_GRAVE,0,1,nil)
 			and Duel.IsExistingTarget(c7030340.filter2,tp,LOCATION_MZONE,0,1,nil)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)

--- a/c87288189.lua
+++ b/c87288189.lua
@@ -54,9 +54,11 @@ function c87288189.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local ct=1
 	if e:GetLabel()==1 then ct=2 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,ct,nil)
-	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,1000)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,ct,nil)
+	if g:GetCount()>0 then
+		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
+		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,1000)
+	end
 end
 function c87288189.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)

--- a/c9748752.lua
+++ b/c9748752.lua
@@ -19,9 +19,9 @@ function c9748752.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() end
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
 	local tc=g:GetFirst()
-	if tc and tc:IsAbleToRemove() then
+	if tc then
 		Duel.SetOperationInfo(0,CATEGORY_REMOVE,tc,1,0,0)
 		if tc:IsFaceup() and tc:IsAttribute(ATTRIBUTE_DARK) then
 			Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,1000)


### PR DESCRIPTION
> 相手のモンスターゾーンに「[霊滅術師 カイクウ](https://ygocdb.com/card/88240808)」が表側表示で存在し、『①：このカードがモンスターゾーンに存在する限り、相手はお互いの墓地のカードを除外できない』永続効果が適用されています。
 この状況で、自分は「[システム・ダウン](https://ygocdb.com/card/18895832)」を発動できますか？
 相手のモンスターゾーンに機械族モンスターが存在する場合であれば発動できます。また、その処理時に「[霊滅術師 カイクウ](https://ygocdb.com/card/88240808)」の①の永続効果が適用されているのであれば、相手のフィールドの機械族モンスターのみを全て除外します。
相手のモンスターゾーンに機械族モンスターが存在せず、相手の墓地にのみ機械族モンスターが存在している場合、自分は「[システム・ダウン](https://ygocdb.com/card/18895832)」を発動できません。