### PR TITLE
fix draw0

### DIFF
--- a/c23434538.lua
+++ b/c23434538.lua
@@ -66,5 +66,5 @@ end
 function c23434538.drop2(e,tp,eg,ep,ev,re,r,rp)
 	local n=Duel.GetFlagEffect(tp,23434538)
 	Duel.ResetFlagEffect(tp,23434538)
-	Duel.Draw(tp,n,REASON_EFFECT)
+	if n>0 then Duel.Draw(tp,n,REASON_EFFECT) end
 end

--- a/c42141493.lua
+++ b/c42141493.lua
@@ -98,7 +98,7 @@ function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetLabelObject():GetLabel()>0
 end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
-	local n=e:GetLabelObject():GetLabel()>0
+	local n=e:GetLabelObject():GetLabel()
 	e:GetLabelObject():SetLabel(0)
 	Duel.Draw(tp,n,REASON_EFFECT)
 end

--- a/c42141493.lua
+++ b/c42141493.lua
@@ -98,7 +98,7 @@ end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
 	local n=Duel.GetFlagEffect(tp,id+o)
 	Duel.ResetFlagEffect(tp,id+o)
-	Duel.Draw(tp,n,REASON_EFFECT)
+	if n>0 then Duel.Draw(tp,n,REASON_EFFECT) end
 end
 function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6

--- a/c42141493.lua
+++ b/c42141493.lua
@@ -56,16 +56,18 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e2:SetCondition(s.regcon)
 	e2:SetOperation(s.regop)
+	e2:SetLabel(0)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e2,tp)
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
 	e3:SetCode(EVENT_CHAIN_SOLVED)
+	e3:SetLabelObject(e2)
 	e3:SetCondition(s.drcon2)
 	e3:SetOperation(s.drop2)
 	e3:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e3,tp)
-	local e4=Effect.CreateEffect(e:GetHandler())
+	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e4:SetCode(EVENT_PHASE+PHASE_END)
 	e4:SetCountLimit(1)
@@ -90,15 +92,15 @@ function s.regcon(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.IsChainSolving()
 end
 function s.regop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.RegisterFlagEffect(tp,id+o,RESET_CHAIN,0,1)
+	e:SetLabel(e:GetLabel()+1)
 end
 function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFlagEffect(tp,id+o)>0
+	return e:GetLabelObject():GetLabel()>0
 end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
-	local n=Duel.GetFlagEffect(tp,id+o)
-	Duel.ResetFlagEffect(tp,id+o)
-	if n>0 then Duel.Draw(tp,n,REASON_EFFECT) end
+	local n=e:GetLabelObject():GetLabel()>0
+	e:GetLabelObject():SetLabel(0)
+	Duel.Draw(tp,n,REASON_EFFECT)
 end
 function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6

--- a/c84192580.lua
+++ b/c84192580.lua
@@ -103,7 +103,7 @@ function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetLabelObject():GetLabel()>0
 end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
-	local n=e:GetLabelObject():GetLabel()>0
+	local n=e:GetLabelObject():GetLabel()
 	e:GetLabelObject():SetLabel(0)
 	Duel.Draw(tp,n,REASON_EFFECT)
 end

--- a/c84192580.lua
+++ b/c84192580.lua
@@ -57,6 +57,7 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetLabel(0)
 	e3:SetCondition(s.regcon)
 	e3:SetOperation(s.regop)
 	e3:SetReset(RESET_PHASE+PHASE_END)
@@ -67,11 +68,12 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
 	e5:SetCode(EVENT_CHAIN_SOLVED)
+	e5:SetLabelObject(e3)
 	e5:SetCondition(s.drcon2)
 	e5:SetOperation(s.drop2)
 	e5:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e5,tp)
-	local e6=Effect.CreateEffect(e:GetHandler())
+	local e6=Effect.CreateEffect(c)
 	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e6:SetCode(EVENT_PHASE+PHASE_END)
 	e6:SetCountLimit(1)
