### PR TITLE
fix--影霊衣の万華鏡

### DIFF
--- a/c51124303.lua
+++ b/c51124303.lua
@@ -22,7 +22,8 @@ function c51124303.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c51124303.spfilter(c,e,tp,mc)
-	return c:IsSetCard(0xb4) and bit.band(c:GetType(),0x81)==0x81 and (not c.mat_filter or c.mat_filter(mc,tp))
+	local mg=Group.FromCards(mc)
+	return c:IsSetCard(0xb4) and bit.band(c:GetType(),0x81)==0x81 and (not c.mat_filter or c.mat_filter(mc,tp)) and (not c.mat_group_check or c.mat_group_check(mg,tp))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true)
 		and mc:IsCanBeRitualMaterial(c)
 end


### PR DESCRIPTION
fix 影霊衣の万華鏡 can RITUAL summon sophiaの影霊衣 by release 1 monster