### PR TITLE
remove s.toss_dice, s.toss_dice_in_pendulum_only

### DIFF
--- a/c10960419.lua
+++ b/c10960419.lua
@@ -19,7 +19,6 @@ function c10960419.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 c10960419.material_race=RACE_SPELLCASTER
-c10960419.toss_dice=true
 function c10960419.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and chkc~=e:GetHandler() end
 	if chk==0 then return true end

--- a/c11808215.lua
+++ b/c11808215.lua
@@ -20,7 +20,6 @@ function c11808215.initial_effect(c)
 	e2:SetOperation(c11808215.diceop)
 	c:RegisterEffect(e2)
 end
-c11808215.toss_dice=true
 function c11808215.thfilter(c)
 	return c:IsCode(47292920) and c:IsAbleToHand()
 end

--- a/c12148078.lua
+++ b/c12148078.lua
@@ -12,7 +12,6 @@ function c12148078.initial_effect(c)
 	e1:SetOperation(c12148078.activate)
 	c:RegisterEffect(e1)
 end
-c12148078.toss_dice=true
 function c12148078.cfilter(c,e,tp)
 	return c:IsDiscardable()
 		and Duel.IsExistingMatchingCard(c12148078.spfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,c,e,tp,6)

--- a/c126218.lua
+++ b/c126218.lua
@@ -13,7 +13,6 @@ function c126218.initial_effect(c)
 	e1:SetOperation(c126218.activate)
 	c:RegisterEffect(e1)
 end
-c126218.toss_dice=true
 function c126218.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)

--- a/c15521027.lua
+++ b/c15521027.lua
@@ -35,7 +35,6 @@ function c15521027.initial_effect(c)
 	e3:SetOperation(c15521027.opd)
 	c:RegisterEffect(e3)
 end
-c15521027.toss_dice=true
 function c15521027.spfilter(c)
 	return c:IsSetCard(0x26) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
 end

--- a/c15744417.lua
+++ b/c15744417.lua
@@ -12,7 +12,6 @@ function c15744417.initial_effect(c)
 	e1:SetOperation(c15744417.operation)
 	c:RegisterEffect(e1)
 end
-c15744417.toss_dice=true
 function c15744417.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,3)

--- a/c16135253.lua
+++ b/c16135253.lua
@@ -12,7 +12,6 @@ function c16135253.initial_effect(c)
 	e1:SetOperation(c16135253.operation)
 	c:RegisterEffect(e1)
 end
-c16135253.toss_dice=true
 function c16135253.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end

--- a/c17530001.lua
+++ b/c17530001.lua
@@ -12,7 +12,6 @@ function c17530001.initial_effect(c)
 	e1:SetOperation(c17530001.operation)
 	c:RegisterEffect(e1)
 end
-c17530001.toss_dice=true
 function c17530001.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)

--- a/c22802010.lua
+++ b/c22802010.lua
@@ -11,7 +11,6 @@ function c22802010.initial_effect(c)
 	e1:SetOperation(c22802010.activate)
 	c:RegisterEffect(e1)
 end
-c22802010.toss_dice=true
 function c22802010.filter(c,lv)
 	return c:IsFaceup() and (c:IsLevelBelow(lv) or c:IsRankBelow(lv))
 end

--- a/c30707994.lua
+++ b/c30707994.lua
@@ -12,7 +12,6 @@ function c30707994.initial_effect(c)
 	e1:SetOperation(c30707994.operation)
 	c:RegisterEffect(e1)
 end
-c30707994.toss_dice=true
 function c30707994.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_ADVANCE)
 end

--- a/c31863912.lua
+++ b/c31863912.lua
@@ -20,7 +20,6 @@ function c31863912.initial_effect(c)
 	e2:SetLabel(1)
 	c:RegisterEffect(e2)
 end
-c31863912.toss_dice=true
 function c31863912.cfilter(c,sp)
 	return c:IsFaceup() and c:IsSummonPlayer(sp)
 end

--- a/c32015116.lua
+++ b/c32015116.lua
@@ -20,7 +20,6 @@ function c32015116.initial_effect(c)
 	e2:SetOperation(c32015116.rdop)
 	c:RegisterEffect(e2)
 end
-c32015116.toss_dice=true
 function c32015116.rdcon(e,tp,eg,ep,ev,re,r,rp)
 	return tp==Duel.GetTurnPlayer()
 end

