### PR TITLE
Fix スケアクロー・クシャトリラ

### DIFF
--- a/c44874522.lua
+++ b/c44874522.lua
@@ -41,8 +41,8 @@ function c44874522.valcheck(e,c)
 	local flag=0
 	local tc=g:GetFirst()
 	while tc do
-		if tc:IsSetCard(0x7) then flag=bit.bor(flag,0x1) end
-		if tc:IsSetCard(0x51) then flag=bit.bor(flag,0x2) end
+		if tc:IsSetCard(0x7) and tc:IsType(TYPE_MONSTER) then flag=bit.bor(flag,0x1) end
+		if tc:IsSetCard(0x51) and tc:IsType(TYPE_MONSTER) then flag=bit.bor(flag,0x2) end
 		tc=g:GetNext()
 	end
 	e:SetLabel(flag)

--- a/c81269231.lua
+++ b/c81269231.lua
@@ -31,8 +31,8 @@ function c81269231.valcheck(e,c)
 	local flag=0
 	local tc=g:GetFirst()
 	while tc do
-		if tc:IsSetCard(0x7) then flag=bit.bor(flag,0x1) end
-		if tc:IsSetCard(0x51) then flag=bit.bor(flag,0x2) end
+		if tc:IsSetCard(0x7) and tc:IsType(TYPE_MONSTER) then flag=bit.bor(flag,0x1) end
+		if tc:IsSetCard(0x51) and tc:IsType(TYPE_MONSTER) then flag=bit.bor(flag,0x2) end
 		tc=g:GetNext()
 	end
 	e:SetLabel(flag)


### PR DESCRIPTION
修复了恐吓爪牙族型俱舍怒威族 ③效果在攻击对象发生转移（如银河栗子球）时不能生效 的问题