### PR TITLE
Fix ヴァリアンツG－グランデューク

### DIFF
--- a/c76075139.lua
+++ b/c76075139.lua
@@ -50,7 +50,7 @@ function c76075139.splimit(e,se,sp,st)
 end
 function c76075139.hspfilter(c,tp,sc)
 	local seq=c:GetSequence()
-	return (seq==1 or seq==3 or seq>4) and not c:IsFusionType(TYPE_FUSION) and c:IsLevelAbove(5) and c:IsSetCard(0x17d)
+	return (seq==1 or seq==3 or seq>4) and not c:IsFusionType(TYPE_FUSION) and c:IsLevelAbove(5) and c:IsFusionSetCard(0x17d)
 		and c:IsControler(tp) and Duel.GetLocationCountFromEx(tp,tp,c,sc)>0 and c:IsCanBeFusionMaterial(sc,SUMMON_TYPE_SPECIAL)
 end
 function c76075139.hspcon(e,c)


### PR DESCRIPTION
修复自己场上有适用「融合超涡」（把作为对象的怪兽作为融合素材的场合，可以当作给人观看的怪兽的同名卡使用）且满足「群豪之创始者-大公」自身特殊召唤条件（把除融合怪兽外的和额外怪兽区域相同纵列1只自己的5星以上的「群豪」怪兽解放的场合可以特殊召唤）的怪兽时，应能把该怪兽解放进行从额外卡组将「群豪之创始者-大公」特殊召唤的问题。