### PR TITLE
fix 深海のミンストレル

### DIFF
--- a/c71978434.lua
+++ b/c71978434.lua
@@ -42,11 +42,13 @@ function c71978434.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,1-tp,LOCATION_HAND)
 end
 function c71978434.rmop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_HAND,nil)
+	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_HAND,nil)
 	if g:GetCount()==0 then return end
 	Duel.ConfirmCards(tp,g)
+	local g1=g:Filter(Card.IsAbleToRemove,nil)
+	if g1:GetCount()==0 then Duel.ShuffleHand(1-tp) return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local tc=g:Select(tp,1,1,nil):GetFirst()
+	local tc=g1:Select(tp,1,1,nil):GetFirst()
 	Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
 	Duel.ShuffleHand(1-tp)
 	local c=e:GetHandler()


### PR DESCRIPTION
fix 深海のミンストレル  should confirm opponent's hand when player can not remove card in this effect resolve.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23664&keyword=&tag=-1
Question
『●デッキから「神碑の穂先」以外の「神碑」カード１枚を手札に加える。その後、相手のデッキの上からカードを１枚除外する』効果を選択して「神碑の穂先」を発動しました。

この効果の処理時に、「アーティファクト－ロンギヌス」の③の『このターン、お互いにカードを除外できない』効果が適用された場合、どうなりますか？
Answer
その場合でも『デッキから「神碑の穂先」以外の「神碑」カード１枚を手札に加える』処理を行います。『相手のデッキの上からカードを１枚除外する』処理を行えませんので、そこで処理を完了します。なお、『このカードの発動後、次の自分バトルフェイズをスキップする』効果は適用されます。

以下のカードについても同様です。
「輝く炎の神碑」「破壊の神碑」「凍てつく呪いの神碑」「まどろみの神碑」「黄金の雫の神碑」「解呪の神碑」