### PR TITLE
Fix set card shuffling

### DIFF
--- a/c24878656.lua
+++ b/c24878656.lua
@@ -45,7 +45,11 @@ function s.stop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local ct=math.min(Duel.GetLocationCount(tp,LOCATION_SZONE),2)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.stfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_MZONE+LOCATION_GRAVE,0,1,ct,nil)
-	Duel.SSet(tp,g)
+	if g:GetCount()>0 then
+		Duel.SSet(tp,g)
+		Duel.ShuffleSetCard(g)
+	end
+
 end
 function s.desfilter(c)
 	return c:GetSequence()<5

--- a/c37495766.lua
+++ b/c37495766.lua
@@ -27,13 +27,14 @@ function s.initial_effect(c)
 	e3:SetCategory(CATEGORY_DESTROY)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e3:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)
-	e3:SetCode(EVENT_LEAVE_FIELD)
+	e3:SetCode(EVENT_CUSTOM+id)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCountLimit(1,id+o*2)
 	e3:SetCondition(s.descon)
 	e3:SetTarget(s.destg)
 	e3:SetOperation(s.desop)
 	c:RegisterEffect(e3)
+	aux.RegisterMergedDelayedEvent(c,id,EVENT_LEAVE_FIELD)
 end
 function s.costfilter(c)
 	return c:IsSetCard(0x18b) and c:IsAbleToRemoveAsCost()
@@ -71,12 +72,13 @@ function s.setop(e,tp,eg,ep,ev,re,r,rp)
 		local sg=g:SelectSubGroup(tp,aux.dncheck,false,1,ft)
 		if sg:GetCount()>0 then
 			Duel.SSet(tp,sg)
+			Duel.ShuffleSetCard(sg)
 		end
 	end
 end
 function s.cfilter(c,tp)
 	return c:IsPreviousControler(tp)
-		and c:GetReasonPlayer()==1-tp and c:IsReason(REASON_EFFECT)
+		and c:GetReasonPlayer()==1-tp and c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.cfilter,1,nil,tp) and not eg:IsContains(e:GetHandler())

--- a/c97800311.lua
+++ b/c97800311.lua
@@ -99,7 +99,10 @@ function s.setop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 		tg=tg:Select(tp,ft,ft,nil)
 	end
-	Duel.SSet(tp,tg)
+	if tg:GetCount()>0 then
+		Duel.SSet(tp,tg)
+		Duel.ShuffleSetCard(tg)
+	end
 end
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_TRAP)


### PR DESCRIPTION
Fix the shuffling of set cards, set by Turbulence, Toy Box and Divine Serpent Apophis, as per rulings. The opponent is not supposed to be shown what card is set where.

https://db.ygoresources.com/card#6868

https://db.ygoresources.com/card#17997