### PR TITLE
Fix 通販売員

### DIFF
--- a/c89928517.lua
+++ b/c89928517.lua
@@ -27,22 +27,17 @@ function c89928517.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Group.FromCards(tc1,tc2)
 	Duel.ConfirmCards(tp,tg)
 	if tc1:IsType(TYPE_MONSTER) and tc2:IsType(TYPE_MONSTER) then
-		local cpl={tp,1-tp}
-		local pl={}
-		for _,p in ipairs(cpl) do
-			local tc=tg:Filter(Card.IsControler,nil,p):GetFirst()
-			if Duel.GetLocationCount(p,LOCATION_MZONE,p)>0
-				and tc:IsCanBeSpecialSummoned(e,0,p,false,false) then
-				table.insert(pl,p)
-			end
-		end
-		for _,p in ipairs(pl) do
+		local i=0
+		local p=tp
+		while i<=1 do
 			local tc=tg:Filter(Card.IsControler,nil,p):GetFirst()
 			if Duel.GetLocationCount(p,LOCATION_MZONE,p)>0
 				and tc:IsCanBeSpecialSummoned(e,0,p,false,false)
 				and Duel.SelectYesNo(p,aux.Stringid(89928517,1)) then
 				Duel.SpecialSummonStep(tc,0,p,p,false,false,POS_FACEUP)
 			end
+			i=i+1
+			p=1-tp
 		end
 		Duel.SpecialSummonComplete()
 	elseif tc1:IsType(TYPE_SPELL) and tc2:IsType(TYPE_SPELL) then

--- a/c89928517.lua
+++ b/c89928517.lua
@@ -27,17 +27,22 @@ function c89928517.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Group.FromCards(tc1,tc2)
 	Duel.ConfirmCards(tp,tg)
 	if tc1:IsType(TYPE_MONSTER) and tc2:IsType(TYPE_MONSTER) then
-		local i=0
-		local p=tp
-		while i<=1 do
+		local cpl={tp,1-tp}
+		local pl={}
+		for _,p in ipairs(cpl) do
 			local tc=tg:Filter(Card.IsControler,nil,p):GetFirst()
-			if Duel.GetLocationCount(p,LOCATION_MZONE)>0
+			if Duel.GetLocationCount(p,LOCATION_MZONE,p)>0
+				and tc:IsCanBeSpecialSummoned(e,0,p,false,false) then
+				table.insert(pl,p)
+			end
+		end
+		for _,p in ipairs(pl) do
+			local tc=tg:Filter(Card.IsControler,nil,p):GetFirst()
+			if Duel.GetLocationCount(p,LOCATION_MZONE,p)>0
 				and tc:IsCanBeSpecialSummoned(e,0,p,false,false)
 				and Duel.SelectYesNo(p,aux.Stringid(89928517,1)) then
 				Duel.SpecialSummonStep(tc,0,p,p,false,false,POS_FACEUP)
 			end
-			i=i+1
-			p=1-tp
 		end
 		Duel.SpecialSummonComplete()
 	elseif tc1:IsType(TYPE_SPELL) and tc2:IsType(TYPE_SPELL) then


### PR DESCRIPTION
对方场上存在「[皇帝斗技场](https://ygocdb.com/card/name/%E7%9A%87%E5%B8%9D%E6%96%97%E6%8A%80%E5%9C%BA)」，双方场上各只存在1只「[通贩卖员](https://ygocdb.com/card/name/%E9%80%9A%E8%B4%A9%E5%8D%96%E5%91%98)」的状况，不论是哪个玩家在自己回合发动「[通贩卖员](https://ygocdb.com/card/name/%E9%80%9A%E8%B4%A9%E5%8D%96%E5%91%98)」的①效果，双方各自把1只「[青眼白龙](https://ygocdb.com/card/name/%E9%9D%92%E7%9C%BC%E7%99%BD%E9%BE%99)」给对方观看的场合，只有对方可以特殊召唤那只「[青眼白龙](https://ygocdb.com/card/name/%E9%9D%92%E7%9C%BC%E7%99%BD%E9%BE%99)」，我方不能特殊召唤。