### PR TITLE
Fix 道化の一座『極芸』&道化の一座『怪演』&覇王龍ズァーク－シンクロ·ユニバース

### DIFF
--- a/c48654267.lua
+++ b/c48654267.lua
@@ -89,34 +89,37 @@ end
 function c48654267.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_PENDULUM) and c:IsLocation(LOCATION_EXTRA)
 end
-function c48654267.gcheck(g,tp,eft)
-	return g:FilterCount(c48654267.filter,nil)<=eft
+function c48654267.filter2(c)
+	return c:IsLocation(LOCATION_EXTRA) and c:IsFacedown() and c:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)
+end
+function c48654267.gcheck(g,ft1,ft2,ft3,ect,ft)
+	return #g<=ft
+		and g:FilterCount(Card.IsLocation,nil,LOCATION_DECK+LOCATION_GRAVE)<=ft1
+		and g:FilterCount(c48654267.filter,nil)<=ft2
+		and g:FilterCount(c48654267.filter2,nil)<=ft3
+		and g:FilterCount(Card.IsLocation,nil,LOCATION_EXTRA)<=ect
 end
 function c48654267.spop(e,tp,eg,ep,ev,re,r,rp)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local eft=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_PENDULUM)
-	if ft<=0 then return end
-	if ft>=2 then ft=2 end
-	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
-	local g=Duel.GetMatchingGroup(c48654267.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA+LOCATION_GRAVE,0,nil,e,tp)
-	if g:GetCount()==0 then return end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local sg=g:SelectSubGroup(tp,c48654267.gcheck,false,1,ft,tp,eft)
-	if sg:GetCount()>0 then
-		local exg=sg:Filter(c48654267.filter,nil)
-		sg:Sub(exg)
-		if exg:GetCount()>0 then
-			for tc in aux.Next(exg) do
-				Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
-			end
-		end
-		if sg:GetCount()>0 then
-			for tc in aux.Next(sg) do
-				Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
-			end
-		end
-		Duel.SpecialSummonComplete()
+	local ft1=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local ft2=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_PENDULUM)
+	local ft3=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)
+	local ft=Duel.GetUsableMZoneCount(tp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then
+		if ft1>0 then ft1=1 end
+		if ft2>0 then ft2=1 end
+		if ft3>0 then ft3=1 end
+		ft=1
 	end
+	local ect=(c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]) or ft
+	local loc=0
+	if ft1>0 then loc=loc+LOCATION_DECK+LOCATION_GRAVE end
+	if ect>0 and (ft2>0 or ft3>0) then loc=loc+LOCATION_EXTRA end
+	if loc==0 then return end
+	local sg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c48654267.spfilter),tp,loc,0,nil,e,tp)
+	if sg:GetCount()==0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local rg=sg:SelectSubGroup(tp,c48654267.gcheck,false,1,2,ft1,ft2,ft3,ect,ft)
+	Duel.SpecialSummon(rg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c48654267.pencon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c70058649.lua
+++ b/c70058649.lua
@@ -69,48 +69,35 @@ end
 function s.filter2(c)
 	return c:IsLocation(LOCATION_EXTRA)
 end
-function s.gcheck(g,tp,eft,ect)
-	return g:FilterCount(s.filter,nil)<=eft and g:FilterCount(s.filter2,nil)<=ect
+function s.gcheck(g,ft1,ft2,ft3,ect,ft)
+	return #g<=ft
+		and g:FilterCount(Card.IsLocation,nil,LOCATION_DECK)<=ft1
+		and g:FilterCount(s.filter,nil)<=ft2
+		and g:FilterCount(s.filter2,nil)<=ft3
+		and g:FilterCount(Card.IsLocation,nil,LOCATION_EXTRA)<=ect
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetLabel()==1 then
+		local ft1=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		local ft2=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_PENDULUM+TYPE_LINK)
+		local ft3=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)
 		local ft=Duel.GetUsableMZoneCount(tp)
-		local eft=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_PENDULUM)
-		if ft>0 then
-			if ft>=2 then ft=2 end
-			local ct=2
-			if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
-			local ect=(c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]) or ft
-			local loc=LOCATION_DECK
-			if ect>0 then loc=loc+LOCATION_EXTRA end
-			local g=Duel.GetMatchingGroup(s.spfilter,tp,loc,0,nil,e,tp)
-			if g:GetCount()>0 then
-				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-				local sg=g:SelectSubGroup(tp,s.gcheck,false,1,ct,tp,eft,ect)
-				if sg:GetCount()>0 then
-					local exg=sg:Filter(s.filter,nil)
-					sg:Sub(exg)
-					if exg:GetCount()>0 then
-						for tc in aux.Next(exg) do
-							Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP)
-						end
-					end
-					local exg2=sg:Filter(s.filter2,nil)
-					sg:Sub(exg2)
-					if exg2:GetCount()>0 then
-						for tc in aux.Next(exg2) do
-							Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP)
-						end
-					end
-					if sg:GetCount()>0 then
-						for tc in aux.Next(sg) do
-							Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP)
-						end
-					end
-					Duel.SpecialSummonComplete()
-				end
+			if Duel.IsPlayerAffectedByEffect(tp,59822133) then
+				if ft1>0 then ft1=1 end
+				if ft2>0 then ft2=1 end
+				if ft3>0 then ft3=1 end
+				ft=1
 			end
