### PR TITLE
fix 黎銘機ヘオスヴァローグ

### DIFF
--- a/c8963089.lua
+++ b/c8963089.lua
@@ -46,7 +46,7 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function s.thfilter(c)
-	return c:IsEffectProperty(aux.EffectCategoryFilter(CATEGORY_FUSION_SUMMON)) and c:IsAbleToHand()
+	return c:IsEffectProperty(aux.EffectPropertyFilter(EFFECT_FLAG_FUSION_SUMMON)) and c:IsAbleToHand()
 end
 function s.thop2(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,id)


### PR DESCRIPTION
Require:
https://github.com/Fluorohydride/ygopro-core/pull/677
#2763 


script:
```bash
git checkout -b test-dawn master
git merge --no-edit patch-dice
git merge --no-edit ROTA
git merge --no-edit patch-dawn
```

single:
```lua--[[message 黎銘機ヘオスヴァローグ]]
Debug.SetAIName("Bug")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)


Debug.AddCard(24094653,0,0,LOCATION_HAND,0,POS_FACEDOWN_DEFENSE)
Debug.AddCard(59514116,0,0,LOCATION_HAND,1,POS_FACEDOWN_DEFENSE)
Debug.AddCard(46986414,0,0,LOCATION_HAND,2,POS_FACEDOWN_DEFENSE)
Debug.AddCard(3627449,0,0,LOCATION_HAND,3,POS_FACEDOWN_DEFENSE)

Debug.AddCard(62651957,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(62651957,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK)

Debug.AddCard(89631139,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,0,0,LOCATION_GRAVE,1,POS_FACEUP_ATTACK)

Debug.AddCard(89631139,0,0,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(89631139,0,0,LOCATION_DECK,1,POS_FACEDOWN)
Debug.AddCard(8963089,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)

--opponent
Debug.AddCard(89631139,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,4,POS_FACEUP_ATTACK)

Debug.AddCard(89631139,1,1,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(89631139,1,1,LOCATION_DECK,1,POS_FACEDOWN)
Debug.AddCard(89631139,1,1,LOCATION_DECK,2,POS_FACEDOWN)

Debug.ReloadFieldEnd()
```