### PR TITLE
fix EFFECT_CANNOT_REMOVE

### DIFF
--- a/c14513273.lua
+++ b/c14513273.lua
@@ -48,7 +48,7 @@ end
 function s.rmlimit(e,c,rp,r,re)
 	local tp=e:GetHandlerPlayer()
 	return c:IsControler(tp) and c:IsOnField() and c:IsCode(13331639) and c:IsFaceup()
-		and r&REASON_EFFECT~=0 and re:GetOwnerPlayer()~=tp
+		and r&REASON_EFFECT~=0 and r&REASON_REDIRECT==0 and rp==1-tp
 end
 function s.penfilter(c)
 	return c:IsSetCard(0x10f8) and c:IsType(TYPE_PENDULUM) and not c:IsCode(id) and not c:IsForbidden()

--- a/c18843291.lua
+++ b/c18843291.lua
@@ -25,13 +25,6 @@ function s.initial_effect(c)
 	e2:SetTargetRange(1,1)
 	e2:SetTarget(s.efilter)
 	c:RegisterEffect(e2)
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetCode(id)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetTargetRange(LOCATION_MZONE,0)
-	e3:SetTarget(s.eftg)
-	c:RegisterEffect(e3)
 	--remove and tograve
 	local e4=Effect.CreateEffect(c)
 	e4:SetCategory(CATEGORY_DECKDES)
@@ -65,10 +58,9 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.efilter(e,c,rp,r,re)
-	return c:IsHasEffect(id) and r&REASON_EFFECT>0
-end
-function s.eftg(e,c)
-	return c:IsSetCard(0x38) and c:IsFaceup()
+	local tp=e:GetHandlerPlayer()
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x38) and c:IsFaceup()
+		and r&REASON_EFFECT>0 and r&REASON_REDIRECT==0
 end
 function s.refilter(c)
 	return c:IsSetCard(0x38) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()

--- a/c53829527.lua
+++ b/c53829527.lua
@@ -32,7 +32,7 @@ end
 function s.rmlimit(e,c,rp,r,re)
 	local tp=e:GetHandlerPlayer()
 	return c:IsControler(tp) and c:IsOnField() and c:IsSetCard(0xea) and c:IsFaceup()
-		and r&REASON_EFFECT~=0 and re:GetOwnerPlayer()~=tp
+		and r&REASON_EFFECT~=0 and r&REASON_REDIRECT==0 and rp==1-tp
 end
 function s.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0xea) and c:IsType(TYPE_SYNCHRO)

--- a/c86682165.lua
+++ b/c86682165.lua
@@ -74,7 +74,8 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.efilter(e,c,rp,r,re)
 	local tp=e:GetHandlerPlayer()
-	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and re and r&REASON_EFFECT>0 and rp==1-tp
+	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
+		and r&REASON_EFFECT>0 and r&REASON_REDIRECT==0 and rp==1-tp
 end
 function s.rmfilter(c,code)
 	return c:IsFaceupEx() and c:IsCode(code) and c:IsAbleToRemove()


### PR DESCRIPTION
According to rulings, them shouldn't protect monsters from being banished by _Macro Cosmos_ after those monsters are destroyed.

> Q.
自分の「クリストロン・クラスター」の効果適用中、相手の「マクロコスモス」の効果適用中、相手が「ブラック・ホール」を発動し、自分フィールド上の「水晶機巧－クオン」が破壊された場合、墓地へ送られるのか、それとも除外されるのか？
A.
除外されます。

> Q.
自分の「クリストロン・クラスター」の効果適用中、相手の「マクロコスモス」の効果適用中、自分が自分フィールド上の「水晶機巧－クオン」をリリースし、「水晶機巧－サルファフナー」を召喚した場合、その「水晶機巧－クオン」は墓地へ送られるのか、それとも除外されるのか？
A.
除外されます。

require https://github.com/Fluorohydride/ygopro-core/pull/755