### PR TITLE
Fix attempt for Sphere Mode

### DIFF
--- a/c10000080.lua
+++ b/c10000080.lua
@@ -123,7 +123,7 @@ function c10000080.retop(e,tp,eg,ep,ev,re,r,rp)
 	--reset
 	local e2=Effect.CreateEffect(e:GetHandler())
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_ADJUST)
+	e2:SetCode(EVENT_LEAVE_FIELD)
 	e2:SetLabelObject(e1)
 	e2:SetOperation(c10000080.reset)
 	Duel.RegisterEffect(e2,tp)


### PR DESCRIPTION
Currently Sphere Mode does not return to the owner if it's facedown during the End Phase of the next turn after being summoned. The effect should still reset if Sphere Mode were to leave the field/temp banished, but not if facedown. I dont know if theres a better way to fix this, but this at least seems to work.

https://db.ygoresources.com/card#11927

"Even if this card that was Summoned to your opponent's field is in face-down Defense Position, the process of "control of this card returns to its original owner at the End Phase of the next turn" will proceed as usual."