### PR TITLE
Fix Bayerock Dragon

### DIFF
--- a/c4472318.lua
+++ b/c4472318.lua
@@ -52,6 +52,8 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.spcfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT)
+		and not c:IsPreviousLocation(LOCATION_SZONE)
+		and (c:IsPreviousLocation(LOCATION_MZONE) or c:GetOriginalType()&TYPE_MONSTER~=0)
 		and c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_HAND+LOCATION_ONFIELD)
 end
 function s.regcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
About effect①
①：自分の手札・フィールドのモンスターが戦闘・効果で破壊された場合に発動できる。このカードを手札から特殊召喚する。
Add type-check for destroyed cards.