### PR TITLE
Fix ゴキポール

### DIFF
--- a/c17535764.lua
+++ b/c17535764.lua
@@ -30,13 +30,14 @@ function c17535764.tgop(e,tp,eg,ep,ev,re,r,rp)
 		if tc:IsType(TYPE_NORMAL) and tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
 			and Duel.SelectYesNo(tp,aux.Stringid(17535764,1)) then
 			Duel.BreakEffect()
-			local g=Duel.GetMatchingGroup(c17535764.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tc:GetAttack())
-			if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 and g:GetCount()>0
-				and Duel.SelectYesNo(tp,aux.Stringid(17535764,2)) then
-				Duel.BreakEffect()
-				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-				local tc2=g:Select(tp,1,1,nil)
-				Duel.Destroy(tc2,REASON_EFFECT)
+			if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+				local g=Duel.GetMatchingGroup(c17535764.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tc:GetAttack())
+				if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(17535764,2)) then
+					Duel.BreakEffect()
+					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+					local tc2=g:Select(tp,1,1,nil)
+					Duel.Destroy(tc2,REASON_EFFECT)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
修复因该效果特殊召唤的是通常怪兽的场合，后续选择执行「破坏场上1只怪兽」的效果不能选择因这个效果特殊召唤的通常怪兽的问题。 
（这个效果把通常怪兽加入的场合，可以再把那只怪兽从手卡特殊召唤。那之后，可以选持有这个效果特殊召唤的怪兽的攻击力以上的攻击力的场上1只怪兽破坏。）