### PR TITLE
Fix special summon check

### DIFF
--- a/c12500059.lua
+++ b/c12500059.lua
@@ -26,7 +26,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return c:IsRace(RACE_FAIRY)
+	return c:IsRace(RACE_FAIRY) and c:IsFaceup()
 end
 function s.cfilter(c)
 	return c:IsFacedown() or not c:IsRace(RACE_FAIRY)

--- a/c12766474.lua
+++ b/c12766474.lua
@@ -29,7 +29,7 @@ function c12766474.initial_effect(c)
 	Duel.AddCustomActivityCounter(12766474,ACTIVITY_SPSUMMON,c12766474.counterfilter)
 end
 function c12766474.counterfilter(c)
-	return c:IsAttribute(ATTRIBUTE_DARK)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsFaceup()
 end
 function c12766474.relfilter(c,g)
 	return g:IsContains(c)

--- a/c17315396.lua
+++ b/c17315396.lua
@@ -14,7 +14,7 @@ function c17315396.initial_effect(c)
 	Duel.AddCustomActivityCounter(17315396,ACTIVITY_SPSUMMON,c17315396.counterfilter)
 end
 function c17315396.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO) and c:IsFaceup()
 end
 function c17315396.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c17719582.lua
+++ b/c17719582.lua
@@ -30,7 +30,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION) and c:IsFaceup()
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(id,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c18294799.lua
+++ b/c18294799.lua
@@ -16,7 +16,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsRace(RACE_DRAGON) and c:IsType(TYPE_XYZ))
+	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsRace(RACE_DRAGON) and c:IsType(TYPE_XYZ) and c:IsFaceup())
 end
 function s.cfilter(c)
 	return c:IsFaceup() and c:IsAttackAbove(2000)

--- a/c18458255.lua
+++ b/c18458255.lua
@@ -28,7 +28,7 @@ function c18458255.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c18458255.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_PENDULUM)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_PENDULUM) and c:IsFaceup()
 end
 function c18458255.rmfilter(c)
 	return c:IsFacedown() and c:IsAbleToRemoveAsCost(POS_FACEDOWN)

--- a/c19316241.lua
+++ b/c19316241.lua
@@ -31,7 +31,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return c:IsAttribute(ATTRIBUTE_LIGHT)
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsFaceup()
 end
 function s.spfilter(c,tp,se)
 	return c:IsControler(tp) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsLevel(4) and c:IsFaceup()

--- a/c19324993.lua
+++ b/c19324993.lua
@@ -31,7 +31,7 @@ function c19324993.initial_effect(c)
 	Duel.AddCustomActivityCounter(19324993,ACTIVITY_SPSUMMON,c19324993.counterfilter)
 end
 function c19324993.counterfilter(c)
-	return c:IsSetCard(0x8)
+	return c:IsSetCard(0x8) and c:IsFaceup()
 end
 function c19324993.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)

--- a/c20455229.lua
+++ b/c20455229.lua
@@ -26,7 +26,7 @@ function c20455229.initial_effect(c)
 	Duel.AddCustomActivityCounter(20455229,ACTIVITY_SPSUMMON,c20455229.counterfilter)
 end
 function c20455229.counterfilter(c)
-	return c:IsRace(RACE_CYBERSE)
+	return c:IsRace(RACE_CYBERSE) and c:IsFaceup()
 end
 function c20455229.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c21720439.lua
+++ b/c21720439.lua
@@ -30,7 +30,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION) and c:IsFaceup()
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(id,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c22435424.lua
+++ b/c22435424.lua
@@ -35,7 +35,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return c:IsRace(RACE_MACHINE) or not c:IsSummonType(SUMMON_TYPE_RITUAL)
+	return c:IsRace(RACE_MACHINE) and c:IsFaceup() or not c:IsSummonType(SUMMON_TYPE_RITUAL)
 end
 function s.splimit(e,se,sp,st)
 	return se:IsHasType(EFFECT_TYPE_ACTIONS)

--- a/c23361526.lua
+++ b/c23361526.lua
@@ -24,7 +24,7 @@ function c23361526.initial_effect(c)
 	Duel.AddCustomActivityCounter(23361526,ACTIVITY_SPSUMMON,c23361526.counterfilter)
 end
 function c23361526.counterfilter(c)
-	return c:IsAttribute(ATTRIBUTE_WIND)
+	return c:IsAttribute(ATTRIBUTE_WIND) and c:IsFaceup()
 end
 function c23361526.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)

