### PR TITLE
Update Synchro Fellows and D/D/D Sky King Zeus Ragnarok

### DIFF
--- a/c30998403.lua
+++ b/c30998403.lua
@@ -74,11 +74,14 @@ end
 function s.cfilter2(c)
 	return c:IsSetCard(0xae) and c:IsAbleToRemoveAsCost()
 end
+function s.fselect(g,c,tp)
+	return aux.gffcheck(g,s.cfilter1,nil,s.cfilter2,nil)
+end
 function s.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local rg=Duel.GetMatchingGroup(s.rmfilter,tp,LOCATION_GRAVE,0,nil)
-	if chk==0 then return rg:CheckSubGroup(aux.gffcheck,2,2,s.cfilter1,nil,s.cfilter2,nil) end
+	if chk==0 then return rg:CheckSubGroup(s.fselect,2,2,s.cfilter1,nil,s.cfilter2,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=rg:SelectSubGroup(tp,aux.gffcheck,false,2,2,s.cfilter1,nil,s.cfilter2,nil)
+	local g=rg:SelectSubGroup(tp,s.fselect,false,2,2,s.cfilter1,nil,s.cfilter2,nil)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
 function s.negtg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c43834302.lua
+++ b/c43834302.lua
@@ -33,18 +33,21 @@ function s.thfilter(c)
 	return (c:IsCode(63977008) or (aux.IsCodeListed(c,60800381) or aux.IsCodeListed(c,44508094)) and c:IsType(TYPE_MONSTER))
 		and c:IsAbleToHand()
 end
+function s.fselect(g,c,tp)
+	return aux.gffcheck(g,s.thfilter1,nil,s.thfilter2,nil)
+end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_DECK,0,nil)
-		return g:CheckSubGroup(aux.gffcheck,2,2,s.thfilter1,nil,s.thfilter2,nil)
+		return g:CheckSubGroup(s.fselect,2,2,s.thfilter1,nil,s.thfilter2,nil)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,2,tp,LOCATION_DECK)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_DECK,0,nil)
-	if not g:CheckSubGroup(aux.gffcheck,2,2,s.thfilter1,nil,s.thfilter2,nil) then return end
+	if not g:CheckSubGroup(s.fselect,2,2,s.thfilter1,nil,s.thfilter2,nil) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local tg1=g:SelectSubGroup(tp,aux.gffcheck,false,2,2,s.thfilter1,nil,s.thfilter2,nil)
+	local tg1=g:SelectSubGroup(tp,s.fselect,false,2,2,s.thfilter1,nil,s.thfilter2,nil)
 	if #tg1==2 then
 		Duel.SendtoHand(tg1,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,tg1)


### PR DESCRIPTION
Fix both scripts to no longer produce a "[string "utility"]1161: attempt to call a nil value (local 'f2')" error on Omega and DNX. I would imagine these may also produce similar errors on ygopro.