--- a/c3280747.lua
+++ b/c3280747.lua
@@ -10,7 +10,6 @@ function c3280747.initial_effect(c)
 	e1:SetOperation(c3280747.activate)
 	c:RegisterEffect(e1)
 end
-c3280747.toss_dice=true
 function c3280747.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=6 end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,2)

--- a/c3493058.lua
+++ b/c3493058.lua
@@ -11,7 +11,6 @@ function c3493058.initial_effect(c)
 	e1:SetOperation(c3493058.activate)
 	c:RegisterEffect(e1)
 end
-c3493058.toss_dice=true
 function c3493058.filter(c)
 	return c:IsType(TYPE_SPELL+TYPE_TRAP)
 end

--- a/c3549275.lua
+++ b/c3549275.lua
@@ -9,7 +9,6 @@ function c3549275.initial_effect(c)
 	e1:SetOperation(c3549275.operation)
 	c:RegisterEffect(e1)
 end
-c3549275.toss_dice=true
 function c3549275.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,PLAYER_ALL,1)

--- a/c35606858.lua
+++ b/c35606858.lua
@@ -40,7 +40,6 @@ function c35606858.initial_effect(c)
 	e3:SetOperation(c35606858.dcop)
 	c:RegisterEffect(e3)
 end
-c35606858.toss_dice=true
 function c35606858.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end

--- a/c35772782.lua
+++ b/c35772782.lua
@@ -26,7 +26,6 @@ function c35772782.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 aux.xyz_number[35772782]=67
-c35772782.toss_dice=true
 function c35772782.dccon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1
 end

--- a/c35798491.lua
+++ b/c35798491.lua
@@ -19,7 +19,6 @@ function c35798491.initial_effect(c)
 	e2:SetOperation(c35798491.disop)
 	c:RegisterEffect(e2)
 end
-c35798491.toss_dice=true
 function c35798491.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end

--- a/c35975813.lua
+++ b/c35975813.lua
@@ -35,7 +35,6 @@ function c35975813.initial_effect(c)
 	e5:SetOperation(c35975813.disop2)
 	c:RegisterEffect(e5)
 end
-c35975813.toss_dice=true
 function c35975813.exfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x45)
 end

--- a/c36708764.lua
+++ b/c36708764.lua
@@ -11,7 +11,6 @@ function c36708764.initial_effect(c)
 	e1:SetOperation(c36708764.activate)
 	c:RegisterEffect(e1)
 end
-c36708764.toss_dice=true
 function c36708764.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp
 end

--- a/c38082437.lua
+++ b/c38082437.lua
@@ -24,7 +24,6 @@ function c38082437.initial_effect(c)
 	e2:SetOperation(c38082437.opd)
 	c:RegisterEffect(e2)
 end
-c38082437.toss_dice=true
 function c38082437.cona(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsAttackPos()
 end

--- a/c38299233.lua
+++ b/c38299233.lua
@@ -20,7 +20,6 @@ function c38299233.initial_effect(c)
 	e2:SetOperation(c38299233.rdop)
 	c:RegisterEffect(e2)
 end
-c38299233.toss_dice=true
 function c38299233.rdcon(e,tp,eg,ep,ev,re,r,rp)
 	return tp==Duel.GetTurnPlayer()
 end

--- a/c41139112.lua
+++ b/c41139112.lua
@@ -12,7 +12,6 @@ function c41139112.initial_effect(c)
 	e1:SetOperation(c41139112.activate)
 	c:RegisterEffect(e1)
 end
-c41139112.toss_dice=true
 function c41139112.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,1000) end
 	Duel.PayLPCost(tp,1000)

--- a/c42421606.lua
+++ b/c42421606.lua
@@ -22,7 +22,6 @@ function c42421606.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 aux.xyz_number[42421606]=85
-c42421606.toss_dice=true
 function c42421606.efcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)

--- a/c43061293.lua
+++ b/c43061293.lua
@@ -12,7 +12,6 @@ function c43061293.initial_effect(c)
 	e1:SetOperation(c43061293.damop)
 	c:RegisterEffect(e1)
 end
-c43061293.toss_dice=true
 function c43061293.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0
 end

--- a/c46303688.lua
+++ b/c46303688.lua
@@ -12,7 +12,6 @@ function c46303688.initial_effect(c)
 	e1:SetOperation(c46303688.activate)
 	c:RegisterEffect(e1)
 end
-c46303688.toss_dice=true
 function c46303688.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,2)

