### PR TITLE
Fix Fabled Kushano & The Fabled Chawa

### DIFF
--- a/c29905795.lua
+++ b/c29905795.lua
@@ -29,8 +29,7 @@ function c29905795.op(e,tp,eg,ep,ev,re,r,rp)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
 	local tc=g:Select(tp,1,1,nil):GetFirst()
-	if tc and Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)>0 and tc:IsLocation(LOCATION_GRAVE)
-		and c:IsRelateToEffect(e) then
+	if tc and Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)>0 and c:IsRelateToEffect(e) then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/c97439806.lua
+++ b/c97439806.lua
@@ -12,7 +12,7 @@ function c97439806.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c97439806.costfilter(c)
-	return c:IsSetCard(0x35) and c:IsType(TYPE_MONSTER) and not c:IsCode(97439806) and c:IsDiscardable()
+	return c:IsSetCard(0x35) and c:IsType(TYPE_MONSTER) and not c:IsCode(97439806) and c:IsDiscardable() and c:IsAbleToGraveAsCost()
 end
 function c97439806.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c97439806.costfilter,tp,LOCATION_HAND,0,1,nil) end

--- a/c97439806.lua
+++ b/c97439806.lua
@@ -12,7 +12,8 @@ function c97439806.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c97439806.costfilter(c)
-	return c:IsSetCard(0x35) and c:IsType(TYPE_MONSTER) and not c:IsCode(97439806) and c:IsDiscardable() and c:IsAbleToGraveAsCost()
+	return c:IsSetCard(0x35) and c:IsType(TYPE_MONSTER) and not c:IsCode(97439806)
+		and c:IsDiscardable() and c:IsAbleToGraveAsCost()
 end
 function c97439806.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c97439806.costfilter,tp,LOCATION_HAND,0,1,nil) end


### PR DESCRIPTION
Fabled Kushano:
> このカードが墓地に存在する場合、手札から「魔轟神クシャノ」以外の「魔轟神」モンスター１体を**墓地へ捨てて発動できる**。

The Fabled Chawa:
> 手札から「魔轟神」と名のついたモンスター１体を**捨て**、このカードを手札から特殊召喚する。