### PR TITLE
Fix サーヴァント・オブ・エンディミオン

### DIFF
--- a/c92559258.lua
+++ b/c92559258.lua
@@ -111,8 +111,7 @@ function c92559258.countercost2(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c92559258.countertg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsCanAddCounter(0x1,1)
-		and Duel.IsExistingMatchingCard(Card.IsCanAddCounter,tp,LOCATION_ONFIELD,0,1,c,0x1,1) end
+	if chk==0 then return c:IsCanAddCounter(0x1,1) end
 	local g=Duel.GetMatchingGroup(Card.IsCanAddCounter,tp,LOCATION_ONFIELD,0,c,0x1,1)
 	g:AddCard(c)
 	Duel.SetOperationInfo(0,CATEGORY_COUNTER,g,#g,0,0)


### PR DESCRIPTION
根据裁定，怪兽②效果在自己场上可以放置魔力指示物只有这张卡时，应该能发动。
自分フィールドに存在する魔力カウンターを置く事ができるカードが、「恩底弥翁的仆从」自身のみの場合でも、『このカード及び自分フィールドの魔力カウンターを置く事ができるカード全てに魔力カウンターを１つずつ置く』モンスター効果を発動する事はできます。

https://ygocdb.com/card/92559258