### PR TITLE
Fix ジャンクリボー

### DIFF
--- a/c38491199.lua
+++ b/c38491199.lua
@@ -7,7 +7,7 @@ function c38491199.initial_effect(c)
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_NEGATE)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
 	e1:SetCode(EVENT_CHAINING)
-	e1:SetRange(LOCATION_HAND)
+	e1:SetRange(LOCATION_HAND+LOCATION_MZONE)
 	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
 	e1:SetCondition(c38491199.negcon)
 	e1:SetCost(c38491199.negcost)
@@ -20,7 +20,7 @@ function c38491199.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
 end
 function c38491199.negcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsChainNegatable(ev) and aux.damcon1(e,tp,eg,ep,ev,re,r,rp)
+	return ep==1-tp and not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev) and aux.damcon1(e,tp,eg,ep,ev,re,r,rp)
 end
 function c38491199.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
修复以下问题：
1、发动范围应包含“场上的这张卡”（この効果を発動する際に、コストとして、手札または自分のモンスターゾーンに表側表示で存在する「ジャンクリボー」自身を墓地へ送ります）；
2、应只能连锁“对方”的效果才能发动（自分にダメージを与える魔法·罠·モンスターの効果を相手が発動した時）；
3、发动效果时自身不能处于“被战斗破坏”的状态。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12256&request_locale=ja