@@ -95,15 +97,15 @@ function s.regcon(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.IsChainSolving()
 end
 function s.regop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.RegisterFlagEffect(tp,id+o,RESET_CHAIN,0,1)
+	e:SetLabel(e:GetLabel()+1)
 end
 function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFlagEffect(tp,id+o)>0
+	return e:GetLabelObject():GetLabel()>0
 end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
-	local n=Duel.GetFlagEffect(tp,id+o)
-	Duel.ResetFlagEffect(tp,id+o)
-	if n>0 then Duel.Draw(tp,n,REASON_EFFECT) end
+	local n=e:GetLabelObject():GetLabel()>0
+	e:GetLabelObject():SetLabel(0)
+	Duel.Draw(tp,n,REASON_EFFECT)
 end
 function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6

--- a/c84192580.lua
+++ b/c84192580.lua
@@ -103,7 +103,7 @@ end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
 	local n=Duel.GetFlagEffect(tp,id+o)
 	Duel.ResetFlagEffect(tp,id+o)
-	Duel.Draw(tp,n,REASON_EFFECT)
+	if n>0 then Duel.Draw(tp,n,REASON_EFFECT) end
 end
 function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6

--- a/c87126721.lua
+++ b/c87126721.lua
@@ -98,7 +98,7 @@ function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetLabelObject():GetLabel()>0
 end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
-	local n=e:GetLabelObject():GetLabel()>0
+	local n=e:GetLabelObject():GetLabel()
 	e:GetLabelObject():SetLabel(0)
 	Duel.Draw(tp,n,REASON_EFFECT)
 end

--- a/c87126721.lua
+++ b/c87126721.lua
@@ -98,7 +98,7 @@ end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
 	local n=Duel.GetFlagEffect(tp,id+o)
 	Duel.ResetFlagEffect(tp,id+o)
-	Duel.Draw(tp,n,REASON_EFFECT)
+	if n>0 then Duel.Draw(tp,n,REASON_EFFECT) end
 end
 function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6

--- a/c87126721.lua
+++ b/c87126721.lua
@@ -56,16 +56,18 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e2:SetCondition(s.regcon)
 	e2:SetOperation(s.regop)
+	e2:SetLabel(0)
 	e2:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e2,tp)
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
 	e3:SetCode(EVENT_CHAIN_SOLVED)
+	e3:SetLabelObject(e2)
 	e3:SetCondition(s.drcon2)
 	e3:SetOperation(s.drop2)
 	e3:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e3,tp)
-	local e4=Effect.CreateEffect(e:GetHandler())
+	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e4:SetCode(EVENT_PHASE+PHASE_END)
 	e4:SetCountLimit(1)
@@ -90,15 +92,15 @@ function s.regcon(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.IsChainSolving()
 end
 function s.regop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.RegisterFlagEffect(tp,id+o,RESET_CHAIN,0,1)
+	e:SetLabel(e:GetLabel()+1)
 end
 function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFlagEffect(tp,id+o)>0
+	return e:GetLabelObject():GetLabel()>0
 end
 function s.drop2(e,tp,eg,ep,ev,re,r,rp)
-	local n=Duel.GetFlagEffect(tp,id+o)
-	Duel.ResetFlagEffect(tp,id+o)
-	if n>0 then Duel.Draw(tp,n,REASON_EFFECT) end
+	local n=e:GetLabelObject():GetLabel()>0
+	e:GetLabelObject():SetLabel(0)
+	Duel.Draw(tp,n,REASON_EFFECT)
 end
 function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6


### PR DESCRIPTION
欢聚友伴系列（42141493，84192580，87126721）同时适用2张，因为入连锁特招效果抽卡时，Duel.Draw函数会抽0导致抽空卡组的败北被取消，因此增加检测
增殖的g（23434538）虽然不会出现这一情况但也一并修改了