### PR TITLE
fix--Emblema Oath

### DIFF
--- a/c77765207.lua
+++ b/c77765207.lua
@@ -69,7 +69,7 @@ end
 function s.splimit(e,c)
 	return not c:IsSetCard(0x1a2) and c:IsLocation(LOCATION_EXTRA)
 end
-function s.setfilter(c)
+function s.setfilter(c,ct)
 	return c:IsSetCard(0x1a2) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable() and (ct>0 or c:IsType(TYPE_FIELD))
 end
 function s.target2(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c77765207.lua
+++ b/c77765207.lua
@@ -70,14 +70,17 @@ function s.splimit(e,c)
 	return not c:IsSetCard(0x1a2) and c:IsLocation(LOCATION_EXTRA)
 end
 function s.setfilter(c)
-	return c:IsSetCard(0x1a2) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable()
+	return c:IsSetCard(0x1a2) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable() and (ct>0 or c:IsType(TYPE_FIELD))
 end
 function s.target2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.setfilter,tp,LOCATION_DECK,0,1,nil) end
+	local ct=Duel.GetLocationCount(tp,LOCATION_SZONE)
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) and not e:GetHandler():IsLocation(LOCATION_SZONE) then ct=ct-1 end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.setfilter,tp,LOCATION_DECK,0,1,nil,ct) end
 end
 function s.activate2(e,tp,eg,ep,ev,re,r,rp)
+	ct=Duel.GetLocationCount(tp,LOCATION_SZONE)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
-	local g=Duel.SelectMatchingCard(tp,s.setfilter,tp,LOCATION_DECK,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,s.setfilter,tp,LOCATION_DECK,0,1,1,nil,ct)
 	if g:GetCount()>0 then
 		Duel.SSet(tp,g:GetFirst())
 	end


### PR DESCRIPTION
fix player can activate Emblema Oath from hands by effect (●Set 1 "Centur-Ion" Spell/Trap directly from your Deck.) when player's Spell & Trap Zone have four cards and player's deck only have "Centur-Ion" Spell/Trap other than "Centur-Ion" Field Spell.
修复可以在魔法与陷阱区域已经有4张卡且卡组只有非场地魔法的「百夫长骑士」魔法·陷阱卡的场合下，选择「●从卡组把1张「百夫长骑士」魔法·陷阱卡在自己场上盖放。」从手卡发动誓言之徽记