### PR TITLE
Fix ゴブリンドバーグ

### DIFF
--- a/c25259669.lua
+++ b/c25259669.lua
@@ -24,8 +24,8 @@ function c25259669.sumop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c25259669.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 		if g:GetCount()>0 then
-			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
-			if c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) then
+			if Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)>0
+				and c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) then
 				Duel.BreakEffect()
 				Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
 			end

--- a/c25259669.lua
+++ b/c25259669.lua
@@ -23,12 +23,10 @@ function c25259669.sumop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,c25259669.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
-		if g:GetCount()>0 then
-			if Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)>0
-				and c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) then
-				Duel.BreakEffect()
-				Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
-			end
+		if g:GetCount()>0 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)>0
+			and c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) then
+			Duel.BreakEffect()
+			Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
 		end
 	end
 end

--- a/c25259669.lua
+++ b/c25259669.lua
@@ -25,10 +25,10 @@ function c25259669.sumop(e,tp,eg,ep,ev,re,r,rp)
 		local g=Duel.SelectMatchingCard(tp,c25259669.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 		if g:GetCount()>0 then
 			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+			if c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) then
+				Duel.BreakEffect()
+				Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
+			end
 		end
-	end
-	if c:IsRelateToEffect(e) and c:IsPosition(POS_FACEUP_ATTACK) then
-		Duel.BreakEffect()
-		Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
 	end
 end


### PR DESCRIPTION
> 処理時に、『手札からレベル４以下のモンスター１体を特殊召喚する』処理を行います。**特殊召喚に成功し、かつこのカードが攻撃表示の場合**、その後、『このカードは守備表示になる』処理を行います。