### PR TITLE
Fix メタル化・強化反射装甲

### DIFF
--- a/c89812483.lua
+++ b/c89812483.lua
@@ -45,11 +45,12 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local ft,lv,race,att=e:GetLabel()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.filter2),tp,LOCATION_DECK+LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,e,tp,e:GetLabel()):GetFirst()
 	if tc and Duel.SpecialSummon(tc,0,tp,tp,true,true,POS_FACEUP)>0 then
 		tc:CompleteProcedure()
-		if c:IsOnField() and c:IsRelateToEffect(e) and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
+		if ft==1 and c:IsOnField() and c:IsRelateToEffect(e) and Duel.SelectYesNo(tp,aux.Stringid(id,2)) then
 			Duel.BreakEffect()
 			c:CancelToGrave(true)
 			if Duel.Equip(tp,c,tc)~=0 then


### PR DESCRIPTION
只要卡组存在对应怪兽，可以对「[金属化·钢炎装甲](https://ygocdb.com/card/name/%E9%87%91%E5%B1%9E%E5%8C%96%C2%B7%E9%92%A2%E7%82%8E%E8%A3%85%E7%94%B2)」发动「[伪羽](https://ygocdb.com/card/name/%E4%BC%AA%E7%BE%BD)」「[黑暗中的陷阱](https://ygocdb.com/card/name/%E9%BB%91%E6%9A%97%E4%B8%AD%E7%9A%84%E9%99%B7%E9%98%B1)」「[事务回滚](https://ygocdb.com/card/name/%E4%BA%8B%E5%8A%A1%E5%9B%9E%E6%BB%9A)」，可以除外「[金属化·钢炎装甲](https://ygocdb.com/card/name/%E9%87%91%E5%B1%9E%E5%8C%96%C2%B7%E9%92%A2%E7%82%8E%E8%A3%85%E7%94%B2)」和「[废品收集者](https://ygocdb.com/card/name/%E5%BA%9F%E5%93%81%E6%94%B6%E9%9B%86%E8%80%85)」发动那个效果，可以连锁「[金属化·钢炎装甲](https://ygocdb.com/card/name/%E9%87%91%E5%B1%9E%E5%8C%96%C2%B7%E9%92%A2%E7%82%8E%E8%A3%85%E7%94%B2)」的发动来发动「[拉比林斯迷宫连环阵](https://ygocdb.com/card/name/%E6%8B%89%E6%AF%94%E6%9E%97%E6%96%AF%E8%BF%B7%E5%AE%AB%E8%BF%9E%E7%8E%AF%E9%98%B5)」，只把那只怪兽特殊召唤，这个效果处理完毕。

---

复制效果发动的强化反射装甲应不能处理装备效果