### PR TITLE
Fix 銀河眼の時源竜

### DIFF
--- a/c45710945.lua
+++ b/c45710945.lua
@@ -90,7 +90,7 @@ function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local at=Duel.GetAttacker()
 	if c:IsRelateToEffect(e) and c:IsCanOverlay()
-		and at:IsRelateToEffect(e) and at:IsRelateToBattle() and not at:IsImmuneToEffect(e) then
+		and at:IsRelateToBattle() and not at:IsImmuneToEffect(e) then
 		Duel.Overlay(at,Group.FromCards(c))
 	end
 end

--- a/c45710945.lua
+++ b/c45710945.lua
@@ -89,7 +89,7 @@ end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local at=Duel.GetAttacker()
-	if c:IsRelateToEffect(e) and at:IsRelateToBattle() then
+	if c:IsRelateToEffect(e) and c:IsCanOverlay() and at:IsRelateToEffect(e) and at:IsRelateToBattle() and not at:IsImmuneToEffect(e) then
 		Duel.Overlay(at,Group.FromCards(c))
 	end
 end

--- a/c45710945.lua
+++ b/c45710945.lua
@@ -89,7 +89,8 @@ end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local at=Duel.GetAttacker()
-	if c:IsRelateToEffect(e) and c:IsCanOverlay() and at:IsRelateToEffect(e) and at:IsRelateToBattle() and not at:IsImmuneToEffect(e) then
+	if c:IsRelateToEffect(e) and c:IsCanOverlay()
+		and at:IsRelateToEffect(e) and at:IsRelateToBattle() and not at:IsImmuneToEffect(e) then
 		Duel.Overlay(at,Group.FromCards(c))
 	end
 end


### PR DESCRIPTION
修复③效果处理时需要判断自身是否能作为超量素材和攻击宣言的怪兽是否会免疫该效果的问题。