### PR TITLE
Fix Flame Swordsrealm

### DIFF
--- a/c73714736.lua
+++ b/c73714736.lua
@@ -2,12 +2,12 @@
 local s,id,o=GetID()
 function s.initial_effect(c)
 	aux.AddCodeList(c,45231177)
-	--
+	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	c:RegisterEffect(e1)
-	--
+	--Fusion Summon
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
@@ -18,7 +18,7 @@ function s.initial_effect(c)
 	e2:SetTarget(s.sptg)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
-	--
+	--Chain Limit
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e3:SetCode(EVENT_SUMMON_SUCCESS)
@@ -26,14 +26,14 @@ function s.initial_effect(c)
 	e3:SetCondition(s.limcon)
 	e3:SetOperation(s.limop)
 	c:RegisterEffect(e3)
-	--
+	--Chain Limit
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e4:SetRange(LOCATION_SZONE)
 	e4:SetCode(EVENT_CHAIN_END)
 	e4:SetOperation(s.limop2)
 	c:RegisterEffect(e4)
-	--
+	--atk Change
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(id,1))
 	e5:SetCategory(CATEGORY_ATKCHANGE)
@@ -117,11 +117,14 @@ end
 function s.chainlm(e,rp,tp)
 	return tp==rp
 end
+function s.atkfilter(c)
+	return c:IsFaceup() and c:IsRace(RACE_WARRIOR) and c:IsAttackAbove(1000)
+end
 function s.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() and chkc:IsRace(RACE_WARRIOR) end
-	if chk==0 then return Duel.IsExistingTarget(aux.AND(Card.IsRace,Card.IsFaceup),tp,LOCATION_MZONE,0,1,nil,RACE_WARRIOR) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and s.atkfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	Duel.SelectTarget(tp,aux.AND(Card.IsRace,Card.IsFaceup),tp,LOCATION_MZONE,0,1,1,nil,RACE_WARRIOR)
+	Duel.SelectTarget(tp,s.atkfilter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/c73714736.lua
+++ b/c73714736.lua
@@ -128,14 +128,14 @@ function s.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsAttackAbove(1000) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetValue(-1000)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1)
-		if not tc:IsHasEffect(EFFECT_REVERSE_UPDATE) then
+		if not tc:IsImmuneToEffect(e) and not tc:IsHasEffect(EFFECT_REVERSE_UPDATE) then
 			local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,tc)
 			local oc=g:GetFirst()
 			while oc do


### PR DESCRIPTION
修复③效果应只能以“攻击力1000以上”的战士族怪兽为对象发动的问题（この効果を発動する際に対象として、自分のモンスターゾーンに表側表示で存在する攻撃力が１０００以上の戦士族モンスター１体を選択します）。 另补全初始化效果注释部分。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19729&request_locale=ja