### PR TITLE
Fix K９－EX “Werewolf”

### DIFF
--- a/c90303227.lua
+++ b/c90303227.lua
@@ -62,6 +62,7 @@ function s.rmop(e,tp,eg,ep,ev,re,r,rp)
 		local g1=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,nil)
 		local g2=Duel.GetMatchingGroup(aux.NecroValleyFilter(Card.IsAbleToRemove),tp,0,LOCATION_GRAVE,nil)
 		g1:Merge(g2)
+		if g1:GetCount()==0 then return end
 		aux.GCheckAdditional=s.gcheck
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 		local sg=g1:SelectSubGroup(tp,aux.TRUE,false,1,2)


### PR DESCRIPTION
Related Card:[K９－EX “Werewolf”/K9-EX “狼人”](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=21382&request_locale=ja)

Bug: When its option1、effect② sloving without any card able to remove,  parameter <code>sg</code> in L69、L70 will get a <code>nil</code> value so that <code>Duel.HintSelection(sg)</code> and <code>Duel.Remove(sg,POS_FACEUP,REASON_EFFECT)</code> connot work.

Fix: Add nil_check
