### PR TITLE
Fix 闇の誘惑

### DIFF
--- a/c1475311.lua
+++ b/c1475311.lua
@@ -18,11 +18,11 @@ function c1475311.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c1475311.activate(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
-	Duel.Draw(p,d,REASON_EFFECT)
-	Duel.ShuffleHand(p)
+	if Duel.Draw(p,d,REASON_EFFECT)<=0 then return end
 	Duel.BreakEffect()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(p,Card.IsAttribute,p,LOCATION_HAND,0,1,1,nil,ATTRIBUTE_DARK)
+	Duel.ShuffleHand(p)
 	local tg=g:GetFirst()
 	if tg then
 		if Duel.Remove(tg,POS_FACEUP,REASON_EFFECT)==0 then


### PR DESCRIPTION
> 処理時に、『自分は２枚ドローする』処理を行います。**ドローに成功し**、自分の手札に闇属性モンスターが存在する場合、その後、『その内の１体を選んで除外する』処理を行います。存在しない場合、その後、『自分の手札を全て墓地へ送る』処理を行います。