### PR TITLE
fix: Ancient Gear Gadget(古代の歯車機械)

### DIFF
--- a/c18486927.lua
+++ b/c18486927.lua
@@ -61,8 +61,9 @@ end
 function c18486927.nametg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local code=e:GetHandler():GetCode()
-	--c:IsSetCard(0x51) and not c:IsCode(code)
-	getmetatable(e:GetHandler()).announce_filter={0x51,OPCODE_ISSETCARD,code,OPCODE_ISCODE,OPCODE_NOT,OPCODE_AND}
+	--c:IsSetCard(0x51) and c:IsType(TYPE_MONSTER) and not c:IsCode(code)
+	-- 0x51 IsSetCard TYPE_MONSTER IsType and code IsCode not and
+	getmetatable(e:GetHandler()).announce_filter={0x51,OPCODE_ISSETCARD,TYPE_MONSTER,OPCODE_ISTYPE,OPCODE_AND,code,OPCODE_ISCODE,OPCODE_NOT,OPCODE_AND}
 	local ac=Duel.AnnounceCard(tp,table.unpack(getmetatable(e:GetHandler()).announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,0)

--- a/c18486927.lua
+++ b/c18486927.lua
@@ -60,11 +60,11 @@ function c18486927.actcon(e)
 end
 function c18486927.nametg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local code=e:GetHandler():GetCode()
+	local c=e:GetHandler()
+	local code=c:GetCode()
 	--c:IsSetCard(0x51) and c:IsType(TYPE_MONSTER) and not c:IsCode(code)
-	-- 0x51 IsSetCard TYPE_MONSTER IsType and code IsCode not and
-	getmetatable(e:GetHandler()).announce_filter={0x51,OPCODE_ISSETCARD,TYPE_MONSTER,OPCODE_ISTYPE,OPCODE_AND,code,OPCODE_ISCODE,OPCODE_NOT,OPCODE_AND}
-	local ac=Duel.AnnounceCard(tp,table.unpack(getmetatable(e:GetHandler()).announce_filter))
+	getmetatable(c).announce_filter={0x51,OPCODE_ISSETCARD,TYPE_MONSTER,OPCODE_ISTYPE,OPCODE_AND,code,OPCODE_ISCODE,OPCODE_NOT,OPCODE_AND}
+	local ac=Duel.AnnounceCard(tp,table.unpack(getmetatable(c).announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,0)
 end


### PR DESCRIPTION
修复了古代的齿车机械可以宣言工具箱子的bug。
Fix bug: Ancient Gear Gadget(古代の歯車機械, 18486927) can announce Gadget Box(ガジェット・ボックス, Gadget Box) since the announce_filter does not filter out cards that are not monster.