### PR TITLE
fix--天威無崩の地

### DIFF
--- a/c39730727.lua
+++ b/c39730727.lua
@@ -39,11 +39,10 @@ function c39730727.drfilter2(c,tp)
 	return c:IsType(TYPE_EFFECT) and c:IsSummonPlayer(1-tp) and c:IsFaceup()
 end
 function c39730727.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(c39730727.drfilter1,tp,LOCATION_MZONE,0,1,nil)
-		and eg:IsExists(c39730727.drfilter2,1,nil,tp)
+	return eg:IsExists(c39730727.drfilter2,1,nil,tp)
 end
 function c39730727.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) end
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) and Duel.IsExistingMatchingCard(c39730727.drfilter1,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(2)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)


### PR DESCRIPTION
fix 天威無崩の地 can not activate when 原始生命態ニビル and 原始生命態トークン special summon 

it's effect like 壱世壊を劈く弦声
『自分フィールドに「珠泪哀歌族」モンスターまたは「维萨斯-斯塔弗罗斯特」が存在していれば』は、この効果を発動するタイミングで満たしている必要がある条件です。（自分のモンスターゾーンに表側表示の「珠泪哀歌族」モンスターが存在する状況や、自分フィールドに表側表示の「维萨斯-斯塔弗罗斯特」が存在する状況で発動できます。）表側表示で『フィールドにモンスターが召喚・特殊召喚された』タイミングでこの条件を満たしている必要はありません。