### PR TITLE
Update Last Turn

### DIFF
--- a/c28566710.lua
+++ b/c28566710.lua
@@ -15,7 +15,8 @@ function c28566710.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetLP(tp)<=1000 and Duel.GetTurnPlayer()~=tp
 end
 function c28566710.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(nil,tp,LOCATION_MZONE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(nil,tp,LOCATION_MZONE,0,1,nil) 
+		and Duel.IsPlayerCanSpecialSummon(1-tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,1-tp,LOCATION_DECK)
 end
 function c28566710.spfilter(c,e,tp)


### PR DESCRIPTION
Update Last Turn to reflect a new ruling from Konami about Last Turn activation legality.

https://yugiohblog.konami.com/2025/genesys/what-gameplay-rules-are-different/

Q. Can I activate Last Turn if my opponent isn’t allowed to Special Summon? A. A great question, since effects that instruct a player to perform a Special Summon after their resolution have changed in form and function since 2003. This card hasn’t seen print in 20 years, but based off the impressive volume of rules Q&A this card generated back in the day, if we rewrote it today, this card would probably say something like “Immediately after this effect resolves, your opponent Special Summons…”Effects that Special Summon cannot be activated if the player that must perform the Summon is not allowed to. So no, you can’t.