### PR TITLE
fix: `Necrovalley` + `G.B. Hunter` vs Pendulum

### DIFF
--- a/c13331639.lua
+++ b/c13331639.lua
@@ -141,6 +141,8 @@ function c13331639.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c13331639.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c13331639.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c18897163.lua
+++ b/c18897163.lua
@@ -119,6 +119,8 @@ function c18897163.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c18897163.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c18897163.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c19510093.lua
+++ b/c19510093.lua
@@ -84,6 +84,8 @@ function c19510093.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c19510093.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c19510093.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c22070401.lua
+++ b/c22070401.lua
@@ -116,6 +116,8 @@ function c22070401.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c22070401.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c22070401.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c22211622.lua
+++ b/c22211622.lua
@@ -139,6 +139,8 @@ function c22211622.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c22211622.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c22211622.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c24070330.lua
+++ b/c24070330.lua
@@ -115,6 +115,8 @@ function c24070330.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c24070330.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c24070330.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c24087580.lua
+++ b/c24087580.lua
@@ -75,6 +75,8 @@ function c24087580.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c24087580.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c24087580.penop(e,tp,eg,ep,ev,re,r,rp)
 	if not Duel.CheckLocation(tp,LOCATION_PZONE,0) and not Duel.CheckLocation(tp,LOCATION_PZONE,1) then return end

--- a/c26435595.lua
+++ b/c26435595.lua
@@ -44,6 +44,8 @@ function c26435595.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c26435595.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c26435595.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c30095833.lua
+++ b/c30095833.lua
@@ -96,6 +96,8 @@ function c30095833.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c30095833.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c30095833.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c31987203.lua
+++ b/c31987203.lua
@@ -69,6 +69,8 @@ function c31987203.thop2(e,tp,eg,ep,ev,re,r,rp)
 end
 function c31987203.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c31987203.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c33656832.lua
+++ b/c33656832.lua
@@ -53,6 +53,8 @@ function c33656832.spcon2(e,tp,eg,ep,ev,re,r,rp)
 end
 function c33656832.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c33656832.penop(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e) then

--- a/c3594985.lua
+++ b/c3594985.lua
@@ -1,0 +1,121 @@
+--マジェスペクター・ドラコ
+--lua by Gim J.Blocks
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,nil,4,2)
+	c:EnableReviveLimit()
+	--pendulum summon
+	aux.EnablePendulumAttribute(c,false)
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND+CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCountLimit(1,id)
+	e1:SetCondition(s.srcon)
+	e1:SetTarget(s.srtg)
+	e1:SetOperation(s.srop)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_RELEASE)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(2,id+o)
+	e2:SetCondition(s.spcon)
+	e2:SetCost(s.spcost)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+	--pendulum
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,2))
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_DESTROYED)
+	e3:SetProperty(EFFECT_FLAG_DELAY)
+	e3:SetCondition(s.pencon)
+	e3:SetTarget(s.pentg)
+	e3:SetOperation(s.penop)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EVENT_RELEASE)
+	c:RegisterEffect(e4)
+end
+s.pendulum_level=4
+function s.cfilter(c)
+	return c:IsSetCard(0xc7,0xd0)
+end
+function s.srcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_PZONE,0,1,e:GetHandler())
+end
+function s.srfilter(c,oc)
+	return c:IsSetCard(0xd0) and c:IsAbleToHand()
+end
+function s.srtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.srfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function s.srop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local tc=Duel.SelectMatchingCard(tp,s.srfilter,tp,LOCATION_DECK,0,1,1,nil):GetFirst()
+	if tc and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND) then
+		Duel.ConfirmCards(1-tp,tc)
+		Duel.ShuffleHand(tp)
+		local g=Duel.GetFieldGroup(tp,LOCATION_PZONE,0)
+		if #g>0 and Duel.SelectYesNo(tp,aux.Stringid(id,3)) then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+			local sg=g:Select(tp,1,1,nil)
+			Duel.BreakEffect()
+			Duel.HintSelection(sg)
+			Duel.Destroy(sg,REASON_EFFECT)
+		end
+	end
+end
+function s.cfilter2(c)
+	return (c:IsType(TYPE_MONSTER) and not c:IsPreviousLocation(LOCATION_SZONE)) or c:IsPreviousLocation(LOCATION_MZONE)
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.cfilter2,1,nil) and not eg:IsContains(e:GetHandler())
+end
+function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVEXYZ)
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function s.spfilter(c,e,tp)
+	return c:IsLevelBelow(6) and c:IsRace(RACE_SPELLCASTER) and c:IsAttribute(ATTRIBUTE_WIND)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,LOCATION_DECK)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function s.pencon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsFaceup()
+end
+function s.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
+end
+function s.penop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+	end
+end

