### PR TITLE
fix Anubis the Last Judge

### DIFF
--- a/c60411677.lua
+++ b/c60411677.lua
@@ -3,6 +3,13 @@ local s,id,o=GetID()
 function s.initial_effect(c)
 	aux.AddCodeList(c,29762407,97522863)
 	c:EnableReviveLimit()
+	--special summon condition
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e0:SetValue(0)
+	c:RegisterEffect(e0)
 	--spsummon rule
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/c60411677.lua
+++ b/c60411677.lua
@@ -58,7 +58,7 @@ end
 function s.sprtg(e,tp,eg,ep,ev,re,r,rp,chk,c)
 	local g=Duel.GetMatchingGroup(s.sprfilter,tp,LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	local sg=g:CancelableSelect(tp,2,2,nil)
+	local sg=g:SelectSubGroup(tp,aux.dncheck,true,2,2)
 	if sg then
 		sg:KeepAlive()
 		e:SetLabelObject(sg)


### PR DESCRIPTION
> 自分の墓地に「王家の神殿」か罠カードが合計３種類以上存在する状態で、その内の**２種類**を１枚ずつ好きな順番でデッキの下に戻した場合**のみ**、手札・墓地から特殊召喚できる。

> ■この方法で特殊召喚された後に墓地へ送られている場合や表側表示で除外されている場合でも、このカードを他のカードの効果で特殊召喚することはできません。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=21037&request_locale=ja
