### PR TITLE
Fix ライゼオル・デッドネーダー

### DIFF
--- a/c34909328.lua
+++ b/c34909328.lua
@@ -56,7 +56,7 @@ function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
-	return re:GetHandlerPlayer()~=e:GetHandlerPlayer()
+	return rp==1-tp
 end
 function s.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end


### PR DESCRIPTION
About effect②
Use true rp-Check
Avoid condition when p2 using monster effect, p1cannot activate the e②， which were originally belonged to p1 and send itself to grave  as cost. Like Maxx C.
****
**Test Single game:**
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)
Debug.AddCard(82385847,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK)
Debug.AddCard(34909328,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK)
Debug.AddCard(8633261,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK)
Debug.AddCard(34022970,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK)
Debug.AddCard(7672244,0,0,LOCATION_HAND,0,POS_FACEUP_ATTACK)
Debug.AddCard(27288416,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK)
Debug.AddCard(27288416,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK)
Debug.AddCard(23434538,0,1,LOCATION_HAND,6,POS_FACEUP_ATTACK)
Debug.ReloadFieldEnd()