### PR TITLE
Fix テスタメント・パラディオン

### DIFF
--- a/c87497553.lua
+++ b/c87497553.lua
@@ -29,7 +29,7 @@ function c87497553.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		e:SetLabel(1)
 		Duel.SelectOption(tp,aux.Stringid(87497553,0))
 		e:SetCategory(0)
-		e:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+		e:SetProperty(0)
 	else
 		e:SetLabel(2)
 		Duel.SelectOption(tp,aux.Stringid(87497553,1))


### PR DESCRIPTION
修复①效果第一个选项应不能在“伤害步骤”发动的问题。
『●このターン、自分の「パラディオン」モンスターの効果の発動に対して相手は魔法・罠・モンスターの効果を発動できない』効果は対象を取る効果ではありません。（この効果を選択して発動する場合、ダメージステップに発動する事はできません。）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14311&request_locale=ja