### PR TITLE
Fix  霊魂の円環  スピリットの誘い

### DIFF
--- a/c276357.lua
+++ b/c276357.lua
@@ -51,7 +51,7 @@ function c276357.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function c276357.filter(c,tp)
 	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
-		and c:IsControler(tp) and c:IsType(TYPE_SPIRIT)
+		and c:IsControler(tp) and c:GetPreviousTypeOnField()&TYPE_SPIRIT>0
 end
 function c276357.descon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c276357.filter,1,nil,tp) and e:GetHandler():IsStatus(STATUS_EFFECT_ENABLED)

--- a/c92394653.lua
+++ b/c92394653.lua
@@ -29,7 +29,7 @@ end
 c92394653.has_text_type=TYPE_SPIRIT
 function c92394653.filter(c,tp)
 	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
-		and c:IsControler(tp) and c:IsType(TYPE_SPIRIT)
+		and c:IsControler(tp) and c:GetPreviousTypeOnField()&TYPE_SPIRIT>0
 end
 function c92394653.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c92394653.filter,1,nil,tp) and e:GetHandler():IsStatus(STATUS_EFFECT_ENABLED)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=20137&keyword=&tag=-1
Question
自分のモンスターゾーンに表側表示で存在する「スピリチューアル・ウィスパー」を対象として、自分の「河伯」の『①：このカードが召喚・リバースした場合、フィールドの表側表示モンスター１体を対象として発動できる。その表側表示モンスターはスピリットモンスター扱いとなり、エンドフェイズに持ち主の手札に戻る』モンスター効果が適用されているターンです。

そのターンのエンドフェイズに、その「スピリチューアル・ウィスパー」が自分の手札に戻った場合、「霊魂の円環」の『①：このカードが魔法＆罠ゾーンに存在し、自分フィールドの表側表示のスピリットモンスターが自分の手札に戻った場合、相手フィールドのカード１枚を対象として発動できる。そのカードを破壊する』効果を発動する事はできますか？
Answer
質問の状況のように、「河伯」の『その表側表示モンスターはスピリットモンスター扱いとなり、エンドフェイズに持ち主の手札に戻る』モンスター効果が適用され、スピリットモンスターとして扱われているモンスターが自分の手札に戻った場合にも、「霊魂の円環」の効果を発動し、相手フィールドのカード1枚を破壊する事ができます。

fix 霊魂の円環  and スピリットの誘い can not activate their effect when spirit monster which was changed by 河伯 return to hand.
修复 灵魂的引诱 和 灵魂的的圆环在受河伯效果（①：这张卡召唤·反转的场合，以场上1只表侧表示怪兽为对象才能发动。那只表侧表示怪兽变成当作灵魂怪兽使用，结束阶段回到持有者手卡。）影响的怪兽回到手卡时无法诱发各自的自己场上的表侧表示的灵魂怪兽回到自己手卡的场合的效果