### PR TITLE
Fix アロマブレンド

### DIFF
--- a/c25861589.lua
+++ b/c25861589.lua
@@ -1,6 +1,7 @@
 --アロマブレンド
 local s,id,o=GetID()
 function c25861589.initial_effect(c)
+	aux.AddCodeList(c,15177750,92266279,28265983)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,1))
@@ -24,6 +25,7 @@ function c25861589.initial_effect(c)
 	e2:SetOperation(s.operation)
 	c:RegisterEffect(e2)
 end
+s.fusion_effect=true
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
@@ -32,8 +34,11 @@ function s.filter(c)
 	return c:IsCode(15177750,92266279,28265983) and not c:IsForbidden()
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil)
-		and Duel.GetLocationCount(tp,LOCATION_SZONE)>0 end
+	if chk==0 then
+		local ft=Duel.GetLocationCount(tp,LOCATION_SZONE)
+		if e:IsHasType(EFFECT_TYPE_ACTIVATE) and not e:GetHandler():IsLocation(LOCATION_SZONE) then ft=ft-1 end
+		return ft>0 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil)
+	end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
修复以下问题：
1、脚本增加CodeList和s.fusion_effect；
2、①效果在自己魔法陷阱区只有一个空位能空发效果（手札を１枚捨てて発動できる。手札・デッキから「潤いの風」「渇きの風」「恵みの風」のいずれか１枚を自分の魔法＆罠ゾーンに表側表示で置く）。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19523&request_locale=ja