### PR TITLE
Fix Extinguishment of the Ashened

### DIFF
--- a/c98828338.lua
+++ b/c98828338.lua
@@ -3,7 +3,7 @@ local s,id,o=GetID()
 function s.initial_effect(c)
 	--
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_TOGRAVE+CATEGORY_SEARCH+CATEGORY_GRAVE_ACTION)
+	e1:SetCategory(CATEGORY_TOGRAVE+CATEGORY_GRAVE_ACTION)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,id)


### PR DESCRIPTION
①：デッキから炎族・闇属性モンスター１体を墓地へ送る。その後、自分の墓地からレベル５以上の炎族モンスター１体を手札に加える事ができる。このカードの発動後、ターン終了時まで自分は炎族モンスターしかＥＸデッキから特殊召喚できない。
****
Send 1 DARK Pyro monster from your Deck to the GY, then you can add 1 Level 5 or higher Pyro monster from your GY to your hand. For the rest of this turn after this card resolves, you cannot Special Summon from the Extra Deck, except Pyro monsters.
****
e① is not supposed to add <code>CATEGORY_SEARCH</code>