### PR TITLE
fix--TG グレイヴ・ブラスター

### DIFF
--- a/c95973569.lua
+++ b/c95973569.lua
@@ -9,6 +9,7 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetValue(aux.synlimit)
 	c:RegisterEffect(e1)
 	--banish
 	local e2=Effect.CreateEffect(c)


### PR DESCRIPTION
fix TG グレイヴ・ブラスター can not special summon by effect which treated as a Synchro Summon.)