### PR TITLE
fix ミュータント・ハイブレイン

### DIFF
--- a/c11508758.lua
+++ b/c11508758.lua
@@ -13,7 +13,7 @@ function c11508758.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c11508758.ctlcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetAttackTarget()~=nil
+	return Duel.GetAttackTarget()~=nil and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>=2
 end
 function c11508758.filter(c)
 	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsControlerCanBeChanged() and c:IsAttackable()


### PR DESCRIPTION
修复在没有满足“对方场上有怪兽2只以上存在的场合”的情况下仍然能发动效果的问题。