### PR TITLE
Fix S:P Little Knight

### DIFF
--- a/c29301450.lua
+++ b/c29301450.lua
@@ -84,6 +84,7 @@ function s.drmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.drmop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetTargetsRelateToChain()
+	g:Remove(aux.NOT(Card.IsAbleToRemove),nil,tp,POS_FACEUP,REASON_EFFECT)
 	if #g~=2 or Duel.Remove(g,0,REASON_EFFECT+REASON_TEMPORARY)==0
 			or not g:IsExists(Card.IsLocation,1,nil,LOCATION_REMOVED) then return end
 	local og=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_REMOVED)


### PR DESCRIPTION
According to rules, when player A uses little night to remove two monsters, and at least one of them cannot be removed by effect, both the monsters will not be removed.

So we should filter out the monsters that cannot be removed by effect by the controler of little night, and then check if the card group to be removed is still of size 2.

[references](https://ocg-rule.readthedocs.io/zh-cn/dev/c06/2025.html#id96)

> 「[S：P小夜](https://ygocdb.com/card/name/S%EF%BC%9AP%E5%B0%8F%E5%A4%9C)」的②效果处理时，作为对象的2张卡其中1张因「[水晶机巧晶簇](https://ygocdb.com/card/name/%E6%B0%B4%E6%99%B6%E6%9C%BA%E5%B7%A7%E6%99%B6%E7%B0%87)」的①效果不能除外的场合，剩下那张也不会除外；因「[No.81 超重型炮塔列车 优越多拉炮](https://ygocdb.com/card/name/No.81%20%E8%B6%85%E9%87%8D%E5%9E%8B%E7%82%AE%E5%A1%94%E5%88%97%E8%BD%A6%20%E4%BC%98%E8%B6%8A%E5%A4%9A%E6%8B%89%E7%82%AE)」的①效果不受影响的场合，剩下那张仍然除外。