### PR TITLE
Fix Vingolf's Blessing

### DIFF
--- a/c75493362.lua
+++ b/c75493362.lua
@@ -3,7 +3,7 @@ local s,id,o=GetID()
 function s.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_TOGRAVE)
+	e1:SetCategory(CATEGORY_TOGRAVE+CATEGORY_DECKDES)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,id+EFFECT_COUNT_CODE_OATH)


### PR DESCRIPTION
修复这张卡发动时，应能被「灰流丽」响应的问题。
（这张卡的发动时：可以从卡组把1只天使族·光属性怪兽送去墓地。）