### PR TITLE
fix--銀河眼の光子竜

### DIFF
--- a/c93717133.lua
+++ b/c93717133.lua
@@ -56,7 +56,7 @@ function c93717133.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local c=e:GetHandler()
 	local bc=c:GetBattleTarget()
-	if chk==0 then return bc and bc:IsOnField() and bc:IsCanBeEffectTarget(e) and c:IsAbleToRemove() and bc:IsAbleToRemove() end
+	if chk==0 then return bc and bc:IsLocation(LOCATION_MZONE) and bc:IsCanBeEffectTarget(e) and c:IsAbleToRemove() and bc:IsAbleToRemove() end
 	Duel.SetTargetCard(bc)
 	local g=Group.FromCards(c,bc)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,2,0,0)


### PR DESCRIPTION
fix 銀河眼の光子竜 can remove monster in pendulum zone.
for example, スターヴ・ヴェネミー・ドラゴン attack 銀河眼の光子竜, player activate 聖なるバリア －ミラーフォース－.
スターヴ・ヴェネミー・ドラゴン will destroy and place to pendulum zone by its effect.
and then 銀河眼の光子竜 can remove スターヴ・ヴェネミー・ドラゴン in pendulum zone.