### PR TITLE
fix `Twin-Barrel Dragon`

### DIFF
--- a/c70050374.lua
+++ b/c70050374.lua
@@ -20,7 +20,7 @@ end
 c70050374.toss_coin=true
 function c70050374.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) end
-	if chk==0 then return true end
+	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,2)


### PR DESCRIPTION
It was allowed to activate its effect if the opponent had nothing for it to target