### PR TITLE
Fix 対壊獣用決戦兵器メカサンダー・キング

### DIFF
--- a/c29913783.lua
+++ b/c29913783.lua
@@ -83,7 +83,7 @@ function c29913783.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return tp==Duel.GetTurnPlayer()
 end
 function c29913783.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	if chk==0 then return e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
 function c29913783.spop2(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
修复④在自己场上没有可用怪兽区域时，应不能发动的问题（自分エンドフェイズに発動できる。このカードを墓地から特殊召喚する）。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14352&request_locale=ja