### PR TITLE
Fix システム・ダウン

### DIFF
--- a/c18895832.lua
+++ b/c18895832.lua
@@ -16,13 +16,10 @@ function c18895832.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,1000)
 end
 function c18895832.filter(c)
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAbleToRemove()
+	return c:IsFaceupEx() and c:IsRace(RACE_MACHINE) and c:IsAbleToRemove()
 end
 function c18895832.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then
-		local g=Duel.GetMatchingGroup(c18895832.filter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,nil)
-		return g:GetCount()>0
-	end
+	if chk==0 then return Duel.IsExistingMatchingCard(c18895832.filter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,1,nil) end
 	local g=Duel.GetMatchingGroup(c18895832.filter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
 end

--- a/c18895832.lua
+++ b/c18895832.lua
@@ -18,13 +18,10 @@ end
 function c18895832.filter(c)
 	return c:IsFaceup() and c:IsRace(RACE_MACHINE)
 end
-function c18895832.tfilter(c)
-	return not c:IsAbleToRemove()
-end
 function c18895832.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local g=Duel.GetMatchingGroup(c18895832.filter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,nil)
-		return g:GetCount()>0 and not g:IsExists(c18895832.tfilter,1,nil)
+		return g:GetCount()>0
 	end
 	local g=Duel.GetMatchingGroup(c18895832.filter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)

--- a/c18895832.lua
+++ b/c18895832.lua
@@ -16,7 +16,7 @@ function c18895832.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,1000)
 end
 function c18895832.filter(c)
-	return c:IsFaceup() and c:IsRace(RACE_MACHINE)
+	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAbleToRemove()
 end
 function c18895832.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7649&keyword=&tag=-1&request_locale=ja
> Question
相手のモンスターゾーンに「霊滅術師 カイクウ」が表側表示で存在し、『①：このカードがモンスターゾーンに存在する限り、相手はお互いの墓地のカードを除外できない』永続効果が適用されています。
この状況で、自分は「システム・ダウン」を発動できますか？
Answer
相手のモンスターゾーンに機械族モンスターが存在する場合であれば発動できます。また、その処理時に「霊滅術師 カイクウ」の①の永続効果が適用されているのであれば、相手のフィールドの機械族モンスターのみを全て除外します。
相手のモンスターゾーンに機械族モンスターが存在せず、相手の墓地にのみ機械族モンスターが存在している場合、自分は「システム・ダウン」を発動できません。