### PR TITLE
Fix 試号閃刀姫－アマツ

### DIFF
--- a/c25072579.lua
+++ b/c25072579.lua
@@ -60,7 +60,7 @@ function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local ac=c:GetBattleTarget()
 	e:SetLabelObject(ac)
-	return ac and ac:IsFaceup() and ac:IsControler(1-tp)
+	return ac and ac:IsControler(1-tp)
 end
 function s.desfilter2(c)
 	return c:IsFaceup() and c:IsSetCard(0x1115)


### PR DESCRIPTION
Related Card: 
[試号閃刀姫－アマツ](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=21600&request_locale=ja)
****
BUG: 
This card should be allow to activate its effect② when it attack a FaceDown Monster.
****
Fix: 
Like [蛇眼の大炎魔](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=19852&request_locale=ja)'s effect①, it's not suppose to check whether the <code>BattleTarget</code> is <code>FaceUp</code>, deleted.