### PR TITLE
fix--雷神龍－サンダー・ドラゴン

### DIFF
--- a/c41685633.lua
+++ b/c41685633.lua
@@ -44,8 +44,23 @@ end
 function c41685633.sprfilter1(c,sc)
 	return c:IsRace(RACE_THUNDER) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial(sc,SUMMON_TYPE_SPECIAL)
 end
+function c41685633.fusioncodechk(c,codetab)
+	local chk=0
+	for i=1,#codetab do
+		if codetab[i]~=41685633 then
+			chk=1
+		end
+	end
+	if chk==0 then
+		return false
+	else
+		return true
+	end
+end
 function c41685633.sprfilter2(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsFusionType(TYPE_FUSION) and not c:IsFusionCode(41685633)
+	local codetab={c:GetFusionCode()} 
+	local codechk=c41685633.fusioncodechk(c,codetab)
+	return c:IsLocation(LOCATION_MZONE) and c:IsFusionType(TYPE_FUSION) and codechk
 end
 function c41685633.fselect(g,tp,sc)
 	return aux.gffcheck(g,Card.IsLocation,LOCATION_HAND,c41685633.sprfilter2,nil)

--- a/c41685633.lua
+++ b/c41685633.lua
@@ -58,7 +58,7 @@ function c41685633.fusioncodechk(c,codetab)
 	end
 end
 function c41685633.sprfilter2(c)
-	local codetab={c:GetFusionCode()} 
+	local codetab={c:GetFusionCode()}
 	local codechk=c41685633.fusioncodechk(c,codetab)
 	return c:IsLocation(LOCATION_MZONE) and c:IsFusionType(TYPE_FUSION) and codechk
 end

--- a/c41685633.lua
+++ b/c41685633.lua
@@ -45,17 +45,13 @@ function c41685633.sprfilter1(c,sc)
 	return c:IsRace(RACE_THUNDER) and c:IsAbleToRemoveAsCost() and c:IsCanBeFusionMaterial(sc,SUMMON_TYPE_SPECIAL)
 end
 function c41685633.fusioncodechk(c,codetab)
-	local chk=0
 	for i=1,#codetab do
 		if codetab[i]~=41685633 then
-			chk=1
+			return true
+			break
 		end
 	end
-	if chk==0 then
-		return false
-	else
-		return true
-	end
+	return false
 end
 function c41685633.sprfilter2(c)
 	local codetab={c:GetFusionCode()}

--- a/c41685633.lua
+++ b/c41685633.lua
@@ -48,7 +48,6 @@ function c41685633.fusioncodechk(c,codetab)
 	for i=1,#codetab do
 		if codetab[i]~=41685633 then
 			return true
-			break
 		end
 	end
 	return false


### PR DESCRIPTION
Q.
「雷神龍－サンダー・ドラゴン」をフィールド上に持ち、「融合識別」を発動し、「双頭の雷龍」を公開しました。効果が発動した後、その「雷神龍－サンダー・ドラゴン」を除外して、エクストラデッキから「雷神龍－サンダー・ドラゴン」を特殊召喚することができるでしょうか。
A.
ご質問の場合、「雷神龍－サンダー・ドラゴン」を「双頭の雷龍」として、手札の雷族モンスター１体と除外して、「雷神龍－サンダー・ドラゴン」を特殊召喚できます。

fix 雷神龍－サンダー・ドラゴン can not be 雷神龍－サンダー・ドラゴン's fusion Material when 雷神龍－サンダー・ドラゴン's name can be treated as the revealed Fusion Monster's, if used for a Fusion Summon this turn.(Fusion Tag/融合識別，reveal 双頭の雷龍)
fix 双頭の雷龍 can not be 雷神龍－サンダー・ドラゴン's fusion Material when 双頭の雷龍's name can be treated as the revealed Fusion Monster's, if used for a Fusion Summon this turn.(Fusion Tag/融合識別，reveal 雷神龍－サンダー・ドラゴン)