### PR TITLE
fix--ハーピィの羽根吹雪

### DIFF
--- a/c87639778.lua
+++ b/c87639778.lua
@@ -5,6 +5,7 @@ function c87639778.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCondition(c87639778.condition)
+	e1:SetTarget(c87639778.target)
 	e1:SetOperation(c87639778.activate)
 	c:RegisterEffect(e1)
 	--act in hand
@@ -32,6 +33,9 @@ end
 function c87639778.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c87639778.disfilter,tp,LOCATION_MZONE,0,1,nil)
 end
+function c87639778.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFlagEffect(tp,87639778)==0 end
+end
 function c87639778.activate(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -40,6 +44,7 @@ function c87639778.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetOperation(c87639778.disop)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
+	Duel.RegisterFlagEffect(tp,87639778,RESET_PHASE+PHASE_END,0,0)
 end
 function c87639778.discon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_MONSTER) and rp==1-tp


### PR DESCRIPTION
Ｑ：自分フィールドに《深淵に潜む者》Ａ、Ｂが存在しています。
　　Ａが(2)の効果を発動し効果が適用された同一ターン中に、Ｂの《深淵に潜む者》は効果を発動できますか？
Ａ：自分が１体目の《深淵に潜む者》の効果を発動し、「このターン、相手は墓地のカードの効果を発動できない」がすでに適用されたターン中、自分は２体目の《深淵に潜む者》の効果を発動する事自体ができません。(21/06/16)

fix player can activate the second ハーピィの羽根吹雪 when first ハーピィの羽根吹雪's effect is solved.