### PR TITLE
Fix 百鬼羅刹大参上

### DIFF
--- a/c90711610.lua
+++ b/c90711610.lua
@@ -27,7 +27,7 @@ function s.filter(c)
 	return c:IsSetCard(0xac) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0xac) and c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(0xac) and c:IsType(TYPE_MONSTER) and c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end


### PR DESCRIPTION
●フィールドのＸ素材を１つ取り除き、手札から**レベル４以下の**「ゴブリン」モンスター１体を特殊召喚する。