### PR TITLE
Fix デモンズ・ゴーレム

### DIFF
--- a/c24662957.lua
+++ b/c24662957.lua
@@ -33,7 +33,7 @@ function c24662957.stfilter(c)
 end
 function c24662957.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
+	if tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
 		tc:RegisterFlagEffect(24662957,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,2)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)


### PR DESCRIPTION
About Remove Operation
そのモンスターを次のターンのエンドフェイズまで除外する。
Target card should be a monster so that could be banished.