### PR TITLE
fix--ジュラック・メテオ

### DIFF
--- a/c17548456.lua
+++ b/c17548456.lua
@@ -28,13 +28,12 @@ end
 function c17548456.desop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	if g:GetCount()>0 then
-		Duel.Destroy(g,REASON_EFFECT)
-	end
-	local sg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c17548456.spfilter),tp,LOCATION_GRAVE,0,nil,e,tp)
-	if sg:GetCount()~=0 and Duel.SelectYesNo(tp,aux.Stringid(17548456,1)) then
-		Duel.BreakEffect()
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sp=sg:Select(tp,1,1,nil)
-		Duel.SpecialSummon(sp,0,tp,tp,false,false,POS_FACEUP)
+		if Duel.Destroy(g,REASON_EFFECT)~=0 and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c17548456.spfilter),tp,LOCATION_GRAVE,0,1,nil,e,tp) and Duel.SelectYesNo(tp,aux.Stringid(17548456,1)) then
+			Duel.BreakEffect()
+			local sg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c17548456.spfilter),tp,LOCATION_GRAVE,0,nil,e,tp)
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sp=sg:Select(tp,1,1,nil)
+			Duel.SpecialSummon(sp,0,tp,tp,false,false,POS_FACEUP)
+		end
 	end
 end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=8577&request_locale=ja
処理時に、『フィールド上のカードを全て破壊する』処理を行います。１枚以上の破壊に成功した場合、その後『自分の墓地からチューナー１体を選んで特殊召喚できる』処理を任意で行うことができます。（これらは同時に行われません。）

fix ジュラック・メテオ can special summon tuner when no monsters were destroyed by it's effect