### PR TITLE
Fix アーティファクト&ゴーティスの紅玉ゼップ

### DIFF
--- a/c11475049.lua
+++ b/c11475049.lua
@@ -28,6 +28,7 @@ end
 function c11475049.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c11475049.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c12697630.lua
+++ b/c12697630.lua
@@ -31,6 +31,7 @@ end
 function c12697630.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c12697630.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c20292186.lua
+++ b/c20292186.lua
@@ -28,6 +28,7 @@ end
 function c20292186.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c20292186.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c34267821.lua
+++ b/c34267821.lua
@@ -31,6 +31,7 @@ end
 function c34267821.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c34267821.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c47863787.lua
+++ b/c47863787.lua
@@ -31,6 +31,7 @@ end
 function c47863787.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c47863787.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c48086335.lua
+++ b/c48086335.lua
@@ -30,6 +30,7 @@ end
 function c48086335.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c48086335.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c69304426.lua
+++ b/c69304426.lua
@@ -39,6 +39,7 @@ end
 function c69304426.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c69304426.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c76133574.lua
+++ b/c76133574.lua
@@ -54,7 +54,8 @@ function s.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()==1-tp
+	local c=e:GetHandler()
+	return Duel.GetTurnPlayer()==1-tp and c:IsPreviousControler(tp)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c80237445.lua
+++ b/c80237445.lua
@@ -32,6 +32,7 @@ end
 function c80237445.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c80237445.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c84268896.lua
+++ b/c84268896.lua
@@ -32,6 +32,7 @@ end
 function c84268896.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c84268896.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c85080444.lua
+++ b/c85080444.lua
@@ -28,6 +28,7 @@ end
 function c85080444.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c85080444.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c85103922.lua
+++ b/c85103922.lua
@@ -31,6 +31,7 @@ end
 function c85103922.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c85103922.sptg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c8873112.lua
+++ b/c8873112.lua
@@ -32,6 +32,7 @@ end
 function c8873112.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEDOWN)
+		and c:IsPreviousControler(tp)
 		and c:IsReason(REASON_DESTROY) and Duel.GetTurnPlayer()~=tp
 end
 function c8873112.sptg(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
修复此类卡在对方回合的对方场上被破坏或被除外的场合应不能触发对应的特殊召唤效果的问题。