### PR TITLE
Fix Magicolloidal Sol

### DIFF
--- a/c67694706.lua
+++ b/c67694706.lua
@@ -95,10 +95,12 @@ function s.scop(e,tp,eg,ep,ev,re,r,rp)
 	else
 		local mg=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
 		local exg=Duel.GetMatchingGroup(s.exgfilter,tp,LOCATION_EXTRA,0,nil,mg,c)
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sc=exg:Select(tp,1,1,nil):GetFirst()
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
-		local msg=mg:SelectSubGroup(tp,s.exgselect,false,1,#mg,sc,c)
-		Duel.XyzSummon(tp,sc,msg,#msg,#msg)
+		if exg:GetCount()>0 then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sc=exg:Select(tp,1,1,nil):GetFirst()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+			local msg=mg:SelectSubGroup(tp,s.exgselect,false,1,#mg,sc,c)
+			Duel.XyzSummon(tp,sc,msg,#msg,#msg)
+		end
 	end
 end


### PR DESCRIPTION
修复②效果在对方回合进行超量召唤处理，若自身场上没有符合要求的超量素材或没有可以进行超量召唤的额外怪兽时，会报错的问题。（attempt to index a nil value (local 'exc')）