### PR TITLE
fix 古代の進軍

### DIFF
--- a/c4064925.lua
+++ b/c4064925.lua
@@ -1,0 +1,133 @@
+--古代の進軍
+function c4064925.initial_effect(c)
+	aux.AddCodeList(c,83104731)
+	--
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,4064925+EFFECT_COUNT_CODE_OATH)
+	e1:SetCost(c4064925.cost)
+	e1:SetTarget(c4064925.target)
+	e1:SetOperation(c4064925.activate)
+	c:RegisterEffect(e1)
+	--
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(4064925,0))
+	e2:SetCategory(CATEGORY_DRAW)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetCost(c4064925.drcost)
+	e2:SetTarget(c4064925.drtg)
+	e2:SetOperation(c4064925.drop)
+	c:RegisterEffect(e2)
+	if not c4064925.global_check then
+		c4064925.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_SSET)
+		ge1:SetOperation(c4064925.checkop)
+		Duel.RegisterEffect(ge1,0)
+		local ge2=ge1:Clone()
+		ge2:SetCode(EVENT_MSET)
+		Duel.RegisterEffect(ge2,0)
+		local ge3=ge1:Clone()
+		ge3:SetCode(EVENT_SPSUMMON_SUCCESS)
+		ge3:SetCondition(c4064925.ssetcon)
+		Duel.RegisterEffect(ge3,0)
+		local ge4=ge1:Clone()
+		ge4:SetCode(EVENT_CHANGE_POS)
+		ge4:SetCondition(c4064925.cpcon)
+		Duel.RegisterEffect(ge4,0)	
+	end
+end
+function c4064925.checkop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.RegisterFlagEffect(rp,4064925,RESET_PHASE+PHASE_END,0,1)
+end
+function c4064925.cfilter(c)
+	return c:IsFacedown()
+end
+function c4064925.ssetcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c4064925.cfilter,1,nil)
+end
+function c4064925.cfilter2(c)
+	return c:IsPreviousPosition(POS_FACEUP) and c:IsFacedown()
+end
+function c4064925.cpcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c4064925.cfilter2,1,nil) and ep==tp
+end
+function c4064925.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFlagEffect(tp,4064925)==0 end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e1:SetCode(EFFECT_CANNOT_MSET)
+	e1:SetTargetRange(1,0)
+	e1:SetTarget(aux.TRUE)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_CANNOT_SSET)
+	Duel.RegisterEffect(e2,tp)
+	local e3=e1:Clone()
+	e3:SetCode(EFFECT_CANNOT_TURN_SET)
+	Duel.RegisterEffect(e3,tp)
+	local e4=e1:Clone()
+	e4:SetCode(EFFECT_LIMIT_SPECIAL_SUMMON_POSITION)
+	e4:SetTarget(c4064925.sumlimit)
+	Duel.RegisterEffect(e4,tp)
+end
+function c4064925.sumlimit(e,c,sump,sumtype,sumpos,targetp)
+	return bit.band(sumpos,POS_FACEDOWN)>0
+end
+function c4064925.filter(c)
+	return not c:IsCode(4064925) and c:IsSetCard(0x7) and (c:IsType(TYPE_SPELL) or c:IsType(TYPE_TRAP)) and c:IsAbleToHand()
+end
+function c4064925.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c4064925.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c4064925.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c4064925.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c4064925.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,nil,1,nil,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+	local g=Duel.SelectReleaseGroup(tp,nil,1,1,nil,tp)
+	Duel.Release(g,REASON_COST)
+end
+function c4064925.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c4064925.drop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	if Duel.Draw(p,d,REASON_EFFECT)~=0 and Duel.GetFlagEffect(tp,4064926)==0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetDescription(aux.Stringid(4064925,2))
+		e1:SetType(EFFECT_TYPE_FIELD)
+		e1:SetCode(EFFECT_SUMMON_PROC)
+		e1:SetTargetRange(LOCATION_HAND,0)
+		e1:SetCountLimit(1,4064925)
+		e1:SetCondition(c4064925.ntcon)
+		e1:SetTarget(c4064925.nttg)
+		e1:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e1,tp)
+		Duel.RegisterFlagEffect(tp,4064926,RESET_PHASE+PHASE_END,EFFECT_FLAG_OATH,1)
+	end
+end
+function c4064925.ntcon(e,c,minc)
+	if c==nil then return true end
+	return minc==0 and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+end
+function c4064925.nttg(e,c)
+	return c:IsLevelAbove(5) and (c:IsCode(83104731) or aux.IsCodeListed(c,83104731))
+end


### PR DESCRIPTION
修复当回合若发动了日全食之书/月之书/隐形鸟等盖放效果后仍然能发动古代的进军的问题。