### PR TITLE
Fix M∀LICE＜C＞TB－11

### DIFF
--- a/c57111661.lua
+++ b/c57111661.lua
@@ -35,7 +35,6 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_EXTRA)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return false end
 	local co=Duel.GetMatchingGroupCount(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,1,nil,e,tp,co,nil)


### PR DESCRIPTION
修复在对方场上存在3张以上的卡，自己额外卡组存在「码丽丝」连接怪兽，自己主要怪兽区域没有可用位置而额外怪兽区域有可用位置时会空发的问题。（相手フィールドにカードが３枚以上存在する場合、代わりにEXデッキから「M∀LICE」Lモンスター１体を特殊召喚する事もできる） 
注：脚本中的s.spfilter已进行了两种情况的可用怪兽区域检查。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=20591&request_locale=ja