### PR TITLE
fix 神光の龍

### DIFF
--- a/c46186135.lua
+++ b/c46186135.lua
@@ -60,20 +60,20 @@ end
 function s.fusfilter(c)
 	return c:IsCode(19959563,57774843) and c:IsAbleToRemoveAsCost()
 end
-function s.fselect(g,tp)
-	return g:GetClassCount(Card.GetCode)==2 and Duel.GetMZoneCount(tp,g)>0
+function s.fselect(g,tp,sc)
+	return g:GetClassCount(Card.GetCode)==2 and Duel.GetLocationCountFromEx(tp,tp,g,sc)>0
 		and g:IsExists(Card.IsLocation,1,nil,LOCATION_MZONE) and g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE)
 end
 function s.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	local g=Duel.GetMatchingGroup(s.fusfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
-	return g:CheckSubGroup(s.fselect,2,2,tp)
+	return g:CheckSubGroup(s.fselect,2,2,tp,c)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,c)
 	local g=Duel.GetMatchingGroup(s.fusfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local sg=g:SelectSubGroup(tp,s.fselect,true,2,2,tp)
+	local sg=g:SelectSubGroup(tp,s.fselect,true,2,2,tp,c)
 	if sg then
 		sg:KeepAlive()
 		e:SetLabelObject(sg)

--- a/c46186135.lua
+++ b/c46186135.lua
@@ -37,8 +37,8 @@ function s.initial_effect(c)
 	--discard deck
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(id,1))
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e4:SetCategory(CATEGORY_DECKDES)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e4:SetCountLimit(1)
 	e4:SetCode(EVENT_PHASE+PHASE_END)
 	e4:SetRange(LOCATION_MZONE)
@@ -49,6 +49,7 @@ function s.initial_effect(c)
 	--to hand
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(id,2))
+	e5:SetCategory(CATEGORY_TOHAND+CATEGORY_SPECIAL_SUMMON)
 	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e5:SetCode(EVENT_DESTROYED)
 	e5:SetProperty(EFFECT_FLAG_DELAY)
@@ -113,31 +114,32 @@ end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return rp==1-tp and e:GetHandler():IsPreviousControler(tp)
 end
-function s.thfilter1(c)
+function s.thfilter1(c,tp)
 	return c:IsFaceup() and c:IsCode(19959563) and c:IsAbleToHand()
+		and Duel.IsExistingMatchingCard(s.thfilter2,tp,LOCATION_REMOVED,0,1,c)
 end
 function s.thfilter2(c)
 	return c:IsFaceup() and c:IsCode(57774843) and c:IsAbleToHand()
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.thfilter1,tp,LOCATION_REMOVED,0,1,nil) and Duel.IsExistingMatchingCard(s.thfilter2,tp,LOCATION_REMOVED,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.thfilter1,tp,LOCATION_REMOVED,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,2,0,LOCATION_REMOVED)
 end
-function s.fselect2(g)
-	return g:GetClassCount(Card.GetCode)==g:GetCount()
-end
 function s.spfilter(c,e,tp)
-	return c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsLocation(LOCATION_HAND) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g1=Duel.GetMatchingGroup(s.thfilter1,tp,LOCATION_REMOVED,0,nil)
-	local g2=Duel.GetMatchingGroup(s.thfilter2,tp,LOCATION_REMOVED,0,nil)
-	if #g1>0 and #g2>0 then
-		Duel.SendtoHand((g1+g2):SelectSubGroup(tp,s.fselect2,false,2,2),nil,REASON_EFFECT)
+	local g1=Duel.SelectMatchingCard(tp,s.thfilter1,tp,LOCATION_REMOVED,0,1,1,nil,tp)
+	if #g1==0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g2=Duel.SelectMatchingCard(tp,s.thfilter2,tp,LOCATION_REMOVED,0,1,1,g1,tp)
+	g1:Merge(g2)
+	if Duel.SendtoHand(g1,nil,REASON_EFFECT)==2 then
 		local tg=Duel.GetOperatedGroup()
-		Duel.ConfirmCards(1-tp,tg)
-		if tg:FilterCount(s.spfilter,nil,e,tp)==2 and Duel.GetLocationCount(tp,LOCATION_MZONE)>=2 and Duel.SelectYesNo(tp,aux.Stringid(id,3)) then
+		if tg:FilterCount(s.spfilter,nil,e,tp)==2
+			and Duel.GetLocationCount(tp,LOCATION_MZONE)>=2 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
+			and Duel.SelectYesNo(tp,aux.Stringid(id,3)) then
 			Duel.BreakEffect()
 			for tc in aux.Next(tg) do
 				Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP)

--- a/c46186135.lua
+++ b/c46186135.lua
@@ -60,20 +60,20 @@ end
 function s.fusfilter(c)
 	return c:IsCode(19959563,57774843) and c:IsAbleToRemoveAsCost()
 end
-function s.fselect(g)
-	return g:GetClassCount(Card.GetCode)==2 and g:IsExists(Card.IsLocation,1,nil,LOCATION_ONFIELD) and g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE)
+function s.fselect(g,tp)
+	return g:GetClassCount(Card.GetCode)==2 and Duel.GetMZoneCount(tp,g)>0
+		and g:IsExists(Card.IsLocation,1,nil,LOCATION_MZONE) and g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE)
 end
 function s.spcon(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	local fg=Duel.GetMatchingGroup(s.fusfilter,tp,LOCATION_ONFIELD+LOCATION_GRAVE,0,nil)
-	return fg:CheckSubGroup(s.fselect,2,2)
+	local g=Duel.GetMatchingGroup(s.fusfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+	return g:CheckSubGroup(s.fselect,2,2,tp)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,c)
-	local cp=c:GetControler()
-	local g=Duel.GetMatchingGroup(s.fusfilter,cp,LOCATION_ONFIELD+LOCATION_GRAVE,0,nil)
-	Duel.Hint(HINT_SELECTMSG,cp,HINTMSG_REMOVE)
-	local sg=g:SelectSubGroup(cp,s.fselect,true,2,2)
+	local g=Duel.GetMatchingGroup(s.fusfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local sg=g:SelectSubGroup(tp,s.fselect,true,2,2,tp)
 	if sg then
 		sg:KeepAlive()
 		e:SetLabelObject(sg)
@@ -84,6 +84,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp,c)
 	local sg=e:GetLabelObject()
 	c:SetMaterial(sg)
 	Duel.Remove(sg,POS_FACEUP,REASON_COST)
+	sg:DeleteGroup()
 end
 function s.recost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,2000) end


### PR DESCRIPTION
> 自分のフィールド及び墓地からそれぞれ**１体**ずつ、上記のカードを除外した場合のみ特殊召喚できる。

> この方法で特殊召喚を行う場合、該当のカードを自分の**モンスターゾーン**から１体、自分の墓地から１体を融合素材として除外する必要があります。

