### PR TITLE
Fix 破壊竜ガンドラG

### DIFF
--- a/c2333466.lua
+++ b/c2333466.lua
@@ -66,7 +66,7 @@ function s.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c) end
+	if chk==0 then return Duel.IsExistingMatchingCard(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c) and Duel.IsPlayerCanRemove(tp) end
 	local sg=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,c)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,LOCATION_DECK)
@@ -74,12 +74,11 @@ end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local sg=Duel.GetMatchingGroup(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,aux.ExceptThisCard(e))
-	local rtg=sg:Filter(aux.AND(Card.IsType,Card.IsAbleToRemove),nil,TYPE_TOKEN,tp)
+	local rtc=sg:IsExists(Card.IsType,1,nil,TYPE_TOKEN) and Duel.IsPlayerCanRemove(tp)
 	local ct=Duel.Destroy(sg,REASON_EFFECT,LOCATION_REMOVED)
 	if ct==0 then return end
-	local dg=Duel.GetOperatedGroup()
 	local rg=sg:Filter(Card.IsLocation,nil,LOCATION_REMOVED)
-	if (rtg&dg):GetCount()==0 and rg:GetCount()==0 then return end
+	if not rtc and rg:GetCount()==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()


### PR DESCRIPTION
処理時に、『フィールドの他のカードを全て破壊し除外する』処理を行います。**１枚以上のカードを除外することに成功した場合**、その後、『デッキから「光之黄金柜」のカード名が記されたレベル７以下のモンスター１体を特殊召喚する』処理を行います。この効果で特殊召喚したモンスターには『レベルは、この効果で破壊したカードの数だけ上がる』効果が適用されます。