### PR TITLE
Fix 空牙団の叡智 ウィズ

### DIFF
--- a/c1527418.lua
+++ b/c1527418.lua
@@ -34,7 +34,7 @@ function c1527418.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c1527418.recfilter,tp,LOCATION_MZONE,0,1,nil) end
 	local g=Duel.GetMatchingGroup(c1527418.recfilter,tp,LOCATION_MZONE,0,nil)
 	local rec=g:GetClassCount(Card.GetCode)*500
-	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,1-tp,rec)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,rec)
 end
 function c1527418.recop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c1527418.recfilter,tp,LOCATION_MZONE,0,nil)


### PR DESCRIPTION
修复①效果脚本中SetOperationInfo里target player应为“tp”的问题。
（这张卡特殊召唤成功的场合才能发动。自己回复「空牙团的睿智 薇兹」以外的自己场上的「空牙团」怪兽种类×500基本分）