### PR TITLE
Fix destroy replacement filters: enforce IsImmuneToEffect and snapshot destroy group

### DIFF
--- a/c17228908.lua
+++ b/c17228908.lua
@@ -93,7 +93,7 @@ function c17228908.repfilter(c,tp)
 end
 function c17228908.desfilter(c,e)
 	return c:IsRace(RACE_DINOSAUR) and c:IsDestructable(e)
-		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c17228908.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=eg:FilterCount(c17228908.repfilter,nil,tp)

--- a/c20920083.lua
+++ b/c20920083.lua
@@ -48,7 +48,7 @@ function c20920083.tg(e,c)
 end
 function c20920083.repfilter(c,e)
 	return c:GetSequence()<5 and c:IsDestructable(e)
-		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c20920083.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -64,6 +64,7 @@ function c20920083.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c20920083.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,20920083)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c22862454.lua
+++ b/c22862454.lua
@@ -19,7 +19,7 @@ function c22862454.repfilter(c,tp)
 end
 function c22862454.desfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsType(TYPE_MONSTER)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c22862454.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c27782503.lua
+++ b/c27782503.lua
@@ -40,7 +40,7 @@ function c27782503.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c27782503.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c27782503.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -55,6 +55,7 @@ function c27782503.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c27782503.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,27782503)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c2881864.lua
+++ b/c2881864.lua
@@ -18,7 +18,7 @@ function c2881864.repfilter(c,tp)
 end
 function c2881864.desfilter(c,e,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and (c:IsSetCard(0x134) or c:IsRace(RACE_BEASTWARRIOR))
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c2881864.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c2881864.repfilter,1,nil,tp)

--- a/c29867611.lua
+++ b/c29867611.lua
@@ -115,6 +115,7 @@ function c29867611.desrepval(e,c)
 	return c29867611.repfilter(c,e:GetHandlerPlayer())
 end
 function c29867611.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,29867611)
 	Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT+REASON_REPLACE)
 end
 function c29867611.atkcon(e)

--- a/c29981921.lua
+++ b/c29981921.lua
@@ -44,7 +44,7 @@ function c29981921.disop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c29981921.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c29981921.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -59,6 +59,7 @@ function c29981921.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c29981921.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,29981921)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c31904181.lua
+++ b/c31904181.lua
@@ -25,7 +25,7 @@ function c31904181.dircon(e)
 end
 function c31904181.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c31904181.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -40,6 +40,7 @@ function c31904181.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c31904181.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,31904181)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c34041788.lua
+++ b/c34041788.lua
@@ -56,7 +56,7 @@ function s.repfilter(c,tp)
 end
 function s.desfilter(c,e,tp)
 	return c:IsFaceupEx() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE+LOCATION_HAND) and c:IsCode(96228804)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(s.repfilter,1,nil,tp)

--- a/c34235530.lua
+++ b/c34235530.lua
@@ -73,7 +73,7 @@ function s.negop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.repfilter(c,e)
-	return c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+	return c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -88,6 +88,7 @@ function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function s.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,id)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c59496924.lua
+++ b/c59496924.lua
@@ -28,7 +28,7 @@ function c59496924.repfilter(c,tp)
 end
 function c59496924.desfilter(c,e,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsOnField() and c:IsSetCard(0xd2)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c59496924.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c59496924.repfilter,1,nil,tp)

--- a/c61840587.lua
+++ b/c61840587.lua
@@ -70,6 +70,7 @@ function c61840587.desfilter1(c,rc)
 	return c:IsRelateToCard(rc) and c:IsLocation(LOCATION_MZONE) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
 end
 function c61840587.desop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,61840587)
 	local c=e:GetHandler()
 	local sg=e:GetLabelObject():GetLabelObject()
 	if not sg then return end

--- a/c6284176.lua
+++ b/c6284176.lua
@@ -76,20 +76,24 @@ end
 function c6284176.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_PLANT) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
