### PR TITLE
Fix Necroquip Princess

### DIFF
--- a/c93860227.lua
+++ b/c93860227.lua
@@ -35,7 +35,7 @@ function s.ffilter1(c,fc,sub,mg,sg)
 	return c:GetEquipGroup():IsExists(s.eqilter,1,nil)
 end
 function s.ffilter2(c,fc,sub,mg,sg)
-	return c:GetOriginalType()&TYPE_MONSTER~=0 and c:GetOriginalRace()&RACE_FIEND~=0
+	return c:GetOriginalType()&TYPE_MONSTER~=0 and c:IsRace(RACE_FIEND)
 end
 function s.tgfilter(c)
 	return c:IsPreviousLocation(LOCATION_HAND) and c:IsType(TYPE_MONSTER)


### PR DESCRIPTION
Fixed type check according to the recent ruling. Function getRace() returns a monster card's current type when it is treated as a monster or its original type when it is treated as a spell or trap card.