### PR TITLE
fix ファントム・オブ・カオス

### DIFF
--- a/c30312361.lua
+++ b/c30312361.lua
@@ -38,7 +38,7 @@ function c30312361.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)==1 and c:IsRelateToEffect(e) and c:IsFaceup() then
 		--copy name, base atk
-		local code=tc:GetOriginalCode()
+		local code=tc:GetOriginalCodeRule()
 		local ba=tc:GetBaseAttack()
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
https://yugioh-wiki.net/index.php?%A1%D4%A5%D5%A5%A1%A5%F3%A5%C8%A5%E0%A1%A6%A5%AA%A5%D6%A1%A6%A5%AB%A5%AA%A5%B9%A1%D5

Ｑ：《ハーピィ・レディ１》や《ハーピィ・レディ・ＳＢ》の効果とカード名をこのカードでコピーした場合、このカードの名前はどうなりますか？
Ａ：《ハーピィ・レディ１》や《ハーピィ・レディ・ＳＢ》のカード名は、ルール上《ハーピィ・レディ》となります。
　　したがって、《ファントム・オブ・カオス》のカード名は、《ハーピィ・レディ》として扱われます。(11/11/07)

fix ファントム・オブ・カオス fix  ファントム・オブ・カオス's name will change to be ハーピィ・レディ・ＳＢ but not ハーピィ・レディ when ファントム・オブ・カオス copy ハーピィ・レディ・ＳＢ