### PR TITLE
Fix ストレイ・ピュアリィ・ストリート

### DIFF
--- a/c20212491.lua
+++ b/c20212491.lua
@@ -77,10 +77,10 @@ function s.matfilter(c,tp)
 		and Duel.IsExistingMatchingCard(s.matfilter2,tp,LOCATION_GRAVE+LOCATION_DECK,0,1,nil)
 end
 function s.mattg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and s.matfilter(chkc,tp) end
-	if chk==0 then return Duel.IsExistingTarget(s.matfilter,tp,LOCATION_MZONE,0,1,nil,tp) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and s.matfilter(chkc,tp) end
+	if chk==0 then return Duel.IsExistingTarget(s.matfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectTarget(tp,s.matfilter,tp,LOCATION_MZONE,0,1,1,nil,tp)
+	Duel.SelectTarget(tp,s.matfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,tp)
 end
 function s.matop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()


### PR DESCRIPTION
修复③效果应是以“双方”场上1只「纯爱妖精」超量怪兽为对象发动的问题。
（お互いのエンドフェイズに、フィールドの「ピュアリィ」Xモンスター１体を対象として発動できる）

【③の効果について】
■フィールドゾーンの表側表示のこのカードが発動できるチェーンブロックの作られる効果です。
■エンドフェイズごとに１度発動できます。
■対象のモンスターに適用される効果です。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18009&request_locale=ja