### PR TITLE
fix--E・HERO ブラック・ネオス

### DIFF
--- a/c28677304.lua
+++ b/c28677304.lua
@@ -49,7 +49,7 @@ end
 function c28677304.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) and not tc:IsImmuneToEffect(e) then
 		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
fix E・HERO ブラック・ネオス's effect can disable monster which unaffected by  activated effects.

タイトル：
エクシーズ素材を５つ持っている「历练纯爱妖精·黑暗妖精」を対象に「幻变骚灵·查询昆提兰那克」の②の効果を発動した場合どうなりますか？

質問：
相手のモンスターゾーンには、エクシーズ素材を５つ持っており、①の『X素材を５つ以上持っているこのカードは相手が発動した効果を受けない』効果が適用されている「历练纯爱妖精·黑暗妖精」が存在しています。
その「历练纯爱妖精·黑暗妖精」を対象として、「幻变骚灵·查询昆提兰那克」の②の『このカードが特殊召喚に成功した場合、相手フィールドの表側表示のカード１枚を対象として発動できる。このモンスターが表側表示で存在する間、そのカードの効果は無効化される』効果を発動した場合、「历练纯爱妖精·黑暗妖精」の効果は無効化されますか？

回答：
その「幻变骚灵·查询昆提兰那克」の②の効果の処理時に、対象の「历练纯爱妖精·黑暗妖精」がエクシーズ素材を５つ以上持っているのであれば、①の効果により「幻变骚灵·查询昆提兰那克」の②の効果を受けませんので、「历练纯爱妖精·黑暗妖精」の効果は無効化されません。
なお、その後「历练纯爱妖精·黑暗妖精」のエクシーズ素材が４つ以下になったとしても、効果が無効化されることはありません。