### PR TITLE
clean checks of EFFECT_KAISER_COLOSSEUM

### DIFF
--- a/c27204311.lua
+++ b/c27204311.lua
@@ -33,13 +33,6 @@ function c27204311.checkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c27204311.spcon(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.IsPlayerAffectedByEffect(tp,EFFECT_KAISER_COLOSSEUM) then
-		local t1=Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)
-		local t2=Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
-		local c1=Duel.GetMatchingGroupCount(c27204311.relfilter,tp,LOCATION_MZONE,0,nil)
-		local c2=Duel.GetMatchingGroupCount(c27204311.relfilter,tp,0,LOCATION_MZONE,nil)
-		if t1-c1 >= t2-c2 then return false end
-	end
 	return Duel.GetFlagEffect(1-tp,27204311)>=5 and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
 end
 function c27204311.relfilter(c)

--- a/c35405755.lua
+++ b/c35405755.lua
@@ -54,13 +54,6 @@ function s.sprcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local rg=Duel.GetMatchingGroup(s.rfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,1-tp)
-	if Duel.IsPlayerAffectedByEffect(tp,EFFECT_KAISER_COLOSSEUM) then
-		local t1=Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)
-		local t2=Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
-		local r1=Duel.GetMatchingGroupCount(s.rfilter,tp,LOCATION_MZONE,0,nil,1-tp)
-		local r2=Duel.GetMatchingGroupCount(s.rfilter,tp,0,LOCATION_MZONE,nil,1-tp)
-		if t1-r1+1 > t2-r2 then return false end
-	end
 	return rg:GetCount()>0 and rg:FilterCount(Card.IsReleasable,nil,REASON_SPSUMMON)==rg:GetCount() and aux.mzctcheck(rg,tp)
 end
 function s.sprop(e,tp,eg,ep,ev,re,r,rp,c)


### PR DESCRIPTION
with https://github.com/Fluorohydride/ygopro-core/pull/600 the `Duel.GetMZoneCount` or `aux.mzctcheck` will do the job, so it's no longer needed.