### PR TITLE
Fix Necroquip Princess

### DIFF
--- a/c93860227.lua
+++ b/c93860227.lua
@@ -10,7 +10,6 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetValue(s.splimit)
 	c:RegisterEffect(e1)
 	--equip or draw
 	local e2=Effect.CreateEffect(c)
@@ -24,9 +23,6 @@ function s.initial_effect(c)
 	e2:SetTarget(s.tstg)
 	e2:SetOperation(s.tsop)
 	c:RegisterEffect(e2)
-end
-function s.splimit(e,se,sp,st)
-	return not e:GetHandler():IsLocation(LOCATION_EXTRA)
 end
 function s.eqilter(c)
 	return c:GetOriginalType()&TYPE_MONSTER~=0


### PR DESCRIPTION
原文为“Must be Special Summoned (from your Extra Deck) by sending the above cards from your hand and/or field to the GY.” 
应翻译为“把自己手卡·场上的上记卡送去墓地的场合才能特殊召唤。”，而不是“才能从额外卡组特殊召唤”。

https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=20423