### PR TITLE
Fix 石版の神殿

### DIFF
--- a/c63017368.lua
+++ b/c63017368.lua
@@ -22,7 +22,6 @@ function s.initial_effect(c)
 	e3:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_CANNOT_DISABLE)
 	e3:SetCondition(s.repcon)
 	e3:SetOperation(s.repop)
-	c:RegisterEffect(e3)
 	--
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_GRANT)


### PR DESCRIPTION
Related Card:
[石版の神殿](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=20233&request_locale=ja)

Bug:
Effect②should not apply to _石版の神殿_ itself.
If 石版の神殿 be summoned by [マジカルシルクハット](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4962&request_locale=ja), it could be placed to SZone by its effect② when it's Battle_Destroyed.

Fix:
Delete the effect_register to itself