### PR TITLE
fix--ユベル－Das Ewig Liebe Wächter

### DIFF
--- a/c47172959.lua
+++ b/c47172959.lua
@@ -73,7 +73,9 @@ function s.damrop(e,tp,eg,ep,ev,re,r,rp)
 	local atk=bc:GetAttack()
 	local def=bc:GetDefense()
 	if atk<0 then atk=0 end
-	Duel.Damage(1-tp,atk,REASON_EFFECT,true)
-	Duel.Remove(bc,0,REASON_EFFECT)
+	if bc:IsControler(tp) or bc:IsFacedown() then return end
+	if Duel.Damage(1-tp,atk,REASON_EFFECT,true)~=0 then
+		Duel.Remove(bc,POS_FACEUP,REASON_EFFECT)
+	end
 	Duel.RDComplete()
 end

--- a/c47172959.lua
+++ b/c47172959.lua
@@ -65,8 +65,9 @@ function s.damrtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	local bc=c:GetBattleTarget()
 	if chk==0 then return c:IsStatus(STATUS_OPPO_BATTLE) and bc~=nil end
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,bc:GetAttack())
-	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,bc:GetDefense())
+	if bc:GetAttack()>0 then
+		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,bc:GetAttack())
+	end
 end
 function s.damrop(e,tp,eg,ep,ev,re,r,rp)
 	local bc=e:GetHandler():GetBattleTarget()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19493
■処理時に、『その相手モンスターの攻撃力分のダメージを相手に与え』の処理を行い、ダメージを与えることに成功した場合、『そのモンスターを除外する』処理を行います。
fix ユベル－Das Ewig Liebe Wächter will remove monster when it don't give damage

https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2024.html#id47
我方发动「闪刀机-黑寡妇抓锚」，无效并得到「于贝尔-永远之爱的守护者」的控制权后，攻击对方「青眼白龙」，被战斗破坏送去对方墓地的场合，「于贝尔-永远之爱的守护者」的③效果也会强制发动。不过，由于这个效果处理时，从对方的角度来看「青眼白龙」不是我方怪兽，『给与对方那只对方怪兽的攻击力数值的伤害』不会给与我方伤害，『那只怪兽除外』的处理也不适用。

fix ユベル－Das Ewig Liebe Wächter will give damage and remove monster when battle with ユベル－Das Ewig Liebe Wächter 's Controller's monster