### PR TITLE
Fix HRUM－ユートピア・フォース

### DIFF
--- a/c67517351.lua
+++ b/c67517351.lua
@@ -71,13 +71,13 @@ function c67517351.tgfilter(c,eg)
 end
 function c67517351.mattg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c67517351.tgfilter(chkc,eg) end
-	if chk==0 then return Duel.IsExistingTarget(c67517351.tgfilter,tp,LOCATION_MZONE,0,1,nil,eg)
+	if chk==0 then return Duel.IsExistingTarget(c67517351.tgfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,eg)
 		and e:GetHandler():IsCanOverlay() end
 	if eg:GetCount()==1 then
 		Duel.SetTargetCard(eg)
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-		Duel.SelectTarget(tp,c67517351.tgfilter,tp,LOCATION_MZONE,0,1,1,nil,eg)
+		Duel.SelectTarget(tp,c67517351.tgfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,eg)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,e:GetHandler(),1,0,0)
 end


### PR DESCRIPTION
修复②效果应也能以“对方”场上符合要求的怪兽作为对象发动效果的问题。（この効果を発動する際に対象として、ランク１０以上の「ホープ」エクシーズモンスターの効果によって特殊召喚された、表側表示のエクシーズモンスター１体を選択します）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16473&request_locale=ja