### PR TITLE
Fix 真なる太陽神

### DIFF
--- a/c11587414.lua
+++ b/c11587414.lua
@@ -56,8 +56,8 @@ end
 function s.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return (e:GetHandler():IsAbleToGrave()
 			or Duel.IsExistingMatchingCard(s.tgfilter1,tp,LOCATION_DECK,0,1,nil))
-		and Duel.IsExistingMatchingCard(s.tgfilter2,tp,LOCATION_ONFIELD,0,1,nil) end
-	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,2,tp,LOCATION_ONFIELD+LOCATION_DECK)
+		and Duel.IsExistingMatchingCard(s.tgfilter2,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,2,tp,LOCATION_MZONE+LOCATION_DECK)
 end
 function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -67,7 +67,7 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local sg1=g:Select(tp,1,1,nil)
 	if Duel.SendtoGrave(sg1,REASON_EFFECT)>0 and sg1:GetFirst():IsLocation(LOCATION_GRAVE) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		local sg2=Duel.SelectMatchingCard(tp,s.tgfilter2,tp,LOCATION_ONFIELD,0,1,1,nil)
+		local sg2=Duel.SelectMatchingCard(tp,s.tgfilter2,tp,LOCATION_MZONE,0,1,1,nil)
 		if #sg2>0 then
 			Duel.BreakEffect()
 			Duel.SendtoGrave(sg2,REASON_EFFECT)


### PR DESCRIPTION
About effect③
DB: 自分のモンスターゾーンに表側表示の「太阳神之翼神龙」が存在する状況で発動できます。
Could only send the 「太阳神之翼神龙」 on Mzone to grave.