### PR TITLE
Fix リブロマンサー・アフェクテッド

### DIFF
--- a/c88083109.lua
+++ b/c88083109.lua
@@ -30,12 +30,11 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	Duel.GetOperationInfo(ev,CATEGORY_TOHAND)
 	local tg=Duel.GetTargetsRelateToChain()
 	local hc=e:GetLabelObject()
-	local tc=(tg-hc):GetFirst()
 	if hc and hc:IsControler(tp) and hc:IsRelateToEffect(e)
 		and Duel.SendtoHand(hc,nil,REASON_EFFECT)>0 and hc:IsLocation(LOCATION_HAND) then
+		local tc=(tg-hc):GetFirst()
 		if tc and tc:IsControler(1-tp) and tc:IsRelateToEffect(e)
 			and Duel.GetControl(tc,tp)>0 and not hc:IsType(TYPE_RITUAL) then
 			local fid=c:GetFieldID()


### PR DESCRIPTION
Related Card: [**リブロマンサー・アフェクテッド**](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=17399&request_locale=ja)
****
Bug: [**トランザクション・ロールバック**](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=19049&request_locale=ja) could not copy **リブロマンサー・アフェクテッド** correctly, cause **リブロマンサー・アフェクテッド**'s <code>Operation</code> get <code>Target_Info</code> from <code>Operation_Info</code>, which **トランザクション・ロールバック** will clear before it copy the <code>Operation</code>.
****
Fix: Update the method to deliver Target_Info.
****
Extra change:
Add nil_check about target_card in the part of <code>Operation</code>.