--- a/c37491810.lua
+++ b/c37491810.lua
@@ -88,6 +88,8 @@ function c37491810.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c37491810.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c37491810.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c39943352.lua
+++ b/c39943352.lua
@@ -60,6 +60,8 @@ function c39943352.pencost1(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c39943352.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c39943352.pmfilter(c)
 	return c:IsType(TYPE_PENDULUM)

--- a/c40680521.lua
+++ b/c40680521.lua
@@ -131,6 +131,8 @@ function c40680521.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c40680521.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c40680521.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c43502497.lua
+++ b/c43502497.lua
@@ -1,0 +1,118 @@
+--coded by Lyris
+--Pendulum Witch
+local s, id, o = GetID()
+function s.initial_effect(c)
+	aux.EnablePendulumAttribute(c)
+	--to extra
+	aux.RegisterMergedDelayedEvent(c,id,EVENT_DESTROYED)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_TOEXTRA)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_CUSTOM+id)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCountLimit(1,id)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e1:SetCondition(s.txcon)
+	e1:SetTarget(s.txtg)
+	e1:SetOperation(s.txop)
+	c:RegisterEffect(e1)
+	--search
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_SEARCH+CATEGORY_TOHAND)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	e2:SetCountLimit(1,id+o)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e2:SetTarget(s.thtg)
+	e2:SetOperation(s.thop)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetCondition(s.thcon)
+	c:RegisterEffect(e3)
+	--to scale
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(id,2))
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_DESTROYED)
+	e4:SetProperty(EFFECT_FLAG_DELAY)
+	e4:SetCondition(s.pzcon)
+	e4:SetTarget(s.pztg)
+	e4:SetOperation(s.pzop)
+	c:RegisterEffect(e4)
+end
+function s.cfilter(c,tp,chk)
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousTypeOnField()&(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)>0
+		and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousControler(tp) and (c:IsReason(REASON_BATTLE)
+			or c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp)
+		and (not chk or Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil,c))
+end
+function s.chk(c,tc)
+	return c:GetOriginalRace()==tc:GetOriginalRace()
+end
+function s.filter(c,r)
+	if not c:IsType(TYPE_PENDULUM) then return false end
+	local t=type(r)
+	if t=='userdata' then
+		local v=aux.GetValueType(r)
+		if v=='Card' then return s.chk(c,r)
+		elseif v=='Group' then return r:IsExists(s.chk,1,c,c)
+		else return false end
+	elseif t=='number' then return c:GetOriginalRace()==r
+	else return false end
+end
+function s.txcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.cfilter,1,nil,tp)
+end
+function s.txtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local g=eg:Filter(s.cfilter,nil,tp,chk==0)
+	if chk==0 then return #g>0 end
+	Duel.SetTargetCard(g)
+	Duel.SetOperationInfo(0,CATEGORY_TOEXTRA,nil,1,tp,LOCATION_DECK)
+end
+function s.txop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetTargetsRelateToChain()
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,3))
+	local tg=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,g)
+	Duel.SendtoExtraP(tg,nil,REASON_EFFECT)
+end
+function s.sfilter(c)
+	return c:IsLevelBelow(4) and c:IsType(TYPE_PENDULUM) and c:IsAbleToHand()
+end
+function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_PZONE) and chkc:IsControler(tp) end
+	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_PZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(s.sfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_PZONE,0,1,1,nil)+e:GetHandler()
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,2,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function s.thop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	local g=Group.FromCards(c,tc):Filter(Card.IsRelateToChain,nil)
+	if #g<2 or Duel.Destroy(g,REASON_EFFECT)<2 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local sg=Duel.SelectMatchingCard(tp,s.sfilter,tp,LOCATION_DECK,0,1,1,nil)
+	Duel.SendtoHand(sg,nil,REASON_EFFECT)
+	Duel.ConfirmCards(1-tp,sg)
+end
+function s.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_PENDULUM)
+end
+function s.pzcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsFaceupEx()
+end
+function s.pztg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
+end
+function s.pzop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToChain() then Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true) end
+end

