### PR TITLE
fix 方舟の選別

### DIFF
--- a/c30888983.lua
+++ b/c30888983.lua
@@ -21,7 +21,7 @@ function c30888983.cfilter(c,rc)
 	return c:IsFaceup() and c:IsRace(rc)
 end
 function c30888983.filter(c)
-	return Duel.IsExistingMatchingCard(c30888983.cfilter,0,LOCATION_MZONE,LOCATION_MZONE,1,nil,c:GetRace())
+	return Duel.IsExistingMatchingCard(c30888983.cfilter,0,LOCATION_MZONE,LOCATION_MZONE,1,c,c:GetRace())
 end
 function c30888983.condition(e,tp,eg,ep,ev,re,r,rp)
 	return aux.NegateSummonCondition() and eg:IsExists(c30888983.filter,1,nil)


### PR DESCRIPTION
> ■「方舟の選別」の効果は、ある種族のモンスターがモンスターゾーンに表側表示で存在する場合に、**2体目**以降となる同じ種族のモンスターが召喚・反転召喚・特殊召喚される際に発動し、それを無効にして破壊する効果です。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6450&request_locale=ja

close #2841 