### PR TITLE
fix--青い涙の天使

### DIFF
--- a/c91706817.lua
+++ b/c91706817.lua
@@ -1,6 +1,8 @@
 --青い涙の天使
 local s,id,o=GetID()
 function s.initial_effect(c)
+	--same effect send this card to grave and summon another card check
+	local e0=aux.AddThisCardInGraveAlreadyCheck(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
@@ -20,6 +22,7 @@ function s.initial_effect(c)
 	e2:SetCode(EVENT_DAMAGE)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetCountLimit(1,id)
+	e2:SetLabelObject(e0)
 	e2:SetCondition(s.setcon)
 	e2:SetCost(aux.bfgcost)
 	e2:SetTarget(s.settg)
@@ -70,7 +73,8 @@ function s.setcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_EFFECT)~=0
 end
 function s.setfilter(c)
-	return c:GetType()==TYPE_TRAP and c:IsSSetable()
+	local se=e:GetLabelObject():GetLabelObject()
+	return bit.band(r,REASON_EFFECT)~=0 and (se==nil or e:GetHandler():GetReasonEffect()~=se)
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.setfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil) end

--- a/c91706817.lua
+++ b/c91706817.lua
@@ -70,11 +70,11 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.setcon(e,tp,eg,ep,ev,re,r,rp)
-	return bit.band(r,REASON_EFFECT)~=0
-end
-function s.setfilter(c)
 	local se=e:GetLabelObject():GetLabelObject()
 	return bit.band(r,REASON_EFFECT)~=0 and (se==nil or e:GetHandler():GetReasonEffect()~=se)
+end
+function s.setfilter(c)
+	return c:GetType()==TYPE_TRAP and c:IsSSetable()
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.setfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil) end


### PR DESCRIPTION
https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id243 2023/11/13
「命运毁灭」的效果处理时，「蓝泪的天使」送去墓地，受到1000伤害的场合，由于送去墓地和受到伤害是同时处理，不能发动「蓝泪的天使」的②效果。

fix  when デステニー・デストロイ's effect send 青い涙の天使 to grave and gain damage, 青い涙の天使 can activate its ② effect