### PR TITLE
Fix GetLinkGount()

### DIFF
--- a/procedure.lua
+++ b/procedure.lua
@@ -2165,7 +2165,7 @@ function Auxiliary.LExtraFilter(c,f,lc,tp)
 	return false
 end
 function Auxiliary.GetLinkCount(c)
-	if c:IsType(TYPE_LINK) and c:GetLink()>1 then
+	if c:IsLinkType(TYPE_LINK) and c:GetLink()>1 then
 		return 1+0x10000*c:GetLink()
 	else return 1 end
 end


### PR DESCRIPTION
Fixed type check to enable szone link monster cards to be link materials with link ratings according to rulings.