--- a/c47292920.lua
+++ b/c47292920.lua
@@ -13,7 +13,7 @@ function c47292920.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c47292920.cfilter(c)
-	return c:IsFaceup() and c.toss_dice
+	return c:IsFaceup() and c:IsEffectProperty(aux.EffectCategoryFilter(CATEGORY_DICE))
 end
 function c47292920.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(c47292920.cfilter,tp,LOCATION_ONFIELD,0,1,nil)
@@ -28,8 +28,8 @@ function c47292920.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function c47292920.spfilter(c,e,tp)
-	return c:IsType(TYPE_MONSTER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and c.toss_dice and not c.toss_dice_in_pendulum_only
+	return c:IsType(TYPE_MONSTER) and c:IsEffectProperty(aux.MonsterEffectCategoryFilter(CATEGORY_DICE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c47292920.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then

--- a/c47558785.lua
+++ b/c47558785.lua
@@ -14,8 +14,6 @@ function c47558785.initial_effect(c)
 	e1:SetOperation(c47558785.scop)
 	c:RegisterEffect(e1)
 end
-c47558785.toss_dice=true
-c47558785.toss_dice_in_pendulum_only=true
 function c47558785.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetLeftScale()>1 end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)

--- a/c53154400.lua
+++ b/c53154400.lua
@@ -21,7 +21,6 @@ function s.initial_effect(c)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
 end
-s.toss_dice=true
 function s.dictg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)

--- a/c5641251.lua
+++ b/c5641251.lua
@@ -29,7 +29,6 @@ function c5641251.initial_effect(c)
 	e3:SetOperation(c5641251.lvlop)
 	c:RegisterEffect(e3)
 end
-c5641251.toss_dice=true
 function c5641251.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
 end

--- a/c61370518.lua
+++ b/c61370518.lua
@@ -19,7 +19,6 @@ function c61370518.initial_effect(c)
 	e2:SetOperation(c61370518.disop)
 	c:RegisterEffect(e2)
 end
-c61370518.toss_dice=true
 function c61370518.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end

--- a/c62893810.lua
+++ b/c62893810.lua
@@ -11,7 +11,6 @@ function c62893810.initial_effect(c)
 	e1:SetOperation(c62893810.operation)
 	c:RegisterEffect(e1)
 end
-c62893810.toss_dice=true
 function c62893810.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g1=Duel.GetFieldGroup(tp,LOCATION_HAND,LOCATION_HAND)
 	if chk==0 then return g1:GetCount()~=0 end

--- a/c69170403.lua
+++ b/c69170403.lua
@@ -22,7 +22,6 @@ function c69170403.initial_effect(c)
 	e2:SetOperation(c69170403.dcop)
 	c:RegisterEffect(e2)
 end
-c69170403.toss_dice=true
 function c69170403.spfilter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end

--- a/c71459017.lua
+++ b/c71459017.lua
@@ -55,7 +55,6 @@ function c71459017.initial_effect(c)
 	e8:SetOperation(c71459017.diceop)
 	c:RegisterEffect(e8)
 end
-c71459017.toss_dice=true
 function c71459017.fuslimit(e,c,sumtype)
 	return sumtype&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION
 end

--- a/c72192100.lua
+++ b/c72192100.lua
@@ -31,7 +31,6 @@ function c72192100.initial_effect(c)
 	e3:SetOperation(c72192100.spop)
 	c:RegisterEffect(e3)
 end
-c72192100.toss_dice=true
 function c72192100.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end

--- a/c73219648.lua
+++ b/c73219648.lua
@@ -27,7 +27,6 @@ function c73219648.initial_effect(c)
 	e3:SetValue(c73219648.atktg)
 	c:RegisterEffect(e3)
 end
-c73219648.toss_dice=true
 function c73219648.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end

--- a/c74137509.lua
+++ b/c74137509.lua
@@ -13,7 +13,6 @@ function c74137509.initial_effect(c)
 	e1:SetOperation(c74137509.activate)
 	c:RegisterEffect(e1)
 end
-c74137509.toss_dice=true
 function c74137509.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)

--- a/c76895648.lua
+++ b/c76895648.lua
@@ -19,7 +19,6 @@ function c76895648.initial_effect(c)
 	e2:SetOperation(c76895648.operation)
 	c:RegisterEffect(e2)
 end
-c76895648.toss_dice=true
 function c76895648.condition(e,tp,eg,ep,ev,re,r,rp)
 	return tp==Duel.GetTurnPlayer()
 end

