### PR TITLE
fix Number 69: Heraldry Crest

### DIFF
--- a/c11522979.lua
+++ b/c11522979.lua
@@ -60,7 +60,7 @@ function c11522979.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if c:IsFaceup() and c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
-		local code=tc:GetCode()
+		local code=tc:GetOriginalCode()
 		local atk=tc:GetBaseAttack()
 		if atk<0 then atk=0 end
 		local e1=Effect.CreateEffect(c)

--- a/c2407234.lua
+++ b/c2407234.lua
@@ -56,7 +56,7 @@ function c2407234.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc and c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsFaceup() and tc:IsRelateToEffect(e) then
-		local code=tc:GetCode()
+		local code=tc:GetOriginalCode()
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)


### PR DESCRIPTION
partly revert https://github.com/Fluorohydride/ygopro-scripts/commit/9976c519f58c08aba55e47d8e7b4d8905e076386

Their text no longer say "選択したモンスターと同名カードとして扱い、同じ効果を得る", but say "そのモンスターの元々のカード名・効果と同じカード名・効果を得る".