-		end
+		local ect=(c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]) or ft
+		local loc=0
+		if ft1>0 then loc=loc+LOCATION_DECK end
+		if ect>0 and (ft2>0 or ft3>0) then loc=loc+LOCATION_EXTRA end
+		if loc==0 then return end
+		local sg=Duel.GetMatchingGroup(s.spfilter,tp,loc,0,nil,e,tp)
+		if sg:GetCount()==0 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local rg=sg:SelectSubGroup(tp,s.gcheck,false,1,2,ft1,ft2,ft3,ect,ft)
+		Duel.SpecialSummon(rg,0,tp,tp,true,false,POS_FACEUP)
 	elseif e:GetLabel()==2 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local g=Duel.SelectMatchingCard(tp,s.thfilter,tp,LOCATION_DECK,0,1,1,nil)

--- a/c83232904.lua
+++ b/c83232904.lua
@@ -42,49 +42,36 @@ function s.filter(c)
 		and c:IsLocation(LOCATION_EXTRA)
 end
 function s.filter2(c)
-	return c:IsLocation(LOCATION_EXTRA)
+	return c:IsLocation(LOCATION_EXTRA) and c:IsFacedown() and c:IsType(TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)
 end
-function s.gcheck(g,tp,eft,ect)
-	return g:FilterCount(s.filter,nil)<=eft and g:FilterCount(s.filter2,nil)<=ect
+function s.gcheck(g,ft1,ft2,ft3,ect,ft)
+	return #g<=ft
+		and g:FilterCount(Card.IsLocation,nil,LOCATION_DECK)<=ft1
+		and g:FilterCount(s.filter,nil)<=ft2
+		and g:FilterCount(s.filter2,nil)<=ft3
+		and g:FilterCount(Card.IsLocation,nil,LOCATION_EXTRA)<=ect
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local ft1=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local ft2=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_PENDULUM+TYPE_LINK)
+	local ft3=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ)
 	local ft=Duel.GetUsableMZoneCount(tp)
-	local eft=Duel.GetLocationCountFromEx(tp,tp,nil,TYPE_PENDULUM)
-	if ft>0 then
-		if ft>=2 then ft=2 end
-		local ct=2
-		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ct=1 end
-		local ect=(c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]) or ft
-		local loc=LOCATION_DECK
-		if ect>0 then loc=loc+LOCATION_EXTRA end
-		local g=Duel.GetMatchingGroup(s.spfilter,tp,loc,0,nil,e,tp)
-		if g:GetCount()>0 then
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-			local sg=g:SelectSubGroup(tp,s.gcheck,false,1,ct,tp,eft,ect)
-			if sg:GetCount()>0 then
-				local exg=sg:Filter(s.filter,nil)
-				sg:Sub(exg)
-				if exg:GetCount()>0 then
-					for tc in aux.Next(exg) do
-						Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP)
-					end
-				end
-				local exg2=sg:Filter(s.filter2,nil)
-				sg:Sub(exg2)
-				if exg2:GetCount()>0 then
-					for tc in aux.Next(exg2) do
-						Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP)
-					end
-				end
-				if sg:GetCount()>0 then
-					for tc in aux.Next(sg) do
-						Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP)
-					end
-				end
-				Duel.SpecialSummonComplete()
-			end
-		end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then
+		if ft1>0 then ft1=1 end
+		if ft2>0 then ft2=1 end
+		if ft3>0 then ft3=1 end
+		ft=1
 	end
+	local ect=(c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]) or ft
+	local loc=0
+	if ft1>0 then loc=loc+LOCATION_DECK end
+	if ect>0 and (ft2>0 or ft3>0) then loc=loc+LOCATION_EXTRA end
+	if loc==0 then return end
+	local sg=Duel.GetMatchingGroup(s.spfilter,tp,loc,0,nil,e,tp)
+	if sg:GetCount()==0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local rg=sg:SelectSubGroup(tp,s.gcheck,false,1,2,ft1,ft2,ft3,ect,ft)
+	Duel.SpecialSummon(rg,0,tp,tp,true,false,POS_FACEUP)
 	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD)


### PR DESCRIPTION
【道化一座『极艺』/道化の一座『極芸』】
（デッキ·EXデッキから「道化の一座」モンスターを２体まで召喚条件を無視して特殊召喚する）
https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=22570 
【道化一座『怪演』/道化の一座『怪演』】
（●デッキ·EXデッキから「道化の一座」モンスターを２体まで召喚条件を無視して特殊召喚する。）
https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=22582 
【霸王龙 扎克-同调宇宙/覇王龍ズァーク－シンクロ·ユニバース】
（②：……自分のデッキ·EXデッキ·墓地から「覇王眷竜」モンスターを２体まで守備表示で特殊召喚する。） https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=19722

这些卡现有脚本涉及“从额外卡组、卡组或其他区域进行多体数量怪兽特殊召唤”的效果会存在以下的问题：
①：自己场上只有一个可用的怪兽区域场合，选择特殊召唤的数量会异常。
如：只有一个可用的主要怪兽区域，「道化一座『极艺』」能选择两只怪兽，处理时其中一只怪兽会被送去墓地； 只有一个可用的额外怪兽区域，「霸王龙 扎克-同调宇宙」发动效果后不能选择额外卡组符合要求的怪兽而导致效果空发。 

②：自己场上仅有一个可用的额外怪兽区域和一个可用的主要怪兽区域场合，若选择的两只怪兽包含在额外卡组和卡组（或墓地）时，额外卡组的怪兽能选择特殊召唤在主要怪兽区域，导致卡组的怪兽无法进行特殊召唤而被送去墓地。


现脚本的修改方式参照【霸王龙之魂/覇王龍の魂】（c92428405.lua）或【霸王的逆鳞/覇王の逆鱗】（c84869738.lua）来解决以上问题。