### PR TITLE
Fix 天魔の聲選姫

### DIFF
--- a/c23093373.lua
+++ b/c23093373.lua
@@ -19,9 +19,11 @@ function s.initial_effect(c)
 	--
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e3:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
+	e3:SetRange(LOCATION_MZONE)
 	e3:SetCondition(s.atcon)
-	e3:SetValue(1)
+	e3:SetValue(aux.imval1)
 	c:RegisterEffect(e3)
 	--
 	local e4=Effect.CreateEffect(c)


### PR DESCRIPTION
修复②效果在自身里侧表示时，应不能适用的问题（自分フィールドに「天魔の聲選姫」以外のモンスターが存在する限り、相手モンスターはこのカードを攻撃対象に選択できない）。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19863&request_locale=ja