--- a/c45014450.lua
+++ b/c45014450.lua
@@ -148,7 +148,7 @@ function c45014450.penop(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) or Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c45014450.penfilter,tp,LOCATION_PZONE,0,1,1,nil,e,tp)
-	if g:GetCount()>0 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)>0 then
+	if g:GetCount()>0 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)>0 and aux.NecroValleyFilter()(c) then
 		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
 	end
 end

--- a/c45627618.lua
+++ b/c45627618.lua
@@ -104,8 +104,9 @@ function c45627618.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c45627618.penop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
 	local g=Duel.GetFieldGroup(tp,LOCATION_PZONE,0)
-	if Duel.Destroy(g,REASON_EFFECT)~=0 and e:GetHandler():IsRelateToEffect(e) then
-		Duel.MoveToField(e:GetHandler(),tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+	if Duel.Destroy(g,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) and aux.NecroValleyFilter()(c) then
+		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
 	end
 end

--- a/c46485778.lua
+++ b/c46485778.lua
@@ -69,6 +69,8 @@ function s.pzcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.pztg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function s.pzop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c46593546.lua
+++ b/c46593546.lua
@@ -117,6 +117,8 @@ function c46593546.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c46593546.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c46593546.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c48654267.lua
+++ b/c48654267.lua
@@ -1,0 +1,100 @@
+--覇王龍ズァーク－シンクロ・ユニバース
+local s,id,o=GetID()
+function s.initial_effect(c)
+	c:EnableReviveLimit()
+	aux.AddSynchroProcedure(c,nil,aux.NonTuner(s.matfilter),1)
+	--change code
+	aux.EnableChangeCode(c,13331639,LOCATION_ONFIELD)
+	--special summon from pendulum zone
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCountLimit(1,id)
+	e1:SetCost(s.pendspcost)
+	e1:SetTarget(s.pendsptg)
+	e1:SetOperation(s.pendspop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_BATTLED)
+	e2:SetCondition(s.spcon)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+	--pendulum
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,2))
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_DESTROYED)
+	e3:SetProperty(EFFECT_FLAG_DELAY)
+	e3:SetCondition(s.pencon)
+	e3:SetTarget(s.pentg)
+	e3:SetOperation(s.penop)
+	c:RegisterEffect(e3)
+end
+function s.matfilter(c)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_PENDULUM)
+end
+function s.cfilter(c,tp)
+	return c:IsSetCard(0x10f8,0x20f8) and Duel.GetMZoneCount(tp,c)>0
+end
+function s.pendspcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,s.cfilter,1,nil,tp) end
+	local g=Duel.SelectReleaseGroup(tp,s.cfilter,1,1,nil,tp)
+	Duel.Release(g,REASON_COST)
+end
+function s.pendsptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+end
+function s.pendspop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local bc=e:GetHandler():GetBattleTarget()
+	return (bc and bc:IsStatus(STATUS_BATTLE_DESTROYED)) or ep~=tp
+end
+function s.spfilter(c,e,tp)
+	return c:IsSetCard(0x20f8) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_GRAVE,0,1,e:GetHandler(),e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_GRAVE)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local ct=2
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
+	ct=math.min(ct,(Duel.GetLocationCount(tp,LOCATION_MZONE)))
+	if ct<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_GRAVE,0,1,ct,e:GetHandler(),e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+	end
+end
+function s.pencon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsFaceup()
+end
+function s.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
+end
+function s.penop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+	end
+end

