### PR TITLE
fix 律導のヴァルモニカ

### DIFF
--- a/c4582942.lua
+++ b/c4582942.lua
@@ -23,6 +23,7 @@ function s.afilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x1a3) and c:IsType(TYPE_LINK)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp,op)
+	if Duel.GetMatchingGroupCount(s.cfilter,tp,LOCATION_ONFIELD,0,nil)==0 then return end
 	if op==nil then
 		local chk=Duel.IsExistingMatchingCard(s.afilter,tp,LOCATION_MZONE,0,1,nil)
 		op=aux.SelectFromOptions(tp,


### PR DESCRIPTION
修复效果处理时若自己场上不存在「异响鸣」怪兽卡，应不继续处理效果的问题。

律導のヴァルモニカ
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19389