### PR TITLE
Fix 封狼雷坊

### DIFF
--- a/c66722103.lua
+++ b/c66722103.lua
@@ -27,7 +27,7 @@ function c66722103.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c66722103.condition(e,tp,eg,ep,ev,re,r,rp)
-	return ep==1-tp and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev)
+	return ep==1-tp and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev) and not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function c66722103.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()


### PR DESCRIPTION
修复①效果在发动时自身应不能处于“被战斗破坏”状态的问题（相手がモンスターの効果を発動した時、特殊召喚したこのカードをリリースして発動できる。その発動を無効にし破壊する）。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14103&request_locale=ja