--- a/c56677752.lua
+++ b/c56677752.lua
@@ -82,6 +82,8 @@ function c56677752.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c56677752.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c56677752.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c58074177.lua
+++ b/c58074177.lua
@@ -119,6 +119,8 @@ function c58074177.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c58074177.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c58074177.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c58707981.lua
+++ b/c58707981.lua
@@ -1,0 +1,84 @@
+--無孔砲塔-ディセイブラスター
+local s,id,o=GetID()
+function s.initial_effect(c)
+	aux.EnablePendulumAttribute(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_CHAIN_SOLVING)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCondition(s.discon)
+	e1:SetOperation(s.disop)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCountLimit(1,id+EFFECT_COUNT_CODE_OATH)
+	e2:SetCondition(s.hspcon)
+	e2:SetValue(s.hspval)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCondition(s.discon)
+	e3:SetOperation(s.disop)
+	c:RegisterEffect(e3)
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(id,0))
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_DESTROYED)
+	e4:SetProperty(EFFECT_FLAG_DELAY)
+	e4:SetCondition(s.pencon)
+	e4:SetTarget(s.pentg)
+	e4:SetOperation(s.penop)
+	c:RegisterEffect(e4)
+end
+function s.discon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local op,loc,seq2=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if loc&LOCATION_SZONE~=0 and seq2>4 then return false end
+	local seq1=aux.MZoneSequence(c:GetSequence())
+	seq2=aux.MZoneSequence(seq2)
+	return bit.band(loc,LOCATION_ONFIELD)~=0
+		and (op==1-tp and seq1==4-seq2 or op==tp and seq1==seq2)
+end
+function s.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,id)
+	Duel.NegateEffect(ev)
+end
+function s.hspzone(tp)
+	local zone=0
+	local lg=Duel.GetFieldGroup(tp,LOCATION_ONFIELD,LOCATION_ONFIELD)
+	for tc in aux.Next(lg) do
+		zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE,tp))
+	end
+	return bit.bnot(zone)
+end
+function s.hspcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	local zone=s.hspzone(tp)
+	return Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD,zone)>0
+end
+function s.hspval(e,c)
+	local tp=c:GetControler()
+	local zone=s.hspzone(tp)
+	return 0,zone
+end
+function s.pencon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsFaceup()
+end
+function s.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
+end
+function s.penop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+	end
+end

--- a/c6218704.lua
+++ b/c6218704.lua
@@ -145,6 +145,8 @@ function c6218704.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c6218704.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c6218704.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c66104644.lua
+++ b/c66104644.lua
@@ -141,6 +141,8 @@ function c66104644.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c66104644.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c66104644.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c66425726.lua
+++ b/c66425726.lua
@@ -119,6 +119,8 @@ function c66425726.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 		e:SetCategory(CATEGORY_DISABLE)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c66425726.spfilter(c,e,tp)
 	return c:IsSetCard(0x99) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0

--- a/c72402069.lua
+++ b/c72402069.lua
@@ -112,6 +112,8 @@ function c72402069.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c72402069.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c72402069.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c80896940.lua
+++ b/c80896940.lua
@@ -143,6 +143,8 @@ function c80896940.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c80896940.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c80896940.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c82112494.lua
+++ b/c82112494.lua
@@ -101,6 +101,8 @@ function c82112494.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c82112494.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c82112494.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c82661461.lua
+++ b/c82661461.lua
@@ -86,6 +86,8 @@ function c82661461.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c82661461.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c82661461.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c84569886.lua
+++ b/c84569886.lua
@@ -111,6 +111,8 @@ function c84569886.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c84569886.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c84569886.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c85969517.lua
+++ b/c85969517.lua
@@ -1,4 +1,6 @@
 --海造賊－荘重のヨルズ号
+--Plunder Patrollship Jord
+--Scripted by XGlitchy30
 local s,id,o=GetID()
 function s.initial_effect(c)
 	aux.EnablePendulumAttribute(c,false)
