### PR TITLE
Fix エレキック・ファイティング・ポーター

### DIFF
--- a/c51303014.lua
+++ b/c51303014.lua
@@ -36,14 +36,14 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 			e1:SetCode(EFFECT_DIRECT_ATTACK)
 			e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 			tc:RegisterEffect(e1)
-			if g:GetClassCount(Card.GetOriginalLevel)==1 then
-				local e2=Effect.CreateEffect(c)
-				e2:SetType(EFFECT_TYPE_SINGLE)
-				e2:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
-				e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-				e2:SetValue(1)
-				tc:RegisterEffect(e2)
-			end
+		end
+		if g:GetClassCount(Card.GetOriginalLevel)==1 and g:GetCount()>1 then
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_SINGLE)
+			e2:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+			e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+			e2:SetValue(1)
+			tc:RegisterEffect(e2)
 		end
 	end
 	Duel.SpecialSummonComplete()


### PR DESCRIPTION
> ①：手札からレベル３以下の光属性モンスターを２体まで特殊召喚する。
この効果で元々の種族が同じモンスター２体を特殊召喚した場合、このターン、そのモンスターは直接攻撃できる。
この効果で元々のレベルが同じモンスター２体を特殊召喚した場合、このターン、そのモンスターは戦闘では破壊されない。

**EFFECT_DIRECT_ATTACK** and **EFFECT_INDESTRUCTABLE_BATTLE** should be independent