--- a/c77994337.lua
+++ b/c77994337.lua
@@ -14,8 +14,6 @@ function c77994337.initial_effect(c)
 	e1:SetOperation(c77994337.lvop)
 	c:RegisterEffect(e1)
 end
-c77994337.toss_dice=true
-c77994337.toss_dice_in_pendulum_only=true
 function c77994337.lvfilter(c)
 	return c:IsFaceup() and c:GetLevel()>0
 end

--- a/c82308875.lua
+++ b/c82308875.lua
@@ -16,7 +16,6 @@ function c82308875.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 aux.xyz_number[82308875]=7
-c82308875.toss_dice=true
 function c82308875.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)

--- a/c83241722.lua
+++ b/c83241722.lua
@@ -8,7 +8,6 @@ function c83241722.initial_effect(c)
 	e1:SetOperation(c83241722.regop)
 	c:RegisterEffect(e1)
 end
-c83241722.toss_dice=true
 function c83241722.regop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)

--- a/c84046493.lua
+++ b/c84046493.lua
@@ -14,8 +14,6 @@ function c84046493.initial_effect(c)
 	e1:SetOperation(c84046493.scop)
 	c:RegisterEffect(e1)
 end
-c84046493.toss_dice=true
-c84046493.toss_dice_in_pendulum_only=true
 function c84046493.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetLeftScale()<10 end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)

--- a/c84290642.lua
+++ b/c84290642.lua
@@ -13,7 +13,6 @@ function c84290642.initial_effect(c)
 	e1:SetOperation(c84290642.activate)
 	c:RegisterEffect(e1)
 end
-c84290642.toss_dice=true
 function c84290642.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)

--- a/c84397023.lua
+++ b/c84397023.lua
@@ -9,7 +9,6 @@ function c84397023.initial_effect(c)
 	e1:SetOperation(c84397023.op)
 	c:RegisterEffect(e1)
 end
-c84397023.toss_dice=true
 function c84397023.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_HAND,0,1,nil,TYPE_MONSTER) end
 end

--- a/c84813516.lua
+++ b/c84813516.lua
@@ -36,7 +36,6 @@ function c84813516.initial_effect(c)
 	e3:SetOperation(c84813516.thop)
 	c:RegisterEffect(e3)
 end
-c84813516.toss_dice=true
 function c84813516.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end

--- a/c85704698.lua
+++ b/c85704698.lua
@@ -22,7 +22,6 @@ function c85704698.initial_effect(c)
 	e2:SetOperation(c85704698.synop)
 	c:RegisterEffect(e2)
 end
-c85704698.toss_dice=true
 function c85704698.filter(c,e,tp)
 	return c:IsSetCard(0x2016) and c:IsType(TYPE_TUNER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end

--- a/c8581705.lua
+++ b/c8581705.lua
@@ -30,7 +30,6 @@ function c8581705.initial_effect(c)
 	e3:SetOperation(c8581705.atkop)
 	c:RegisterEffect(e3)
 end
-c8581705.toss_dice=true
 function c8581705.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end

--- a/c86154370.lua
+++ b/c86154370.lua
@@ -27,7 +27,6 @@ function c86154370.initial_effect(c)
 	e2:SetOperation(c86154370.spop)
 	c:RegisterEffect(e2)
 end
-c86154370.toss_dice=true
 c86154370.material_type=TYPE_SYNCHRO
 function c86154370.sfilter(c)
 	return c:IsAttribute(ATTRIBUTE_WIND) and c:IsType(TYPE_SYNCHRO)

--- a/c87897777.lua
+++ b/c87897777.lua
@@ -36,7 +36,6 @@ function c87897777.initial_effect(c)
 	e3:SetOperation(c87897777.mvop)
 	c:RegisterEffect(e3)
 end
-c87897777.toss_dice=true
 function c87897777.cfilter(c)
 	return c:IsSetCard(0x17d) and c:IsAttribute(ATTRIBUTE_FIRE) and c:IsFaceup()
 end

--- a/c8868767.lua
+++ b/c8868767.lua
@@ -11,7 +11,6 @@ function c8868767.initial_effect(c)
 	e1:SetOperation(c8868767.activate)
 	c:RegisterEffect(e1)
 end
-c8868767.toss_dice=true
 function c8868767.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if Duel.GetTurnPlayer()==tp then
 		if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_GRAVE,0,1,nil) end

