### PR TITLE
Fix 戦華史略－矯詔之叛

### DIFF
--- a/c45115956.lua
+++ b/c45115956.lua
@@ -10,7 +10,7 @@ function c45115956.initial_effect(c)
 	--special summon
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(45115956,0))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_DAMAGE)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCountLimit(1,45115956)


### PR DESCRIPTION
①效果脚本SetCategory增加CATEGORY_DAMAGE（自分メインフェイズに発動できる。手札から「戦華」モンスター１体を特殊召喚し、自分はそのモンスターのレベル×１００のダメージを受ける）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17175&request_locale=ja