### PR TITLE
Fix 熾天の騎士ガイアプロミネンス

### DIFF
--- a/c95095116.lua
+++ b/c95095116.lua
@@ -31,8 +31,8 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 c95095116.material_type=TYPE_SYNCHRO
-function s.mfilter(c)
-	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE)
+function s.mfilter(c,fc)
+	return c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsControler(fc:GetControler())
 end
 function s.negcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()


### PR DESCRIPTION
修复应只能用“自己”场上的表侧表示怪兽作为融合素材的问题。（自分フィールドの表側表示モンスター）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19175&request_locale=ja