@@ -17,7 +19,7 @@ function s.initial_effect(c)
 	--search
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,1))
-	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH+CATEGORY_SPECIAL_SUMMON+CATEGORY_DECKDES)
+	e2:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
@@ -68,7 +70,7 @@ function s.tktg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATTRIBUTE)
 	local attr=Duel.AnnounceAttribute(tp,1,s.GetLegalAttributesOnly(tp))
 	Duel.SetTargetParam(attr)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,c,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,c,1,tp,LOCATION_PZONE)
 	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,PLAYER_ALL,0)
 end
@@ -77,13 +79,13 @@ function s.tkop(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) or Duel.SendtoDeck(c,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)==0 or not c:IsLocation(LOCATION_EXTRA) then return end
 	local attr=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	if not attr or attr==0
-		or not Duel.IsPlayerCanSpecialSummonMonster(tp,id+o,0x13f,TYPES_TOKEN_MONSTER,0,0,4,RACE_FIEND,attr,POS_FACEUP_DEFENSE,tp)
-		or not Duel.IsPlayerCanSpecialSummonMonster(tp,id+o,0x13f,TYPES_TOKEN_MONSTER,0,0,4,RACE_FIEND,attr,POS_FACEUP_DEFENSE,1-tp)
+		or not Duel.IsPlayerCanSpecialSummonMonster(tp,id+o,0x13f,TYPES_TOKEN_MONSTER,0,0,4,RACE_FIEND,a,POS_FACEUP_DEFENSE,tp)
+		or not Duel.IsPlayerCanSpecialSummonMonster(tp,id+o,0x13f,TYPES_TOKEN_MONSTER,0,0,4,RACE_FIEND,a,POS_FACEUP_DEFENSE,1-tp)
 		or Duel.GetMZoneCount(tp,c)<=0 or Duel.GetMZoneCount(1-tp,c,tp)<=0
 		or Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		return
 	end
-	for p in aux.TurnPlayers() do
+	for p=tp,1-tp,1-2*tp do
 		local token=Duel.CreateToken(tp,id+o)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -133,14 +135,14 @@ function s.thtg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		and (Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1)) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectTarget(tp,s.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,#g,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,#g,tp,LOCATION_GRAVE)
 end
 function s.thop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND)
 		and (Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1))
-		and c:IsRelateToEffect(e) and not c:IsForbidden() then
+		and c:IsRelateToEffect(e) and not c:IsForbidden() and aux.NecroValleyFilter()(c) then
 		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
 	end
 end

--- a/c87468732.lua
+++ b/c87468732.lua
@@ -115,7 +115,7 @@ function c87468732.tpop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
 		if not Duel.CheckLocation(tp,LOCATION_PZONE,0) and not Duel.CheckLocation(tp,LOCATION_PZONE,1) then return end
-		if c:IsRelateToEffect(e) then
+		if c:IsRelateToEffect(e) and aux.NecroValleyFilter()(c) then
 			Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
 		end
 	end

