### PR TITLE
fix material is detached effect

### DIFF
--- a/c11132674.lua
+++ b/c11132674.lua
@@ -56,7 +56,7 @@ function c11132674.srop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c11132674.descon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(Card.IsLocation,1,nil,LOCATION_MZONE)
+	return eg:IsExists(Card.IsLocation,1,nil,LOCATION_MZONE) and not ((r&REASON_RULE)>0)
 end
 function c11132674.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() end

--- a/c34001672.lua
+++ b/c34001672.lua
@@ -61,7 +61,7 @@ function c34001672.xmfilter(c)
 	return c:IsFaceup() and c:IsCanOverlay()
 end
 function c34001672.xmcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(Card.IsLocation,1,nil,LOCATION_MZONE)
+	return eg:IsExists(Card.IsLocation,1,nil,LOCATION_MZONE) and not ((r&REASON_RULE)>0)
 end
 function c34001672.xmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()


### PR DESCRIPTION
https://ocg-rule.readthedocs.io/zh-cn/latest/c06/2023.html#id71
邮件：
用2只持有X素材的X怪兽为素材，X召唤了「未来No.0 未来皇 霍普」，这2只X怪兽的X素材送去墓地的场合，「巨大喷流“冠军”尾宿五」的②效果不能发动。

fix 百鬼羅刹 巨魁ガボンガ and ギガンティック“チャンピオン”サルガス can active effect when use xyz monsters which have xyz material to xyz summon FNo.0 未来皇ホープ