### PR TITLE
fix--登竜華転生紋

### DIFF
--- a/c55276522.lua
+++ b/c55276522.lua
@@ -53,7 +53,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.hgrfilter,tp,LOCATION_DECK,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,2))
 	local sg=g:SelectSubGroup(tp,s.gcheck,false,3,3,tp)
-	if sg:GetCount()>2 then
+	if sg and sg:GetCount()>2 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local g1=sg:FilterSelect(tp,s.thfiter,1,1,nil,sg)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)


### PR DESCRIPTION
fix 登竜華転生紋 will have Script Error when player can not select card  when this card is activated
修复登竜華転生紋在发动时的效果处理时因其他效果而无法选卡时（如王宫的铁壁）会产生报错
[Script Error]: [string "./script/c55276522.lua"]:56: attempt to index a nil value (local 'sg')