### PR TITLE
Fix 魅惑の女王 LV３５７

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1904,12 +1904,10 @@ end
 ---@param id integer
 ---@return boolean
 function Auxiliary.IsSelfEquip(c,id)
-	local eg=c:GetEquipGroup()
-	local flag=0
-	for tc in aux.Next(eg) do
-		flag=flag+tc:GetFlagEffect(id)
-	end
-	return flag>0
+	return c:GetEquipGroup():IsExists(Auxiliary.SelfEquipFilter,1,nil,id)
+end
+function Auxiliary.SelfEquipFilter(c,id)
+	return c:GetFlagEffect(id)>0
 end
 ---Orcustrated Babel
 ---@param c Card

--- a/utility.lua
+++ b/utility.lua
@@ -1904,7 +1904,12 @@ end
 ---@param id integer
 ---@return boolean
 function Auxiliary.IsSelfEquip(c,id)
-	return c:GetEquipGroup():IsExists(Card.GetFlagEffect,1,nil,id)
+	local eg=c:GetEquipGroup()
+	local flag=0
+	for tc in aux.Next(eg) do
+		flag=flag+tc:GetFlagEffect(id)
+	end
+	return flag>0
 end
 ---Orcustrated Babel
 ---@param c Card


### PR DESCRIPTION
Related Cards: [魅惑の女王 LV３](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=6870&request_locale=ja)、[魅惑の女王 LV5](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=6871&request_locale=ja)、[魅惑の女王 LV7](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=6872&request_locale=ja)

Bug: These monsters should be allow to use their effect① while equipping any equip card not from their effect①.

Fix: Fix <code>Auxiliary.IsSelfEquip</code> to correctly check whether these monster have been equiped by themselves.