### PR TITLE
SP小夜 水机红阵

### DIFF
--- a/c29301450.lua
+++ b/c29301450.lua
@@ -84,6 +84,7 @@ function s.drmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.drmop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetTargetsRelateToChain()
+	g:Remove(aux.NOT(Card.IsAbleToRemove),nil,tp,POS_FACEUP,REASON_EFFECT)
 	if #g~=2 or Duel.Remove(g,0,REASON_EFFECT+REASON_TEMPORARY)==0
 			or not g:IsExists(Card.IsLocation,1,nil,LOCATION_REMOVED) then return end
 	local og=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_REMOVED)

--- a/c29301450.lua
+++ b/c29301450.lua
@@ -83,8 +83,7 @@ function s.drmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,2,0,0)
 end
 function s.drmop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetTargetsRelateToChain()
-	g:Remove(aux.NOT(Card.IsAbleToRemove),nil,tp,POS_FACEUP,REASON_EFFECT)
+	local g=Duel.GetTargetsRelateToChain():Filter(Card.IsAbleToRemove,nil,tp,POS_FACEUP,REASON_EFFECT)
 	if #g~=2 or Duel.Remove(g,0,REASON_EFFECT+REASON_TEMPORARY)==0
 			or not g:IsExists(Card.IsLocation,1,nil,LOCATION_REMOVED) then return end
 	local og=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_REMOVED)


### PR DESCRIPTION
修复一个bug，这个bug曾导致：
C2,SP小夜2效果和C3水机红阵，或冰水啼霓石静海神，‘对方不能把自己的XX卡除外’效果适用下，小夜仅将自己除外。
预期为：双方都不除外。