### PR TITLE
Update c64664373.lua

### DIFF
--- a/c64664373.lua
+++ b/c64664373.lua
@@ -14,7 +14,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.tgfilter(c,e,tp)
-	return c:IsFaceup() and not c:IsType(TYPE_TOKEN) and not c:IsDisabled() and c:IsType(TYPE_EFFECT) 
+	return aux.NegateEffectMonsterFilter(c) 
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_HAND,0,1,nil,e,tp,c:GetRace(),c:GetAttribute(),c:GetAttack())
 end
 function s.spfilter(c,e,tp,race,att,atk)

--- a/c64664373.lua
+++ b/c64664373.lua
@@ -14,7 +14,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.tgfilter(c,e,tp)
-	return c:IsFaceup() and not c:IsType(TYPE_TOKEN)
+	return c:IsFaceup() and not c:IsType(TYPE_TOKEN) and not c:IsDisabled() and c:IsType(TYPE_EFFECT) 
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_HAND,0,1,nil,e,tp,c:GetRace(),c:GetAttribute(),c:GetAttack())
 end
 function s.spfilter(c,e,tp,race,att,atk)

--- a/c64664373.lua
+++ b/c64664373.lua
@@ -14,7 +14,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.tgfilter(c,e,tp)
-	return aux.NegateEffectMonsterFilter(c) 
+	return aux.NegateEffectMonsterFilter(c) and not c:IsType(TYPE_TOKEN)
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_HAND,0,1,nil,e,tp,c:GetRace(),c:GetAttribute(),c:GetAttack())
 end
 function s.spfilter(c,e,tp,race,att,atk)


### PR DESCRIPTION
Fix to prevent use on Normal monsters, or monsters who are already negated.

https://db.ygoresources.com/card#19910

"It cannot be activated by targeting normal monsters or monsters whose effects are nullified."