### PR TITLE
fix--ブラック・ガーデン

### DIFF
--- a/c71645242.lua
+++ b/c71645242.lua
@@ -64,7 +64,7 @@ function c71645242.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
 end
 function c71645242.opfilter(c,e)
-	return c:IsRelateToEffect(e) and not c:IsImmuneToEffect(e)
+	return c:IsOnField() and c:IsRelateToEffect(e) and not c:IsImmuneToEffect(e)
 end
 function c71645242.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=eg:Filter(c71645242.opfilter,nil,e)

--- a/c71645242.lua
+++ b/c71645242.lua
@@ -64,7 +64,7 @@ function c71645242.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
 end
 function c71645242.opfilter(c,e)
-	return c:IsOnField() and c:IsRelateToEffect(e) and not c:IsImmuneToEffect(e)
+	return c:IsLocation(LOCATION_MZONE) and c:IsRelateToEffect(e) and not c:IsImmuneToEffect(e)
 end
 function c71645242.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=eg:Filter(c71645242.opfilter,nil,e)


### PR DESCRIPTION
タイトル：
「黑色花园」の効果処理時に、召喚・特殊召喚に成功したモンスターがフィールドを離れている場合、効果処理はどうなりますか？
質問：
自分のフィールドゾーンに「黑色花园」が表側表示で存在しています。
自分が「植物狮子」を召喚した際に、「黑色花园」の『「黑色花园」の効果以外の方法でモンスターが召喚・特殊召喚に成功した時、そのモンスターの攻撃力を半分にし、そのモンスターのコントローラーから見て相手のフィールド上に「蔷薇衍生物」（植物族・闇・星２・攻／守８００）１体を攻撃表示で特殊召喚する』効果が発動しました。
その発動にチェーンして相手が「强制脱出装置」を発動し、その「植物狮子」が持ち主の手札に戻った場合、効果処理はどうなりますか？
回答：
質問の状況のように、「黑色花园」の効果処理時に、その発動のきっかけとなった召喚・特殊召喚されたモンスターがフィールドに存在しなくなっている場合には、『そのモンスターの攻撃力を半分にし』の処理も、『そのモンスターのコントローラーから見て相手のフィールド上に「蔷薇衍生物」（植物族・闇・星２・攻／守８００）１体を攻撃表示で特殊召喚する』処理も適用されません。

fix ブラック・ガーデン will special 2 toke when RUM－ソウル・シェイブ・フォース activated