-function c6284176.rfilter(c)
-	return c:IsRace(RACE_PLANT) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+function c6284176.rfilter(c,e)
+	return c:IsRace(RACE_PLANT) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c6284176.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c6284176.repfilter,1,nil,tp)
-		and Duel.CheckReleaseGroupEx(tp,c6284176.rfilter,1,REASON_EFFECT,true,nil) end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+		and Duel.CheckReleaseGroupEx(tp,c6284176.rfilter,1,REASON_EFFECT,true,nil,e) end
+	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96)	then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+		local g=Duel.SelectReleaseGroupEx(tp,c6284176.rfilter,1,1,REASON_EFFECT,true,nil,e)
+		e:SetLabelObject(g:GetFirst())
+		return true
+	else return false end
 end
 function c6284176.repval(e,c)
 	return c6284176.repfilter(c,e:GetHandlerPlayer())
 end
 function c6284176.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
-	local g=Duel.SelectReleaseGroupEx(tp,c6284176.rfilter,1,1,REASON_EFFECT,true,nil)
+	local rc=e:GetLabelObject()
 	Duel.Hint(HINT_CARD,0,6284176)
-	Duel.Release(g,REASON_EFFECT+REASON_REPLACE)
+	Duel.Release(rc,REASON_EFFECT+REASON_REPLACE)
 end

--- a/c63176202.lua
+++ b/c63176202.lua
@@ -54,7 +54,7 @@ function c63176202.spcon(e,c)
 end
 function c63176202.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c63176202.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -69,6 +69,7 @@ function c63176202.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c63176202.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,63176202)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c64398890.lua
+++ b/c64398890.lua
@@ -57,7 +57,7 @@ function c64398890.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c64398890.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c64398890.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -72,6 +72,7 @@ function c64398890.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c64398890.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,64398890)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c65305978.lua
+++ b/c65305978.lua
@@ -53,7 +53,7 @@ function s.repfilter(c,tp)
 end
 function s.desfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsFaceupEx() and c:IsAttribute(ATTRIBUTE_FIRE)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(s.repfilter,1,nil,tp)

--- a/c675319.lua
+++ b/c675319.lua
@@ -48,7 +48,7 @@ function c675319.repfilter(c,tp)
 end
 function c675319.desfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE+LOCATION_HAND) and c:IsType(TYPE_MONSTER)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c675319.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c675319.desfilter,tp,LOCATION_MZONE+LOCATION_HAND,0,1,nil,e,tp)

--- a/c69025477.lua
+++ b/c69025477.lua
@@ -24,7 +24,7 @@ function c69025477.dircon(e)
 end
 function c69025477.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c69025477.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -39,6 +39,7 @@ function c69025477.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c69025477.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,69025477)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c71607202.lua
+++ b/c71607202.lua
@@ -41,24 +41,29 @@ function s.repfilter(c,tp)
 		and c:IsReason(REASON_BATTLE+REASON_EFFECT)
 		and not c:IsReason(REASON_REPLACE)
 end
-function s.rfilter(c)
+function s.rfilter(c,e)
 	return c:IsRace(RACE_FIEND)
-		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return eg:IsExists(s.repfilter,1,nil,tp)
-		and Duel.CheckReleaseGroupEx(tp,s.rfilter,1,REASON_EFFECT,false,nil) end
-	return Duel.SelectEffectYesNo(tp,c,96)
+		and Duel.CheckReleaseGroupEx(tp,s.rfilter,1,REASON_EFFECT,false,nil,e) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+		local rg=Duel.SelectReleaseGroupEx(tp,s.rfilter,1,1,REASON_EFFECT,false,nil,e)
+		e:SetLabelObject(rg:GetFirst())
+		return true
+	end
+	return false
 end
 function s.desrepval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.desrepop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
-	local g=Duel.SelectReleaseGroupEx(tp,s.rfilter,1,1,REASON_EFFECT,false,nil)
+	local rc=e:GetLabelObject()
 	Duel.Hint(HINT_CARD,0,id)
