### PR TITLE
fix--トリックスター・コルチカ

### DIFF
--- a/c298846.lua
+++ b/c298846.lua
@@ -32,7 +32,7 @@ function s.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return not eg:IsContains(e:GetHandler()) and eg:IsExists(s.damfilter,1,nil,tp,e)
 end
 function s.tgfilter(c,e)
-	return c:IsFaceupEx() and c:GetBaseAttack()>0 and c:IsType(TYPE_MONSTER) and c:IsCanBeEffectTarget(e)
+	return not c:IsType(TYPE_TOKEN) and c:IsFaceupEx() and c:GetBaseAttack()>0 and c:IsType(TYPE_MONSTER) and c:IsCanBeEffectTarget(e)
 end
 function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end


### PR DESCRIPTION
fix トリックスター・コルチカ's effect can target token monster which is destroyed by battle and crash the game.