### PR TITLE
Fix 堕天使ルシフェル

### DIFF
--- a/c25451652.lua
+++ b/c25451652.lua
@@ -75,7 +75,7 @@ function c25451652.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=Duel.GetMatchingGroupCount(c25451652.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,ct) end
 	Duel.SetOperationInfo(0,CATEGORY_DECKDES,nil,0,tp,ct)
-	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,ct*1000)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,ct*500)
 end
 function c25451652.ctfilter2(c)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsSetCard(0xef)


### PR DESCRIPTION
修复③效果脚本中的OperationInfo回复数值应该是ct*500（自分はこの効果で墓地へ送った「堕天使」カードの数×５００LP回復する）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12723&request_locale=ja