### PR TITLE
Fix 巳剣勧請

### DIFF
--- a/c45171524.lua
+++ b/c45171524.lua
@@ -54,7 +54,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		if op~=0 then
 			Duel.BreakEffect()
 		end
-		Duel.Damage(tp,800,REASON_EFFECT)
+		if Duel.Damage(tp,800,REASON_EFFECT)<=0 then return end
 		local b3=Duel.GetMZoneCount(tp)>0 and Duel.IsExistingMatchingCard(aux.NecroValleyFilter(s.spfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,e,tp)
 		if b3 and Duel.SelectYesNo(tp,aux.Stringid(id,4)) then
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
処理時に、『自分は８００ダメージを受ける』処理を行います。**ダメージを受けた場合**、その後、『自分の手札・墓地から「巳剣」モンスター１体を特殊召喚』する処理を行うことができます。