--- a/c90036274.lua
+++ b/c90036274.lua
@@ -106,6 +106,8 @@ function c90036274.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c90036274.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c90036274.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c90276649.lua
+++ b/c90276649.lua
@@ -1,0 +1,108 @@
+--幻奏の歌姫クープレ
+function c90276649.initial_effect(c)
+	aux.EnablePendulumAttribute(c)
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_FIELD)
+	e0:SetRange(LOCATION_PZONE)
+	e0:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e0:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_CANNOT_DISABLE)
+	e0:SetTargetRange(1,0)
+	e0:SetTarget(c90276649.splimit)
+	c:RegisterEffect(e0)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(90276649,0))
+	e1:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCountLimit(1,90276649)
+	e1:SetCondition(c90276649.thcon)
+	e1:SetTarget(c90276649.thtg)
+	e1:SetOperation(c90276649.thop)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(90276649,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_TO_HAND)
+	e2:SetCountLimit(1,101204110)
+	e2:SetCondition(c90276649.spcon)
+	e2:SetCost(c90276649.spcost)
+	e2:SetTarget(c90276649.sptg)
+	e2:SetOperation(c90276649.spop)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(90276649,2))
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetProperty(EFFECT_FLAG_DELAY)
+	e3:SetRange(LOCATION_EXTRA)
+	e3:SetCountLimit(1,101204210)
+	e3:SetCondition(c90276649.pencon)
+	e3:SetTarget(c90276649.pentg)
+	e3:SetOperation(c90276649.penop)
+	c:RegisterEffect(e3)
+end
+function c90276649.splimit(e,c,tp,sumtp,sumpos)
+	return not c:IsAttribute(ATTRIBUTE_LIGHT) and bit.band(sumtp,SUMMON_TYPE_PENDULUM)==SUMMON_TYPE_PENDULUM 
+end
+function c90276649.thcfilter(c)
+	return c:IsFaceup() and not c:IsSetCard(0x9b)
+end
+function c90276649.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return not Duel.IsExistingMatchingCard(c90276649.thcfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c90276649.thfilter(c)
+	return c:IsSetCard(0x9b) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToHand()
+end
+function c90276649.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c90276649.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c90276649.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c90276649.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c90276649.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return not (r==REASON_RULE)
+end
+function c90276649.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not e:GetHandler():IsPublic() end
+end
+function c90276649.spfilter(c,e,tp)
+	return c:IsLevelBelow(4) and c:IsSetCard(0x9b) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c90276649.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c90276649.spfilter,tp,LOCATION_GRAVE+LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE+LOCATION_HAND)
+end
+function c90276649.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c90276649.spfilter),tp,LOCATION_GRAVE+LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c90276649.cfilter(c,tp)
+	return c:IsFaceup() and c:IsType(TYPE_FUSION) and c:IsSetCard(0x9b) and c:IsControler(tp)
+end
+function c90276649.pencon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsFaceup() and eg:IsExists(c90276649.cfilter,1,nil,tp)
+end
+function c90276649.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
+end
+function c90276649.penop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and (Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1)) then
+		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+	end
+end

--- a/c90587641.lua
+++ b/c90587641.lua
@@ -103,7 +103,7 @@ function c90587641.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sg=g:Select(tp,1,1,nil)
 	if Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)>0
-		and c:IsRelateToEffect(e) and (Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1))
+		and c:IsRelateToEffect(e) and (Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1)) and aux.NecroValleyFilter()(c)
 		and Duel.SelectYesNo(tp,aux.Stringid(90587641,2)) then
 		Duel.BreakEffect()
 		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)

--- a/c92559258.lua
+++ b/c92559258.lua
@@ -132,6 +132,8 @@ function c92559258.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c92559258.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c92559258.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c93729065.lua
+++ b/c93729065.lua
@@ -164,6 +164,8 @@ function c93729065.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c93729065.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c93729065.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c95568112.lua
+++ b/c95568112.lua
@@ -95,6 +95,8 @@ function c95568112.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c95568112.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c95568112.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c95685352.lua
+++ b/c95685352.lua
@@ -98,6 +98,8 @@ function c95685352.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c95685352.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c95685352.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c96227613.lua
+++ b/c96227613.lua
@@ -145,6 +145,8 @@ function c96227613.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c96227613.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c96227613.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c97417863.lua
+++ b/c97417863.lua
@@ -109,7 +109,7 @@ function c97417863.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)==0 then return end
 	c:CompleteProcedure()
 	local g=Duel.GetMatchingGroup(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
-	if Duel.Destroy(g,REASON_EFFECT)>0 and Duel.SelectYesNo(tp,aux.Stringid(97417863,1)) then
+	if Duel.Destroy(g,REASON_EFFECT)>0 and aux.NecroValleyFilter()(c) and Duel.SelectYesNo(tp,aux.Stringid(97417863,1)) then
 		Duel.BreakEffect()
 		Duel.MoveToField(c,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
 	end

--- a/c98452268.lua
+++ b/c98452268.lua
@@ -123,6 +123,8 @@ function c98452268.pencon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c98452268.pentg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1) end
+	local c=e:GetHandler()
+	if c:IsLocation(LOCATION_GRAVE) then Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,c,1,0,0) end
 end
 function c98452268.penop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
Effects like that of `Majespecter Draco - Ryu` should be negated if any attempt is made to move it from the GY to a different place, but a loophole was present where Ryu _can_ set itself from the GY into a Pendulum Scale while `Necrovalley` is active.

This should _not_ be the case.