### PR TITLE
Fix 破壊剣の使い手－バスター・ブレイダー

### DIFF
--- a/c3428069.lua
+++ b/c3428069.lua
@@ -53,6 +53,7 @@ function c3428069.eqop(e,tp,eg,ep,ev,re,r,rp)
 		if not Duel.Equip(tp,tc,c,false) then return end
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE)
 		e1:SetCode(EFFECT_EQUIP_LIMIT)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		e1:SetValue(c3428069.eqlimit)


### PR DESCRIPTION
Fix when ``破壊剣の使い手－バスター・ブレイダー`` is disabled, equipped monster won't destroy.