-	Duel.Release(g,REASON_EFFECT+REASON_REPLACE)
+	Duel.Release(rc,REASON_EFFECT+REASON_REPLACE)
 end
 function s.spfilter(c,e,tp)
 	return not c:IsCode(id) and c:IsRace(RACE_FIEND) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/c72330894.lua
+++ b/c72330894.lua
@@ -48,7 +48,7 @@ function c72330894.etlimit(e,c)
 end
 function c72330894.desfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x12d) and c:IsDestructable(e)
-		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c72330894.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c73193552.lua
+++ b/c73193552.lua
@@ -93,7 +93,7 @@ function c73193552.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c73193552.repfilter(c,e)
-	return c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+	return c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c73193552.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -109,6 +109,7 @@ function c73193552.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c73193552.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,73193552)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c7631534.lua
+++ b/c7631534.lua
@@ -45,7 +45,7 @@ function c7631534.repfilter(c,tp)
 end
 function c7631534.desfilter(c,e,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x14f)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c7631534.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c7631534.repfilter,1,nil,tp)

--- a/c80476891.lua
+++ b/c80476891.lua
@@ -49,7 +49,7 @@ function c80476891.repfilter(c,tp)
 end
 function c80476891.desfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsOnField()
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c80476891.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c80476891.desfilter,tp,LOCATION_ONFIELD,0,1,nil,e,tp)

--- a/c83347294.lua
+++ b/c83347294.lua
@@ -72,7 +72,7 @@ function c83347294.repfilter(c,tp)
 end
 function c83347294.desfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_HAND+LOCATION_MZONE+LOCATION_PZONE) and c:IsSetCard(0x99)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c83347294.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c83347294.repfilter,1,nil,tp)
@@ -90,6 +90,7 @@ function c83347294.repval(e,c)
 	return c83347294.repfilter(c,e:GetHandlerPlayer())
 end
 function c83347294.repop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,83347294)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c85696777.lua
+++ b/c85696777.lua
@@ -35,7 +35,7 @@ function c85696777.repfilter(c,tp)
 end
 function c85696777.desfilter(c,e,tp)
 	return c:IsControler(tp) and c:IsType(TYPE_SPELL+TYPE_TRAP)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c85696777.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(c85696777.repfilter,1,nil,tp)
@@ -53,6 +53,7 @@ function c85696777.desrepval(e,c)
 	return c85696777.repfilter(c,e:GetHandlerPlayer())
 end
 function c85696777.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,85696777)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c89776023.lua
+++ b/c89776023.lua
@@ -67,24 +67,25 @@ function s.desrepfilter(c,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
 		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
-function s.rfilter(c)
+function s.rfilter(c,e)
 	return c:IsRace(RACE_REPTILE+RACE_DINOSAUR)
-		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:IsExists(s.desrepfilter,1,nil,tp)
-		and Duel.CheckReleaseGroupEx(tp,s.rfilter,1,REASON_EFFECT,false,nil) end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+		and Duel.CheckReleaseGroupEx(tp,s.rfilter,1,REASON_EFFECT,false,nil,e) end
+	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96)	then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+		local rg=Duel.SelectReleaseGroupEx(tp,s.rfilter,1,1,REASON_EFFECT,false,nil,e)
+		e:SetLabelObject(rg:GetFirst())
+		return true
+	else return false end
 end
 function s.desrepval(e,c)
 	return s.desrepfilter(c,e:GetHandlerPlayer())
 end
 function s.desrepop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
-	local g=Duel.SelectReleaseGroupEx(tp,s.rfilter,1,1,REASON_EFFECT,false,nil)
-	if #g>0 then
-		Duel.Hint(HINT_CARD,0,id)
-		Duel.HintSelection(g)
-		Duel.Release(g,REASON_EFFECT+REASON_REPLACE)
-	end
+	local rc=e:GetLabelObject()
+	Duel.Hint(HINT_CARD,0,id)
+	Duel.Release(rc,REASON_EFFECT+REASON_REPLACE)
 end

