### PR TITLE
Fix  マシンナーズ・フォース and   督戦官コヴィントン

### DIFF
--- a/c22666164.lua
+++ b/c22666164.lua
@@ -23,7 +23,7 @@ function c22666164.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(sg,REASON_COST)
 end
 function c22666164.filter(c,e,tp)
-	return c:IsCode(58054262) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsCode(58054262) and c:IsCanBeSpecialSummoned(e,0,tp,false,true)
 end
 function c22666164.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-3
@@ -35,6 +35,7 @@ function c22666164.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c22666164.filter,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,e,tp)
 	if g:GetCount()>0 then
-		Duel.SpecialSummon(g,0,tp,tp,true,false,POS_FACEUP)
+		Duel.SpecialSummon(g,0,tp,tp,false,true,POS_FACEUP)
+		g:GetFirst():CompleteProcedure()
 	end
 end

--- a/c58054262.lua
+++ b/c58054262.lua
@@ -1,12 +1,13 @@
 --マシンナーズ・フォース
 function c58054262.initial_effect(c)
 	c:EnableReviveLimit()
-	--cannot special summon
+	--splimit
 	local e1=Effect.CreateEffect(c)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	c:RegisterEffect(e1)
+	e1:SetValue(c58054262.splimit)
+	c:RegisterEffect(e1)  
 	--attack cost
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
@@ -27,6 +28,9 @@ function c58054262.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 c58054262.spchecks=aux.CreateChecks(Card.IsCode,{60999392,23782705,96384007})
+function c58054262.splimit(e,se,sp,st)
+	return se:GetHandler():IsCode(22666164)
+end
 function c58054262.atcost(e,c,tp)
 	return Duel.CheckLPCost(tp,1000)
 end


### PR DESCRIPTION
https://yugioh-wiki.net/index.php?%A1%D4%C6%C4%C0%EF%B4%B1%A5%B3%A5%F4%A5%A3%A5%F3%A5%C8%A5%F3%A1%D5#faq
Ｑ：このカードのカード名が《ヒーロー・マスク》の効果でカード名が《Ｅ・ＨＥＲＯ ネオス》として扱われている場合、自身の効果を発動して《マシンナーズ・フォース》を特殊召喚できますか？
Ａ：ご質問の場合、このカードの効果を発動できませんので、《マシンナーズ・フォース》を特殊召喚できません。(24/02/18)

fix 督戦官コヴィントン was changed name by ヒーロー・マスク can activate its effect to special summon  マシンナーズ・フォース.
fix 督戦官コヴィントン's effect special summon マシンナーズ・フォース can not Complete Procedure