### PR TITLE
Fix ブルーアイズ・タイラント・ドラゴン

### DIFF
--- a/c11443677.lua
+++ b/c11443677.lua
@@ -42,8 +42,7 @@ function c11443677.initial_effect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e5:SetCode(EVENT_DAMAGE_STEP_END)
 	e5:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e5:SetCountLimit(1)
-	e5:SetCondition(aux.dsercon)
+	e5:SetCondition(c11443677.setcon)
 	e5:SetTarget(c11443677.settg)
 	e5:SetOperation(c11443677.setop)
 	c:RegisterEffect(e5)
@@ -80,6 +79,9 @@ end
 function c11443677.efilter(e,te)
 	return te:IsActiveType(TYPE_TRAP)
 end
+function c11443677.setcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(11443677)==0 and aux.dsercon(e,tp,eg,ep,ev,re,r,rp)
+end
 function c11443677.setfilter(c)
 	return c:IsType(TYPE_TRAP) and c:IsSSetable()
 end
@@ -89,6 +91,9 @@ function c11443677.settg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local g=Duel.SelectTarget(tp,c11443677.setfilter,tp,LOCATION_GRAVE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
+	if e:IsCostChecked() then
+		e:GetHandler():RegisterFlagEffect(11443677,RESET_EVENT|RESET_TOFIELD|RESET_TURN_SET|RESET_PHASE|PHASE_END,0,0,1)
+	end
 end
 function c11443677.setop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()


### PR DESCRIPTION
> Question
「ブルーアイズ・タイラント・ドラゴン」が戦闘を行い、そのダメージステップ終了時にフィールドで『③』の『１ターンに１度、このカードが戦闘を行ったダメージステップ終了時に、自分の墓地の罠カード１枚を対象として発動できる』効果を発動しました。
そのターン中にその「ブルーアイズ・タイラント・ドラゴン」が再び戦闘を行い、戦闘で破壊された場合、そのダメージステップ終了時にフィールドを離れた「ブルーアイズ・タイラント・ドラゴン」は再度『③』の効果を発動できますか？
Answer
「ブルーアイズ・タイラント・ドラゴン」が戦闘を行い、フィールドで『③』の効果を発動したターンに、その後の別の戦闘でその「ブルーアイズ・タイラント・ドラゴン」が破壊されフィールドを離れた場合でも、そのダメージステップ終了時に再度『③』の効果を発動することはできません。

test puzzle:

```lua
--[[message TEST]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,255000,0,0)
Debug.SetPlayerInfo(1,80000,0,0)

Debug.AddCard(14087893,0,0,LOCATION_HAND,1,POS_FACEDOWN)

Debug.AddCard(11443677,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
Debug.AddCard(37955049,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)

Debug.AddCard(97077563,0,0,LOCATION_SZONE,2,POS_FACEDOWN)

Debug.AddCard(69632396,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(69632396,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(69632396,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(69632396,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(69632396,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)

Debug.AddCard(1533292,1,1,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)
Debug.AddCard(2316186,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
Debug.AddCard(2322421,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
Debug.AddCard(26096328,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)

Debug.ReloadFieldEnd()
--aux.BeginPuzzle()

Debug.ReloadFieldEnd()
```