### PR TITLE
Fix for スターダスト・ミラージュ

### DIFF
--- a/c13556444.lua
+++ b/c13556444.lua
@@ -20,6 +20,7 @@ function c13556444.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c13556444.spfilter(c,e,tp,tid)
 	return c:GetTurnID()==tid and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and c:IsReason(REASON_DESTROY)
 		and (c:IsReason(REASON_BATTLE) or c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp)
 end
 function c13556444.sptg(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
《スターダスト・ミラージュ/Stardust Mirage》
通常罠
このカード名のカードは１ターンに１枚しか発動できない。
(1)：自分フィールドにレベル８以上のドラゴン族Ｓモンスターが存在する場合に発動できる。
このターンに戦闘または相手の効果で**破壊され**自分の墓地へ送られたモンスターを可能な限り特殊召喚する。

<hr>

Should have checked if the monster was destroyed.