### PR TITLE
Fix 巳剣勧請

### DIFF
--- a/c45171524.lua
+++ b/c45171524.lua
@@ -1,4 +1,4 @@
---Mitsurugi Prayers
+--巳剣勧請
 local s,id,o=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -65,7 +65,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 				Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP)
 				local e1=Effect.CreateEffect(e:GetHandler())
 				e1:SetType(EFFECT_TYPE_SINGLE)
-				e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_OATH)
+				e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 				e1:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
 				e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 				tc:RegisterEffect(e1)


### PR DESCRIPTION
Current bug:

1. You activate 1st ``巳剣勧請`` and spsummon a monster.
2. You activate it again and its activation is negated
3. The monster spsummoned by 1st ``巳剣勧請`` can attack now.