### PR TITLE
Fusion response limitation fix

### DIFF
--- a/c18973184.lua
+++ b/c18973184.lua
@@ -46,7 +46,7 @@ function c18973184.efilter(e,ct)
 	return p==tp and te:IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c18973184.limfilter(c,tp)
-	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION)
+	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION) and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c18973184.limcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c18973184.limfilter,1,nil,tp)

--- a/c18973184.lua
+++ b/c18973184.lua
@@ -46,7 +46,8 @@ function c18973184.efilter(e,ct)
 	return p==tp and te:IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c18973184.limfilter(c,tp)
-	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION) and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
+	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION)
+		and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c18973184.limcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c18973184.limfilter,1,nil,tp)

--- a/c47679935.lua
+++ b/c47679935.lua
@@ -48,7 +48,7 @@ function c47679935.efilter(e,ct)
 	return p==tp and te:IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c47679935.limfilter(c,tp)
-	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION)
+	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION) and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c47679935.limcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c47679935.limfilter,1,nil,tp)

--- a/c47679935.lua
+++ b/c47679935.lua
@@ -48,7 +48,8 @@ function c47679935.efilter(e,ct)
 	return p==tp and te:IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c47679935.limfilter(c,tp)
-	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION) and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
+	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION)
+		and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c47679935.limcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c47679935.limfilter,1,nil,tp)

--- a/c9069157.lua
+++ b/c9069157.lua
@@ -87,7 +87,8 @@ function c9069157.efilter(e,ct)
 	return p==tp and te:IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c9069157.limfilter(c,tp)
-	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION) and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
+	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION)
+		and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c9069157.limcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c9069157.limfilter,1,nil,tp)

--- a/c9069157.lua
+++ b/c9069157.lua
@@ -87,7 +87,7 @@ function c9069157.efilter(e,ct)
 	return p==tp and te:IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c9069157.limfilter(c,tp)
-	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION)
+	return c:IsSummonPlayer(tp) and c:IsSummonType(SUMMON_TYPE_FUSION) and c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT):IsHasCategory(CATEGORY_FUSION_SUMMON)
 end
 function c9069157.limcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c9069157.limfilter,1,nil,tp)


### PR DESCRIPTION
Fix cards/effects that limit a player from responding when a fusion summon occurs via a card/effect that performs a fusion summon. No longer limits the player if fusion summoned by a card/effect that copies a fusion summon effect, as per https://db.ygoresources.com/qa#22936