### PR TITLE
Fix Duel.ChangePosition

### DIFF
--- a/c60398723.lua
+++ b/c60398723.lua
@@ -25,8 +25,8 @@ function c60398723.rfilter(c)
 end
 function c60398723.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsControler(1-tp) and tc:IsFaceup() then
-		Duel.ChangePosition(tc,POS_FACEDOWN_DEFENSE)
+	if tc:IsRelateToEffect(e) and tc:IsControler(1-tp) and tc:IsFaceup()
+		and Duel.ChangePosition(tc,POS_FACEDOWN_DEFENSE)>0 then
 		local rg=Duel.GetMatchingGroup(c60398723.rfilter,tp,LOCATION_FZONE,LOCATION_FZONE,nil)
 		if rg:GetCount()~=0 and Duel.SelectYesNo(tp,aux.Stringid(60398723,0)) then
 			Duel.BreakEffect()

--- a/c86999951.lua
+++ b/c86999951.lua
@@ -32,8 +32,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsCanTurnSet,tp,0,LOCATION_MZONE,nil)
-	if g:GetCount()>0 then
-		Duel.ChangePosition(g,POS_FACEDOWN_DEFENSE)
+	if g:GetCount()>0 and Duel.ChangePosition(g,POS_FACEDOWN_DEFENSE)>0 then
 		local g1=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_ONFIELD,nil)
 		if g1:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
 			Duel.BreakEffect()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=24145&keyword=&tag=-1&request_locale=ja

> Question
「黄金郷のコンキスタドール」とリンクモンスターの２体のみが相手のモンスターゾーンに存在し、自分のモンスターゾーンに表側表示モンスターが存在しない状況で自分が「魔砲戦機ダルマ・カルマ」を発動した場合、「魔砲戦機ダルマ・カルマ」の『その後、フィールドに表側表示でモンスターが存在する場合、そのコントローラーは自身のフィールドの表側表示モンスターを全て墓地へ送らなければならない』処理を行いますか？
Answer
行いません。
「黄金郷のコンキスタドール」のようなモンスターゾーンで罠カードとしても扱われるカードは、裏側守備表示になる際は魔法&罠ゾーンにセットされるため、『裏側守備表示にする』処理に成功した扱いにはなりません。
以下のカードの効果で「黄金郷のコンキスタドール」のようなモンスターゾーンで罠カードとしても扱われるカードにのみ裏側守備表示にする効果が適用された場合でも、裏側守備表示にする処理に成功した扱いにはなりません。
「結晶神ティスティナ」①
「ティスティナの息吹」②
「ティスティナの半神」②
「壱世壊に軋む爪音」①
「森のざわめき」
「リバースポッド」
「ゴーストリック・フロスト 」
「サブテラーの妖魔」②