### PR TITLE
Fix 暗黒界の鬼神 ケルト

### DIFF
--- a/c34968834.lua
+++ b/c34968834.lua
@@ -20,7 +20,9 @@ function c34968834.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 	if rp==1-tp and tp==e:GetLabel() then
-		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+		e:SetCategory(CATEGORY_SPECIAL_SUMMON|CATEGORY_DECKDES)
+	else
+		e:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	end
 end
 function c34968834.filter(c,e,tp)


### PR DESCRIPTION
Fix 暗黒界の鬼神 ケルト can be special summoned even if 王家の眠る谷－ネクロバレー is activated