### PR TITLE
fix: 青い涙の天使

### DIFF
--- a/c91706817.lua
+++ b/c91706817.lua
@@ -71,7 +71,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.setcon(e,tp,eg,ep,ev,re,r,rp)
 	local se=e:GetLabelObject():GetLabelObject()
-	return bit.band(r,REASON_EFFECT)~=0 and (se==nil or e:GetHandler():GetReasonEffect()~=se)
+	return bit.band(r,REASON_EFFECT)~=0 and (se==nil or re~=se)
 end
 function s.setfilter(c)
 	return c:GetType()==TYPE_TRAP and c:IsSSetable()


### PR DESCRIPTION
修正了c1落泪c2宰制送蓝泪，处理烧血后蓝泪无法触发的bug。

原因：74行的本意大概是“判断送墓是否和造成伤害是同一个时点”，或者说“造成伤害的时候卡是否已经存在于墓地”。se是AddThisCardInGraveAlreadyCheck里面注册的，根据函数内容判断应该是造成其进入墓地的效果，那么应该与之对比的就是“造成伤害的效果”，在code是EVENT_DAMAGE的情况下应该就是re，而e:GetHandler():GetReasonEffect()指的是改变e:GetHandler()也就是蓝泪位置的效果，故在此连锁上应该必定是se。

我不确定EVENT_DAMAGE情况下造成伤害的效果是否是re，以及AddThisCardInGraveAlreadyCheck对于多步效果的详细处理方式，这个修正仅是来源于直觉。

Fix the bug that when first send "Angel of Blue Tears" to graveyard and then dealing damage, "Angel of Blue Tears" cannot be triggered.

E.g. use “Beatrice, Lady of the Eternal”(with “Fiendsmith's Lacrima” as material), “Fiendsmith's Sequence” and “Ghost Ogre & Snow Rabbit” to link summon "Curious, the Lightsworn Dominion“, and activate the effect of “Fiendsmith's Lacrima” on chain 1(to deal 1200 damage), "Curious, the Lightsworn Dominion“ on chain 2(to send "Angel of Blue Tears" to graveyard). The effect of "Angel of Blue Tears" should be triggered, but in fact not.

Reason: it seems that "se" represents for the effect that sends "Angel of Blue Tears" to graveyard. The condition is trying to decide that it is not in the same effect(or at the same time) that "Angel of Blue Tears" is sent to graveyard while the damage is dealt. So to decide whether it is the same effect or not, we should use re(which should be the reason effect for the damage), but not e:GetHandler():GetReasonEffect()(which should be the effect to change the location of e:GetHandler(), which is just se).