### PR TITLE
Update c45112597.lua

### DIFF
--- a/c45112597.lua
+++ b/c45112597.lua
@@ -87,7 +87,7 @@ function c45112597.rmop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.SpecialSummonComplete()
 			local cg=spg:Filter(Card.IsFacedown,nil)
 			if #cg>0 then
-				Duel.ConfirmCards(1-tp,g)
+				Duel.ConfirmCards(1-tp,cg)
 			end
 		end
 	end


### PR DESCRIPTION
Fix Zealantis bug that can cause game freezing if a token was banished by its effect, as it attempts to "reveal" the token after special summoning monsters facedown, even though the token could not be summoned back.