### PR TITLE
fix Play the Diabell

### DIFF
--- a/c39881252.lua
+++ b/c39881252.lua
@@ -26,9 +26,14 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.cfilter(c,re)
-	return c:IsType(TYPE_SPELL+TYPE_TRAP)
-		and c:IsReason(REASON_COST) and re:IsActivated()
-		and (not c:IsPreviousLocation(LOCATION_ONFIELD) or c:GetPreviousTypeOnField()&(TYPE_SPELL+TYPE_TRAP)~=0)
+	if not c:IsType(TYPE_SPELL+TYPE_TRAP) or not c:IsReason(REASON_COST) then return false end
+	if c:IsPreviousLocation(LOCATION_ONFIELD) and c:GetPreviousTypeOnField()&(TYPE_SPELL+TYPE_TRAP)==0 then return false end
+	local recode=re:GetCode()
+	return re:IsActivated()
+		or recode==EFFECT_TRAP_ACT_IN_HAND
+		or recode==EFFECT_TRAP_ACT_IN_SET_TURN
+		or recode==EFFECT_QP_ACT_IN_NTPHAND
+		or recode==EFFECT_QP_ACT_IN_SET_TURN
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.cfilter,1,nil,re)


### PR DESCRIPTION
mail:
> Q.
このターンにセットされた「ホールティアの蟲惑魔」を発動するために、手札の「激流葬」を捨てた場合、「プレイ・ザ・ディアベル」の効果を発動できますか？
A.
ご質問の場合、自分がその「ホールティアの蟲惑魔」の『①』の効果を発動した一連のチェーン処理後に、あらためて自分は「プレイ・ザ・ディアベル」の『①』の効果を発動することができます。