### PR TITLE
Fix 幽世離レ

### DIFF
--- a/c85698115.lua
+++ b/c85698115.lua
@@ -64,7 +64,7 @@ function s.rfilter(c)
 	return c:IsLevel(1) and c:IsAbleToDeck()
 end
 function s.stfilter(c)
-	return c:IsCode(63086455,11110218,id) and not c:IsForbidden()
+	return c:IsCode(63086455,11110218,id) and not c:IsForbidden() and c:IsSSetable()
 end
 function s.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.rfilter(chkc) end
@@ -75,7 +75,8 @@ function s.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=Duel.GetFirstTarget()
-	if rc:IsRelateToEffect(e) and Duel.SendtoDeck(rc,nil,SEQ_DECKBOTTOM,REASON_EFFECT)~=0 then
+	if rc:IsRelateToEffect(e) and Duel.SendtoDeck(rc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and rc:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
+		Duel.BreakEffect()
 		local g=Duel.GetMatchingGroup(s.stfilter,tp,LOCATION_DECK,0,nil)
 		if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1))then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)


### PR DESCRIPTION
修复②效果以下问题：
1、对象怪兽应是“回到卡组”而不是“回到卡组底部”（そのモンスターをデッキに戻す）；
2、“回到卡组”和“盖放陷阱”是不同时处理（デッキに戻す処理とセットする処理を両方行う場合、それらは同時に行われません）； 
3、适用「转生断绝」的场合，对象怪兽没有回到卡组或者额外卡组的情况下，后续的“是否选择盖放陷阱”应不进行处理；
4、自己的魔法陷阱区没有可用位置时，应不能选择陷阱盖放。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19534&request_locale=ja