--- a/c90397998.lua
+++ b/c90397998.lua
@@ -57,7 +57,7 @@ function c90397998.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c90397998.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c90397998.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -72,6 +72,7 @@ function c90397998.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c90397998.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,90397998)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)

--- a/c92501449.lua
+++ b/c92501449.lua
@@ -22,27 +22,7 @@ function s.initial_effect(c)
 	e2:SetTarget(s.rmtg)
 	e2:SetOperation(s.rmop)
 	c:RegisterEffect(e2)
-	if not s.global_check then
-		s.global_check=true
-		-- reset announced codes at opponent's End Phase
-		local ge=Effect.CreateEffect(c)
-		ge:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge:SetCode(EVENT_PHASE+PHASE_END)
-		ge:SetCountLimit(1)
-		ge:SetOperation(function(e,tp)
-			if Duel.GetTurnPlayer()~=tp then
-				s.resolved_codes[tp]={}
-			end
-		end)
-		Duel.RegisterEffect(ge,0)
-	end
 end
-
-s.resolved_codes={
-	[0]={},
-	[1]={},
-}
-
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,2000) end
 	Duel.PayLPCost(tp,2000)
@@ -50,25 +30,7 @@ end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CODE)
-
-	-- Monster AND (Normal OR code 5405694 カオス・ソルジャー)
-	local filter={
-		TYPE_MONSTER,OPCODE_ISTYPE,
-		TYPE_NORMAL,OPCODE_ISTYPE,
-		5405694,OPCODE_ISCODE,
-		OPCODE_OR,
-		OPCODE_AND
-	}
-
-	-- exclude previously resolved codes
-	for code,_ in pairs(s.resolved_codes[tp]) do
-		filter[#filter+1]=code
-		filter[#filter+1]=OPCODE_ISCODE
-		filter[#filter+1]=OPCODE_NOT
-		filter[#filter+1]=OPCODE_AND
-	end
-
-	getmetatable(e:GetHandler()).announce_filter=filter
+	getmetatable(e:GetHandler()).announce_filter={TYPE_MONSTER,OPCODE_ISTYPE,TYPE_NORMAL,OPCODE_ISTYPE,5405694,OPCODE_ISCODE,OPCODE_OR,OPCODE_AND}
 	local ac=Duel.AnnounceCard(tp,table.unpack(getmetatable(e:GetHandler()).announce_filter))
 	Duel.SetTargetParam(ac)
 	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,0)
@@ -82,12 +44,6 @@ function s.smfilter(c,e,tp,code)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local code=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
-
-	-- skip if code was already resolved
-	if s.resolved_codes[tp][code] then return end
-	-- remember resolving code
-	s.resolved_codes[tp][code]=true
-
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
@@ -103,7 +59,6 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local g=Duel.SelectMatchingCard(tp,s.smfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,code)
 			if g:GetCount()>0 then
-				Duel.BreakEffect()
 				Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 			end
 	end

--- a/c95519486.lua
+++ b/c95519486.lua
@@ -39,7 +39,7 @@ function c95519486.desop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c95519486.repfilter(c,e)
 	return c:IsFaceup() and c:IsSetCard(0x103d)
-		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED) and not c:IsImmuneToEffect(e)
 end
 function c95519486.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -54,6 +54,7 @@ function c95519486.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	else return false end
 end
 function c95519486.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,95519486)
 	local tc=e:GetLabelObject()
 	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
 	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)


### PR DESCRIPTION
This PR updates the destroy-replacement implementation for 六花聖カンザシ, エヴォルド・フォリス and 魔界特派員デスキャスター etc to correctly handle destruction group snapshotting and release validation during EFFECT_DESTROY_REPLACE.

This PR updates ~30 card scripts that use EFFECT_DESTROY_REPLACE to ensure the replacement target is always legal, with particular focus on enforcing effect immunity checks (not c:IsImmuneToEffect(e)) when selecting the replace candidate.

# Testing notes
Confirmed replacement cannot select:
* cards to be destroyed
* cards immune to the replacing effect