### PR TITLE
王宮の弾圧: Fix activation while Set

### DIFF
--- a/c93016201.lua
+++ b/c93016201.lua
@@ -1,77 +1,79 @@
--- 王宮の弾圧
-local s, id, o = GetID()
+--王宮の弾圧
+local s,id,o=GetID()
 function s.initial_effect(c)
-    -- Activate
-    local e1 = Effect.CreateEffect(c)
-    e1:SetType(EFFECT_TYPE_ACTIVATE)
-    e1:SetCode(EVENT_FREE_CHAIN)
-    c:RegisterEffect(e1)
-    -- Activate(timing)
-    local e2 = Effect.CreateEffect(c)
-    e2:SetDescription(aux.Stringid(id, 0))
-    e2:SetType(EFFECT_TYPE_ACTIVATE)
-    e2:SetRange(LOCATION_SZONE)
-    e2:SetCode(EVENT_SPSUMMON)
-    e2:SetCondition(s.con2)
-    e2:SetCost(s.cost2)
-    e2:SetTarget(s.target2)
-    e2:SetOperation(s.activate2)
-    c:RegisterEffect(e2)
-    -- instant
-    local e3 = Effect.CreateEffect(c)
-    e3:SetDescription(aux.Stringid(id, 0))
-    e3:SetType(EFFECT_TYPE_QUICK_O)
-    e3:SetRange(LOCATION_SZONE)
-    e3:SetProperty(EFFECT_FLAG_BOTH_SIDE)
-    e3:SetCode(EVENT_SPSUMMON)
-    e3:SetCondition(s.con2)
-    e3:SetCost(s.cost2)
-    e3:SetTarget(s.target2)
-    e3:SetOperation(s.activate2)
-    c:RegisterEffect(e3)
-    -- instant(chain)
-    local e4 = Effect.CreateEffect(c)
-    e4:SetDescription(aux.Stringid(id, 0))
-    e4:SetType(EFFECT_TYPE_QUICK_O)
-    e4:SetRange(LOCATION_SZONE)
-    e4:SetProperty(EFFECT_FLAG_BOTH_SIDE)
-    e4:SetCode(EVENT_CHAINING)
-    e4:SetCondition(s.condition3)
-    e4:SetCost(s.cost3)
-    e4:SetTarget(s.target3)
-    e4:SetOperation(s.activate3)
-    c:RegisterEffect(e4)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--Activate(timing)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,0))
+	e2:SetType(EFFECT_TYPE_ACTIVATE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_SPSUMMON)
+	e2:SetCondition(s.con2)
+	e2:SetCost(s.cost2)
+	e2:SetTarget(s.target2)
+	e2:SetOperation(s.activate2)
+	c:RegisterEffect(e2)
+	--instant
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,0))
+	e3:SetType(EFFECT_TYPE_QUICK_O)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetProperty(EFFECT_FLAG_BOTH_SIDE)
+	e3:SetCode(EVENT_SPSUMMON)
+	e3:SetCondition(s.con2)
+	e3:SetCost(s.cost2)
+	e3:SetTarget(s.target2)
+	e3:SetOperation(s.activate2)
+	c:RegisterEffect(e3)
+	--instant(chain)
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(id,0))
+	e4:SetType(EFFECT_TYPE_QUICK_O)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetProperty(EFFECT_FLAG_BOTH_SIDE)
+	e4:SetCode(EVENT_CHAINING)
+	e4:SetCondition(s.condition3)
+	e4:SetCost(s.cost3)
+	e4:SetTarget(s.target3)
+	e4:SetOperation(s.activate3)
+	c:RegisterEffect(e4)
 end
-function s.con2(e, tp, eg, ep, ev, re, r, rp)
-    return aux.NegateSummonCondition()
+function s.con2(e,tp,eg,ep,ev,re,r,rp)
+	return aux.NegateSummonCondition()
 end
-function s.cost2(e, tp, eg, ep, ev, re, r, rp, chk)
-    if chk == 0 then return Duel.CheckLPCost(tp, 800) end
-    Duel.PayLPCost(tp, 800)
+function s.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLPCost(tp,800) end
+	Duel.PayLPCost(tp,800)
 end
-function s.target2(e, tp, eg, ep, ev, re, r, rp, chk)
-    if chk == 0 then return true end
-    Duel.SetOperationInfo(0, CATEGORY_DISABLE_SUMMON, eg, eg:GetCount(), 0, 0)
-    Duel.SetOperationInfo(0, CATEGORY_DESTROY, eg, eg:GetCount(), 0, 0)
+function s.target2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE_SUMMON,eg,eg:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,eg:GetCount(),0,0)
 end
-function s.activate2(e, tp, eg, ep, ev, re, r, rp)
-    Duel.NegateSummon(eg)
-    Duel.Destroy(eg, REASON_EFFECT)
+function s.activate2(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateSummon(eg)
+	Duel.Destroy(eg,REASON_EFFECT)
 end
-function s.condition3(e, tp, eg, ep, ev, re, r, rp)
-    return re:IsHasCategory(CATEGORY_SPECIAL_SUMMON) and Duel.IsChainDisablable(ev)
+function s.condition3(e,tp,eg,ep,ev,re,r,rp)
+	return re:IsHasCategory(CATEGORY_SPECIAL_SUMMON) and Duel.IsChainDisablable(ev)
 end
-function s.cost3(e, tp, eg, ep, ev, re, r, rp, chk)
-    if chk == 0 then return Duel.CheckLPCost(tp, 800) end
-    Duel.PayLPCost(tp, 800)
+function s.cost3(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLPCost(tp,800) end
+	Duel.PayLPCost(tp,800)
 end
-function s.target3(e, tp, eg, ep, ev, re, r, rp, chk)
-    if chk == 0 then return true end
-    Duel.SetOperationInfo(0, CATEGORY_DISABLE, eg, 1, 0, 0)
-    if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
-        Duel.SetOperationInfo(0, CATEGORY_DESTROY, eg, 1, 0, 0)
-    end
+function s.target3(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
 end
-function s.activate3(e, tp, eg, ep, ev, re, r, rp)
-    if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then Duel.Destroy(eg, REASON_EFFECT) end
+function s.activate3(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
 end


### PR DESCRIPTION
# Description

This PR fixes an issue where 王宮の弾圧 could not be activated while Set to negate a Special Summon.

According to correct rulings, 王宮の弾圧 can be activated directly from the Set state in response to a Special Summon. The previous implementation incorrectly required the card to be face-up, preventing activation at the proper timing.

# Changes

* Allow 王宮の弾圧 to activate while Set
* Fix Special Summon negation timing to match correct behavior

For review, please use the GitHub web diff between these two commits:
https://github.com/Fluorohydride/ygopro-scripts/compare/527bb073bba2ca383ddd00e8a993d13157547f99...5754caaa01e68ec51669b2840d3205d5d09e33e9
