### PR TITLE
Fix 磁石の戦士ε

### DIFF
--- a/c52566270.lua
+++ b/c52566270.lua
@@ -43,6 +43,7 @@ function c52566270.operation(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetValue(e:GetLabel())
 	c:RegisterEffect(e1)
 	if Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c52566270.spfilter),tp,LOCATION_GRAVE,0,1,nil,e,tp)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.SelectYesNo(tp,aux.Stringid(52566270,1)) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
修复①效果后续部分“那之后，可以从自己墓地选同名卡不在自己场上存在的1只「磁石战士」怪兽特殊召唤”没有判断自己场上是否有可用怪兽区域的问题。
 （その後、同名カードが自分フィールドに存在しない、「マグネット・ウォリアー」モンスターまたは「磁石の戦士」モンスター１体を自分の墓地から選んで特殊召喚できる）

【①の効果について】
■モンスターゾーンで発動できる誘発効果です。
■ダメージステップでも発動できます。
■処理時に、『このカードはエンドフェイズまで、墓地へ送ったモンスターと同名カードとして扱う』処理を行います。その後、『同名カードが自分フィールドに存在しない、「マグネット・ウォリアー」モンスターまたは「磁石の戦士」モンスター１体を自分の墓地から選んで特殊召喚できる』処理を行えます。（これらの処理は同時に行われません。） 
■特殊召喚する際に、コストで墓地へ送ったモンスター及びその同名モンスターを特殊召喚することはできません。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16825&request_locale=ja