### PR TITLE
Fix special summon about blue eyes spirit dragon

### DIFF
--- a/c22404675.lua
+++ b/c22404675.lua
@@ -31,10 +31,10 @@ function c22404675.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c22404675.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not Duel.IsPlayerAffectedByEffect(tp,59822133) and c:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) then
 		if Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP) then
 			if Duel.GetLocationCount(1-tp,LOCATION_MZONE,tp)>0
-				and Duel.IsPlayerCanSpecialSummonMonster(tp,22404676,0,TYPES_TOKEN_MONSTER,800,1000,1,RACE_THUNDER,ATTRIBUTE_LIGHT,POS_FACEUP_DEFENSE) then
+				and Duel.IsPlayerCanSpecialSummonMonster(tp,22404676,0,TYPES_TOKEN_MONSTER,800,1000,1,RACE_THUNDER,ATTRIBUTE_LIGHT,POS_FACEUP_DEFENSE) and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 				local token=Duel.CreateToken(tp,22404676)
 				Duel.SpecialSummonStep(token,0,tp,1-tp,false,false,POS_FACEUP_DEFENSE)
 			end

--- a/c37343995.lua
+++ b/c37343995.lua
@@ -64,8 +64,8 @@ function c37343995.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c37343995.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
-	if Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c37343995.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 		if g:GetCount()>0 then

--- a/c38041940.lua
+++ b/c38041940.lua
@@ -23,6 +23,7 @@ end
 function c38041940.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c38041940.spfilter(chkc,e,tp) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
+		and not Duel.IsPlayerAffectedByEffect(tp,59822133)
 		and Duel.IsExistingTarget(c38041940.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,38041941,0,TYPES_TOKEN_MONSTER,0,0,1,RACE_PLANT,ATTRIBUTE_EARTH,POS_FACEUP_DEFENSE,1-tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
@@ -34,6 +35,7 @@ function c38041940.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and tc:IsRace(RACE_PLANT) and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
 		if Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
+			and not Duel.IsPlayerAffectedByEffect(tp,59822133)
 			and Duel.IsPlayerCanSpecialSummonMonster(tp,38041941,0,TYPES_TOKEN_MONSTER,0,0,1,RACE_PLANT,ATTRIBUTE_EARTH,POS_FACEUP_DEFENSE,1-tp) then
 			local token=Duel.CreateToken(tp,38041941)
 			Duel.SpecialSummonStep(token,0,tp,1-tp,false,false,POS_FACEUP_DEFENSE)

--- a/c53485634.lua
+++ b/c53485634.lua
@@ -45,7 +45,7 @@ end
 function c53485634.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c53485634.filter,nil,e,tp)
-	if not Duel.IsPlayerAffectedByEffect(tp,59822133) and c:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) then
 		if Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP_DEFENSE) then
 			local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 			if ft>0 and g:GetCount()>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then

--- a/c73355951.lua
+++ b/c73355951.lua
@@ -23,7 +23,8 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
 		and Duel.IsExistingTarget(s.filter,tp,LOCATION_REMOVED,0,1,nil,e,tp)
-		and Duel.IsExistingTarget(s.filter,tp,0,LOCATION_REMOVED,1,nil,e,tp) end
+		and Duel.IsExistingTarget(s.filter,tp,0,LOCATION_REMOVED,1,nil,e,tp)
+		and not Duel.IsPlayerAffectedByEffect(tp,59822133) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g1=Duel.SelectTarget(tp,s.filter,tp,LOCATION_REMOVED,0,1,1,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
@@ -33,10 +34,9 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetTargetsRelateToChain()
-	if #g==2 and Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
 	local sc1=g:Filter(Card.IsControler,nil,tp):GetFirst()
 	local sc2=g:Filter(Card.IsControler,nil,1-tp):GetFirst()
-	if sc1 and Duel.SpecialSummonStep(sc1,0,tp,1-tp,false,false,POS_FACEUP) and sc2 then
+	if sc1 and Duel.SpecialSummonStep(sc1,0,tp,1-tp,false,false,POS_FACEUP) and sc2 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		Duel.SpecialSummonStep(sc2,0,tp,tp,false,false,POS_FACEUP)
 	end
 	Duel.SpecialSummonComplete()

--- a/c9336190.lua
+++ b/c9336190.lua
@@ -51,7 +51,8 @@ function c9336190.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
 		and Duel.IsPlayerCanSpecialSummonCount(tp,2)
-		and Duel.IsExistingTarget(c9336190.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+		and Duel.IsExistingTarget(c9336190.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp)
+		and not Duel.IsPlayerAffectedByEffect(tp,59822133) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectTarget(tp,c9336190.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 	g:AddCard(e:GetHandler())
@@ -61,6 +62,7 @@ function c9336190.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)>0
+		and not Duel.IsPlayerAffectedByEffect(tp,59822133)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and c:IsRelateToEffect(e)
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,9336190,0x10db,TYPES_NORMAL_TRAP_MONSTER,0,0,tc:GetLevel(),RACE_WARRIOR,ATTRIBUTE_DARK) then
 		c:AddMonsterAttribute(TYPE_NORMAL,0,0,tc:GetLevel(),0,0)

--- a/c98905.lua
+++ b/c98905.lua
@@ -49,6 +49,7 @@ end
 function c98905.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local tc=Duel.GetFirstTarget()
+	if not tc:IsRelateToEffect(e) then return end
 	if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c98905.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc:GetCode())

--- a/c98905.lua
+++ b/c98905.lua
@@ -47,15 +47,14 @@ function c98905.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function c98905.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c98905.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc:GetCode())
 		if g:GetCount()>0 then
-			g:AddCard(tc)
-			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+			Duel.SpecialSummonStep(g:GetFirst(),0,tp,tp,false,false,POS_FACEUP)
 		end
 	end
+	Duel.SpecialSummonComplete()
 end


### PR DESCRIPTION
https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id210
「魔法名-「解体与统合」」的①效果处理时，「青眼精灵龙」的①效果适用的场合，只进行『作为对象的自己怪兽在对方场上特殊召唤』效果处理。
「救祓少女·马尔法」「雷帝家臣 密特拉」的①效果发动时，对方连锁发动「活死人的呼声」特殊召唤了「青眼精灵龙」的场合，「救祓少女·马尔法」「雷帝家臣 密特拉」的①效果处理时，只把自身特殊召唤，这个效果处理完毕。

fix special summon effect resolve about 青眼の精霊龍
card name and its effect 
雷帝家臣ミスラ's ①
魔法名－「解体し統合せよ」
エクソシスター・マルファ's ①
光波分光
真紅眼の遡刻竜's ①
幻影騎士団ミストクロウズ's ②
シード・オブ・フレイム