### PR TITLE
Fix 始祖の守護者ティラス

### DIFF
--- a/c31386180.lua
+++ b/c31386180.lua
@@ -21,6 +21,7 @@ function c31386180.initial_effect(c)
 	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
 	e2:SetCountLimit(1)
 	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c31386180.decon)
 	e2:SetTarget(c31386180.destg)
 	e2:SetOperation(c31386180.desop)
 	c:RegisterEffect(e2)
@@ -37,6 +38,9 @@ function c31386180.initial_effect(c)
 end
 function c31386180.condition(e)
 	return e:GetHandler():GetOverlayCount()>0
+end
+function c31386180.decon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
 end
 function c31386180.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() end


### PR DESCRIPTION
修复②效果在这张卡没有进行战斗的战斗阶段结束时仍会发动的问题。（このカードが戦闘を行ったバトルフェイズ終了時に1度、必ず発動する効果です）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9661&request_locale=ja