### PR TITLE
fix--終戒超獸－ヴァルドラス

### DIFF
--- a/c70636044.lua
+++ b/c70636044.lua
@@ -73,7 +73,7 @@ function s.disop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.descon1(e)
 	local c=e:GetHandler()
-	return c:GetOverlayCount()>0
+	return c:GetOverlayCount()>0 and Duel.GetAttacker()==c
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetFieldGroup(tp,LOCATION_ONFIELD,LOCATION_ONFIELD)


### PR DESCRIPTION
fix 終戒超獸－ヴァルドラス can activate its effect（②：X素材を持っているこのカードが攻撃するダメージステップ開始時に発動できる。フィールドのカード１枚を破壊する。）when other monster attack