### PR TITLE
Fix ダーク・コーリング

### DIFF
--- a/c12071500.lua
+++ b/c12071500.lua
@@ -74,7 +74,7 @@ function c12071500.activate(e,tp,eg,ep,ev,re,r,rp)
 		else
 			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
 			local fop=ce:GetOperation()
-			fop(ce,e,tp,tc,mat2,SUMMON_TYPE_FUSION)
+			fop(ce,e,tp,tc,mat2,SUMMON_VALUE_DARK_FUSION)
 		end
 		tc:CompleteProcedure()
 	end


### PR DESCRIPTION
About Summon Type when fsummon with this card.
The summon type should treat as 【暗黑融合ダーク・フュージョンDark Fusion】 even though any【Chain_Metrial_Effect】 was used.