### PR TITLE
Fix Haggard Lizardose

### DIFF
--- a/c9763474.lua
+++ b/c9763474.lua
@@ -23,7 +23,7 @@ function s.atkcheck(c,atk)
 	return c:IsFaceup() and c:GetAttack()~=atk
 end
 function s.cfilter(c)
-	return c:IsAttackBelow(2000) and c:IsAbleToRemoveAsCost() and (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE))
+	return c:IsAttackBelow(2000) and c:GetTextAttack()>=0 and c:IsAbleToRemoveAsCost() and (c:IsFaceup() or c:IsLocation(LOCATION_GRAVE))
 		and (Duel.IsPlayerCanDraw(c:GetControler(),1) or c:GetOriginalRace()~=RACE_REPTILE)
 		and Duel.IsExistingTarget(s.atkcheck,0,LOCATION_MZONE,LOCATION_MZONE,1,c,c:GetBaseAttack())
 end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=20065&request_locale=ja

修复①效果应不能除外文本攻击力为？的怪兽（コストとして、カードに記載されている攻撃力が？のモンスターを除外することはできません）。