### PR TITLE
Fix 神蝕む光 ティスティナ

### DIFF
--- a/c87676171.lua
+++ b/c87676171.lua
@@ -90,8 +90,9 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and #g>0 then
+	if #g>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
修复③效果在处理时若自己怪兽区没有可用的格子，则应不进行后续处理的问题（X素材を持っているこのカードが相手によって破壊された場合に発動できる。自分の墓地から「ティスティナ」モンスター１体を特殊召喚する）。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19419&request_locale=ja