### PR TITLE
fix セカンド・チャンス

### DIFF
--- a/c36562627.lua
+++ b/c36562627.lua
@@ -15,7 +15,6 @@ function c36562627.initial_effect(c)
 	e2:SetOperation(c36562627.coinop)
 	c:RegisterEffect(e2)
 end
-c36562627.toss_coin=true
 function c36562627.coincon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and Duel.GetFlagEffect(tp,36562627)==0
 end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5391

■このカードは『コイントスを行う効果を持つカード』ではありません。

fix セカンド・チャンス has a coin tossing effect