--- a/c23379054.lua
+++ b/c23379054.lua
@@ -15,7 +15,7 @@ function c23379054.initial_effect(c)
 	Duel.AddCustomActivityCounter(23379054,ACTIVITY_SPSUMMON,c23379054.counterfilter)
 end
 function c23379054.counterfilter(c)
-	return c:IsRace(RACE_DRAGON)
+	return c:IsRace(RACE_DRAGON) and c:IsFaceup()
 end
 function c23379054.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0

--- a/c24506253.lua
+++ b/c24506253.lua
@@ -23,7 +23,7 @@ function c24506253.initial_effect(c)
 	Duel.AddCustomActivityCounter(24506253,ACTIVITY_SPSUMMON,c24506253.counterfilter)
 end
 function c24506253.counterfilter(c)
-	return c:IsSetCard(0x70)
+	return c:IsSetCard(0x70) and c:IsFaceup()
 end
 function c24506253.filter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x70)

--- a/c25191307.lua
+++ b/c25191307.lua
@@ -27,7 +27,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return c:IsAttribute(ATTRIBUTE_DARK)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsFaceup()
 end
 function s.cfilter(c)
 	return c:IsFaceup() and not c:IsRace(RACE_WINDBEAST)

--- a/c31059809.lua
+++ b/c31059809.lua
@@ -27,7 +27,7 @@ function c31059809.initial_effect(c)
 	Duel.AddCustomActivityCounter(31059809,ACTIVITY_SPSUMMON,c31059809.counterfilter)
 end
 function c31059809.counterfilter(c)
-	return c:IsAttribute(ATTRIBUTE_WATER)
+	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsFaceup()
 end
 function c31059809.cfilter(c)
 	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_WATER)

--- a/c34761841.lua
+++ b/c34761841.lua
@@ -28,7 +28,7 @@ function c34761841.initial_effect(c)
 end
 function c34761841.counterfilter(c)
 	return not c:IsSummonLocation(LOCATION_EXTRA)
-		or (c:IsRace(RACE_DRAGON) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_SYNCHRO))
+		or (c:IsRace(RACE_DRAGON) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_SYNCHRO) and c:IsFaceup())
 end
 function c34761841.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0

--- a/c34974462.lua
+++ b/c34974462.lua
@@ -29,7 +29,7 @@ function c34974462.initial_effect(c)
 	Duel.AddCustomActivityCounter(34974462,ACTIVITY_SPSUMMON,c34974462.counterfilter)
 end
 function c34974462.counterfilter(c)
-	return c:IsSetCard(0x9b)
+	return c:IsSetCard(0x9b) and c:IsFaceup()
 end
 function c34974462.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)

--- a/c35629124.lua
+++ b/c35629124.lua
@@ -15,7 +15,7 @@ function c35629124.initial_effect(c)
 	Duel.AddCustomActivityCounter(35629124,ACTIVITY_SPSUMMON,c35629124.counterfilter)
 end
 function c35629124.counterfilter(c)
-	return c:IsRace(RACE_DRAGON)
+	return c:IsRace(RACE_DRAGON) and c:IsFaceup()
 end
 function c35629124.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetActivityCount(tp,ACTIVITY_BATTLE_PHASE)==0

--- a/c3580032.lua
+++ b/c3580032.lua
@@ -39,7 +39,7 @@ function c3580032.initial_effect(c)
 	Duel.AddCustomActivityCounter(3580032,ACTIVITY_SPSUMMON,c3580032.counterfilter)
 end
 function c3580032.counterfilter(c)
-	return c:IsSetCard(0x107a)
+	return c:IsSetCard(0x107a) and c:IsFaceup()
 end
 function c3580032.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsReleasable()

--- a/c37343995.lua
+++ b/c37343995.lua
@@ -28,7 +28,7 @@ function c37343995.initial_effect(c)
 	Duel.AddCustomActivityCounter(37343995,ACTIVITY_SPSUMMON,c37343995.counterfilter)
 end
 function c37343995.counterfilter(c)
