### PR TITLE
fix--PSYフレームロード・Λ

### DIFF
--- a/c8802510.lua
+++ b/c8802510.lua
@@ -26,7 +26,7 @@ function c8802510.initial_effect(c)
 end
 function c8802510.cfilter(c,tp)
 	return c:IsFaceup() and c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousLocation(LOCATION_MZONE)
-		and bit.band(c:GetPreviousRaceOnField(),RACE_PSYCHO)~=0 and c:IsPreviousControler(tp)
+		and bit.band(c:GetPreviousRaceOnField(),RACE_PSYCHO)~=0 and c:IsPreviousControler(tp) and c:IsRace(RACE_PSYCHO)
 end
 function c8802510.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c8802510.cfilter,1,nil,tp)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22283&keyword=&tag=-1
Question
相手の魔法＆罠ゾーンに、サイキック族を宣言して発動した「DNA改造手術」が表側表示で存在し、エクストラモンスターゾーンに自分の「PSYフレームロード・Λ」、自分のメインモンスターゾーンに「ゼンマイラビット」がそれぞれ表側表示で存在しています。
この状況で、「ゼンマイラビット」が自身の『自分フィールド上の「ゼンマイ」と名のついたモンスター１体を選択して発動できる。選択したモンスターを次の自分のスタンバイフェイズ時までゲームから除外する。この効果は相手ターンでも発動できる。また、この効果はこのカードがフィールド上に表側表示で存在する限り１度しか使用できない』モンスター効果によって除外された場合、「PSYフレームロード・Λ」の『②：このカードが既にモンスターゾーンに存在する状態で、このカード以外の自分フィールドの表側表示のサイキック族モンスターが除外された場合に発動できる。このターンのエンドフェイズに、デッキから「PSYフレーム」カード１枚を手札に加える』モンスター効果を発動する事はできますか？

Answer
質問の状況の場合、「DNA改造手術」の『このカードがフィールド上に存在する限り、フィールド上に表側表示で存在する全てのモンスターは宣言した種族になる』効果によって、「ゼンマイラビット」はフィールドではサイキック族として扱われていますが、「ゼンマイラビット」の元々の種族は獣戦士族です。
この状況で「ゼンマイラビット」が除外されたとしても、「PSYフレームロード・Λ」の『このターンのエンドフェイズに、デッキから「PSYフレーム」カード１枚を手札に加える』モンスター効果を発動する事はできません。

修复宣言念动力族的DNA改造手术适用中时，原本种族不为念动力族的怪兽被除外的场合可以发动PSYフレームロード・Λ的效果的bug
fix PSYフレームロード・Λ can activate its effect when monsters whose Original Race isn't PSYCHO was removed.(DNA Surgery is on field and announce PSYCHO).
