### PR TITLE
Fix 森のメルフィーズ

### DIFF
--- a/c30439101.lua
+++ b/c30439101.lua
@@ -56,10 +56,10 @@ function c30439101.discon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c30439101.cfilter,1,nil,tp)
 end
 function c30439101.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and aux.NegateMonsterFilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(aux.NegateMonsterFilter,tp,0,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISABLE)
-	local g=Duel.SelectTarget(tp,aux.NegateMonsterFilter,tp,0,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,1,0,0)
 end
 function c30439101.disop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Q.
「森のメルフィーズ」の②の効果わ、「青眼の白龍」を対象として発動できる？
「森のメルフィーズ」の②の効果わ、効果が無効になっている「陽炎獣 サーベラス」を対象として発動できる？
A.
ご質問の場合、「青眼の白龍」や効果が無効化されている「陽炎獣 サーベラス」を対象に「森のメルフィーズ」の『②』の効果を発動できます。
発動した場合、そのモンスターはフィールドに表側表示で存在する限り、攻撃できず、効果は無効化されます。