### PR TITLE
fix--光の召集

### DIFF
--- a/c16255442.lua
+++ b/c16255442.lua
@@ -25,6 +25,7 @@ function c16255442.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c16255442.operation(e,tp,eg,ep,ev,re,r,rp)
 	local sg=Duel.GetFieldGroup(tp,LOCATION_HAND,0)
+	if not Duel.IsExistingMatchingCard(c16255442.filter,tp,LOCATION_GRAVE,0,#sg,nil) then return end
 	Duel.SendtoGrave(sg,REASON_EFFECT+REASON_DISCARD)
 	local ct=sg:FilterCount(Card.IsLocation,nil,LOCATION_GRAVE)
 	local tg=Duel.GetMatchingGroup(c16255442.filter,tp,LOCATION_GRAVE,0,nil)


### PR DESCRIPTION
「光之召集」的①效果处理时，墓地的光属性怪兽比自己手卡数要少的场合，这个效果完全不适用，也不会丢弃手卡。09/3/14
https://yugioh-wiki.net/index.php?%A1%D4%B8%F7%A4%CE%BE%A4%BD%B8%A1%D5#faq
Ｑ：手札と同じ枚数の光属性が墓地に存在するとき、このカードを発動しました。
　　《Ｄ.Ｄ.クロウ》をチェーンされるなどの結果、このカードの効果処理時に墓地に手札よりも少ない光属性しか存在しなくなったとき、どのように処理しますか？
Ａ：効果処理時に、捨てる手札の枚数よりも墓地に存在する光属性モンスターが少ない場合、「手札を全て墓地へ捨てる」処理から不発となります。
　　手札に加える処理も行いません。(09/03/14)