### PR TITLE
fix--ナイトメア・スローン

### DIFF
--- a/c93729896.lua
+++ b/c93729896.lua
@@ -52,14 +52,26 @@ function s.spfilter(c,e,tp,eg)
 	return c:IsSetCard(0x1a5) and c:IsFaceupEx() and c:IsAbleToHand()
 		and eg:IsExists(s.filter,1,nil,lv,tp)
 end
+--check in Operation
+function s.spfilter2(c,e,tp,g)
+	local lv=c:GetLevel()
+	return c:IsSetCard(0x1a5) and c:IsFaceupEx() and c:IsAbleToHand()
+		and g:IsExists(s.filter2,1,nil,lv,tp)
+end
+function s.filter2(c,lv,tp)
+	return (c:IsLevel(lv-1) or c:IsLevel(lv+1))
+end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK+LOCATION_GRAVE+LOCATION_REMOVED,0,1,nil,e,tp,eg) end
-	e:SetLabelObject(eg)
+	local g1=eg:Filter(s.cfilter,nil,tp)
+	g1:KeepAlive()
+	e:SetLabelObject(g1)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK+LOCATION_GRAVE+LOCATION_REMOVED)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local g1=e:GetLabelObject()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local sg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,LOCATION_DECK+LOCATION_GRAVE+LOCATION_REMOVED,0,1,1,nil,e,tp,e:GetLabelObject())
+	local sg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter2),tp,LOCATION_DECK+LOCATION_GRAVE+LOCATION_REMOVED,0,1,1,nil,e,tp,g1)
 	local tc=sg:GetFirst()
 	if tc and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.ConfirmCards(1-tp,tc)


### PR DESCRIPTION
https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2024.html#id44

「于贝尔」怪兽因「雷破」的效果从场上离开，发动「噩梦之玉座」的②效果时，连锁发动「转生的预言」，那只「于贝尔」怪兽回到卡组的场合，「噩梦之玉座」的②效果也正常适用。

fix ナイトメア・スローン can not search 「ユベル」monster when 「ユベル」monster which leave field was send to deck by 転生の予言