### PR TITLE
Fix 精霊コロゾ

### DIFF
--- a/c66532962.lua
+++ b/c66532962.lua
@@ -39,13 +39,13 @@ end
 function s.natg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local a=Duel.GetAttacker()
 	if chkc then return chkc==a end
-	if chk==0 then return a~=nil and a:IsCanBeEffectTarget(e) and a:GetAttack()>0 end
+	if chk==0 then return a~=nil and a:IsCanBeEffectTarget(e) end
 	Duel.SetTargetCard(a)
 end
 function s.naop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if Duel.NegateAttack() and tc:IsRelateToEffect(e) and c:IsFaceup() and c:IsRelateToEffect(e) then
+	if Duel.NegateAttack() and tc:IsRelateToEffect(e) and tc:GetAttack()>0 and c:IsFaceup() and c:IsRelateToEffect(e) then
 		local preatk=c:GetAttack()
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
■攻撃力０のモンスターを対象として発動することもできます。
■処理時に、対象のモンスターの攻撃力が０の場合、攻撃を無効にする処理は行われますが、『対象のモンスターの攻撃力分アップする』処理によって攻撃力のアップには成功していませんので、『対象のモンスターを手札に戻す』処理は行われません。