### PR TITLE
Fix 蛇眼の大炎魔

### DIFF
--- a/c27260347.lua
+++ b/c27260347.lua
@@ -38,17 +38,19 @@ function s.mvcon(e,tp,eg,ep,ev,re,r,rp)
 	else
 		ft2=ft2+1
 	end
-	e:SetLabelObject(ac)
 	return ac and ac:IsControler(1-tp) and Duel.GetLocationCount(tp,LOCATION_SZONE)>=ft1
 		and Duel.GetLocationCount(1-tp,LOCATION_SZONE)>=ft2
 end
 function s.mvtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	local c=e:GetHandler()
+	local ac=c:GetBattleTarget()
+	if chk==0 then return ac~=nil end
+	Duel.SetTargetCard(ac)
 end
 function s.mvop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local ac=e:GetLabelObject()
-	if not ac:IsRelateToBattle() or not c:IsRelateToEffect(e) then return false end
+	local ac=Duel.GetFirstTarget()
+	if not ac:IsRelateToEffect(e) or not c:IsRelateToEffect(e) or ac:IsStatus(STATUS_BATTLE_DESTROYED) or c:IsStatus(STATUS_BATTLE_DESTROYED) or not ac:IsControler(1-tp) then return false end
 	local ft1=0
 	local ft2=0
 	if c:GetOwner()==tp then


### PR DESCRIPTION
「[蛇眼大炎魔](https://ygocdb.com/card/name/%E8%9B%87%E7%9C%BC%E5%A4%A7%E7%82%8E%E9%AD%94)」攻击对方「[青眼白龙](https://ygocdb.com/card/name/%E9%9D%92%E7%9C%BC%E7%99%BD%E9%BE%99)」，发动①效果时，对方连锁发动「[No.38 希望魁龙 银河巨神](https://ygocdb.com/card/name/No.38%20%E5%B8%8C%E6%9C%9B%E9%AD%81%E9%BE%99%20%E9%93%B6%E6%B2%B3%E5%B7%A8%E7%A5%9E)」②效果的场合，如果「[No.38 希望魁龙 银河巨神](https://ygocdb.com/card/name/No.38%20%E5%B8%8C%E6%9C%9B%E9%AD%81%E9%BE%99%20%E9%93%B6%E6%B2%B3%E5%B7%A8%E7%A5%9E)」是攻击表示，导致「[蛇眼大炎魔](https://ygocdb.com/card/name/%E8%9B%87%E7%9C%BC%E5%A4%A7%E7%82%8E%E9%AD%94)」确定被战斗破坏的状况，这个①效果不适用，都不会变成永续魔法卡；如果「[No.38 希望魁龙 银河巨神](https://ygocdb.com/card/name/No.38%20%E5%B8%8C%E6%9C%9B%E9%AD%81%E9%BE%99%20%E9%93%B6%E6%B2%B3%E5%B7%A8%E7%A5%9E)」是守备表示，「[蛇眼大炎魔](https://ygocdb.com/card/name/%E8%9B%87%E7%9C%BC%E5%A4%A7%E7%82%8E%E9%AD%94)」没有被战斗破坏的状况，这个①效果适用，「[蛇眼大炎魔](https://ygocdb.com/card/name/%E8%9B%87%E7%9C%BC%E5%A4%A7%E7%82%8E%E9%AD%94)」和「[青眼白龙](https://ygocdb.com/card/name/%E9%9D%92%E7%9C%BC%E7%99%BD%E9%BE%99)」当作永续魔法卡表侧表示放置到原本持有者的魔法·陷阱卡区域。