### PR TITLE
Fix 背信聖徒シルヴィア

### DIFF
--- a/c46396218.lua
+++ b/c46396218.lua
@@ -53,7 +53,7 @@ function s.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function s.distg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return aux.nbcon(tp,re) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 end
 function s.disop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
修复②效果在适用“自身不能把卡片除外”的状态下（如对方场上存在混沌猎人，适用王宫的铁壁、古遗物-圣枪的效果等）不能发动的问题。（相手が魔法・罠・モンスターの効果を発動した時、このカードをリリースして発動できる。その効果を無効にする）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=20506&request_locale=ja