### PR TITLE
fix--閉ザサレシ天ノ月

### DIFF
--- a/c71818935.lua
+++ b/c71818935.lua
@@ -28,15 +28,15 @@ function s.lmop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	local c=e:GetHandler()
 	if tc and tc:IsRelateToEffect(e) then
-		if not tc:IsImmuneToEffect(e) then
-			tc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
-		end
+		local fid=c:GetFieldID()
+		c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1,fid)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 		e1:SetCode(EFFECT_EXTRA_LINK_MATERIAL)
 		e1:SetRange(LOCATION_MZONE)
 		e1:SetLabelObject(c)
+		e1:SetLabel(fid)
 		e1:SetCondition(s.mcon)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		e1:SetValue(s.matval)
@@ -49,6 +49,7 @@ function s.mcon(e)
 end
 function s.matval(e,lc,mg,c,tp)
 	local ct=e:GetLabelObject()
-	if not lc:IsLink(5) then return false,nil end
+	local fid=e:GetLabel()
+	if not lc:IsLink(5) or ct:GetFlagEffectLabel(id)~=fid then return false,nil end
 	return true,not mg or mg:IsContains(ct)
 end


### PR DESCRIPTION
fix player can use opponent's monster as link material when 閉ザサレシ天ノ月 leave field and special summon again.
修复闭锁天之月发动效果并适用后，闭锁天之月离场后再次特招那只闭锁天之月后，可以适用闭锁天之月的效果使用对象怪兽进行连接召唤。

 and delete unused flageffect。
删除了注册了但未使用的flageffect。