### PR TITLE
fix--おとり人形

### DIFF
--- a/c7165085.lua
+++ b/c7165085.lua
@@ -34,7 +34,9 @@ function c7165085.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tep=tc:GetControler()
 		if not te then
 			Duel.ChangePosition(tc,POS_FACEUP)
-			Duel.Destroy(tc,REASON_EFFECT)
+			if Duel.Destroy(tc,REASON_EFFECT)==0 then
+				Duel.SendtoGrave(tc,REASON_RULE)
+			end
 		else
 			local condition=te:GetCondition()
 			local cost=te:GetCost()
@@ -68,7 +70,9 @@ function c7165085.activate(e,tp,eg,ep,ev,re,r,rp)
 					tg=g:GetNext()
 				end
 			else
-				Duel.Destroy(tc,REASON_EFFECT)
+				if Duel.Destroy(tc,REASON_EFFECT)==0 then
+					Duel.SendtoGrave(tc,REASON_RULE)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7614&keyword=&tag=-1
Question
相手のモンスターゾーンに「白竜の忍者」が表側表示で存在しています。

この状況で、自分が「おとり人形」を発動しました。
「おとり人形」の対象となった相手のカードが発動タイミングの正しくない罠カードだった場合、処理はどうなりますか？
Answer
相手フィールド上に「白竜の忍者」が存在している場合、自分の発動した「おとり人形」の効果の対象とされたカードが永続罠カードだった場合、そのカードは破壊されませんが、発動が行われた事にはならず墓地へ送られる事になります。

「おとり人形」の対象とされたカードが通常罠カード・カウンター罠カードだった場合も同様です。そのカードは破壊されませんが、発動が行われた事にはならず墓地へ送られる事になります。

fix おとり人形 will not send trap card to grave(if the activation timing is incorrect) when 白竜の忍者 is on field.