### PR TITLE
Fix キラーチューン?ラウドネスウォー

### DIFF
--- a/c41069676.lua
+++ b/c41069676.lua
@@ -58,7 +58,6 @@ function s.cptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=g:GetFirst()
 	local te=tc.killer_tune_be_material_effect
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
-	e:SetProperty(te:GetProperty())
 	Duel.ClearTargetCard()
 	e:SetLabelObject(te)
 	local tg=te:GetTarget()


### PR DESCRIPTION
修复②效果在适用其他「杀手级调整曲」怪兽发动的效果后，会把除外怪兽的SetProperty参数替换原效果参数的问题，导致此效果有可能变成属于“取对象”或“场合型诱发”。