### PR TITLE
Fix 雲魔物－タービュランス

### DIFF
--- a/c16197610.lua
+++ b/c16197610.lua
@@ -22,7 +22,7 @@ function c16197610.initial_effect(c)
 	e3:SetCode(EVENT_SUMMON_SUCCESS)
 	e3:SetOperation(c16197610.addc)
 	c:RegisterEffect(e3)
-	--destroy
+	--special summon
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(16197610,1))
 	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -54,13 +54,13 @@ function c16197610.spfilter(c,e,tp)
 end
 function c16197610.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(c16197610.spfilter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp) end
+		and Duel.IsExistingMatchingCard(c16197610.spfilter,tp,LOCATION_DECK+LOCATION_GRAVE,LOCATION_GRAVE,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_GRAVE)
 end
 function c16197610.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c16197610.spfilter),tp,LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c16197610.spfilter),tp,LOCATION_DECK+LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,e,tp)
 	if g:GetCount()>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end


### PR DESCRIPTION
修复④效果以下问题：
1、初始化函数部分注释有误（此效果应为“特殊召唤”相关）；
2、应能选择特殊召唤对方墓地的「云魔物-小烟球」（自分のデッキまたはお互いの墓地から「雲魔物－スモークボール」１体を選んで特殊召喚する）。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7281&request_locale=ja