### PR TITLE
fix corresponding race

### DIFF
--- a/c1683982.lua
+++ b/c1683982.lua
@@ -58,7 +58,7 @@ function c1683982.atktg(e,c)
 end
 function c1683982.cfilter(c,tp)
 	return c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE)
-		and c:GetPreviousRaceOnField()&RACE_REPTILE~=0 and c:IsPreviousPosition(POS_FACEUP)
+		and c:GetPreviousRaceOnField()&RACE_REPTILE~=0 and c:IsRace(RACE_REPTILE) and c:IsPreviousPosition(POS_FACEUP)
 end
 function c1683982.regcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c1683982.cfilter,1,nil,tp)

--- a/c29177818.lua
+++ b/c29177818.lua
@@ -27,7 +27,7 @@ function c29177818.initial_effect(c)
 end
 function c29177818.cfilter(c,tp)
 	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousControler(tp) and c:IsPreviousPosition(POS_FACEUP)
-		and bit.band(c:GetPreviousRaceOnField(),RACE_PLANT)>0
+		and bit.band(c:GetPreviousRaceOnField(),RACE_PLANT)>0 and c:IsRace(RACE_PLANT)
 end
 function c29177818.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c29177818.cfilter,1,nil,tp)

--- a/c56818742.lua
+++ b/c56818742.lua
@@ -70,7 +70,7 @@ end
 function s.cfilter(c,tp,lc)
 	local seq=c:GetPreviousSequence()
 	if c:IsPreviousControler(1-tp) then seq=seq+16 end
-	return c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousRaceOnField()&RACE_DINOSAUR>0
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousRaceOnField()&RACE_DINOSAUR>0 and c:IsRace(RACE_DINOSAUR)
 		and c:IsPreviousLocation(LOCATION_MZONE) and bit.extract(lc:GetLinkedZone(),seq)>0
 end
 function s.drcon(e,tp,eg,ep,ev,re,r,rp)

--- a/c78540593.lua
+++ b/c78540593.lua
@@ -17,7 +17,7 @@ function c78540593.descon(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
 	return eg:GetCount()==1 and tc:IsReason(REASON_DESTROY) and tc:IsReason(REASON_BATTLE+REASON_EFFECT)
 		and tc:IsPreviousLocation(LOCATION_MZONE) and tc:IsPreviousControler(tp)
-		and bit.band(tc:GetPreviousRaceOnField(),RACE_PLANT)~=0
+		and bit.band(tc:GetPreviousRaceOnField(),RACE_PLANT)~=0 and tc:IsRace(RACE_PLANT)
 end
 function c78540593.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() end

--- a/c80839052.lua
+++ b/c80839052.lua
@@ -28,7 +28,7 @@ function c80839052.initial_effect(c)
 end
 function c80839052.spfilter(c,tp)
 	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousControler(tp)
-		and (c:GetPreviousRaceOnField()&RACE_ROCK)>0
+		and (c:GetPreviousRaceOnField()&RACE_ROCK)>0 and c:IsRace(RACE_ROCK)
 end
 function c80839052.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c80839052.spfilter,1,nil,tp)


### PR DESCRIPTION
修复该类效果送墓前后都要求满足对应种族条件才能发动的问题。
Ｑ：「フィールドで植物族になっている、元々は別の種族のモンスター」が破壊された時に発動しますか？
　　また、「フィールドで別の種族になっている、元々は植物族のモンスター」が破壊された時に発動しますか？
Ａ：いいえ、どちらの場合も発動しません。(16/12/14)
Tag: 《姫葵マリーナ》