### PR TITLE
Fix 天盃龍 IsSynchroSummonable_check

### DIFF
--- a/c39931513.lua
+++ b/c39931513.lua
@@ -66,21 +66,16 @@ function s.sccon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE
 end
-function s.mfilter(c)
-	return not c:IsStatus(STATUS_SUMMONING)
-end
 function s.sctarg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	local mg=Duel.GetMatchingGroup(s.mfilter,tp,LOCATION_MZONE,0,nil)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,c,mg) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,c) end
 	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(id,1))
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function s.scop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsControler(1-tp) or not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	local mg=Duel.GetMatchingGroup(s.mfilter,tp,LOCATION_MZONE,0,nil)
-	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,c,mg)
+	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,c)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local sg=g:Select(tp,1,1,nil)

--- a/c65326118.lua
+++ b/c65326118.lua
@@ -1,6 +1,6 @@
 --天盃龍ファドラ
 function c65326118.initial_effect(c)
-	--
+	--Special summon from grave
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(65326118,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -19,7 +19,7 @@ function c65326118.initial_effect(c)
 	e3:SetCode(EVENT_BATTLE_START)
 	e3:SetRange(LOCATION_MZONE)
 	c:RegisterEffect(e3)
-	--
+	--inde
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD)
 	e4:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
@@ -28,7 +28,7 @@ function c65326118.initial_effect(c)
 	e4:SetTarget(c65326118.indtg)
 	e4:SetValue(1)
 	c:RegisterEffect(e4)
-	--
+	--synchro summon
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(65326118,2))
 	e5:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -69,12 +69,9 @@ function c65326118.sccon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE
 end
-function c65326118.mfilter(c)
-	return not c:IsStatus(STATUS_SUMMONING)
-end
 function c65326118.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local mg=Duel.GetMatchingGroup(c65326118.mfilter,tp,LOCATION_MZONE,0,nil)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,e:GetHandler(),mg) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,e:GetHandler()) end
 	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(65326118,2))
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
@@ -82,7 +79,7 @@ function c65326118.scop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local mg=Duel.GetMatchingGroup(c65326118.mfilter,tp,LOCATION_MZONE,0,nil)
 	if c:IsControler(1-tp) or not c:IsRelateToEffect(e) or c:IsFacedown() then return end
-	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,c,mg)
+	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,c)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local sg=g:Select(tp,1,1,nil)

--- a/c91810826.lua
+++ b/c91810826.lua
@@ -1,6 +1,6 @@
 --天盃龍チュンドラ
 function c91810826.initial_effect(c)
-	--
+	--Self special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(91810826,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -11,7 +11,7 @@ function c91810826.initial_effect(c)
 	e1:SetTarget(c91810826.sptg)
 	e1:SetOperation(c91810826.spop)
 	c:RegisterEffect(e1)
-	--
+	--Special summon from deck
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(91810826,1))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -23,7 +23,7 @@ function c91810826.initial_effect(c)
 	e2:SetTarget(c91810826.sptg2)
 	e2:SetOperation(c91810826.spop2)
 	c:RegisterEffect(e2)
-	--
+	--Synchro summon
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(91810826,2))
 	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -75,12 +75,10 @@ function c91810826.sccon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE
 end
-function c91810826.mfilter(c)
-	return not c:IsStatus(STATUS_SUMMONING)
-end
 function c91810826.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local mg=Duel.GetMatchingGroup(c91810826.mfilter,tp,LOCATION_MZONE,0,nil)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,e:GetHandler(),mg) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,1,nil,e:GetHandler())
+	end
 	Duel.Hint(HINT_OPSELECTED,1-tp,aux.Stringid(91810826,2))
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
@@ -88,7 +86,7 @@ function c91810826.scop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsControler(1-tp) or not c:IsRelateToEffect(e) or c:IsFacedown() then return end
 	local mg=Duel.GetMatchingGroup(c91810826.mfilter,tp,LOCATION_MZONE,0,nil)
-	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,c,mg)
+	local g=Duel.GetMatchingGroup(Card.IsSynchroSummonable,tp,LOCATION_EXTRA,0,nil,c)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local sg=g:Select(tp,1,1,nil)


### PR DESCRIPTION
Use<code>Card.IsSynchroSummonable</code> with parameter <code>mg</code> in this way cause wrong check.
With change from core,it's no need to use  <code>c:IsStatus(STATUS_SUMMONING)</code>.
So    deleted.

by the way
天盃龍パイドラ & 天盃龍ファドラ keep using themselves as truner in <code>Card.IsSynchroSummonable</code> may cause bug in future.
