### PR TITLE
Fix魅惑の女王

### DIFF
--- a/c23756165.lua
+++ b/c23756165.lua
@@ -52,7 +52,7 @@ function c23756165.eqcon1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c23756165.eqcon2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and Duel.IsPlayerAffectedByEffect(tp,95937545)
+	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and Duel.IsPlayerAffectedByEffect(tp,95937545) and e:GetHandler():IsOriginalSetCard(0x3)
 end
 function c23756165.filter(c)
 	return c:IsLevelBelow(5) and c:IsFaceup() and c:IsAbleToChangeControler()

--- a/c50140163.lua
+++ b/c50140163.lua
@@ -40,7 +40,7 @@ function c50140163.eqcon1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c50140163.eqcon2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and Duel.IsPlayerAffectedByEffect(tp,95937545)
+	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and Duel.IsPlayerAffectedByEffect(tp,95937545) and e:GetHandler():IsOriginalSetCard(0x3)
 end
 function c50140163.filter(c)
 	return c:IsAbleToChangeControler()

--- a/c87257460.lua
+++ b/c87257460.lua
@@ -37,7 +37,7 @@ function c87257460.eqcon1(e,tp,eg,ep,ev,re,r,rp)
 	return not aux.IsSelfEquip(e:GetHandler(),id) and not Duel.IsPlayerAffectedByEffect(tp,95937545)
 end
 function c87257460.eqcon2(e,tp,eg,ep,ev,re,r,rp)
-	return not aux.IsSelfEquip(e:GetHandler(),id) and Duel.IsPlayerAffectedByEffect(tp,95937545)
+	return not aux.IsSelfEquip(e:GetHandler(),id) and Duel.IsPlayerAffectedByEffect(tp,95937545) and e:GetHandler():IsOriginalSetCard(0x3)
 end
 function c87257460.filter(c)
 	return c:IsLevelBelow(3) and c:IsFaceup() and c:IsAbleToChangeControler()


### PR DESCRIPTION
fix ファントム・オブ・カオス copy 魅惑の女王'effect and it will change to quick effect by 金色の魅惑の女王.
(②：元々のカード名に「魅惑の女王」を含む自分のモンスターが持つ、自身にモンスターを装備する効果は、相手ターンでも発動できる効果になる)
修复混沌幻影复制魅惑的女王的效果和卡名后，其持有的自身把怪兽装备的效果会被金色魅惑的女王变成对方回合也能发动的效果。