### PR TITLE
Fix E・HERO ゴッド・ネオス

### DIFF
--- a/c31111109.lua
+++ b/c31111109.lua
@@ -80,7 +80,7 @@ function c31111109.rstop(e,tp,eg,ep,ev,re,r,rp)
 		atke:SetReset(RESET_EVENT+RESETS_STANDARD)
 	end
 	c:ResetEffect(cid,RESET_COPY)
-	c:ResetEffect(RESET_DISABLE,RESET_EVENT)
+	c:ResetEffect(RESET_DISABLE,RESET_EVENT+RESETS_STANDARD)
 	if atke then
 		atke:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
 	end


### PR DESCRIPTION
修复此卡在场上第二次使用效果时，回合结束会导致上升的攻击力失效的问题。（500ポイントアップした攻撃力の数値は、このモンスターがフィールド上に表側表示で存在する限り適用され続けます）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7806&request_locale=ja