### PR TITLE
fix--CNo.107 超銀河眼の時空龍

### DIFF
--- a/c68396121.lua
+++ b/c68396121.lua
@@ -55,7 +55,7 @@ function c68396121.negop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function c68396121.aclimit(e,re,tp)
-	return re:GetHandler():IsOnField()
+	return re:GetHandler():IsOnField() or re:IsHasType(EFFECT_TYPE_ACTIVATE)
 end
 function c68396121.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11070

■『このターン相手はフィールドで発動する効果を発動できず』の効果が適用された場合、相手は既にフィールドに存在するカードの効果だけでなく、手札から魔法・罠カードを発動することもできなくなります。

fix opponent can activate spell or trap card from hand after this effect resolves