### PR TITLE
Fix 分かつ烙印

### DIFF
--- a/c1041278.lua
+++ b/c1041278.lua
@@ -89,7 +89,7 @@ function c1041278.activate(e,tp,eg,ep,ev,re,r,rp)
 			and g:IsExists(c1041278.spfilter3,2,nil,e,tp)
 		if b2 and (not b1 or Duel.SelectYesNo(tp,aux.Stringid(1041278,0))) then
 			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
-		else
+		elseif b1 then
 			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(1041278,1))
 			local sg=g:FilterSelect(tp,c1041278.spfilter1,1,1,nil,e,tp,g)
 			if #sg==0 then return end


### PR DESCRIPTION
修复在处理效果时，若自己场上没有可用怪兽区域，应不能选择把怪兽特殊召唤到对方场上的问题。
■処理時に、対象のモンスターのうち少なくとも片方を特殊召喚できなくなった場合、処理は行われません。（コストとしてリリースしたモンスターを問わず、処理時には１体も特殊召喚されません。）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17472&request_locale=ja