### PR TITLE
Fix マルチャミー・フワロス

### DIFF
--- a/c42141493.lua
+++ b/c42141493.lua
@@ -76,6 +76,7 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.filter(c,sp)
 	return c:IsSummonPlayer(sp) and c:IsSummonLocation(LOCATION_DECK+LOCATION_EXTRA)
+		and c:GetOriginalType()&TYPE_MONSTER>0
 end
 function s.drcon1(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.filter,1,nil,1-tp)

--- a/c42141493.lua
+++ b/c42141493.lua
@@ -76,7 +76,7 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.filter(c,sp)
 	return c:IsSummonPlayer(sp) and c:IsSummonLocation(LOCATION_DECK+LOCATION_EXTRA)
-		and c:GetOriginalType()&TYPE_MONSTER>0
+		and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function s.drcon1(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.filter,1,nil,1-tp)


### PR DESCRIPTION
我方「[欢聚友伴·茸茸长尾山雀](https://ygocdb.com/card/name/%E6%AC%A2%E8%81%9A%E5%8F%8B%E4%BC%B4%C2%B7%E8%8C%B8%E8%8C%B8%E9%95%BF%E5%B0%BE%E5%B1%B1%E9%9B%80)」的①效果适用中，对方「[暗黑圣域](https://ygocdb.com/card/name/%E6%9A%97%E9%BB%91%E5%9C%A3%E5%9F%9F)」的①效果让「[死之信息](https://ygocdb.com/?search=%E6%AD%BB%E4%B9%8B%E4%BF%A1%E6%81%AF)」魔法卡在怪兽区域特殊召唤，或者「[魔术礼帽](https://ygocdb.com/card/name/%E9%AD%94%E6%9C%AF%E7%A4%BC%E5%B8%BD)」的①效果让魔法·陷阱卡在怪兽区域特殊召唤的场合，我方不会抽卡。