### PR TITLE
fix attach xyz material effect by Ryzeal

### DIFF
--- a/c33787730.lua
+++ b/c33787730.lua
@@ -40,7 +40,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 end
 function s.xyzfilter(c,e,tp)
-	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsRank(4)
+	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsRank(4) and not c:IsImmuneToEffect(e)
 		and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(s.mtfilter),tp,LOCATION_GRAVE,0,1,nil,e)
 end
 function s.mtfilter(c,e)

--- a/c34909328.lua
+++ b/c34909328.lua
@@ -48,7 +48,7 @@ function s.mttg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.mtfilter),tp,LOCATION_GRAVE,0,1,1,nil,e)
 	if g:GetCount()>0 then

--- a/c60394026.lua
+++ b/c60394026.lua
@@ -30,7 +30,7 @@ function s.xyzfilter(c,e,tp)
 		and Duel.IsExistingMatchingCard(s.mtfilter,tp,LOCATION_DECK,0,1,nil,e)
 end
 function s.mtfilter(c,e)
-	return c:IsSetCard(0x1be)
+	return c:IsSetCard(0x1be) and not c:IsImmuneToEffect(e)
 		and c:IsCanOverlay() and not (e and c:IsImmuneToEffect(e))
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)

--- a/c7511613.lua
+++ b/c7511613.lua
@@ -49,7 +49,7 @@ function s.mttg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
+	if not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.mtfilter),tp,LOCATION_GRAVE,0,1,1,nil,e)
 	if g:GetCount()>0 then


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13415&request_locale=ja
https://ocg-rule.readthedocs.io/zh-cn/latest/c03/%E5%8D%A1%E7%89%87%E7%9A%84%E6%8A%97%E6%80%A7.html#id8
在X怪兽下面重叠作为X素材，或给怪兽放置指示物的效果，都影响那个怪兽。

修复雷火沸动卡把卡作为超量素材的效果没有检查抗性
fix this effect don't check card is Immune this effect