### PR TITLE
Fix BF－毒風のシムーン

### DIFF
--- a/c81470373.lua
+++ b/c81470373.lua
@@ -87,7 +87,7 @@ function c81470373.splimit(e,c)
 end
 function c81470373.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if Duel.SendtoGrave(c,REASON_EFFECT)~=0 and c:IsLocation(LOCATION_GRAVE) then
+	if Duel.SendtoGrave(c,REASON_EFFECT)~=0 then
 		Duel.Damage(tp,1000,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21946&keyword=&tag=-1&request_locale=ja
> 「マクロコスモス」の効果によって結果的に「黒い旋風」は除外される事になりますが、処理自体は適用されていますので、1000ダメージを受ける処理も適用される事になります。