### PR TITLE
fix 究極融合

### DIFF
--- a/c71143015.lua
+++ b/c71143015.lua
@@ -29,7 +29,8 @@ function c71143015.filter1(c,e,tp,m,f,chkf)
 	return res
 end
 function c71143015.fcheck(tp,sg,fc)
-	return sg:IsExists(Card.IsFusionCode,1,nil,89631139) and aux.IsMaterialListCode(fc,89631139) or sg:IsExists(Card.IsFusionCode,1,nil,23995346) and aux.IsMaterialListCode(fc,23995346)
+	return sg:IsExists(Card.IsFusionCode,1,nil,89631139) and aux.IsMaterialListCode(fc,89631139)
+		or sg:IsExists(Card.IsFusionCode,1,nil,23995346) and aux.IsMaterialListCode(fc,23995346)
 end
 function c71143015.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c71143015.lua
+++ b/c71143015.lua
@@ -29,7 +29,7 @@ function c71143015.filter1(c,e,tp,m,f,chkf)
 	return res
 end
 function c71143015.fcheck(tp,sg,fc)
-	return sg:IsExists(Card.IsFusionCode,1,nil,89631139,23995346)
+	return sg:IsExists(Card.IsFusionCode,1,nil,89631139) and aux.IsMaterialListCode(fc,89631139) or sg:IsExists(Card.IsFusionCode,1,nil,23995346) and aux.IsMaterialListCode(fc,23995346)
 end
 function c71143015.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then


### PR DESCRIPTION
Q:「究极融合」の効果で「究极龙魔导师」を融合召喚する場合、３体の「青眼白龙」と「混沌」儀式モンスター１体を融合素材として使用できますか？

A:できません。

「究极融合」の効果で融合召喚を行う場合、その融合モンスターの融合素材としてカード名が記載された「青眼白龙」または「青眼究极龙」を１体以上融合素材とする必要があります。「究极龙魔导师」の融合素材としてカード名が記載されているのは「青眼究极龙」のみですので、必ずカード名が「青眼究极龙」であるモンスターを融合素材として含める必要があります。