### PR TITLE
Fix 氷水啼エジル・ギュミル

### DIFF
--- a/c86682165.lua
+++ b/c86682165.lua
@@ -57,8 +57,14 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e2,tp)
 	local ch=Duel.GetCurrentChain()
 	if ch>1 then
-		local p,code=Duel.GetChainInfo(ch-1,CHAININFO_TRIGGERING_PLAYER,CHAININFO_TRIGGERING_CODE)
+		local p,code,te=Duel.GetChainInfo(ch-1,CHAININFO_TRIGGERING_PLAYER,CHAININFO_TRIGGERING_CODE,CHAININFO_TRIGGERING_EFFECT)
 		if p==1-tp then
+			if te then
+				local tc=te:GetHandler()
+				if tc and tc:IsRelateToEffect(te) then
+					code=tc:GetCode()
+				end
+			end
 			local g=Duel.GetMatchingGroup(s.rmfilter,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,nil,code)
 			if #g>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
 				Duel.BreakEffect()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23907&keyword=&tag=-1&request_locale=ja
> 原則として「氷水啼エジル・ギュミル」の①の効果の処理時に、効果を発動したカードのカード名を参照して除外する処理を行います。（モンスターゾーンで効果を発動したモンスターが裏側守備表示になっている場合でも、処理時のカード名を参照して処理を行います。）