### PR TITLE
Fix 覇王天龍オッドアイズ・アークレイ・ドラゴン

### DIFF
--- a/c6218704.lua
+++ b/c6218704.lua
@@ -74,7 +74,7 @@ function c6218704.splimit(e,se,sp,st)
 	return true
 end
 function c6218704.hspfilter(c,tp,sc)
-	return c:IsCode(13331639) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsLevel(12) and c:IsFaceup()
+	return c:IsCode(13331639) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsLevel(12)
 		and c:IsControler(tp) and Duel.GetLocationCountFromEx(tp,tp,c,sc)>0 and c:IsCanBeFusionMaterial(sc,SUMMON_TYPE_SPECIAL)
 end
 function c6218704.hspcon(e,c)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19172&request_locale=ja

修复应能把里侧表示的「霸王龙 扎克」解放来特殊召唤的问题（裏側守備表示の「覇王龍ズァーク」をリリースして特殊召喚することもできます）。