### PR TITLE
Fix SPYRAL MISSION－強襲

### DIFF
--- a/c27642961.lua
+++ b/c27642961.lua
@@ -70,6 +70,7 @@ function c27642961.drcon(e,tp,eg,ep,ev,re,r,rp)
 		local rc=re:GetHandler()
 		return eg:IsExists(c27642961.cfilter,1,nil,tp)
 			and rc and rc:IsSetCard(0xee) and rc:IsControler(tp) and re:IsActiveType(TYPE_MONSTER)
+			and re:GetActivateLocation()==LOCATION_MZONE
 	end
 	return false
 end


### PR DESCRIPTION
修复①效果应是“场上”的「秘旋谍」怪兽的效果把卡破坏的场合才能触发的问题。
「秘旋谍-龙卷风」②效果因是在墓地里诱发，应不会触发该卡的①效果。
または自分フィールドの「SPYRAL」モンスターの効果でフィールドのカードを破壊した場合に発動できる

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12826&request_locale=ja