### PR TITLE
Fix ティンダングル・ドロネー

### DIFF
--- a/c99157310.lua
+++ b/c99157310.lua
@@ -29,7 +29,7 @@ function c99157310.cfilter1(c)
 end
 function c99157310.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and Duel.GetAttacker():IsControler(1-tp)
-		and Duel.IsExistingMatchingCard(c99157310.cfilter1,tp,LOCATION_GRAVE,0,3,nil)
+		and Duel.GetMatchingGroup(c99157310.cfilter1,tp,LOCATION_GRAVE,0,nil):GetClassCount(Card.GetCode)>2
 end
 function c99157310.filter(c,e,tp)
 	return c:IsCode(75119040) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0


### PR DESCRIPTION
About effect①-Condition.
Add correct check of monster classes.
****
①：自分の墓地に「[廷达魔三角](https://ygocdb.com/?search=%E3%83%86%E3%82%A3%E3%83%B3%E3%83%80%E3%83%B3%E3%82%B0%E3%83%AB)」モンスターが３種類以上存在し、相手モンスターの攻撃で自分が戦闘ダメージを受けた時に発動できる。
①：自己墓地有「[廷达魔三角](https://ygocdb.com/?search=%E5%BB%B7%E8%BE%BE%E9%AD%94%E4%B8%89%E8%A7%92)」怪兽3种类以上存在，对方怪兽的攻击让自己受到战斗伤害时才能发动。