### PR TITLE
change CancelToGrave

### DIFF
--- a/c1329620.lua
+++ b/c1329620.lua
@@ -44,8 +44,7 @@ end
 function c1329620.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()
 	if Duel.NegateActivation(ev) and ec:IsRelateToEffect(re) then
-		ec:CancelToGrave()
-		if Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
+		if Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 			local g=Duel.SelectMatchingCard(tp,c1329620.cfilter,tp,LOCATION_HAND,0,1,1,nil)
 			if #g>0 then

--- a/c25050038.lua
+++ b/c25050038.lua
@@ -20,13 +20,12 @@ function c25050038.recop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Recover(p,d,REASON_EFFECT)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
+	if not (c:IsRelateToEffect(e) and e:IsHasType(EFFECT_TYPE_ACTIVATE)) then return end
 	local ct=Duel.GetCurrentChain()
 	if ct>3 then
 		c:CancelToGrave()
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	elseif ct>1 then
-		c:CancelToGrave()
-		Duel.SendtoDeck(c,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		Duel.SendtoDeck(c,nil,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)
 	end
 end

--- a/c28877100.lua
+++ b/c28877100.lua
@@ -16,7 +16,8 @@ function c28877100.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c28877100.filter,tp,LOCATION_MZONE,0,1,nil)
 end
 function c28877100.activate(e,tp,eg,ep,ev,re,r,rp)
-	local e1=Effect.CreateEffect(e:GetHandler())
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
@@ -24,15 +25,14 @@ function c28877100.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(1)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
-	local e2=Effect.CreateEffect(e:GetHandler())
+	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
 	e2:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
 	e2:SetTargetRange(LOCATION_MZONE,0)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	e2:SetValue(1)
 	Duel.RegisterEffect(e2,tp)
-	if e:GetHandler():IsRelateToEffect(e) then
-		e:GetHandler():CancelToGrave()
-		Duel.SendtoDeck(e:GetHandler(),nil,SEQ_DECKBOTTOM,REASON_EFFECT)
+	if c:IsRelateToEffect(e) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		Duel.SendtoDeck(c,nil,SEQ_DECKBOTTOM,REASON_EFFECT,tp,true)
 	end
 end

--- a/c34507039.lua
+++ b/c34507039.lua
@@ -23,7 +23,6 @@ end
 function c34507039.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()
 	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
-		ec:CancelToGrave()
-		Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)
 	end
 end

--- a/c42444868.lua
+++ b/c42444868.lua
@@ -46,8 +46,7 @@ end
 function c42444868.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()
 	if Duel.NegateActivation(ev) and ec:IsRelateToEffect(re) then
-		ec:CancelToGrave()
-		if Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
+		if Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
 			local g=Duel.GetMatchingGroup(c42444868.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,nil,e,tp)
 			if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(42444868,0)) then
 				Duel.BreakEffect()

--- a/c51449743.lua
+++ b/c51449743.lua
@@ -20,7 +20,7 @@ function c51449743.damop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Damage(p,d,REASON_EFFECT)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
+	if not (c:IsRelateToEffect(e) and e:IsHasType(EFFECT_TYPE_ACTIVATE)) then return end
 	local ct=Duel.GetCurrentChain()
 	if ct>3 then
 		c:CancelToGrave()

--- a/c57831349.lua
+++ b/c57831349.lua
@@ -30,8 +30,7 @@ end
 function c57831349.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()
 	if Duel.NegateActivation(ev) and ec:IsRelateToEffect(re) then
-		ec:CancelToGrave()
-		if Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
+		if Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)~=0 and ec:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
 			local g=Duel.GetMatchingGroup(c57831349.desfilter,tp,LOCATION_ONFIELD,0,aux.ExceptThisCard(e))
 			if g:GetCount()>0 then
 				Duel.BreakEffect()

--- a/c59957503.lua
+++ b/c59957503.lua
@@ -39,7 +39,6 @@ end
 function c59957503.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ec=re:GetHandler()
 	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
-		ec:CancelToGrave()
-		Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		Duel.SendtoDeck(ec,nil,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)
 	end
 end

--- a/c63571750.lua
+++ b/c63571750.lua
@@ -11,14 +11,13 @@ function c63571750.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c63571750.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToDeck() end
+	if chk==0 then return e:IsCostChecked() and e:GetHandler():IsAbleToDeck() end
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c63571750.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	c:CancelToGrave()
-	Duel.SendtoDeck(c,tp,SEQ_DECKSHUFFLE,REASON_EFFECT)
+	Duel.SendtoDeck(c,tp,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)
 	if not c:IsLocation(LOCATION_DECK) then return end
 	Duel.ShuffleDeck(tp)
 	c:ReverseInDeck()

--- a/c66194206.lua
+++ b/c66194206.lua
@@ -20,14 +20,13 @@ function c66194206.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c66194206.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToDeck() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and e:GetHandler():IsAbleToDeck() end
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c66194206.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) then
-		c:CancelToGrave()
-		Duel.SendtoDeck(c,nil,SEQ_DECKTOP,REASON_EFFECT)
+		Duel.SendtoDeck(c,nil,SEQ_DECKTOP,REASON_EFFECT,tp,true)
 	end
 end
 function c66194206.thcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c86060749.lua
+++ b/c86060749.lua
@@ -33,7 +33,6 @@ end
 function c86060749.activate(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if Duel.NegateActivation(ev) and rc:IsRelateToEffect(re) then
-		rc:CancelToGrave()
-		Duel.SendtoDeck(rc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		Duel.SendtoDeck(rc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT,tp,true)
 	end
 end

--- a/c93078761.lua
+++ b/c93078761.lua
@@ -34,8 +34,7 @@ function c93078761.activate(e,tp,eg,ep,ev,re,r,rp)
 			c:CancelToGrave()
 			Duel.SendtoHand(c,nil,REASON_EFFECT)
 		elseif dice2>=2 and dice2<=5 then
-			c:CancelToGrave()
-			Duel.SendtoDeck(c,nil,SEQ_DECKTOP,REASON_EFFECT)
+			Duel.SendtoDeck(c,nil,SEQ_DECKTOP,REASON_EFFECT,tp,true)
 		end
 	end
 end


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro-core/pull/555

-----

>Q.
「トランザクション・ロールバック」の①の効果を発動した場合、相手の墓地の「ディフェンシブ・タクティクス」を対象に選択できますか？
A.
ご質問の場合、自分フィールド上に「剣闘獣」と名のついたモンスターが表側表示で存在するのであれば、「ディフェンシブ・タクティクス」を対象に発動することができ、発動後、このカードをデッキの一番下に戻します。
 
>Q.
「トランザクション・ロールバック」の②の効果を発動した場合、自分の墓地の「ディフェンシブ・タクティクス」を対象に選択できますか？
A.
ご質問の場合、自分フィールド上に「剣闘獣」と名のついたモンスターが表側表示で存在するのであれば、「ディフェンシブ・タクティクス」を対象に発動することができますが、『デッキの一番下に戻す』処理は行われません。
 
>Q.
「トランザクション・ロールバック」の①の効果を発動した場合、相手の墓地の「ライトロードの裁き」を対象に選択できますか？
A.
ご質問の場合、「ライトロードの裁き」を対象に「トランザクション・ロールバック」の『①』の効果を発動できます。
 
>Q.
「トランザクション・ロールバック」の②の効果を発動した場合、自分の墓地の「ライトロードの裁き」を対象に選択できますか？
A.
ご質問の場合、「ライトロードの裁き」を対象に「トランザクション・ロールバック」の『②』の効果を発動することはできません。