### PR TITLE
fix CONTAIN!

### DIFF
--- a/c62777823.lua
+++ b/c62777823.lua
@@ -22,11 +22,14 @@ end
 function s.checkfilter(c)
 	return c:IsCode(37617348) and c:IsFaceup()
 end
+function s.tgfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_EFFECT)
+end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and aux.NegateEffectMonsterFilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(aux.NegateEffectMonsterFilter,tp,0,LOCATION_MZONE,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and s.tgfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.tgfilter,tp,0,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISABLE)
-	local g=Duel.SelectTarget(tp,aux.NegateEffectMonsterFilter,tp,0,LOCATION_MZONE,1,1,nil)
+	local g=Duel.SelectTarget(tp,s.tgfilter,tp,0,LOCATION_MZONE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,1,0,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
@@ -39,24 +42,22 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCode(EFFECT_CANNOT_ATTACK)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1)
-		if not tc:IsDisabled() then
-			Duel.NegateRelatedChain(tc,RESET_TURN_SET)
-			local e2=Effect.CreateEffect(c)
-			e2:SetType(EFFECT_TYPE_SINGLE)
-			e2:SetCode(EFFECT_DISABLE)
-			e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-			tc:RegisterEffect(e2)
-			local e3=e2:Clone()
-			e3:SetCode(EFFECT_DISABLE_EFFECT)
-			e3:SetValue(RESET_TURN_SET)
-			tc:RegisterEffect(e3)
-			if tc:IsType(TYPE_TRAPMONSTER) then
-				local e4=e2:Clone()
-				e4:SetCode(EFFECT_DISABLE_TRAPMONSTER)
-				tc:RegisterEffect(e4)
-			end
-			Duel.AdjustInstantly()
+		Duel.NegateRelatedChain(tc,RESET_TURN_SET)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
+		local e3=e2:Clone()
+		e3:SetCode(EFFECT_DISABLE_EFFECT)
+		e3:SetValue(RESET_TURN_SET)
+		tc:RegisterEffect(e3)
+		if tc:IsType(TYPE_TRAPMONSTER) then
+			local e4=e2:Clone()
+			e4:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+			tc:RegisterEffect(e4)
 		end
+		Duel.AdjustInstantly()
 		if check and not tc:IsImmuneToEffect(e) then
 			local e5=Effect.CreateEffect(c)
 			e5:SetType(EFFECT_TYPE_SINGLE)


### PR DESCRIPTION
mail:
> Q.
「スキルドレイン」の効果適用中、「CONTAIN！」を発動できますか？
A.
ご質問の場合、発動できます。

> Q.
「スキルドレイン」の効果適用中、「CONTAIN！」の効果処理後、「スキルドレイン」が破壊された場合、「CONTAIN！」の対象モンスターはまだ無効化されますか？
A.
ご質問の場合、無効化されたままです。

> Q.
相手フィールドの「惑星探査車」を対象として「無限泡影」を発動したところ、相手がチェーンして「スキルドレイン」を発動しました。チェーン処理後、相手が「惑星探査車」の効果を発動した場合、その効果の処理時は無効になりますか？
（「惑星探査車」が「スキルドレイン」の効果しか受けていない場合、効果処理時にフィールドを離れていれば無効にはなりませんが、「無限泡影」の効果を受けている場合は、フィールドで発動した限り無効になります。）
A.
ご質問の場合、無効になりません。

> Q.
また、上記の「無限泡影」を「CONTAIN！」に置き換えた場合も同様の処理になりますか？
A.
ご質問の場合、無効になります。