### PR TITLE
Fix BF－無頼のヴァータ

### DIFF
--- a/c71187462.lua
+++ b/c71187462.lua
@@ -51,7 +51,7 @@ function c71187462.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local clv=c:GetLevel()
 	local lv=8-clv
-	if c:IsRelateToEffect(e) and not c:IsFacedown() and lv>0 then
+	if c:IsRelateToEffect(e) and lv>0 then
 		local g=Duel.GetMatchingGroup(c71187462.tgfilter,tp,LOCATION_DECK,0,nil)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local tg=g:SelectWithSumEqual(tp,Card.GetLevel,lv,1,99)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23804&keyword=&tag=-1&request_locale=ja
> 処理時にモンスターゾーンで裏側守備表示になっていた場合でも、処理は行われます。