### PR TITLE
Fix 創星竜華－光巴

### DIFF
--- a/c92487128.lua
+++ b/c92487128.lua
@@ -90,7 +90,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
 	local g=Duel.SelectMatchingCard(tp,s.rfilter,tp,LOCATION_MZONE,0,1,1,aux.ExceptThisCard(e),tp,c)
-	if Duel.Release(g,REASON_EFFECT) and c:IsRelateToEffect(e) and Duel.SpecialSummon(c,SUMMON_TYPE_RITUAL,tp,tp,true,true,POS_FACEUP)~=0 then
+	if Duel.Release(g,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) and Duel.SpecialSummon(c,SUMMON_TYPE_RITUAL,tp,tp,true,true,POS_FACEUP)~=0 then
 		c:CompleteProcedure()
 		if Duel.IsExistingMatchingCard(s.desfilter,tp,LOCATION_ONFIELD,0,1,nil,tp)
 			and Duel.IsExistingMatchingCard(s.pfilter,tp,LOCATION_DECK,0,1,nil,tp)


### PR DESCRIPTION
修复怪兽①效果在处理时若没有解放「龙华」怪兽成功应不执行后续特殊召唤自身的问题。【処理時に、『自分フィールドのレベル１０の「竜華」モンスター１体をリリースし』の処理を行います。リリースする処理に成功し、使用可能なエクストラモンスターゾーン、またはリンクモンスターのリンク先が存在する場合、『このカードを儀式召喚扱いで特殊召喚する』処理を行います（使用可能なエクストラモンスターゾーン、またはリンクモンスターのリンク先が存在しない場合、このカードはエクストラデッキから墓地へ送られます）。】