-	return c:IsSetCard(0x172)
+	return c:IsSetCard(0x172) and c:IsFaceup()
 end
 function c37343995.cfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ)

--- a/c4145915.lua
+++ b/c4145915.lua
@@ -29,7 +29,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x1083)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x1083) and c:IsFaceup()
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(id,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c42542842.lua
+++ b/c42542842.lua
@@ -16,7 +16,7 @@ function c42542842.initial_effect(c)
 	Duel.AddCustomActivityCounter(42542842,ACTIVITY_SPSUMMON,c42542842.counterfilter)
 end
 function c42542842.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x121)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x121) and c:IsFaceup()
 end
 function c42542842.cfilter(c,tp)
 	return c:IsSetCard(0x121) and c:IsSummonLocation(LOCATION_EXTRA) and c:IsControler(tp)

--- a/c42790071.lua
+++ b/c42790071.lua
@@ -28,7 +28,7 @@ function c42790071.initial_effect(c)
 	Duel.AddCustomActivityCounter(42790071,ACTIVITY_SPSUMMON,c42790071.counterfilter)
 end
 function c42790071.counterfilter(c)
-	return c:IsSetCard(0x103)
+	return c:IsSetCard(0x103) and c:IsFaceup()
 end
 function c42790071.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	return rp==tp and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_TRAP)

--- a/c43129357.lua
+++ b/c43129357.lua
@@ -30,7 +30,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return c:IsRace(RACE_INSECT+RACE_PLANT+RACE_REPTILE)
+	return c:IsRace(RACE_INSECT+RACE_PLANT+RACE_REPTILE) and c:IsFaceup()
 end
 function s.lcheck(g)
 	return g:IsExists(Card.IsLinkRace,1,nil,RACE_INSECT+RACE_PLANT+RACE_REPTILE)

--- a/c43464884.lua
+++ b/c43464884.lua
@@ -28,7 +28,7 @@ function c43464884.initial_effect(c)
 	Duel.AddCustomActivityCounter(43464884,ACTIVITY_SPSUMMON,c43464884.counterfilter)
 end
 function c43464884.counterfilter(c)
-	return c:IsRace(RACE_BEASTWARRIOR)
+	return c:IsRace(RACE_BEASTWARRIOR) and c:IsFaceup()
 end
 function c43464884.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(43464884,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c43722862.lua
+++ b/c43722862.lua
@@ -29,7 +29,7 @@ function c43722862.initial_effect(c)
 	Duel.AddCustomActivityCounter(43722862,ACTIVITY_SPSUMMON,c43722862.counterfilter)
 end
 function c43722862.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsLevelAbove(5) and c:IsAttribute(ATTRIBUTE_WIND))
+	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsLevelAbove(5) and c:IsAttribute(ATTRIBUTE_WIND) and c:IsFaceup())
 end
 function c43722862.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0

--- a/c44139064.lua
+++ b/c44139064.lua
@@ -33,7 +33,7 @@ function c44139064.initial_effect(c)
 	Duel.AddCustomActivityCounter(44139064,ACTIVITY_SPSUMMON,c44139064.counterfilter)
 end
 function c44139064.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION) and c:IsFaceup()
 end
 function c44139064.splimit(e,c,sump,sumtype,sumpos,targetp,se)
 	return not c:IsType(TYPE_FUSION) and c:IsLocation(LOCATION_EXTRA)

--- a/c46947713.lua
+++ b/c46947713.lua
@@ -33,7 +33,7 @@ function c46947713.initial_effect(c)
 	Duel.AddCustomActivityCounter(46947713,ACTIVITY_SPSUMMON,c46947713.counterfilter)
 end
 function c46947713.counterfilter(c)
