### PR TITLE
Fix ハードアームドラゴン

### DIFF
--- a/c68473226.lua
+++ b/c68473226.lua
@@ -56,7 +56,7 @@ function c68473226.regop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(1)
 	e1:SetCondition(c68473226.indcon)
 	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-	rc:RegisterEffect(e1)
+	rc:RegisterEffect(e1,true)
 end
 function c68473226.indcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_MZONE)


### PR DESCRIPTION
修复②效果不能正常适用的问题（把这张卡解放作召唤的7星以上的怪兽不会被效果破坏）。