### PR TITLE
Fix 空隙の原星竜

### DIFF
--- a/c72578374.lua
+++ b/c72578374.lua
@@ -36,7 +36,7 @@ function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_FUSION)
 end
 function s.desfilter(c,tp)
-	return c:IsAttribute(ATTRIBUTE_DARK+ATTRIBUTE_LIGHT) and c:GetOwner()==tp
+	return c:IsAttribute(ATTRIBUTE_DARK+ATTRIBUTE_LIGHT) and c:GetPreviousControler()==tp
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) end


### PR DESCRIPTION
我方发动「心变」，得到对方1只暗属性的龙族怪兽控制权后，和我方另1只暗属性龙族怪兽作为素材融合召唤「空隙之原星龙」，发动①效果的场合，『作为融合素材的自己的光·暗属性怪兽数量』是2张。