### PR TITLE
Fix Necroquip Princess

### DIFF
--- a/c93860227.lua
+++ b/c93860227.lua
@@ -4,7 +4,7 @@ function s.initial_effect(c)
 	c:SetUniqueOnField(1,0,id)
 	c:EnableReviveLimit()
 	aux.AddFusionProcFunFun(c,s.ffilter1,s.ffilter2,1,true)
-	aux.AddContactFusionProcedure(c,Card.IsAbleToGraveAsCost,LOCATION_ONFIELD,0,Duel.SendtoGrave,REASON_COST)
+	aux.AddContactFusionProcedure(c,Card.IsAbleToGraveAsCost,LOCATION_ONFIELD+LOCATION_HAND,0,Duel.SendtoGrave,REASON_COST)
 	--special summon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
修复该卡应能使用“手卡”的恶魔族怪兽卡作为素材进行特殊召唤的问题。
Must be Special Summoned (from your Extra Deck) by sending the above cards from your hand and/or field to the GY.

https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=20423