-	return c:IsRace(RACE_CYBERSE)
+	return c:IsRace(RACE_CYBERSE) and c:IsFaceup()
 end
 function c46947713.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(46947713,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c48048590.lua
+++ b/c48048590.lua
@@ -29,7 +29,7 @@ function c48048590.initial_effect(c)
 	Duel.AddCustomActivityCounter(48048590,ACTIVITY_SPSUMMON,c48048590.counterfilter)
 end
 function c48048590.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_FUSION) and c:IsFaceup()
 end
 function c48048590.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(48048590,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c52382379.lua
+++ b/c52382379.lua
@@ -27,7 +27,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_PENDULUM)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_PENDULUM) and c:IsFaceup()
 end
 function s.rmfilter(c)
 	return c:IsAbleToRemoveAsCost(POS_FACEDOWN) and not c:IsCode(70155677)

--- a/c5325155.lua
+++ b/c5325155.lua
@@ -17,7 +17,7 @@ function c5325155.initial_effect(c)
 	Duel.AddCustomActivityCounter(5325155,ACTIVITY_SPSUMMON,c5325155.counterfilter)
 end
 function c5325155.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x121)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x121) and c:IsFaceup()
 end
 function c5325155.cfilter(c,tp,rp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsSetCard(0x121) and not c:IsCode(5325155)

--- a/c55034079.lua
+++ b/c55034079.lua
@@ -43,7 +43,7 @@ function c55034079.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c55034079.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsType(TYPE_LINK) and c:IsAttribute(ATTRIBUTE_DARK))
+	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsType(TYPE_LINK) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsFaceup())
 end
 function c55034079.ctcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep==tp and bit.band(r,REASON_BATTLE)==REASON_BATTLE

--- a/c56337500.lua
+++ b/c56337500.lua
@@ -31,7 +31,7 @@ function c56337500.initial_effect(c)
 	Duel.AddCustomActivityCounter(56337500,ACTIVITY_SPSUMMON,c56337500.counterfilter)
 end
 function c56337500.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsRace(RACE_CYBERSE)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsRace(RACE_CYBERSE) and c:IsFaceup()
 end
 function c56337500.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(56337500,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c58004362.lua
+++ b/c58004362.lua
@@ -30,7 +30,7 @@ function c58004362.initial_effect(c)
 	Duel.AddCustomActivityCounter(58004362,ACTIVITY_SPSUMMON,c58004362.counterfilter)
 end
 function c58004362.counterfilter(c)
-	return c:IsSetCard(0x8)
+	return c:IsSetCard(0x8) and c:IsFaceup()
 end
 function c58004362.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(58004362,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c58288218.lua
+++ b/c58288218.lua
@@ -31,7 +31,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x8)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x8) and c:IsFaceup()
 end
 function s.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not e:GetHandler():IsPublic()

--- a/c58288565.lua
+++ b/c58288565.lua
@@ -31,7 +31,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsAttribute(ATTRIBUTE_WATER)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsAttribute(ATTRIBUTE_WATER) and c:IsFaceup()
 end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsReason(REASON_COST) and re:IsActivated() and re:IsActiveType(TYPE_MONSTER)

--- a/c59048135.lua
+++ b/c59048135.lua
@@ -30,7 +30,7 @@ function c59048135.initial_effect(c)
 	Duel.AddCustomActivityCounter(59048135,ACTIVITY_SPSUMMON,c59048135.counterfilter)
 end
 function c59048135.counterfilter(c)
-	return c:IsRace(RACE_PSYCHO) and c:IsType(TYPE_XYZ) or c:IsSetCard(0x76)
+	return (c:IsRace(RACE_PSYCHO) and c:IsType(TYPE_XYZ) or c:IsSetCard(0x76)) and c:IsFaceup()
 end
 function c59048135.etarget(e,c)
 	return c:IsRace(RACE_PSYCHO) and c:IsType(TYPE_XYZ)

--- a/c59281922.lua
+++ b/c59281922.lua
@@ -23,7 +23,7 @@ function c59281922.initial_effect(c)
 	Duel.AddCustomActivityCounter(59281922,ACTIVITY_SPSUMMON,c59281922.counterfilter)
 end
 function c59281922.counterfilter(c)
