### PR TITLE
Fix エーリアン・マザー

### DIFF
--- a/c24104865.lua
+++ b/c24104865.lua
@@ -97,6 +97,6 @@ function c24104865.desfilter(c,rc)
 	return c:GetFlagEffect(24104865)~=0 and rc:IsRelateToCard(c)
 end
 function c24104865.desop(e,tp,eg,ep,ev,re,r,rp)
-	local dg=Duel.GetMatchingGroup(c24104865.desfilter,tp,LOCATION_MZONE,0,nil,e:GetHandler())
+	local dg=Duel.GetMatchingGroup(c24104865.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,e:GetHandler())
 	Duel.Destroy(dg,REASON_EFFECT)
 end


### PR DESCRIPTION
Related Card: [エーリアン・マザー/Alien Mother](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=6805&request_locale=ja)
****
Bug: If a monster special summoned by this card(Player1), then change its controler(Player2), it will not be destoryed when this card leave filed.
****
Fix: Fix the range of LeaveField_destroy_effect will check.