### PR TITLE
fix--超量妖精アルファン

### DIFF
--- a/c58753372.lua
+++ b/c58753372.lua
@@ -61,9 +61,6 @@ end
 function c58753372.spfilter1(c,e,tp)
 	return c:IsSetCard(0xdc) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
-function c58753372.spfilter2(c)
-	return c:IsSetCard(0xdc) and c:IsType(TYPE_MONSTER)
-end
 function c58753372.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local g=Duel.GetMatchingGroup(c58753372.spfilter1,tp,LOCATION_DECK,0,nil,e,tp)
@@ -72,7 +69,7 @@ function c58753372.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,LOCATION_DECK)
 end
 function c58753372.spop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c58753372.spfilter2,tp,LOCATION_DECK,0,nil)
+	local g=Duel.GetMatchingGroup(c58753372.spfilter1,tp,LOCATION_DECK,0,nil,e,tp)
 	if g:GetClassCount(Card.GetCode)>=3 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local cg=g:SelectSubGroup(tp,aux.dncheck,false,3,3)


### PR DESCRIPTION
タイトル：
自身をリリースして発動した「超级量子妖精 阿尔方」の効果処理時に、「虚无空间」が適用されている場合、処理はどうなりますか？
質問：
「超级量子妖精 阿尔方」の『②：このカードをリリースして発動できる。デッキから「超级量子」モンスター３種類を相手に見せ、相手はその中からランダムに１体選ぶ。そのモンスター１体を自分フィールドに特殊召喚し、残りを墓地へ送る』効果の発動にチェーンして「虚无空间」が発動した場合、処理はどうなりますか？
回答：
自身をリリースして発動した「超级量子妖精 阿尔方」の効果処理時に、「虚无空间」が適用されている場合、特殊召喚を行う事ができませんので、効果処理は適用されません。
（デッキからモンスターを選ぶ事自体行いません。）