### PR TITLE
fix--S：Pリトルナイト

### DIFF
--- a/c29301450.lua
+++ b/c29301450.lua
@@ -107,6 +107,10 @@ end
 function s.retfilter(c,fid)
 	return c:GetFlagEffectLabel(id)==fid
 end
+function s.retchkfilter(c)
+	local tp=c:GetPreviousControler()
+	return Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD)>0
+end
 function s.retcon(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetLabelObject():IsExists(s.retfilter,1,nil,e:GetLabel()) then
 		e:GetLabelObject():DeleteGroup()
@@ -119,9 +123,11 @@ function s.retop(e,tp,eg,ep,ev,re,r,rp)
 	local fid=e:GetLabel()
 	local g=e:GetLabelObject():Filter(s.retfilter,nil,fid)
 	if #g<=0 then return end
+	local g1=g:Filter(s.retchkfilter,nil)
+	local g2=Group.__sub(g,g1)
 	Duel.Hint(HINT_CARD,0,id)
 	for p in aux.TurnPlayers() do
-		local tg=g:Filter(Card.IsPreviousControler,nil,p)
+		local tg=g1:Filter(Card.IsPreviousControler,nil,p)
 		local ft=Duel.GetLocationCount(p,LOCATION_MZONE)
 		if #tg>1 and ft==1 then
 			Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TOFIELD)
@@ -132,6 +138,9 @@ function s.retop(e,tp,eg,ep,ev,re,r,rp)
 		for tc in aux.Next(tg) do
 			Duel.ReturnToField(tc)
 		end
+	end
+	if g2~=0 then
+		Duel.SendtoGrave(g2,REASON_RETURN+REASON_RULE)
 	end
 	e:GetLabelObject():DeleteGroup()
 end

--- a/c29301450.lua
+++ b/c29301450.lua
@@ -139,7 +139,7 @@ function s.retop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.ReturnToField(tc)
 		end
 	end
-	if g2~=0 then
+	if #g2>0 then
 		Duel.SendtoGrave(g2,REASON_RETURN+REASON_RULE)
 	end
 	e:GetLabelObject():DeleteGroup()

--- a/c29301450.lua
+++ b/c29301450.lua
@@ -109,7 +109,7 @@ function s.retfilter(c,fid)
 end
 function s.retchkfilter(c)
 	local tp=c:GetPreviousControler()
-	return Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD)>0
+	return Duel.GetMZoneCount(tp,nil,tp,LOCATION_REASON_TOFIELD)>0
 end
 function s.retcon(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetLabelObject():IsExists(s.retfilter,1,nil,e:GetLabel()) then

--- a/c29301450.lua
+++ b/c29301450.lua
@@ -124,7 +124,7 @@ function s.retop(e,tp,eg,ep,ev,re,r,rp)
 	local g=e:GetLabelObject():Filter(s.retfilter,nil,fid)
 	if #g<=0 then return end
 	local g1=g:Filter(s.retchkfilter,nil)
-	local g2=Group.__sub(g,g1)
+	local g2=g-g1
 	Duel.Hint(HINT_CARD,0,id)
 	for p in aux.TurnPlayers() do
 		local tg=g1:Filter(Card.IsPreviousControler,nil,p)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=24001&keyword=&tag=-1&request_locale=ja
タイトル：
「皇帝斗技场」によってモンスターを出せない状況で、一時的に除外されたお互いのモンスターを同時にフィールドに戻せますか？
質問：
「S：P小夜」の②の『相手の効果が発動した時、自分フィールドのモンスターを含むフィールドの表側表示モンスター２体を対象として発動できる。そのモンスター２体をエンドフェイズまで除外する』効果によって、お互いのモンスターが１体ずつ除外されました。
このターンのエンドフェイズに、自分の「皇帝斗技场」が存在し、かつ以下の場合それぞれにおいて、「S：P小夜」の効果で除外したモンスターをお互いのフィールドに戻せますか？
(A)自分フィールドにモンスターが存在せず、相手フィールドにもモンスターが存在しない場合
(B)自分フィールドにモンスターが存在せず、相手フィールドにモンスターが存在する場合
(C)自分フィールドにモンスターが存在し、相手フィールドのモンスターの数が自分フィールドのモンスターの数より少ない場合
(D)自分フィールドにモンスターが存在し、相手フィールドのモンスターの数が自分フィールドのモンスターの数と同じ場合
(E)自分フィールドにモンスターが存在し、相手フィールドのモンスターの数が自分フィールドのモンスターの数より多い場合

回答：
同一の効果にて一時的に除外されている複数体のモンスターをフィールドに戻す際には、まずそのそれぞれについてフィールドに戻せるかどうかを確認します。戻せるモンスターが複数存在する場合にはそのすべてを同時にフィールドに戻し、戻せないモンスターは墓地へ置かれます。（ターンプレイヤーや「S：P小夜」のコントローラーがいずれのプレイヤーであるかは結果に影響しません。）
具体的に、それぞれの場合において以下の処理を行います。
(A)(B)(C)の場合、お互いのモンスターを戻す処理を行う際、「皇帝斗技场」によってモンスターを出すことが制限されていない状況ですので、相手フィールドのモンスターの数に関わらず、除外されているモンスターはいずれもフィールドに戻せるモンスターということになります。
そのため、２体はそれぞれのフィールドに戻ります。
(D)(E)の場合、お互いのモンスターを戻す処理を行う際、自分はモンスターを出せますが、相手は「皇帝斗技场」によってモンスターを出せない状況ですので、自分のモンスターのみフィールドに戻せるモンスターということになります。
そのため、自分のモンスターはフィールドに戻り、相手のモンスターは墓地へ置かれます。（相手のモンスターは墓地へ送られた扱いになりません。）

「S：P小夜」的②效果让双方怪兽各1只直到结束阶段除外后，结束阶段时，我方场上存在「皇帝斗技场」和1只怪兽的状况，如果对方场上存在怪兽，只让我方怪兽回到场上。一时除外的多只怪兽回到场上时，先确认每只是否可以回到场上，让其中可以回到场上的怪兽都回到场上，不能回到场上的怪兽放置到墓地。23/7/29
fix S：Pリトルナイト's effect can not send monster to grave correctly when カイザーコロシアム is on field。