### PR TITLE
Update auxiliary.golden allure queen condition

### DIFF
--- a/c21441617.lua
+++ b/c21441617.lua
@@ -21,10 +21,10 @@ function c21441617.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c21441617.spcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return not aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c21441617.spcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c21441617.spfilter(c,e,tp)
 	return c:IsSetCard(0x11b) and not c:IsCode(21441617) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c23756165.lua
+++ b/c23756165.lua
@@ -48,11 +48,11 @@ function c23756165.regop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c23756165.eqcon1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and not aux.GoldenAllureQueenCondition(c,tp)
+	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and not aux.IsCanbeQuickEffect(c,tp,95937545,0x3)
 end
 function c23756165.eqcon2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and aux.GoldenAllureQueenCondition(c,tp)
+	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and aux.IsCanbeQuickEffect(c,tp,95937545,0x3)
 end
 function c23756165.filter(c)
 	return c:IsLevelBelow(5) and c:IsFaceup() and c:IsAbleToChangeControler()

--- a/c30741503.lua
+++ b/c30741503.lua
@@ -37,10 +37,10 @@ function c30741503.indcon(e)
 	return e:GetHandler():IsLinkState()
 end
 function c30741503.tdcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return not aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c30741503.tdcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c30741503.tdfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAbleToDeck()

--- a/c3134857.lua
+++ b/c3134857.lua
@@ -42,10 +42,10 @@ function c3134857.indcon(e)
 	return e:GetHandler():IsLinkState()
 end
 function c3134857.tdcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return not aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c3134857.tdcon2(e,tp,eg,ep,ev,re,r,rp)
-	return aux.dscon(e,tp,eg,ep,ev,re,r,rp) and Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return aux.dscon(e,tp,eg,ep,ev,re,r,rp) and aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c3134857.tdfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAbleToDeck()

--- a/c4055337.lua
+++ b/c4055337.lua
@@ -29,10 +29,10 @@ function c4055337.indval(e,c)
 	return c:IsType(TYPE_LINK)
 end
 function c4055337.atkcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return not aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c4055337.atkcon2(e,tp,eg,ep,ev,re,r,rp)
-	return aux.dscon(e,tp,eg,ep,ev,re,r,rp) and Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return aux.dscon(e,tp,eg,ep,ev,re,r,rp) and aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c4055337.tgfilter(c)
 	return c:IsFaceup()

--- a/c50140163.lua
+++ b/c50140163.lua
@@ -36,11 +36,11 @@ function c50140163.regop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c50140163.eqcon1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and not aux.GoldenAllureQueenCondition(c,tp)
+	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and not aux.IsCanbeQuickEffect(c,tp,95937545,0x3)
 end
 function c50140163.eqcon2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and aux.GoldenAllureQueenCondition(c,tp)
+	return c:GetFlagEffect(id+1)>0 and not aux.IsSelfEquip(c,id) and aux.IsCanbeQuickEffect(c,tp,95937545,0x3)
 end
 function c50140163.filter(c)
 	return c:IsAbleToChangeControler()

--- a/c57835716.lua
+++ b/c57835716.lua
@@ -20,10 +20,10 @@ function c57835716.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c57835716.spcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return not aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c57835716.spcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c57835716.spfilter(c,e,tp)
 	return c:IsSetCard(0x11b) and not c:IsCode(57835716) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c76145142.lua
+++ b/c76145142.lua
@@ -39,10 +39,10 @@ function c76145142.indcon(e)
 	return e:GetHandler():IsLinkState()
 end
 function c76145142.tdcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return not aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c76145142.tdcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c76145142.tdcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetAttackAnnouncedCount()==0 end

--- a/c87257460.lua
+++ b/c87257460.lua
@@ -34,10 +34,10 @@ function c87257460.initial_effect(c)
 end
 c87257460.lvup={23756165}
 function c87257460.eqcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not aux.IsSelfEquip(e:GetHandler(),id) and not aux.GoldenAllureQueenCondition(e:GetHandler(),tp)
+	return not aux.IsSelfEquip(e:GetHandler(),id) and not aux.IsCanbeQuickEffect(c,tp,95937545,0x3)
 end
 function c87257460.eqcon2(e,tp,eg,ep,ev,re,r,rp)
-	return not aux.IsSelfEquip(e:GetHandler(),id) and aux.GoldenAllureQueenCondition(e:GetHandler(),tp)
+	return not aux.IsSelfEquip(e:GetHandler(),id) and aux.IsCanbeQuickEffect(c,tp,95937545,0x3)
 end
 function c87257460.filter(c)
 	return c:IsLevelBelow(3) and c:IsFaceup() and c:IsAbleToChangeControler()

--- a/c94046012.lua
+++ b/c94046012.lua
@@ -20,10 +20,10 @@ function c94046012.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c94046012.spcon1(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return not aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c94046012.spcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsPlayerAffectedByEffect(tp,90351981)
+	return aux.IsCanbeQuickEffect(e:GetHandler(),tp,90351981,0x11b)
 end
 function c94046012.spfilter(c,e,tp)
 	return c:IsSetCard(0x11b) and not c:IsCode(94046012) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/utility.lua
+++ b/utility.lua
@@ -1646,10 +1646,12 @@ end
 function Auxiliary.IsSelfEquip(c,id)
 	return c:GetEquipGroup():IsExists(Card.GetFlagEffect,1,nil,id)
 end
----Check if the equip effect of c becomes a Quick Effect.
+---Check if the effect of c becomes a Quick Effect.
 ---@param c Card
 ---@param tp integer
+---@param code integer
+---@param setname integer
 ---@return boolean
-function Auxiliary.GoldenAllureQueenCondition(c,tp)
-	return Duel.IsPlayerAffectedByEffect(tp,95937545) and c:IsOriginalSetCard(0x3)
+function Auxiliary.IsCanbeQuickEffect(c,tp,code,setname)
+	return Duel.IsPlayerAffectedByEffect(tp,code) and c:IsOriginalSetCard(setname)
 end


### PR DESCRIPTION
@salix5 
because Phantom of Chaos copy Galatea, the Orcust Automaton's effect can become quick effect by Orcustrated Babel. and this is the same problem as golden allure queen. So, update the auxiliary.golden allure queen condition to fix Orcustrated Babel.

因为混沌幻影复制自奏圣乐·伽拉忒亚的效果和卡名后其复制的效果会被自奏圣乐的通天塔变成在对方回合也能发动的效果。而这个问题和金色魅惑的女王的问题是一样的。因此对auxiliary.golden allure queen condition进行修改来适配自奏圣乐的通天塔

Added 2 parameters(code, setname). code is player affect by effect's code and setname will check c:IsOriginalSetCard(setname).
具体增加了2个参数（code, setname）.参数code为玩家受到的种类为code的效果，setname为c的原本卡名是否持有的字段