### PR TITLE
Fix 六武衆の影－紫炎

### DIFF
--- a/c1828513.lua
+++ b/c1828513.lua
@@ -23,7 +23,7 @@ function c1828513.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c1828513.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x103d) and c:IsAttackBelow(2000)
+	return c:IsFaceup() and c:IsSetCard(0x103d) and c:GetAttack()<2000
 end
 function c1828513.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c1828513.filter(chkc) end


### PR DESCRIPTION
修复应只能以攻击力“未满2000”的「六武众」怪兽为对象才能发动该效果的问题。（不是“攻击力2000以下”）
自分のモンスターゾーンに表側表示で存在する、攻撃力が2000未満の「六武衆」と名のついたモンスター1体を対象に取る効果です

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10217&request_locale=ja