### PR TITLE
Fix RR－ライジング・リベリオン・ファルコン

### DIFF
--- a/c71222868.lua
+++ b/c71222868.lua
@@ -56,9 +56,14 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local atk=g:GetSum(s.damval1)
 	if atk>0 then Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0) end
 end
+function s.xfilter(c)
+	return c:IsType(TYPE_XYZ) and c:IsSetCard(0xba)
+end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
-	if Duel.Destroy(g,REASON_EFFECT)>0 and e:GetHandler():GetOverlayGroup():Filter(Card.IsType,nil,TYPE_XYZ):Filter(Card.IsSetCard,nil,0xba):GetClassCount(Card.GetCode)>=3 then
+	if Duel.Destroy(g,REASON_EFFECT)>0 and c:IsRelateToEffect(e)
+		and c:GetOverlayGroup():Filter(s.xfilter,nil):GetClassCount(Card.GetCode)>=3 then
 		local dg=Duel.GetOperatedGroup()
 		local atk=dg:GetSum(s.damval2)
 		if atk>0 then

--- a/c71222868.lua
+++ b/c71222868.lua
@@ -58,7 +58,7 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
-	if Duel.Destroy(g,REASON_EFFECT)>0 and e:GetHandler():GetOverlayGroup():Filter(Card.IsType,nil,TYPE_XYZ):GetClassCount(Card.GetCode)>=3 then
+	if Duel.Destroy(g,REASON_EFFECT)>0 and e:GetHandler():GetOverlayGroup():Filter(Card.IsType,nil,TYPE_XYZ):Filter(Card.IsSetCard,nil,0xba):GetClassCount(Card.GetCode)>=3 then
 		local dg=Duel.GetOperatedGroup()
 		local atk=dg:GetSum(s.damval2)
 		if atk>0 then
@@ -68,7 +68,7 @@ function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.filter(c)
-	return c:IsSetCard(0xba) and c:IsType(TYPE_MONSTER) and c:IsType(TYPE_XYZ) and not c:IsForbidden()
+	return c:IsSetCard(0xba) and c:IsType(TYPE_MONSTER) and c:IsType(TYPE_XYZ)
 end
 function s.copycost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()


### PR DESCRIPTION
About Effect①-Operation：
DB:その後、このカードが「RR」Xモンスターを３種類以上素材としている場合、この効果で破壊したモンスターの元々の攻撃力の合計分のダメージを相手に与える。
Add IsSetCard_Check for OverlayGroup.
****
About Effect③-Target：
DB:エンドフェイズまで、このカードはそのモンスターと同じ効果を得る。
Delete wrong limit.