### PR TITLE
fix--睨み統べるスネークアイズ

### DIFF
--- a/c74906081.lua
+++ b/c74906081.lua
@@ -20,7 +20,7 @@ function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE,0,nil):GetSum(Card.GetLevel)>1
 end
 function s.mfilter(c,tp,ft)
-	if not (c:IsFaceupEx() and c:GetOriginalType()&TYPE_MONSTER>0) then return false end
+	if not (c:IsFaceupEx() and c:IsType(TYPE_MONSTER)) then return false end
 	local p=c:GetOwner()
 	if p~=tp then ft=0 end
 	local r=LOCATION_REASON_TOFIELD


### PR DESCRIPTION
fix 睨み統べるスネークアイズ's effect(●Target 1 face-up monster your opponent controls or in their GY; place it face-up in its owner's Spell & Trap Zone as a Continuous Spell.) can not select trap monster in monster zone.