### PR TITLE
Fix 転輪のスフィンクス

### DIFF
--- a/c46148485.lua
+++ b/c46148485.lua
@@ -78,7 +78,7 @@ function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:FilterCount(aux.TRUE,nil,e:GetHandler())>0
+	return eg:FilterCount(aux.TRUE,e:GetHandler())>0
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsOnField() and chkc:IsAbleToHand() end


### PR DESCRIPTION
修复③效果脚本中“排除自身”的参数写错了位置的问题。
（1回合1次，场上的其他怪兽的表示形式变更的场合，以场上1张卡为对象才能发动。那张卡回到手卡。）