### PR TITLE
Update utility.lua

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1158,7 +1158,7 @@ function Auxiliary.gffcheck(g,f1,a1,f2,a2)
 	if #g~=2 then return false end
 	local c1=g:GetFirst()
 	local c2=g:GetNext()
-	return f1(c1,a1) and f2(c2,a2) or f1(c2,a1) and f2(c1,a2)
+	return (f1(c1,a1) and f2(c2,a2)) or (f1(c2,a1) and f2(c1,a2))
 end
 function Auxiliary.mzctcheck(g,tp)
 	return Duel.GetMZoneCount(tp,g)>0


### PR DESCRIPTION
Fix an issue where cards using "aux.gffcheck", such as Synchro Fellows(43834302), would produce an error on Omega:

"[string "utility"]1161: attempt to call a nil value (local 'f2')"