### PR TITLE
Fix hand link effect

### DIFF
--- a/c2347477.lua
+++ b/c2347477.lua
@@ -22,15 +22,15 @@ function c2347477.initial_effect(c)
 	e3:SetOperation(c2347477.thop)
 	c:RegisterEffect(e3)
 end
-function c2347477.mfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE)
+function c2347477.mfilter(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE) and c:IsControler(tp)
 end
 function c2347477.exmfilter(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsCode(2347477)
 end
 function c2347477.matval(e,lc,mg,c,tp)
 	if not lc:IsSetCard(0x101) then return false,nil end
-	return true,not mg or mg:IsExists(c2347477.mfilter,1,nil) and not mg:IsExists(c2347477.exmfilter,1,nil)
+	return true,not mg or mg:IsExists(c2347477.mfilter,1,nil,tp) and not mg:IsExists(c2347477.exmfilter,1,nil)
 end
 function c2347477.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c30114823.lua
+++ b/c30114823.lua
@@ -22,15 +22,15 @@ function c30114823.initial_effect(c)
 	e3:SetOperation(c30114823.tdop)
 	c:RegisterEffect(e3)
 end
-function c30114823.mfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE)
+function c30114823.mfilter(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE) and c:IsControler(tp)
 end
 function c30114823.exmfilter(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsCode(30114823)
 end
 function c30114823.matval(e,lc,mg,c,tp)
 	if not lc:IsSetCard(0x101) then return false,nil end
-	return true,not mg or mg:IsExists(c30114823.mfilter,1,nil) and not mg:IsExists(c30114823.exmfilter,1,nil)
+	return true,not mg or mg:IsExists(c30114823.mfilter,1,nil,tp) and not mg:IsExists(c30114823.exmfilter,1,nil)
 end
 function c30114823.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c37119142.lua
+++ b/c37119142.lua
@@ -22,15 +22,15 @@ function c37119142.initial_effect(c)
 	e2:SetOperation(c37119142.thop)
 	c:RegisterEffect(e2)
 end
-function c37119142.mfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE)
+function c37119142.mfilter(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE) and c:IsControler(tp)
 end
 function c37119142.exmfilter(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsCode(37119142)
 end
 function c37119142.matval(e,lc,mg,c,tp)
 	if not lc:IsSetCard(0x101) then return false,nil end
-	return true,not mg or mg:IsExists(c37119142.mfilter,1,nil) and not mg:IsExists(c37119142.exmfilter,1,nil)
+	return true,not mg or mg:IsExists(c37119142.mfilter,1,nil,tp) and not mg:IsExists(c37119142.exmfilter,1,nil)
 end
 function c37119142.thcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c53782828.lua
+++ b/c53782828.lua
@@ -31,15 +31,15 @@ function c53782828.initial_effect(c)
 	e3:SetCountLimit(1,53782830)
 	c:RegisterEffect(e3)
 end
-function c53782828.mfilter(c)
-	return c:IsLocation(LOCATION_MZONE)
+function c53782828.mfilter(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsControler(tp)
 end
 function c53782828.exmfilter(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsCode(53782828)
 end
 function c53782828.matval(e,lc,mg,c,tp)
 	if not lc:IsSetCard(0x156) then return false,nil end
-	return true,not mg or mg:IsExists(c53782828.mfilter,1,nil) and not mg:IsExists(c53782828.exmfilter,1,nil)
+	return true,not mg or mg:IsExists(c53782828.mfilter,1,nil,tp) and not mg:IsExists(c53782828.exmfilter,1,nil)
 end
 function c53782828.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2

--- a/c59185998.lua
+++ b/c59185998.lua
@@ -23,15 +23,15 @@ function c59185998.initial_effect(c)
 	e2:SetOperation(c59185998.thop)
 	c:RegisterEffect(e2)
 end
-function c59185998.mfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x103)
+function c59185998.mfilter(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x103) and c:IsControler(tp)
 end
 function c59185998.exmfilter(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsCode(59185998)
 end
 function c59185998.matval(e,lc,mg,c,tp)
 	if not lc:IsSetCard(0x103) then return false,nil end
-	return true,not mg or mg:IsExists(c59185998.mfilter,1,nil) and not mg:IsExists(c59185998.exmfilter,1,nil)
+	return true,not mg or mg:IsExists(c59185998.mfilter,1,nil,tp) and not mg:IsExists(c59185998.exmfilter,1,nil)
 end
 function c59185998.cfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsSetCard(0x103) and c:IsType(TYPE_LINK) and c:IsSummonType(SUMMON_TYPE_LINK)

--- a/c75130221.lua
+++ b/c75130221.lua
@@ -22,15 +22,15 @@ function c75130221.initial_effect(c)
 	e3:SetOperation(c75130221.disop)
 	c:RegisterEffect(e3)
 end
-function c75130221.mfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE)
+function c75130221.mfilter(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE) and c:IsControler(tp)
 end
 function c75130221.exmfilter(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsCode(75130221)
 end
 function c75130221.matval(e,lc,mg,c,tp)
 	if not lc:IsSetCard(0x101) then return false,nil end
-	return true,not mg or mg:IsExists(c75130221.mfilter,1,nil) and not mg:IsExists(c75130221.exmfilter,1,nil)
+	return true,not mg or mg:IsExists(c75130221.mfilter,1,nil,tp) and not mg:IsExists(c75130221.exmfilter,1,nil)
 end
 function c75130221.discon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c77189532.lua
+++ b/c77189532.lua
@@ -29,15 +29,15 @@ function s.initial_effect(c)
 	e3:SetValue(s.matval2)
 	c:RegisterEffect(e3)
 end
-function s.mfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE)
+function s.mfilter(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_CYBERSE) and c:IsControler(tp)
 end
 function s.exmfilter(c)
 	return c:IsLocation(LOCATION_HAND) and c:IsCode(id)
 end
 function s.matval1(e,lc,mg,c,tp)
 	if not lc:IsSetCard(0x101) then return false,nil end
-	return true,not mg or mg:IsExists(s.mfilter,1,nil) and not mg:IsExists(s.exmfilter,1,nil)
+	return true,not mg or mg:IsExists(s.mfilter,1,nil,tp) and not mg:IsExists(s.exmfilter,1,nil)
 end
 function s.exmatcheck(c,lc,tp)
 	if not c:IsLocation(LOCATION_HAND) then return false end


### PR DESCRIPTION
> **自分フィールドの**サイバース族モンスターを「コード・トーカー」モンスターのリンク素材とする場合、手札のこのカードもリンク素材にできる。

Should not be able to use ``閉ザサレシ天ノ月``, opponent's ``I：Pマスカレーナ`` and hand link monsters to summon ``アコード・トーカー＠イグニスター``