-	return c:IsRace(RACE_MACHINE)
+	return c:IsRace(RACE_MACHINE) and c:IsFaceup()
 end
 function c59281922.lvcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(59281922,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c5929801.lua
+++ b/c5929801.lua
@@ -25,7 +25,7 @@ function c5929801.initial_effect(c)
 	Duel.AddCustomActivityCounter(5929801,ACTIVITY_SPSUMMON,c5929801.counterfilter)
 end
 function c5929801.counterfilter(c)
-	return c:IsSetCard(0xba)
+	return c:IsSetCard(0xba) and c:IsFaceup()
 end
 function c5929801.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(5929801,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c6142488.lua
+++ b/c6142488.lua
@@ -14,7 +14,7 @@ function c6142488.initial_effect(c)
 	Duel.AddCustomActivityCounter(6142488,ACTIVITY_SPSUMMON,c6142488.counterfilter)
 end
 function c6142488.counterfilter(c)
-	return c:IsSetCard(0xad) or not c:IsSummonLocation(LOCATION_EXTRA)
+	return c:IsSetCard(0xad) and c:IsFaceup() or not c:IsSummonLocation(LOCATION_EXTRA)
 end
 function c6142488.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(6142488,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c63825486.lua
+++ b/c63825486.lua
@@ -27,7 +27,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x1083)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsSetCard(0x1083) and c:IsFaceup()
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(id,tp,ACTIVITY_SPSUMMON)==0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp) end

--- a/c66141736.lua
+++ b/c66141736.lua
@@ -30,7 +30,7 @@ function c66141736.initial_effect(c)
 	Duel.AddCustomActivityCounter(66141736,ACTIVITY_SPSUMMON,c66141736.counterfilter)
 end
 function c66141736.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsType(TYPE_SYNCHRO) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_DRAGON))
+	return not c:IsSummonLocation(LOCATION_EXTRA) or (c:IsType(TYPE_SYNCHRO) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_DRAGON) and c:IsFaceup())
 end
 function c66141736.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)

--- a/c67378935.lua
+++ b/c67378935.lua
@@ -31,7 +31,7 @@ function c67378935.initial_effect(c)
 	Duel.AddCustomActivityCounter(67378935,ACTIVITY_SPSUMMON,c67378935.counterfilter)
 end
 function c67378935.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_XYZ)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_XYZ) and c:IsFaceup()
 end
 function c67378935.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(67378935,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c68144350.lua
+++ b/c68144350.lua
@@ -14,7 +14,7 @@ function c68144350.initial_effect(c)
 	Duel.AddCustomActivityCounter(68144350,ACTIVITY_SPSUMMON,c68144350.counterfilter)
 end
 function c68144350.counterfilter(c)
-	return c:IsSetCard(0x1084)
+	return c:IsSetCard(0x1084) and c:IsFaceup()
 end
 function c68144350.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(68144350,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c703897.lua
+++ b/c703897.lua
@@ -24,7 +24,7 @@ function c703897.initial_effect(c)
 	Duel.AddCustomActivityCounter(703897,ACTIVITY_SPSUMMON,c703897.counterfilter)
 end
 function c703897.counterfilter(c)
-	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_DARK)
+	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsFaceup()
 end
 function c703897.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x11b) and c:IsType(TYPE_LINK)

--- a/c70465810.lua
+++ b/c70465810.lua
@@ -24,7 +24,7 @@ function c70465810.initial_effect(c)
 	Duel.AddCustomActivityCounter(70465810,ACTIVITY_SPSUMMON,c70465810.counterfilter)
 end
 function c70465810.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO) and c:IsFaceup()
 end
 function c70465810.thfilter(c)
 	return aux.IsCodeListed(c,9012916) and not c:IsCode(70465810) and c:IsAbleToHand()

--- a/c71821687.lua
+++ b/c71821687.lua
@@ -14,7 +14,7 @@ function c71821687.initial_effect(c)
 	Duel.AddCustomActivityCounter(71821687,ACTIVITY_SPSUMMON,c71821687.counterfilter)
 end
 function c71821687.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO) and c:IsFaceup()
 end
 function c71821687.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/c77075360.lua
