### PR TITLE
fix--炎王神 ガルドニクス・エタニティ

### DIFF
--- a/c64182380.lua
+++ b/c64182380.lua
@@ -86,6 +86,7 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=e:GetHandler():GetPreviousOverlayCountOnField()
 	if chk==0 then return ct>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsStatus(STATUS_PROC_COMPLETE)
 		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	e:SetLabel(ct)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19403
【③の効果について】
■このカードのエクシーズ召喚が無効になり、破壊された場合は発動できません。
fix 炎王神 ガルドニクス・エタニティ can active effect when it's summon was Negated.