### PR TITLE
Fix EFFECT_CANNOT_DISCARD_HAND

### DIFF
--- a/c425934.lua
+++ b/c425934.lua
@@ -8,6 +8,10 @@ function c425934.initial_effect(c)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetTargetRange(1,1)
 	e1:SetCode(EFFECT_CANNOT_DISCARD_HAND)
+	e1:SetTarget(c425934.target)
 	e1:SetValue(1)
 	c:RegisterEffect(e1)
+end
+function c425934.target(e,dc,re,r)
+	return r==REASON_COST
 end

--- a/c425934.lua
+++ b/c425934.lua
@@ -13,5 +13,5 @@ function c425934.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c425934.target(e,dc,re,r)
-	return r==REASON_COST
+	return r&REASON_COST==REASON_COST
 end

--- a/c49655592.lua
+++ b/c49655592.lua
@@ -97,5 +97,5 @@ function c49655592.excon(e)
 	return e:GetHandler():IsLevelAbove(7)
 end
 function c49655592.extarget(e,dc,re,r)
-	return r==REASON_COST
+	return r&REASON_COST==REASON_COST
 end

--- a/c49655592.lua
+++ b/c49655592.lua
@@ -47,6 +47,7 @@ function c49655592.initial_effect(c)
 	e5:SetTargetRange(0,1)
 	e5:SetCode(EFFECT_CANNOT_DISCARD_HAND)
 	e5:SetCondition(c49655592.excon)
+	e5:SetTarget(c49655592.extarget)
 	e5:SetValue(1)
 	c:RegisterEffect(e5)
 	local e6=Effect.CreateEffect(c)
@@ -94,4 +95,7 @@ function c49655592.costop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c49655592.excon(e)
 	return e:GetHandler():IsLevelAbove(7)
+end
+function c49655592.extarget(e,dc,re,r)
+	return r==REASON_COST
 end


### PR DESCRIPTION
**F.A.ウィップクロッサー** and **強欲ゴブリン** should only forbid player from discard hands as cost, not effect.

Test puzzle:

```
--[[message TEST]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,3)
Debug.SetPlayerInfo(0,255000,0,0)
Debug.SetPlayerInfo(1,80000,0,0)

Debug.AddCard(69162969,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(83518674,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(4392470,0,0,LOCATION_HAND,0,POS_FACEDOWN)

-- Debug.AddCard(49655592,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
Debug.AddCard(425934,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)

Debug.AddCard(73594093,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
Debug.AddCard(1061200,1,1,LOCATION_SZONE,5,POS_FACEUP)
Debug.AddCard(1061200,0,0,LOCATION_SZONE,5,POS_FACEUP)

Debug.ReloadFieldEnd()
--aux.BeginPuzzle()
```