### PR TITLE
Add syncard for gc in aux.SynMixCheckGoal

### DIFF
--- a/procedure.lua
+++ b/procedure.lua
@@ -373,7 +373,7 @@ function Auxiliary.SynMixCheckGoal(tp,sg,minc,ct,syncard,sg1,smat,gc,mgchk)
 	local g=sg:Clone()
 	g:Merge(sg1)
 	if Duel.GetLocationCountFromEx(tp,tp,g,syncard)<=0 then return false end
-	if gc and not gc(g) then return false end
+	if gc and not gc(g,syncard) then return false end
 	if smat and not g:IsContains(smat) then return false end
 	if not Auxiliary.MustMaterialCheck(g,tp,EFFECT_MUST_BE_SMATERIAL) then return false end
 	if Duel.IsPlayerAffectedByEffect(tp,8173184)


### PR DESCRIPTION
Add param ``syncard`` to gc in SynchroMixProcedure for calling Card.IsTuner(syncard) or Card.IsNonTuner(syncard)
