### PR TITLE
fix--精神操作

### DIFF
--- a/c37520316.lua
+++ b/c37520316.lua
@@ -22,7 +22,7 @@ function c37520316.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.GetControl(tc,tp,PHASE_END,1)~=0 then
 		local e1=Effect.CreateEffect(c)
-		local reset=RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_PHASE+PHASE_END
+		local reset=RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UNRELEASABLE_SUM)
 		e1:SetReset(reset)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=24100&keyword=&tag=-1
Question
「精神操作」の効果で相手モンスターの表側表示モンスターのコントロールを得ました。
その後にコントロールを得たモンスターが裏側守備表示になった場合、適用されている効果はどうなりますか？
Answer

『コントロールをエンドフェイズまで得る』効果は適用されたままですが、『この効果でコントロールを得たモンスターは攻撃宣言できず、リリースできない』効果の適用はなくなります。
（そのコントロールはエンドフェイズまで得たままですが、リリースできるようになり、その後攻撃表示になった場合には攻撃宣言もできるようになります。）
なお、「精神操作」で裏側守備表示のモンスターのコントロールを得た場合、『この効果でコントロールを得たモンスターは攻撃宣言できず、リリースできない』効果は適用されたままです。（その後に表側表示になった場合も、モンスターゾーンに表側表示で存在する限り攻撃宣言及びリリースを行うことはできません。）
