### PR TITLE
Fix Start for VS！

### DIFF
--- a/c35550352.lua
+++ b/c35550352.lua
@@ -72,6 +72,7 @@ function s.repfilter(c,tp)
 end
 function s.spcostfilter(c)
 	return c:IsSetCard(0x195) and c:IsType(TYPE_MONSTER) and not c:IsPublic()
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()


### PR DESCRIPTION
我方场上存在「向征服斗魂进发！」「征服斗魂 蛟龙」，手卡存在「征服斗魂 螺禅」，对方发动「死之卡组破坏病毒」的场合，那个效果处理时我方不能适用「向征服斗魂进发！」的②效果给对方观看「征服斗魂 螺禅」让「征服斗魂 蛟龙」不被破坏。

我方场上存在「向征服斗魂进发！」和「征服斗魂 螺禅」，手卡存在「征服斗魂 狂爱博士」时，对方发动「死之卡组破坏病毒」，我方手卡全部确认，破坏「征服斗魂 螺禅」的场合，可以适用「向征服斗魂进发！」的②效果给对方观看「征服斗魂 狂爱博士」来代替破坏。

---

Should not show cards that's confirmed to be destroyed