### PR TITLE
Fix 月光彩雛

### DIFF
--- a/c35618217.lua
+++ b/c35618217.lua
@@ -27,6 +27,7 @@ function c35618217.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e3:SetProperty(EFFECT_FLAG_DELAY)
 	e3:SetCode(EVENT_REMOVE)
+	e3:SetCondition(aux.bpcon)
 	e3:SetOperation(c35618217.actop)
 	c:RegisterEffect(e3)
 end


### PR DESCRIPTION
修复③效果应不能在“不能进入战斗阶段”的回合里发动的问题。
（バトルフェイズを行えないターンや、既にバトルフェイズを行ったターンには発動できません。）