### PR TITLE
fix 魅惑の宮殿, 魅惑の舞

### DIFF
--- a/c31322640.lua
+++ b/c31322640.lua
@@ -51,9 +51,9 @@ function s.costfilter(c,code)
 	return c:GetFlagEffect(code)~=0
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local qg=e:GetHandler():GetEquipGroup()
-	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() and qg:IsExists(s.costfilter,1,nil,e:GetHandler():GetCode())  end
-	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToGraveAsCost() and aux.IsSelfEquip(c,FLAG_ID_ALLURE_QUEEN) end
+	Duel.SendtoGrave(c,REASON_COST)
 end
 function s.spfilter(c,e,tp)
 	return c:IsAttackBelow(1500) and c:IsRace(RACE_SPELLCASTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c68316358.lua
+++ b/c68316358.lua
@@ -16,6 +16,7 @@ function s.initial_effect(c)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetTarget(s.atktg)
 	e2:SetValue(s.val)
 	c:RegisterEffect(e2)
 	--spsummon
@@ -46,11 +47,16 @@ function s.atkfilter(c,code)
 	return c:IsFaceup() and bit.band(c:GetOriginalType(),TYPE_MONSTER)==TYPE_MONSTER
 		and c:GetFlagEffect(code)~=0
 end
+function s.atktg(e,c)
+	return c:IsSetCard(0x3)
+end
 function s.val(e,c)
-	local g=c:GetEquipGroup():Filter(s.atkfilter,nil,c:GetCode())
+	local g=c:GetEquipGroup():Filter(s.atkfilter,nil,FLAG_ID_ALLURE_QUEEN)
 	if g:GetCount()>0 then
 		return g:GetSum(Card.GetBaseAttack)
-	else return 0 end
+	else
+		return 0
+	end
 end
 function s.spcfilter(c,tp)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP)


### PR DESCRIPTION
require #2593 

Activate the effect of Allure Queen LV3 (target: X, ATK=500)
Activate Allure Dance
ATK of Allure Queen LV3: 500+500

If the name of `Allure Queen LV3` becomes `Allure Queen LV5`:

Before #2593 
```lua
c:GetEquipGroup():Filter(s.atkfilter,nil,c:GetCode())
```
It will not work because 
c:GetCode(): Allure Queen LV5
flag effect id of equip card: Allure Queen LV3

After #2593 
flag effect id of equip card: FLAG_ID_ALLURE_QUEEN
All Allure Queen monsters use
```lua
tc:RegisterFlagEffect(FLAG_ID_ALLURE_QUEEN,RESET_EVENT+RESETS_STANDARD,0,0,id)
```

The effect of Allure Queen is an example.

----
魅惑的女王應該使用共通的flag effect id

流程：
發動魅惑的女王 LV3效果，裝備攻擊力500怪獸
發動魅惑之舞
魅惑的女王 LV3的攻擊力：500+500

如果「魅惑的女王 LV3」的卡名變成「魅惑的女王 LV5」
使用現有卡名來檢查flag effect id會出現錯誤
混沌魅惑的女王就是具體的例子

修改後：
魅惑的女王怪獸都改成用
```lua
tc:RegisterFlagEffect(FLAG_ID_ALLURE_QUEEN,RESET_EVENT+RESETS_STANDARD,0,0,id)
```

@mercury233 
@purerosefallen 
@Wind2009-Louse 
@kiritosoft 


