### PR TITLE
fix--騎士皇プリメラ・プリムス

### DIFF
--- a/c8841431.lua
+++ b/c8841431.lua
@@ -71,7 +71,7 @@ function s.thdop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.indcon(e)
-	return not e:GetHandler():IsSummonLocation(LOCATION_EXTRA)
+	return e:GetHandler():GetSummonLocation()~=0 and not e:GetHandler():IsSummonLocation(LOCATION_EXTRA)
 end
 function s.cfilter(c,tp,rp)
 	return c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousControler(tp) and c:IsPreviousSetCard(0x1a2)


### PR DESCRIPTION
【②の効果について】
モンスターゾーンで適用する永続効果です。
どこから特殊召喚した場合でも、このカードが一度裏側守備表示になり、その後リバースした場合、この効果は適用されません。