### PR TITLE
Fix card's effect fusion summon can cancel

### DIFF
--- a/c14088859.lua
+++ b/c14088859.lua
@@ -40,14 +40,14 @@ function c14088859.filter2(c,e,tp,m,chkf)
 end
 function c14088859.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local chkf=tp|0x200
+		local chkf=tp|0x100
 		local mg=Duel.GetMatchingGroup(c14088859.filter1,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_DECK,0,nil,e)
 		return Duel.IsExistingMatchingCard(c14088859.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,chkf)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c14088859.activate(e,tp,eg,ep,ev,re,r,rp)
-	local chkf=tp|0x200
+	local chkf=tp|0x100
 	local mg=Duel.GetMatchingGroup(c14088859.filter1,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_DECK,0,nil,e)
 	local sg=Duel.GetMatchingGroup(c14088859.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg,chkf)
 	if sg:GetCount()>0 then

--- a/c35255456.lua
+++ b/c35255456.lua
@@ -20,7 +20,7 @@ function c35255456.filter2(c,e,tp,m,chkf)
 end
 function c35255456.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local chkf=tp|0x200
+		local chkf=tp|0x100
 		local mg=Duel.GetMatchingGroup(c35255456.filter1,tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
 		return Duel.IsExistingMatchingCard(c35255456.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,chkf)
 	end
@@ -30,7 +30,7 @@ function c35255456.cffilter(c)
 	return c:IsLocation(LOCATION_HAND) or (c:IsLocation(LOCATION_MZONE) and c:IsFacedown())
 end
 function c35255456.activate(e,tp,eg,ep,ev,re,r,rp)
-	local chkf=tp|0x200
+	local chkf=tp|0x100
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c35255456.filter1),tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
 	local sg=Duel.GetMatchingGroup(c35255456.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg,chkf)
 	if sg:GetCount()>0 then

--- a/c66290900.lua
+++ b/c66290900.lua
@@ -42,7 +42,7 @@ function c66290900.filter2(c,e,tp,m,chkf)
 end
 function c66290900.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local chkf=tp|0x200
+		local chkf=tp|0x100
 		local mg=Duel.GetMatchingGroup(c66290900.filter1,tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
 		return Duel.IsExistingMatchingCard(c66290900.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,chkf)
 	end
@@ -53,7 +53,7 @@ function c66290900.cffilter(c)
 	return c:IsLocation(LOCATION_HAND) or (c:IsLocation(LOCATION_MZONE) and c:IsFacedown())
 end
 function c66290900.activate(e,tp,eg,ep,ev,re,r,rp)
-	local chkf=tp|0x200
+	local chkf=tp|0x100
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c66290900.filter1),tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_MZONE,0,nil,e)
 	local sg=Duel.GetMatchingGroup(c66290900.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg,chkf)
 	if sg:GetCount()>0 then

--- a/c75047173.lua
+++ b/c75047173.lua
@@ -34,14 +34,14 @@ function s.fscfilter(c)
 end
 function s.fstg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local chkf=tp|0x200
+		local chkf=tp|0x100
 		local mg=Duel.GetMatchingGroup(s.fsfilter1,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED,0,nil,e)
 		return Duel.IsExistingMatchingCard(s.fsfilter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,chkf) end
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,nil,0,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function s.fsop(e,tp,eg,ep,ev,re,r,rp)
-	local chkf=tp|0x200
+	local chkf=tp|0x100
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(s.fsfilter1),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE+LOCATION_REMOVED,0,nil,e)
 	local sg=Duel.GetMatchingGroup(s.fsfilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg,chkf)
 	if sg:GetCount()>0 then

--- a/c89190953.lua
+++ b/c89190953.lua
@@ -21,7 +21,7 @@ function c89190953.chfilter(c)
 end
 function c89190953.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local chkf=tp|0x200
+		local chkf=tp|0x100
 		local mg=Duel.GetMatchingGroup(c89190953.filter1,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
 		return Duel.IsExistingMatchingCard(c89190953.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg,chkf)
 	end
@@ -32,7 +32,7 @@ function c89190953.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c89190953.activate(e,tp,eg,ep,ev,re,r,rp)
-	local chkf=tp|0x200
+	local chkf=tp|0x100
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c89190953.filter1),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil,e)
 	local sg=Duel.GetMatchingGroup(c89190953.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg,chkf)
 	if sg:GetCount()>0 then


### PR DESCRIPTION
fix that card's effect can cancel Select Fusion Material to special summon fusion monster.
(ネオス・フュージョン、次元融合殺、フェイバリット・コンタクト、ミラクル・コンタクト、団結する剣闘獣）
修复上述卡片的效果处理时可以取消选择融合素材并直接特招融合怪兽。