### PR TITLE
Fix 蛇眼の断罪龍

### DIFF
--- a/c79415624.lua
+++ b/c79415624.lua
@@ -33,7 +33,8 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.mvcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsMainPhase() and e:GetHandler():GetFlagEffect(id)==0
+	local c=e:GetHandler()
+	return Duel.IsMainPhase() and (c:GetFlagEffect(id)==0 or c:GetFlagEffectLabel(id)~=tp)
 end
 function s.mvfilter(c,tp)
 	local r=LOCATION_REASON_TOFIELD
@@ -68,7 +69,7 @@ function s.mvop(e,tp,eg,ep,ev,re,r,rp)
 	end
 	local c=e:GetHandler()
 	if c:IsRelateToEffect(e) then
-		c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,2)
+		c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,2,tp)
 	end
 end
 function s.descon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Related Card: [蛇眼の断罪龍/蛇眼断罪龙](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=21177&request_locale=ja)

Bug: In the same turn, if Player_B got control of [蛇眼の断罪龍](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=21177&request_locale=ja) after Player_A using  [蛇眼の断罪龍](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=21177&request_locale=ja) 's effect①, Player_B should be allowed to use [蛇眼の断罪龍](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=21177&request_locale=ja) 's effect①.

Fix: Add information about the activator of the effect as<code>tp</code> and check it in <code>s.mvcon</code>.