### PR TITLE
fix--夙めてはしろ 二人ではしろ

### DIFF
--- a/c38625110.lua
+++ b/c38625110.lua
@@ -39,6 +39,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,7,0,LOCATION_EXTRA+LOCATION_DECK)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp,chk)
+	if not Duel.IsPlayerCanRemove(1-tp) then return end
 	local dg=s.getrmdg(tp)
 	local edg=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_EXTRA,nil,1-tp,POS_FACEDOWN,REASON_RULE)
 	local ct1=dg:GetCount()


### PR DESCRIPTION
fix 夙めてはしろ 二人ではしろ can remove when 王宮の鉄壁 is on field face up
不能除外效果适用中，夙めてはしろ 二人ではしろ的效果处理仍能让对方除外卡