+++ b/c77075360.lua
@@ -31,7 +31,7 @@ function c77075360.tfilter(c)
 	return c:IsSetCard(0x1017) or c:IsHasEffect(20932152)
 end
 function c77075360.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_SYNCHRO) and c:IsFaceup()
 end
 function c77075360.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(77075360,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c82697428.lua
+++ b/c82697428.lua
@@ -22,7 +22,7 @@ function c82697428.initial_effect(c)
 	Duel.AddCustomActivityCounter(82697428,ACTIVITY_SPSUMMON,c82697428.counterfilter)
 end
 function c82697428.counterfilter(c)
-	return c:IsSetCard(0x8)
+	return c:IsSetCard(0x8) and c:IsFaceup()
 end
 function c82697428.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(82697428,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c83315222.lua
+++ b/c83315222.lua
@@ -36,7 +36,7 @@ function c83315222.initial_effect(c)
 	Duel.AddCustomActivityCounter(83315222,ACTIVITY_SPSUMMON,c83315222.counterfilter)
 end
 function c83315222.counterfilter(c)
-	return c:IsSetCard(0x1084)
+	return c:IsSetCard(0x1084) and c:IsFaceup()
 end
 function c83315222.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(83315222,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c84546257.lua
+++ b/c84546257.lua
@@ -27,7 +27,7 @@ function c84546257.initial_effect(c)
 	Duel.AddCustomActivityCounter(84546257,ACTIVITY_SPSUMMON,c84546257.counterfilter)
 end
 function c84546257.counterfilter(c)
-	return c:IsAttribute(ATTRIBUTE_WATER)
+	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsFaceup()
 end
 function c84546257.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(84546257,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c95134948.lua
+++ b/c95134948.lua
@@ -38,7 +38,7 @@ function c95134948.initial_effect(c)
 end
 aux.xyz_number[95134948]=99
 function c95134948.counterfilter(c)
-	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_XYZ)
+	return not c:IsSummonLocation(LOCATION_EXTRA) or c:IsType(TYPE_XYZ) and c:IsFaceup()
 end
 function c95134948.dacheck(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()

--- a/c95833645.lua
+++ b/c95833645.lua
@@ -14,7 +14,7 @@ function c95833645.initial_effect(c)
 	Duel.AddCustomActivityCounter(95833645,ACTIVITY_SPSUMMON,c95833645.counterfilter)
 end
 function c95833645.counterfilter(c)
-	return c:IsRace(RACE_WYRM)
+	return c:IsRace(RACE_WYRM) and c:IsFaceup()
 end
 function c95833645.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(95833645,tp,ACTIVITY_SPSUMMON)==0 end

--- a/c97476032.lua
+++ b/c97476032.lua
@@ -44,7 +44,7 @@ function s.initial_effect(c)
 	Duel.AddCustomActivityCounter(id,ACTIVITY_SPSUMMON,s.counterfilter)
 end
 function s.counterfilter(c)
-	return c:IsAttribute(ATTRIBUTE_WATER)
+	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsFaceup()
 end
 function s.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetCustomActivityCount(id,tp,ACTIVITY_SPSUMMON)==0 end


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10073&keyword=&tag=-1&request_locale=ja
> Question
自分が「浅すぎた墓穴」の効果で「コドモドラゴン」を裏側守備表示で特殊召喚しました。
その「コドモドラゴン」が「激流葬」の効果によって破壊された場合、「コドモドラゴン」の効果を発動し、手札からドラゴン族モンスター１体を特殊召喚する事はできますか？
また、「コドモドラゴン」の効果によって手札からドラゴン族モンスターを特殊召喚しているターン、自分は「浅すぎた墓穴」の効果によってドラゴン族モンスターを裏側守備表示で特殊召喚する事はできますか？

> Answer
「浅すぎた墓穴」の効果によって、裏側守備表示でモンスターを特殊召喚しているターンには「コドモドラゴン」の効果を発動する事はできません。
（質問の状況のように、**裏側守備表示で特殊召喚したモンスターがドラゴン族のモンスターであった場合でも、裏側守備表示でモンスターを特殊召喚したターンに、「コドモドラゴン」の効果を発動する事はできません。**）
また、「コドモドラゴン」の効果を発動しているターンに、自分は「浅すぎた墓穴」を発動する事はできますが、その場合に自分が対象として選択するモンスターはドラゴン族モンスターでなければなりません。
（ドラゴン族以外のモンスターは特殊召喚する事自体ができません。）