### PR TITLE
fix--シエンの間者

### DIFF
--- a/c7672244.lua
+++ b/c7672244.lua
@@ -22,7 +22,7 @@ function c7672244.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c7672244.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc:IsRelateToEffect(e) then
 		Duel.GetControl(tc,1-tp,PHASE_END,1)
 	end
 end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6437
この効果の処理時に対象のモンスターが裏側守備表示になっている場合でも、効果処理は通常通り適用され、対象のモンスターのコントロールを相手に移します。