### PR TITLE
Fix 碑像の天使－アズルーン

### DIFF
--- a/c44822037.lua
+++ b/c44822037.lua
@@ -44,7 +44,8 @@ function c44822037.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,SUMMON_VALUE_SELF,tp,tp,true,false,POS_FACEUP)
 end
 function c44822037.discon(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=ep and Duel.GetCurrentChain()==0
+	local se=e:GetHandler():GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT)
+	return tp~=ep and Duel.GetCurrentChain()==0 and se and se:GetHandler()==e:GetHandler()
 end
 function c44822037.discfilter(c)
 	return c:IsFaceup() and c:IsAbleToGraveAsCost() and c:IsSummonLocation(LOCATION_SZONE) and (c:GetType()&(TYPE_TRAP+TYPE_CONTINUOUS))==TYPE_TRAP+TYPE_CONTINUOUS


### PR DESCRIPTION
修复②效果应只有用自身效果特殊召唤的场合才能发动的问题（被「和平之像」等效果适用而特殊召唤的场合应不能发动）

②效果描述：这张卡是已用这张卡的效果特殊召唤的场合，1回合1次，对方把怪兽特殊召唤之际，把从魔法与陷阱区域特殊召唤的自己的怪兽区域1张永续陷阱卡送去墓地才能发动。那次特殊召唤无效，那些怪兽破坏。