### PR TITLE
Fix ARG☆S－HomeStadium

### DIFF
--- a/c2674965.lua
+++ b/c2674965.lua
@@ -75,7 +75,7 @@ end
 function s.discon(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	return rc:IsAllTypes(TYPE_TRAP+TYPE_CONTINUOUS)	and re:GetActivateLocation()==LOCATION_MZONE
-		and Duel.IsExistingMatchingCard(s.cfilter2,tp,LOCATION_REMOVED,0,1,nil)
+		and Duel.IsExistingMatchingCard(s.cfilter2,tp,LOCATION_REMOVED,0,1,nil) and rp==tp
 end
 function s.distg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() and aux.NegateAnyFilter(chkc) end


### PR DESCRIPTION
修复③效果应只有自己的永续陷阱卡在怪兽区域把效果发动的场合才能触发的问题。（自分の永続罠カードがモンスターゾーンで効果を発動した場合）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=20795&request_locale=ja