### PR TITLE
Fix 黒羽の旋風

### DIFF
--- a/c7602800.lua
+++ b/c7602800.lua
@@ -38,7 +38,7 @@ function c7602800.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:FilterCount(c7602800.cfilter,nil,tp)>0
 end
 function c7602800.spfilter(c,e,tp,atk)
-	return (c:IsSetCard(0x33) and c:GetAttack()<atk or c:IsCode(9012916))
+	return (c:IsSetCard(0x33) or c:IsCode(9012916)) and c:GetAttack()<atk
 		and (not c:IsLocation(LOCATION_REMOVED) or c:IsFaceup())
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end


### PR DESCRIPTION
そのモンスターより低い攻撃力を持つ、自分の墓地・除外状態の、**「ＢＦ」モンスターか「ブラックフェザー・ドラゴン」１体**を対象として発動できる。

You can target 1 of your **"Blackwing" monsters, or "Black-Winged Dragon"**, that is banished or in your GY, with less ATK than that Special Summoned monster