### PR TITLE
Fix RR－ストラングル・レイニアス

### DIFF
--- a/c87321742.lua
+++ b/c87321742.lua
@@ -60,7 +60,7 @@ function c87321742.mfilter(c)
 	return c:IsType(TYPE_XYZ) and c:IsAttribute(ATTRIBUTE_DARK)
 end
 function c87321742.ffilter(c)
-	return c:IsType(TYPE_XYZ) and c:GetOverlayGroup():IsExists(c87321742.mfilter,1,nil)
+	return c:IsType(TYPE_XYZ) and c:GetOverlayGroup():IsExists(c87321742.mfilter,1,nil) and c:IsFaceup()
 end
 function c87321742.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c87321742.ffilter,tp,LOCATION_MZONE,0,1,nil)


### PR DESCRIPTION
修复②效果在自己场上只有用暗属性超量怪兽在作为超量素材中的超量怪兽里侧表示的场合，应不能发动的问题。

https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2020.html#id137