### PR TITLE
fix: Amazement Administrator Arlekino(驚楽園の支配人 ＜∀rlechino＞)

### DIFF
--- a/c94821366.lua
+++ b/c94821366.lua
@@ -56,7 +56,7 @@ function c94821366.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c94821366.eqfilter1(c,e,tp)
-	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsCanBeEffectTarget(e) and c:IsSummonPlayer(1-tp)
+	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsCanBeEffectTarget(e) and c:IsControler(1-tp) and c:IsSummonPlayer(1-tp)
 		and Duel.IsExistingMatchingCard(c94821366.eqfilter2,tp,LOCATION_DECK,0,1,nil)
 end
 function c94821366.eqfilter2(c)


### PR DESCRIPTION
The effect of "Amazement Administrator Arlekino":
If your opponent Normal or Special Summons a monster(s) (except during the Damage Step): You can target 1 of those face-up monsters they control; equip 1 "Attraction" Trap from your Deck to that target.

In current script, when checking whether the effect can be triggered or not, only "whether the monster is summoned/special summoned by opponent" and "whether it is located on monster zone" are checked, but not "whether it is controlled by opponent". So if you control "Amazement Administrator Arlekino" and another monster, and your opponent special summon "Gameciel, the Sea Turtle Kaiju" on your field with the other monster released, you can still trigger the effect of "Amazement Administrator Arlekino", while in the operation part it is checked so nothing happens.