### PR TITLE
Update 光の結界

### DIFF
--- a/c73206827.lua
+++ b/c73206827.lua
@@ -20,12 +20,11 @@ function c73206827.initial_effect(c)
 	c:RegisterEffect(e2)
 	--
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetCode(73206827)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
 	e3:SetRange(LOCATION_FZONE)
-	e3:SetTargetRange(LOCATION_MZONE,0)
-	e3:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0x5))
 	e3:SetCondition(c73206827.effectcon)
+	e3:SetOperation(c73206827.effectop)
 	c:RegisterEffect(e3)
 	--
 	local e4=Effect.CreateEffect(c)
@@ -54,9 +53,23 @@ function c73206827.coinop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterFlagEffect(73206828,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN,0,2)
 	end
 end
-function c73206827.effectcon(e)
+function c73206827.effectcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
 	return c:GetFlagEffect(73206828)==0 or c:IsHasEffect(EFFECT_CANNOT_DISABLE)
+		and re:IsActiveType(TYPE_MONSTER) and loc==LOCATION_MZONE and re:GetHandler():IsSetCard(0x5)
+end
+function c73206827.effectop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=re:GetHandler()
+	local c=e:GetHandler()
+	if tc:IsSetCard(0x5) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetCode(73206827)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_CHAIN)
+		tc:RegisterEffect(e1)
+	end
 end
 function c73206827.reccon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c73206827.lua
+++ b/c73206827.lua
@@ -55,9 +55,9 @@ function c73206827.coinop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c73206827.effectcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
-	return c:GetFlagEffect(73206828)==0 or c:IsHasEffect(EFFECT_CANNOT_DISABLE)
-		and re:IsActiveType(TYPE_MONSTER) and loc==LOCATION_MZONE and re:GetHandler():IsSetCard(0x5)
+	local loc,p=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_PLAYER)
+	return (c:GetFlagEffect(73206828)==0 or c:IsHasEffect(EFFECT_CANNOT_DISABLE))
+		and p==tp and re:IsActiveType(TYPE_MONSTER) and loc==LOCATION_MZONE and re:GetHandler():IsSetCard(0x5)
 end
 function c73206827.effectop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=re:GetHandler()


### PR DESCRIPTION
fix 光の結界 can not let アルカナフォース monster choose effect when they leave field.
for example, summon アルカナフォースⅤ－THE HIEROPHANT  and activate its effect, and then activate 幽鬼うさぎ's effect to destroy アルカナフォースⅤ－THE HIEROPHANT. when アルカナフォースⅤ－THE HIEROPHANT's effect solved, it can not choose effect by 光の結界

修复光之结界无法让离开场上的秘仪之力怪兽选择效果。
例如，通常召唤アルカナフォースⅤ－THE HIEROPHANT并发动效果，此时连锁发动幽鬼うさぎ的效果将アルカナフォースⅤ－THE HIEROPHANT破坏。此时到アルカナフォースⅤ－THE HIEROPHANT的效果处理时会无法适用光之结界的效果进行效果的选择