### PR TITLE
Fix 天底の使徒

### DIFF
--- a/c1984618.lua
+++ b/c1984618.lua
@@ -14,6 +14,9 @@ end
 function c1984618.tgfilter(c,tp)
 	return c:IsAbleToGrave() and Duel.IsExistingMatchingCard(c1984618.thfilter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil,c:GetAttack())
 end
+function c1984618.opfilter(c,tp)
+	return c:IsAbleToGrave() and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c1984618.thfilter),tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil,c:GetAttack())
+end
 function c1984618.thfilter(c,atk)
 	return (c:IsSetCard(0x145) and c:IsType(TYPE_MONSTER) or c:IsCode(68468459)) and c:IsAttackBelow(atk) and c:IsAbleToHand()
 end
@@ -24,7 +27,7 @@ function c1984618.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c1984618.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g=Duel.SelectMatchingCard(tp,c1984618.tgfilter,tp,LOCATION_EXTRA,0,1,1,nil,tp)
+	local g=Duel.SelectMatchingCard(tp,c1984618.opfilter,tp,LOCATION_EXTRA,0,1,1,nil,tp)
 	local tc=g:GetFirst()
 	if tc and Duel.SendtoGrave(tc,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_GRAVE) then
 		local atk=tc:GetAttack()


### PR DESCRIPTION
> なお、「[王家の眠る谷－ネクロバレー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5533)」の効果が適用されている状況で、墓地に「ドラグマ」モンスターまたは「[アルバスの落胤](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=15245)」が存在し、デッキに「ドラグマ」モンスターまたは「[アルバスの落胤](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=15245)」が1体も存在しない場合でも「[天底の使徒](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=15286)」を発動する事ができます。

> その場合、『EXデッキからモンスター１体を墓地へ送る。その後、墓地へ送ったモンスターの攻撃力以下の攻撃力を持つ、「ドラグマ」モンスターまたは「[アルバスの落胤](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=15245)」１体を自分のデッキ・墓地から選んで手札に加える』処理は行われませんが、『このカードの発動後、ターン終了時まで自分はEXデッキからモンスターを特殊召喚できない』効果は適用されます。