### PR TITLE
Fix 転生炎獣レイジング・フェニックス

### DIFF
--- a/c57134592.lua
+++ b/c57134592.lua
@@ -68,7 +68,7 @@ end
 function s.cfilter(c,tp)
 	return not c:IsType(TYPE_TOKEN) and c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousControler(tp)
 		and c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousAttributeOnField()&ATTRIBUTE_FIRE~=0
-		and c:IsReason(REASON_BATTLE+REASON_EFFECT)
+		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsAttackAbove(1)
 end
 function s.tgfilter(c,e,tp)
 	return s.cfilter(c,tp) and c:IsCanBeEffectTarget(e)


### PR DESCRIPTION
この効果を発動する際に、破壊された（墓地または除外状態の）モンスター１体を対象として選択します。**ただし、カードに記載されている攻撃力が０や？であるモンスターは選択できません。**