### PR TITLE
fix--漆黒の太陽

### DIFF
--- a/c96029570.lua
+++ b/c96029570.lua
@@ -112,7 +112,7 @@ function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 		tg=eg:FilterSelect(tp,s.thfilter,1,1,nil,tp)
 	end
 	Duel.SetTargetCard(tg)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,tg,1,0,0)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c96029570.lua
+++ b/c96029570.lua
@@ -38,13 +38,14 @@ function s.initial_effect(c)
 	e4:SetCategory(CATEGORY_TOHAND)
 	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e4:SetRange(LOCATION_SZONE)
-	e4:SetCode(EVENT_DISCARD)
+	e4:SetCode(EVENT_CUSTOM+id+o)
 	e4:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
 	e4:SetCountLimit(1,id+o*2)
 	e4:SetCondition(s.thcon)
 	e4:SetTarget(s.thtg)
 	e4:SetOperation(s.thop)
 	c:RegisterEffect(e4)
+	aux.RegisterMergedDelayedEvent(c,id+o,EVENT_DISCARD)
 end
 function s.cfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsPreviousControler(tp)
@@ -101,9 +102,16 @@ function s.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:FilterCount(s.thfilter,nil,tp)>0
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingTarget(s.thfilter,tp,LOCATION_GRAVE,0,1,nil,tp) end
+	if chk==0 then return eg:FilterCount(s.thfilter,nil,tp)>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectTarget(tp,s.thfilter,tp,LOCATION_GRAVE,0,1,1,nil,tp)
+	local tg
+	if #eg==1 then
+		tg=eg:Clone()
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+		tg=eg:FilterSelect(tp,s.thfilter,1,1,nil,tp)
+	end
+	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)

--- a/c96029570.lua
+++ b/c96029570.lua
@@ -41,7 +41,6 @@ function s.initial_effect(c)
 	e4:SetCode(EVENT_CUSTOM+id+o)
 	e4:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
 	e4:SetCountLimit(1,id+o*2)
-	e4:SetCondition(s.thcon)
 	e4:SetTarget(s.thtg)
 	e4:SetOperation(s.thop)
 	c:RegisterEffect(e4)
@@ -94,22 +93,20 @@ function s.auop(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e1)
 	end
 end
-function s.thfilter(c,tp)
+function s.thfilter(c,e,tp)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsPreviousControler(tp)
 		and c:IsPreviousLocation(LOCATION_HAND) and c:IsReason(REASON_DISCARD)
-end
-function s.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:FilterCount(s.thfilter,nil,tp)>0
+		and c:IsCanBeEffectTarget(e) and c:IsAbleToHand()
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return eg:FilterCount(s.thfilter,nil,tp)>0 end
+	if chk==0 then return eg:FilterCount(s.thfilter,nil,e,tp)>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local tg
 	if #eg==1 then
 		tg=eg:Clone()
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-		tg=eg:FilterSelect(tp,s.thfilter,1,1,nil,tp)
+		tg=eg:FilterSelect(tp,s.thfilter,1,1,nil,e,tp)
 	end
 	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,tg,1,0,0)


### PR DESCRIPTION
fix 漆黒の太陽 can target spell/trap card which is discard at earlier time.
修复漆黒の太陽可以以之前丢弃的魔陷为对象发动③效果。
add aux.RegisterMergedDelayedEvent
③效果添加aux.RegisterMergedDelayedEvent