### PR TITLE
Fix 次元の裂け目

### DIFF
--- a/c81674782.lua
+++ b/c81674782.lua
@@ -26,7 +26,7 @@ function c81674782.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c81674782.rmtarget(e,c)
-	return not c:IsLocation(0x80) and not c:IsType(TYPE_SPELL+TYPE_TRAP)
+	return c:GetOriginalType()&TYPE_MONSTER>0 and not c:IsLocation(0x80) and not c:IsType(TYPE_SPELL+TYPE_TRAP)
 end
 function c81674782.checktg(e,c)
 	return not c:IsPublic()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7959&keyword=&tag=-1&request_locale=ja

> Question
自分の魔法＆罠ゾーンに「[次元の裂け目](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6707)」が表側表示で存在し、『墓地へ送られるモンスターは墓地へは行かずゲームから除外される』効果が適用されています。
この状況で、自身の『②：このカードが墓地に存在する場合、このカード以外の自分の墓地の「帝王」魔法・罠カード１枚を除外して発動できる。このカードは通常モンスター（天使族・光・星５・攻１０００／守２４００）となり、モンスターゾーンに守備表示で特殊召喚する（罠カードとしては扱わない）』効果によってモンスターカード扱いとなっている「[真源の帝王](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12095)」と、自身の『①：このカードは発動後、効果モンスター（悪魔族・闇・星６・攻１０００／守２４００）となり、モンスターゾーンに特殊召喚する。このカードは罠カードとしても扱う』効果によってモンスターカード扱いとなっている「[始源の帝王](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10993)」が、「[ブラック・ホール](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4342)」の効果によって破壊される場合、それぞれのカードは除外されますか？
Answer
質問の状況の場合、「[ブラック・ホール](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4342)」の効果で破壊された「[真源の帝王](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12095)」と「[始源の帝王](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10993)」は、どちらも除外されず、通常通り墓地へ送られる事になります。

「次元的裂缝」在场上存在时，陷阱怪兽被战斗·效果破坏的场合，从场上离开后不是『被送去墓地的怪兽』，不会除外，送去墓地。