### PR TITLE
Defer chain-attack marker addition for ファイアウォール・ドラゴン・ダークフルード until end of Damage Step

### DIFF
--- a/c68934651.lua
+++ b/c68934651.lua
@@ -93,6 +93,18 @@ function c68934651.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	Duel.NegateActivation(ev)
 	if e:GetLabel()==1 and c:IsRelateToEffect(e) and c:IsChainAttackable(0) then
+		--Needed for the end of the Damage Step
 		Duel.ChainAttack()
+		--Make another attack in a row
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_DAMAGE_STEP_END)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetOperation(c68934651.chainop)
+		e1:SetReset(RESET_PHASE|PHASE_DAMAGE)
+		c:RegisterEffect(e1)
 	end
+end
+function c68934651.chainop()
+	Duel.ChainAttack()
 end


### PR DESCRIPTION
ファイアウォール・ドラゴン・ダークフルード was unable to perform its chain attack if ③ effect activated before Damage Step.

The chain-attack marker was being added before the Damage Step, but the core resets this attack-related marker during the Damage Step, causing the marker to be cleared before it could be consumed.

ref: [processor = 34 (PROCESSOR_BATTLE_COMMAND) step: 19](https://github.com/Fluorohydride/ygopro-core/blob/master/processor.cpp#L2809)

# Test Scenario
```lua
--[[message chain attack]]
Debug.SetAIName("Chain Attack")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,5)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(68934651,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
Debug.AddCard(24731391,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)
Debug.AddCard(42717221,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
Debug.AddCard(60279710,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)

Debug.AddCard(71607202,1,1,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(82489470,1,1,LOCATION_HAND,0,POS_FACEDOWN)

Debug.ReloadFieldEnd()
Debug.ShowHint("GAME START!")
aux.BeginPuzzle()
```