--- a/c93078761.lua
+++ b/c93078761.lua
@@ -11,9 +11,8 @@ function c93078761.initial_effect(c)
 	e1:SetOperation(c93078761.activate)
 	c:RegisterEffect(e1)
 end
-c93078761.toss_dice=true
 function c93078761.filter(c)
-	return c.toss_dice and c:IsAbleToHand()
+	return c:IsEffectProperty(aux.EffectCategoryFilter(CATEGORY_DICE)) and c:IsAbleToHand()
 end
 function c93078761.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c93078761.filter,tp,LOCATION_DECK,0,1,nil) end

--- a/c93542102.lua
+++ b/c93542102.lua
@@ -23,7 +23,6 @@ function c93542102.initial_effect(c)
 	e2:SetOperation(c93542102.opd)
 	c:RegisterEffect(e2)
 end
-c93542102.toss_dice=true
 function c93542102.cona(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsDisabled() and e:GetHandler():IsAttackPos()
 end

--- a/c96015976.lua
+++ b/c96015976.lua
@@ -18,7 +18,6 @@ function c96015976.initial_effect(c)
 	e2:SetOperation(c96015976.operation)
 	c:RegisterEffect(e2)
 end
-c96015976.toss_dice=true
 function c96015976.filter(c)
 	local lv=c:GetLevel()
 	local olv=c:GetOriginalLevel()

--- a/c9603356.lua
+++ b/c9603356.lua
@@ -25,7 +25,6 @@ function c9603356.initial_effect(c)
 	e3:SetValue(aux.ChangeBattleDamage(1,HALF_DAMAGE))
 	c:RegisterEffect(e3)
 end
-c9603356.toss_dice=true
 function c9603356.mtcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
 end

--- a/c97642679.lua
+++ b/c97642679.lua
@@ -13,7 +13,6 @@ function c97642679.initial_effect(c)
 	e1:SetOperation(c97642679.operation)
 	c:RegisterEffect(e1)
 end
-c97642679.toss_dice=true
 function c97642679.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DICE,nil,0,tp,1)

--- a/utility.lua
+++ b/utility.lua
@@ -1793,3 +1793,16 @@ function Auxiliary.BecomeOriginalCode(c,tc,reset)
 	c:RegisterEffect(e1)
 	return e1
 end
+---@param category integer
+---@return function
+function Auxiliary.EffectCategoryFilter(category)
+	return aux.FilterBoolFunction(Effect.IsHasCategory,category)
+end
+---@param category integer
+---@return function
+function Auxiliary.MonsterEffectCategoryFilter(category)
+	---@param e Effect
+	return function (e)
+		return e:IsHasCategory(category) and not e:IsHasRange(LOCATION_PZONE)
+	end
+end


### PR DESCRIPTION
Require:
https://github.com/Fluorohydride/ygopro-core/pull/648

```lua
---@param filter function filter(e)
function Card.IsOriginalEffectProperty(filter) end
```
Check if c is a card with some effect in text.
是否為記載X效果的卡

```lua
---@param filter function filter(e)
function Card.IsEffectProperty(filter) end
```
Check if c is a card with some effect.
是否為持有X效果的卡


```lua
function filter1(c)
return c:IsEffectProperty(aux.EffectCategoryFilter(CATEGORY_DICE))
end
```
サイコロを振る効果を持つカード
card with an effect that requires a die roll
持有擲骰子效果的卡

Test single script:
```lua
--[[message #2730]]
Debug.SetAIName("Test")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(84046493,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(24081957,0,0,LOCATION_HAND,1,POS_FACEDOWN)
Debug.AddCard(47292920,0,0,LOCATION_HAND,1,POS_FACEDOWN)

Debug.AddCard(30312361,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(84046493,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK)

Debug.AddCard(89631139,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,0,0,LOCATION_GRAVE,1,POS_FACEUP_ATTACK)
Debug.AddCard(3549275,0,0,LOCATION_GRAVE,2,POS_FACEUP_ATTACK)

Debug.AddCard(3549275,0,0,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(84046493,0,0,LOCATION_DECK,1,POS_FACEDOWN)

Debug.AddCard(66570171,1,1,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(40044918,1,1,LOCATION_DECK,1,POS_FACEDOWN)
Debug.AddCard(27660735,1,1,LOCATION_DECK,2,POS_FACEDOWN)

Debug.AddCard(89631139,1,1,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK)

Debug.ReloadFieldEnd()

```

@mercury233 
@purerosefallen 
@Wind2009-Louse 