### PR TITLE
Fix Elemental HERO Tempest

### DIFF
--- a/c83121692.lua
+++ b/c83121692.lua
@@ -44,7 +44,6 @@ function c83121692.operation(e,tp,eg,ep,ev,re,r,rp)
 	else
 		c:SetCardTarget(tc)
 	end
-	c:RegisterFlagEffect(83121693,RESET_EVENT+RESETS_STANDARD,0,0)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)

--- a/c83121692.lua
+++ b/c83121692.lua
@@ -28,11 +28,15 @@ function c83121692.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_ONFIELD,0,1,1,e:GetHandler())
 	Duel.SendtoGrave(g,REASON_COST)
 end
+function c83121692.tgfilter(c,ec)
+	return c:GetFlagEffect(83121692)==0 and not ec:IsHasCardTarget(c)
+end
 function c83121692.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) end
-	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_MZONE,0,1,nil) end
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c83121692.tgfilter(chkc,c) end
+	if chk==0 then return Duel.IsExistingTarget(c83121692.tgfilter,tp,LOCATION_MZONE,0,1,nil,c) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,nil,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c83121692.tgfilter,tp,LOCATION_MZONE,0,1,1,nil,c)
 end
 function c83121692.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c83121692.lua
+++ b/c83121692.lua
@@ -44,17 +44,15 @@ function c83121692.operation(e,tp,eg,ep,ev,re,r,rp)
 	else
 		c:SetCardTarget(tc)
 	end
-	if c:GetFlagEffect(83121693)==0 then
-		c:RegisterFlagEffect(83121693,RESET_EVENT+RESETS_STANDARD,0,0)
-		local e1=Effect.CreateEffect(c)
-		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
-		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e1:SetCondition(c83121692.indcon)
-		e1:SetValue(1)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
-		tc:RegisterEffect(e1)
-	end
+	c:RegisterFlagEffect(83121693,RESET_EVENT+RESETS_STANDARD,0,0)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetCondition(c83121692.indcon)
+	e1:SetValue(1)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+	tc:RegisterEffect(e1)
 end
 function c83121692.indcon(e)
 	local c=e:GetHandler()


### PR DESCRIPTION
Fix effect so it can protect more than just the first target, instead of only providing protection to the first monster the effect is used on, and failing to protect any subsequent targets of the effect.