### PR TITLE
fix--ホップ・イヤー飛行隊

### DIFF
--- a/c1980574.lua
+++ b/c1980574.lua
@@ -38,7 +38,7 @@ function c1980574.synop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)==0 then return end
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) or tc:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or tc:IsFacedown() or not tc:IsControler(tp) then return end
 	Duel.AdjustAll()
 	local mg=Group.FromCards(c,tc)
 	if mg:FilterCount(Card.IsLocation,nil,LOCATION_MZONE)<2 then return end


### PR DESCRIPTION
fix ホップ・イヤー飛行隊 can Synchro Summon when target monster was changed controller.