### PR TITLE
Fix VS 蛟龍

### DIFF
--- a/c9091064.lua
+++ b/c9091064.lua
@@ -45,7 +45,8 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetFlagEffect(tp,id)==0 end
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.GetFlagEffect(tp,id)==0 end
 	Duel.RegisterFlagEffect(tp,id,RESET_CHAIN,0,1)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end

--- a/c9091064.lua
+++ b/c9091064.lua
@@ -45,7 +45,8 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetFlagEffect(tp,id)==0 end
+	Duel.RegisterFlagEffect(tp,id,RESET_CHAIN,0,1)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
修复①②效果在同一连锁上应只能使用其中一个的问题。
このカード名の①②の効果は、それぞれ１ターンに１度しか使用できず、同一チェーン上では発動できない。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19160&request_locale=ja