### PR TITLE
Fix Auxiliary.DrytronSpSummonLimit

### DIFF
--- a/c94187078.lua
+++ b/c94187078.lua
@@ -23,7 +23,7 @@ function c94187078.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
 	e1:SetTargetRange(1,0)
-	e1:SetTarget(c94187078.splimit)
+	e1:SetTarget(Auxiliary.DrytronSpSummonLimit)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 	--cant special summon summonable card check

--- a/c94187078.lua
+++ b/c94187078.lua
@@ -35,9 +35,6 @@ function c94187078.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e2,tp)
 end
-function c94187078.splimit(e,c,sump,sumtype,sumpos,targetp,se)
-	return c:IsSummonableCard()
-end
 function c94187078.filter(c,e,tp)
 	return c:IsSetCard(0x154) and c:IsCanBeSpecialSummoned(e,0,tp,false,aux.DrytronSpSummonType(c))
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1052,7 +1052,7 @@ function Auxiliary.DrytronSpSummonCost(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function Auxiliary.DrytronSpSummonLimit(e,c,sump,sumtype,sumpos,targetp,se)
-	return c:IsSummonableCard()
+	return c:IsSummonableCard() and c:GetOriginalType()&(TYPE_SPELL|TYPE_TRAP|TYPE_TRAPMONSTER)==0
 end
 function Auxiliary.DrytronSpSummonTarget(e,tp,eg,ep,ev,re,r,rp,chk)
 	local res=e:GetLabel()==100 or Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
Fix: After activated Drytron effect, trap monsters cannot special summon.

修复发动龙辉巧系效果后，陷阱怪兽不能特殊召唤的bug