### PR TITLE
fix--DDD双暁王カリ・ユガ

### DIFF
--- a/c15939229.lua
+++ b/c15939229.lua
@@ -52,6 +52,14 @@ function c15939229.sumsuc(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	e2:SetLabel(c:GetFieldID())
 	Duel.RegisterEffect(e2,tp)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetCondition(c15939229.discon)
+	e3:SetOperation(c15939229.disop)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	e3:SetLabel(c:GetFieldID())
+	Duel.RegisterEffect(e3,tp)
 	c:RegisterFlagEffect(15939229,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1,c:GetFieldID())
 end
 function c15939229.aclimit(e,re,tp)
@@ -60,6 +68,14 @@ function c15939229.aclimit(e,re,tp)
 end
 function c15939229.disable(e,c)
 	return c:GetFlagEffectLabel(15939229)~=e:GetLabel() and (not c:IsType(TYPE_MONSTER) or (c:IsType(TYPE_EFFECT) or bit.band(c:GetOriginalType(),TYPE_EFFECT)==TYPE_EFFECT))
+end
+function c15939229.discon(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	return bit.band(loc,LOCATION_ONFIELD)~=0 and rc:GetFlagEffectLabel(15939229)~=e:GetLabel()
+end
+function c15939229.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
 end
 function c15939229.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end


### PR DESCRIPTION
裁定变更：
连锁1发动魔法·陷阱卡，连锁2发动「升阶魔法-幻影骑士团的出击」或「奇妙超量」，连锁3把连锁1发动的那张卡作为cost送去墓地发动「禁忌的一滴」，连锁2把「DDD 双晓王 末法神」X召唤成功时，连锁1的那张魔法·陷阱卡已经不在场上，效果也会被无效。
「DDD 双晓王 末法神」X召唤成功的回合，对方从手卡发动「黑洞」，然后连锁把这张「黑洞」送去墓地从手卡发动「禁忌的一滴」的场合，「黑洞」「禁忌的一滴」的效果都仍然无效。

fix After DDD双暁王カリ・ユガ is Xyz Summoned, ブラック・ホール isn't negated because it was sent to grave by 禁じられた一滴's cost
修复在超量召唤DDD双暁王カリ・ユガ后，作为禁じられた一滴的发动cost而送去墓地的ブラック・ホール发动的效果不会被无效