### PR TITLE
Fix ShuffleDeck

### DIFF
--- a/c27015862.lua
+++ b/c27015862.lua
@@ -58,7 +58,6 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		local tag=g:Select(tp,1,1,nil)
 		Duel.SendtoHand(tag,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,tag)
-		Duel.ShuffleDeck(tp)
 	end
 end
 function s.desfilter2(c,tp)

--- a/c28912357.lua
+++ b/c28912357.lua
@@ -44,7 +44,6 @@ function c28912357.operation(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
-		Duel.ShuffleDeck(tp)
 	end
 end
 function c28912357.spcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
修复 齿轮齿巨人X、吠陀-迦兰多效果涉及到卡组，但实际处理并没有用到卡组时仍然会洗一次牌 的问题