### PR TITLE
Refactor subgroup checks and simplify ritual additional hooks

### DIFF
--- a/c11020863.lua
+++ b/c11020863.lua
@@ -45,7 +45,7 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if not Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) then return false end
 		local tg=Duel.GetMatchingGroup(s.tgfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil)
-		return aux.CheckSubGroupByCheckSpec(tg,aux.dlvcheck_spec,nil,5,5)
+		return tg:WithCheckSpec(aux.dlvcheck_spec):CheckSubGroup(nil,5,5)
 	end
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,5,tp,LOCATION_HAND+LOCATION_DECK)
@@ -54,7 +54,7 @@ end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetMatchingGroup(s.tgfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local sg=aux.SelectSubGroupByCheckSpec(tg,tp,aux.dlvcheck_spec,nil,false,5,5)
+	local sg=tg:WithCheckSpec(aux.dlvcheck_spec):SelectSubGroup(tp,nil,false,5,5)
 	if sg then
 		Duel.SendtoGrave(sg,REASON_EFFECT)
 		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)

--- a/c11020863.lua
+++ b/c11020863.lua
@@ -45,7 +45,12 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if not Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) then return false end
 		local tg=Duel.GetMatchingGroup(s.tgfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil)
-		return tg:CheckSubGroup(aux.dlvcheck,5,5)
+		aux.GCheckAdditional=aux.dlvcheck_additional
+		aux.GCheckClassifier=aux.dlvcheck_classifier
+		local res=tg:CheckSubGroup(aux.dlvcheck,5,5)
+		aux.GCheckClassifier=nil
+		aux.GCheckAdditional=nil
+		return res
 	end
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,5,tp,LOCATION_HAND+LOCATION_DECK)
@@ -54,7 +59,11 @@ end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetMatchingGroup(s.tgfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	aux.GCheckAdditional=aux.dlvcheck_additional
+	aux.GCheckClassifier=aux.dlvcheck_classifier
 	local sg=tg:SelectSubGroup(tp,aux.dlvcheck,false,5,5)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	if sg then
 		Duel.SendtoGrave(sg,REASON_EFFECT)
 		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)

--- a/c11020863.lua
+++ b/c11020863.lua
@@ -45,12 +45,7 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if not Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) then return false end
 		local tg=Duel.GetMatchingGroup(s.tgfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil)
-		aux.GCheckAdditional=aux.dlvcheck_additional
-		aux.GCheckClassifier=aux.dlvcheck_classifier
-		local res=tg:CheckSubGroup(aux.dlvcheck,5,5)
-		aux.GCheckClassifier=nil
-		aux.GCheckAdditional=nil
-		return res
+		return aux.CheckSubGroupByCheckSpec(tg,aux.dlvcheck_spec,nil,5,5)
 	end
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,5,tp,LOCATION_HAND+LOCATION_DECK)
@@ -59,11 +54,7 @@ end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=Duel.GetMatchingGroup(s.tgfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	aux.GCheckAdditional=aux.dlvcheck_additional
-	aux.GCheckClassifier=aux.dlvcheck_classifier
-	local sg=tg:SelectSubGroup(tp,aux.dlvcheck,false,5,5)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local sg=aux.SelectSubGroupByCheckSpec(tg,tp,aux.dlvcheck_spec,nil,false,5,5)
 	if sg then
 		Duel.SendtoGrave(sg,REASON_EFFECT)
 		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)

--- a/c12215894.lua
+++ b/c12215894.lua
@@ -70,7 +70,7 @@ function c12215894.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c12215894.cfilter,tp,LOCATION_GRAVE+LOCATION_ONFIELD,0,nil)
 	if chk==0 then return g:GetClassCount(Card.GetCode)>=9 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local rg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,aux.TRUE,false,9,9)
+	local rg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,aux.TRUE,false,9,9)
 	Duel.Remove(rg,POS_FACEUP,REASON_COST)
 end
 function c12215894.target2(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c12215894.lua
+++ b/c12215894.lua
@@ -70,11 +70,7 @@ function c12215894.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c12215894.cfilter,tp,LOCATION_GRAVE+LOCATION_ONFIELD,0,nil)
 	if chk==0 then return g:GetClassCount(Card.GetCode)>=9 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local rg=g:SelectSubGroup(tp,aux.TRUE,false,9,9)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local rg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,aux.TRUE,false,9,9)
 	Duel.Remove(rg,POS_FACEUP,REASON_COST)
 end
 function c12215894.target2(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c12215894.lua
+++ b/c12215894.lua
@@ -70,8 +70,10 @@ function c12215894.cost2(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c12215894.cfilter,tp,LOCATION_GRAVE+LOCATION_ONFIELD,0,nil)
 	if chk==0 then return g:GetClassCount(Card.GetCode)>=9 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	aux.GCheckAdditional=aux.dncheck
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local rg=g:SelectSubGroup(tp,aux.TRUE,false,9,9)
+	aux.GCheckClassifier=nil
 	aux.GCheckAdditional=nil
 	Duel.Remove(rg,POS_FACEUP,REASON_COST)
 end

--- a/c12289247.lua
+++ b/c12289247.lua
@@ -45,7 +45,7 @@ function c12289247.initial_effect(c)
 	end
 end
 c12289247.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
-function c12289247.hnclassifier(c,sg,g)
+function c12289247.hnclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
 	return aux.GetCheckSignature(c,c12289247.hnchecks)
 end

--- a/c12289247.lua
+++ b/c12289247.lua
@@ -47,7 +47,7 @@ end
 c12289247.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
 function c12289247.hnclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return aux.GetCheckSignature(c,c12289247.hnchecks)
+	return aux.GetCheckMask(c,c12289247.hnchecks)
 end
 function c12289247.spcfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT)

--- a/c12289247.lua
+++ b/c12289247.lua
@@ -45,6 +45,10 @@ function c12289247.initial_effect(c)
 	end
 end
 c12289247.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
+function c12289247.hnclassifier(c,sg,g)
+	if c:IsLocation(LOCATION_MZONE) then return nil end
+	return aux.GetCheckSignature(c,c12289247.hnchecks)
+end
 function c12289247.spcfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT)
 		and c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_ONFIELD)
@@ -127,11 +131,18 @@ end
 function c12289247.hncost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	local mg=Duel.GetMatchingGroup(c12289247.cfilter,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
-	if chk==0 then return c:IsAbleToRemoveAsCost()
-		and Duel.IsExistingMatchingCard(c12289247.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp)
-		and mg:CheckSubGroupEach(c12289247.hnchecks,c12289247.hngoal,e,tp,c) end
+	if chk==0 then
+		if not (c:IsAbleToRemoveAsCost()
+			and Duel.IsExistingMatchingCard(c12289247.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp)) then return false end
+		aux.GCheckClassifier=c12289247.hnclassifier
+		local res=mg:CheckSubGroupEach(c12289247.hnchecks,c12289247.hngoal,e,tp,c)
+		aux.GCheckClassifier=nil
+		return res
+	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	aux.GCheckClassifier=c12289247.hnclassifier
 	local sg=mg:SelectSubGroupEach(tp,c12289247.hnchecks,false,c12289247.hngoal,e,tp,c)
+	aux.GCheckClassifier=nil
 	sg:AddCard(c)
 	Duel.Remove(sg,POS_FACEUP,REASON_COST)
 end

--- a/c12289247.lua
+++ b/c12289247.lua
@@ -134,15 +134,14 @@ function c12289247.hncost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if not (c:IsAbleToRemoveAsCost()
 			and Duel.IsExistingMatchingCard(c12289247.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp)) then return false end
-		aux.GCheckClassifier=c12289247.hnclassifier
-		local res=mg:CheckSubGroupEach(c12289247.hnchecks,c12289247.hngoal,e,tp,c)
-		aux.GCheckClassifier=nil
-		return res
+		return aux.WithSubGroupContext(nil,c12289247.hnclassifier,function()
+			return mg:CheckSubGroupEach(c12289247.hnchecks,c12289247.hngoal,e,tp,c)
+		end)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	aux.GCheckClassifier=c12289247.hnclassifier
-	local sg=mg:SelectSubGroupEach(tp,c12289247.hnchecks,false,c12289247.hngoal,e,tp,c)
-	aux.GCheckClassifier=nil
+	local sg=aux.WithSubGroupContext(nil,c12289247.hnclassifier,function()
+		return mg:SelectSubGroupEach(tp,c12289247.hnchecks,false,c12289247.hngoal,e,tp,c)
+	end)
 	sg:AddCard(c)
 	Duel.Remove(sg,POS_FACEUP,REASON_COST)
 end

--- a/c12289247.lua
+++ b/c12289247.lua
@@ -134,14 +134,10 @@ function c12289247.hncost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if not (c:IsAbleToRemoveAsCost()
 			and Duel.IsExistingMatchingCard(c12289247.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp)) then return false end
-		return aux.WithSubGroupContext(nil,c12289247.hnclassifier,function()
-			return mg:CheckSubGroupEach(c12289247.hnchecks,c12289247.hngoal,e,tp,c)
-		end)
+		return mg:WithSubGroupContext(nil,c12289247.hnclassifier):CheckSubGroupEach(c12289247.hnchecks,c12289247.hngoal,e,tp,c)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local sg=aux.WithSubGroupContext(nil,c12289247.hnclassifier,function()
-		return mg:SelectSubGroupEach(tp,c12289247.hnchecks,false,c12289247.hngoal,e,tp,c)
-	end)
+	local sg=mg:WithSubGroupContext(nil,c12289247.hnclassifier):SelectSubGroupEach(tp,c12289247.hnchecks,false,c12289247.hngoal,e,tp,c)
 	sg:AddCard(c)
 	Duel.Remove(sg,POS_FACEUP,REASON_COST)
 end

--- a/c12289247.lua
+++ b/c12289247.lua
@@ -45,9 +45,9 @@ function c12289247.initial_effect(c)
 	end
 end
 c12289247.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
-function c12289247.hnclassifier(c,sg,g)
+function c12289247.hnclassifier(c,g)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return aux.GetCheckSignature(c,c12289247.hnchecks)
+	return 1
 end
 function c12289247.spcfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT)

--- a/c14386013.lua
+++ b/c14386013.lua
@@ -57,11 +57,7 @@ function c14386013.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c14386013.drfilter),p,LOCATION_HAND+LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TODECK)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local sg=g:SelectSubGroup(p,aux.TRUE,false,1,Duel.GetFieldGroupCount(p,LOCATION_DECK,0))
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local sg=aux.SelectSubGroupByCheckSpec(g,p,aux.dncheck_spec,aux.TRUE,false,1,Duel.GetFieldGroupCount(p,LOCATION_DECK,0))
 	if sg then
 		Duel.ConfirmCards(1-p,sg)
 		local ct=aux.PlaceCardsOnDeckBottom(p,sg)

--- a/c14386013.lua
+++ b/c14386013.lua
@@ -57,7 +57,7 @@ function c14386013.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c14386013.drfilter),p,LOCATION_HAND+LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TODECK)
-	local sg=aux.SelectSubGroupByCheckSpec(g,p,aux.dncheck_spec,aux.TRUE,false,1,Duel.GetFieldGroupCount(p,LOCATION_DECK,0))
+	local sg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(p,aux.TRUE,false,1,Duel.GetFieldGroupCount(p,LOCATION_DECK,0))
 	if sg then
 		Duel.ConfirmCards(1-p,sg)
 		local ct=aux.PlaceCardsOnDeckBottom(p,sg)

--- a/c14386013.lua
+++ b/c14386013.lua
@@ -57,8 +57,10 @@ function c14386013.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c14386013.drfilter),p,LOCATION_HAND+LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TODECK)
-	aux.GCheckAdditional=aux.dncheck
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local sg=g:SelectSubGroup(p,aux.TRUE,false,1,Duel.GetFieldGroupCount(p,LOCATION_DECK,0))
+	aux.GCheckClassifier=nil
 	aux.GCheckAdditional=nil
 	if sg then
 		Duel.ConfirmCards(1-p,sg)

--- a/c15094540.lua
+++ b/c15094540.lua
@@ -81,11 +81,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return ft>=5 and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_REMOVED,0,5,nil,e,tp) and g:GetClassCount(Card.GetCode)>=5
 		and not Duel.IsPlayerAffectedByEffect(tp,59822133) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local tg=g:SelectSubGroup(tp,aux.dncheck,false,5,5)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local tg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,5,5)
 	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,tg:GetCount(),0,0)
 end

--- a/c15094540.lua
+++ b/c15094540.lua
@@ -81,7 +81,11 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return ft>=5 and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_REMOVED,0,5,nil,e,tp) and g:GetClassCount(Card.GetCode)>=5
 		and not Duel.IsPlayerAffectedByEffect(tp,59822133) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local tg=g:SelectSubGroup(tp,aux.dncheck,false,5,5)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,tg:GetCount(),0,0)
 end

--- a/c15094540.lua
+++ b/c15094540.lua
@@ -81,7 +81,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return ft>=5 and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_REMOVED,0,5,nil,e,tp) and g:GetClassCount(Card.GetCode)>=5
 		and not Duel.IsPlayerAffectedByEffect(tp,59822133) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local tg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,5,5)
+	local tg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,5,5)
 	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,tg:GetCount(),0,0)
 end

--- a/c16329071.lua
+++ b/c16329071.lua
@@ -25,8 +25,10 @@ function c16329071.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c16329071.filter),tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_ONFIELD+LOCATION_REMOVED,0,nil)
 	if g:GetClassCount(Card.GetCode)<5 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	aux.GCheckAdditional=aux.dncheck
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local sg=g:SelectSubGroup(tp,aux.TRUE,false,5,5)
+	aux.GCheckClassifier=nil
 	aux.GCheckAdditional=nil
 	local cg=sg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 	if cg:GetCount()>0 then

--- a/c16329071.lua
+++ b/c16329071.lua
@@ -25,7 +25,7 @@ function c16329071.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c16329071.filter),tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_ONFIELD+LOCATION_REMOVED,0,nil)
 	if g:GetClassCount(Card.GetCode)<5 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,aux.TRUE,false,5,5)
+	local sg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,aux.TRUE,false,5,5)
 	local cg=sg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 	if cg:GetCount()>0 then
 		Duel.ConfirmCards(1-tp,cg)

--- a/c16329071.lua
+++ b/c16329071.lua
@@ -25,11 +25,7 @@ function c16329071.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c16329071.filter),tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_ONFIELD+LOCATION_REMOVED,0,nil)
 	if g:GetClassCount(Card.GetCode)<5 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local sg=g:SelectSubGroup(tp,aux.TRUE,false,5,5)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,aux.TRUE,false,5,5)
 	local cg=sg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 	if cg:GetCount()>0 then
 		Duel.ConfirmCards(1-tp,cg)

--- a/c17197110.lua
+++ b/c17197110.lua
@@ -58,11 +58,7 @@ function c17197110.activate(e,tp,eg,ep,ev,re,r,rp)
 	if ft<ct or ft<=0 then return end
 	local g=Duel.GetMatchingGroup(c17197110.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local sg=g:SelectSubGroup(tp,aux.dncheck,false,ct,ct)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,ct,ct)
 	if sg then
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c17197110.lua
+++ b/c17197110.lua
@@ -58,7 +58,7 @@ function c17197110.activate(e,tp,eg,ep,ev,re,r,rp)
 	if ft<ct or ft<=0 then return end
 	local g=Duel.GetMatchingGroup(c17197110.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,ct,ct)
+	local sg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,ct,ct)
 	if sg then
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c17197110.lua
+++ b/c17197110.lua
@@ -58,7 +58,11 @@ function c17197110.activate(e,tp,eg,ep,ev,re,r,rp)
 	if ft<ct or ft<=0 then return end
 	local g=Duel.GetMatchingGroup(c17197110.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local sg=g:SelectSubGroup(tp,aux.dncheck,false,ct,ct)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	if sg then
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 	end

--- a/c20537097.lua
+++ b/c20537097.lua
@@ -70,7 +70,7 @@ function c20537097.thop(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsControler(1-tp) then ct=ct+1 end
 	if ct<=0 or g:GetClassCount(Card.GetCode)<ct then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local hg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,ct,ct)
+	local hg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,ct,ct)
 	Duel.SendtoHand(hg,nil,REASON_EFFECT)
 	Duel.ConfirmCards(1-tp,hg)
 end

--- a/c20537097.lua
+++ b/c20537097.lua
@@ -70,7 +70,11 @@ function c20537097.thop(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsControler(1-tp) then ct=ct+1 end
 	if ct<=0 or g:GetClassCount(Card.GetCode)<ct then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local hg=g:SelectSubGroup(tp,aux.dncheck,false,ct,ct)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	Duel.SendtoHand(hg,nil,REASON_EFFECT)
 	Duel.ConfirmCards(1-tp,hg)
 end

--- a/c20537097.lua
+++ b/c20537097.lua
@@ -70,11 +70,7 @@ function c20537097.thop(e,tp,eg,ep,ev,re,r,rp)
 	if c:IsControler(1-tp) then ct=ct+1 end
 	if ct<=0 or g:GetClassCount(Card.GetCode)<ct then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local hg=g:SelectSubGroup(tp,aux.dncheck,false,ct,ct)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local hg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,ct,ct)
 	Duel.SendtoHand(hg,nil,REASON_EFFECT)
 	Duel.ConfirmCards(1-tp,hg)
 end

--- a/c22398665.lua
+++ b/c22398665.lua
@@ -68,9 +68,9 @@ function c22398665.operation(e,tp,eg,ep,ev,re,r,rp)
 			mg:RemoveCard(tc)
 		end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-		aux.GCheckAdditional=c22398665.RitualCheckAdditional(tc,tc:GetAttack(),"Greater")
-		local mat=mg:SelectSubGroup(tp,c22398665.RitualCheck,true,1,#mg,tp,tc,tc:GetAttack(),"Greater")
-		aux.GCheckAdditional=nil
+		local mat=aux.WithSubGroupContext(c22398665.RitualCheckAdditional(tc,tc:GetAttack(),"Greater"),c22398665.RitualClassifier,function()
+			return mg:SelectSubGroup(tp,c22398665.RitualCheck,true,1,#mg,tp,tc,tc:GetAttack(),"Greater")
+		end)
 		if not mat then goto cancel end
 		tc:SetMaterial(mat)
 		Duel.ReleaseRitualMaterial(mat)
@@ -107,6 +107,10 @@ function c22398665.RitualCheckAdditional(c,atk,greater_or_equal)
 				end
 	end
 end
+function c22398665.RitualClassifier(c)
+	if c:IsLocation(LOCATION_MZONE) then return nil end
+	return aux.GetCappedAttack(c)
+end
 function c22398665.RitualUltimateFilter(c,filter,e,tp,m1,m2,attack_function,greater_or_equal,chk)
 	if bit.band(c:GetType(),0x81)~=0x81 or (filter and not filter(c,e,tp,chk)) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
 	local mg=m1:Filter(Card.IsCanBeRitualMaterial,c,c)
@@ -119,8 +123,7 @@ function c22398665.RitualUltimateFilter(c,filter,e,tp,m1,m2,attack_function,grea
 		mg:RemoveCard(c)
 	end
 	local atk=attack_function(c)
-	aux.GCheckAdditional=c22398665.RitualCheckAdditional(c,atk,greater_or_equal)
-	local res=mg:CheckSubGroup(c22398665.RitualCheck,1,#mg,tp,c,atk,greater_or_equal)
-	aux.GCheckAdditional=nil
-	return res
+	return aux.WithSubGroupContext(c22398665.RitualCheckAdditional(c,atk,greater_or_equal),c22398665.RitualClassifier,function()
+		return mg:CheckSubGroup(c22398665.RitualCheck,1,#mg,tp,c,atk,greater_or_equal)
+	end)
 end

--- a/c22398665.lua
+++ b/c22398665.lua
@@ -68,9 +68,7 @@ function c22398665.operation(e,tp,eg,ep,ev,re,r,rp)
 			mg:RemoveCard(tc)
 		end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-		local mat=aux.WithSubGroupContext(c22398665.RitualCheckAdditional(tc,tc:GetAttack(),"Greater"),c22398665.RitualClassifier,function()
-			return mg:SelectSubGroup(tp,c22398665.RitualCheck,true,1,#mg,tp,tc,tc:GetAttack(),"Greater")
-		end)
+		local mat=mg:WithSubGroupContext(c22398665.RitualCheckAdditional(tc,tc:GetAttack(),"Greater"),c22398665.RitualClassifier):SelectSubGroup(tp,c22398665.RitualCheck,true,1,#mg,tp,tc,tc:GetAttack(),"Greater")
 		if not mat then goto cancel end
 		tc:SetMaterial(mat)
 		Duel.ReleaseRitualMaterial(mat)
@@ -123,7 +121,5 @@ function c22398665.RitualUltimateFilter(c,filter,e,tp,m1,m2,attack_function,grea
 		mg:RemoveCard(c)
 	end
 	local atk=attack_function(c)
-	return aux.WithSubGroupContext(c22398665.RitualCheckAdditional(c,atk,greater_or_equal),c22398665.RitualClassifier,function()
-		return mg:CheckSubGroup(c22398665.RitualCheck,1,#mg,tp,c,atk,greater_or_equal)
-	end)
+	return mg:WithSubGroupContext(c22398665.RitualCheckAdditional(c,atk,greater_or_equal),c22398665.RitualClassifier):CheckSubGroup(c22398665.RitualCheck,1,#mg,tp,c,atk,greater_or_equal)
 end

--- a/c22398665.lua
+++ b/c22398665.lua
@@ -98,13 +98,12 @@ function c22398665.RitualCheckAdditional(c,atk,greater_or_equal)
 					return (not aux.RGCheckAdditional or aux.RGCheckAdditional(g)) and g:GetSum(aux.GetCappedAttack)<=atk
 				end
 	else
-		return	function(g,ec)
+		return	function(g)
 					if atk==0 then return #g<=1 end
-					if ec then
-						return (not aux.RGCheckAdditional or aux.RGCheckAdditional(g,ec)) and g:GetSum(aux.GetCappedAttack)-aux.GetCappedAttack(ec)<=atk
-					else
-						return not aux.RGCheckAdditional or aux.RGCheckAdditional(g)
-					end
+					local sum=g:GetSum(aux.GetCappedAttack)
+					if aux.RGCheckAdditional and not aux.RGCheckAdditional(g) then return false end
+					local _,minatk=g:GetMinGroup(aux.GetCappedAttack)
+					return sum-minatk<=atk
 				end
 	end
 end

--- a/c22398665.lua
+++ b/c22398665.lua
@@ -103,7 +103,7 @@ function c22398665.RitualCheckAdditional(c,atk,greater_or_equal)
 					local sum=g:GetSum(aux.GetCappedAttack)
 					if aux.RGCheckAdditional and not aux.RGCheckAdditional(g) then return false end
 					local _,minatk=g:GetMinGroup(aux.GetCappedAttack)
-					return sum-minatk<=atk
+					return sum-minatk<atk
 				end
 	end
 end

--- a/c24166324.lua
+++ b/c24166324.lua
@@ -129,13 +129,12 @@ function s.RitualCheckAdditional(c,atk,greater_or_equal)
 					return (not aux.RGCheckAdditional or aux.RGCheckAdditional(g)) and g:GetSum(aux.GetCappedAttack)<=atk
 				end
 	else
-		return  function(g,ec)
+		return  function(g)
 					if atk==0 then return #g<=1 end
-					if ec then
-						return (not aux.RGCheckAdditional or aux.RGCheckAdditional(g,ec)) and g:GetSum(aux.GetCappedAttack)-aux.GetCappedAttack(ec)<=atk
-					else
-						return not aux.RGCheckAdditional or aux.RGCheckAdditional(g)
-					end
+					local sum=g:GetSum(aux.GetCappedAttack)
+					if aux.RGCheckAdditional and not aux.RGCheckAdditional(g) then return false end
+					local _,minatk=g:GetMinGroup(aux.GetCappedAttack)
+					return sum-minatk<=atk
 				end
 	end
 end

--- a/c24166324.lua
+++ b/c24166324.lua
@@ -134,7 +134,7 @@ function s.RitualCheckAdditional(c,atk,greater_or_equal)
 					local sum=g:GetSum(aux.GetCappedAttack)
 					if aux.RGCheckAdditional and not aux.RGCheckAdditional(g) then return false end
 					local _,minatk=g:GetMinGroup(aux.GetCappedAttack)
-					return sum-minatk<=atk
+					return sum-minatk<atk
 				end
 	end
 end

--- a/c28189908.lua
+++ b/c28189908.lua
@@ -38,7 +38,11 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil):SelectSubGroup(tp,aux.dncheck,false,2,2)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	if g then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)

--- a/c28189908.lua
+++ b/c28189908.lua
@@ -38,11 +38,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil):SelectSubGroup(tp,aux.dncheck,false,2,2)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local g=aux.SelectSubGroupByCheckSpec(Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil),tp,aux.dncheck_spec,nil,false,2,2)
 	if g then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)

--- a/c28189908.lua
+++ b/c28189908.lua
@@ -38,7 +38,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=aux.SelectSubGroupByCheckSpec(Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil),tp,aux.dncheck_spec,nil,false,2,2)
+	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil):WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,2,2)
 	if g then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)

--- a/c32270212.lua
+++ b/c32270212.lua
@@ -39,11 +39,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 		local ct=math.min(ft,2)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		aux.GCheckAdditional=aux.dncheck_additional
-		aux.GCheckClassifier=aux.dncheck_classifier
-		local sg=g:SelectSubGroup(tp,aux.dncheck,false,1,ct)
-		aux.GCheckClassifier=nil
-		aux.GCheckAdditional=nil
+		local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,ct)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 	end
 	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then

--- a/c32270212.lua
+++ b/c32270212.lua
@@ -39,7 +39,11 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 		local ct=math.min(ft,2)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		aux.GCheckAdditional=aux.dncheck_additional
+		aux.GCheckClassifier=aux.dncheck_classifier
 		local sg=g:SelectSubGroup(tp,aux.dncheck,false,1,ct)
+		aux.GCheckClassifier=nil
+		aux.GCheckAdditional=nil
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 	end
 	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then

--- a/c32270212.lua
+++ b/c32270212.lua
@@ -39,7 +39,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 		local ct=math.min(ft,2)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,ct)
+		local sg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,1,ct)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 	end
 	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then

--- a/c41516133.lua
+++ b/c41516133.lua
@@ -35,11 +35,7 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(s.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,nil)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local tg=g:SelectSubGroup(tp,aux.dncheck,false,1,5)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local tg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,5)
 	Duel.SendtoGrave(tg,REASON_COST)
 	e:SetLabel(tg:GetCount())
 end

--- a/c41516133.lua
+++ b/c41516133.lua
@@ -35,7 +35,7 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(s.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,nil)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local tg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,5)
+	local tg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,1,5)
 	Duel.SendtoGrave(tg,REASON_COST)
 	e:SetLabel(tg:GetCount())
 end

--- a/c41516133.lua
+++ b/c41516133.lua
@@ -35,7 +35,11 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(s.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,nil)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.costfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local tg=g:SelectSubGroup(tp,aux.dncheck,false,1,5)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	Duel.SendtoGrave(tg,REASON_COST)
 	e:SetLabel(tg:GetCount())
 end

--- a/c57093995.lua
+++ b/c57093995.lua
@@ -33,7 +33,11 @@ function c57093995.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c57093995.tgfilter,tp,LOCATION_DECK,0,nil)
 	local ct=Duel.GetMatchingGroupCount(Card.IsSummonLocation,tp,0,LOCATION_MZONE,nil,LOCATION_EXTRA)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local sg=g:SelectSubGroup(tp,aux.dncheck,false,1,ct+1)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	if sg and sg:GetCount()>0 then
 		Duel.SendtoGrave(sg,REASON_EFFECT)
 	end

--- a/c57093995.lua
+++ b/c57093995.lua
@@ -33,11 +33,7 @@ function c57093995.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c57093995.tgfilter,tp,LOCATION_DECK,0,nil)
 	local ct=Duel.GetMatchingGroupCount(Card.IsSummonLocation,tp,0,LOCATION_MZONE,nil,LOCATION_EXTRA)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local sg=g:SelectSubGroup(tp,aux.dncheck,false,1,ct+1)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,ct+1)
 	if sg and sg:GetCount()>0 then
 		Duel.SendtoGrave(sg,REASON_EFFECT)
 	end

--- a/c57093995.lua
+++ b/c57093995.lua
@@ -33,7 +33,7 @@ function c57093995.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c57093995.tgfilter,tp,LOCATION_DECK,0,nil)
 	local ct=Duel.GetMatchingGroupCount(Card.IsSummonLocation,tp,0,LOCATION_MZONE,nil,LOCATION_EXTRA)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,ct+1)
+	local sg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,1,ct+1)
 	if sg and sg:GetCount()>0 then
 		Duel.SendtoGrave(sg,REASON_EFFECT)
 	end

--- a/c61411502.lua
+++ b/c61411502.lua
@@ -12,14 +12,24 @@ function c61411502.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c61411502.rchecks=aux.CreateChecks(Card.IsAttribute,{ATTRIBUTE_WIND,ATTRIBUTE_WATER,ATTRIBUTE_FIRE,ATTRIBUTE_EARTH})
+function c61411502.rclassifier(c,sg,g)
+	return aux.GetCheckSignature(c,c61411502.rchecks)
+end
 function c61411502.rgoal(g,tp)
 	return Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,g)
 end
 function c61411502.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetReleaseGroup(tp)
-	if chk==0 then return g:CheckSubGroupEach(c61411502.rchecks,c61411502.rgoal,tp) end
+	if chk==0 then
+		aux.GCheckClassifier=c61411502.rclassifier
+		local res=g:CheckSubGroupEach(c61411502.rchecks,c61411502.rgoal,tp)
+		aux.GCheckClassifier=nil
+		return res
+	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+	aux.GCheckClassifier=c61411502.rclassifier
 	local rg=g:SelectSubGroupEach(tp,c61411502.rchecks,false,c61411502.rgoal,tp)
+	aux.GCheckClassifier=nil
 	aux.UseExtraReleaseCount(rg,tp)
 	Duel.Release(rg,REASON_COST)
 end

--- a/c61411502.lua
+++ b/c61411502.lua
@@ -12,8 +12,8 @@ function c61411502.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c61411502.rchecks=aux.CreateChecks(Card.IsAttribute,{ATTRIBUTE_WIND,ATTRIBUTE_WATER,ATTRIBUTE_FIRE,ATTRIBUTE_EARTH})
-function c61411502.rclassifier(c,sg,g)
-	return aux.GetCheckSignature(c,c61411502.rchecks)
+function c61411502.rclassifier(c,g)
+	return 1
 end
 function c61411502.rgoal(g,tp)
 	return Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,g)

--- a/c61411502.lua
+++ b/c61411502.lua
@@ -21,15 +21,14 @@ end
 function c61411502.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetReleaseGroup(tp)
 	if chk==0 then
-		aux.GCheckClassifier=c61411502.rclassifier
-		local res=g:CheckSubGroupEach(c61411502.rchecks,c61411502.rgoal,tp)
-		aux.GCheckClassifier=nil
-		return res
+		return aux.WithSubGroupContext(nil,c61411502.rclassifier,function()
+			return g:CheckSubGroupEach(c61411502.rchecks,c61411502.rgoal,tp)
+		end)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-	aux.GCheckClassifier=c61411502.rclassifier
-	local rg=g:SelectSubGroupEach(tp,c61411502.rchecks,false,c61411502.rgoal,tp)
-	aux.GCheckClassifier=nil
+	local rg=aux.WithSubGroupContext(nil,c61411502.rclassifier,function()
+		return g:SelectSubGroupEach(tp,c61411502.rchecks,false,c61411502.rgoal,tp)
+	end)
 	aux.UseExtraReleaseCount(rg,tp)
 	Duel.Release(rg,REASON_COST)
 end

--- a/c61411502.lua
+++ b/c61411502.lua
@@ -21,14 +21,10 @@ end
 function c61411502.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetReleaseGroup(tp)
 	if chk==0 then
-		return aux.WithSubGroupContext(nil,c61411502.rclassifier,function()
-			return g:CheckSubGroupEach(c61411502.rchecks,c61411502.rgoal,tp)
-		end)
+		return g:WithSubGroupContext(nil,c61411502.rclassifier):CheckSubGroupEach(c61411502.rchecks,c61411502.rgoal,tp)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
-	local rg=aux.WithSubGroupContext(nil,c61411502.rclassifier,function()
-		return g:SelectSubGroupEach(tp,c61411502.rchecks,false,c61411502.rgoal,tp)
-	end)
+	local rg=g:WithSubGroupContext(nil,c61411502.rclassifier):SelectSubGroupEach(tp,c61411502.rchecks,false,c61411502.rgoal,tp)
 	aux.UseExtraReleaseCount(rg,tp)
 	Duel.Release(rg,REASON_COST)
 end

--- a/c61411502.lua
+++ b/c61411502.lua
@@ -12,7 +12,7 @@ function c61411502.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c61411502.rchecks=aux.CreateChecks(Card.IsAttribute,{ATTRIBUTE_WIND,ATTRIBUTE_WATER,ATTRIBUTE_FIRE,ATTRIBUTE_EARTH})
-function c61411502.rclassifier(c,sg,g)
+function c61411502.rclassifier(c)
 	return aux.GetCheckSignature(c,c61411502.rchecks)
 end
 function c61411502.rgoal(g,tp)

--- a/c61411502.lua
+++ b/c61411502.lua
@@ -13,7 +13,7 @@ function c61411502.initial_effect(c)
 end
 c61411502.rchecks=aux.CreateChecks(Card.IsAttribute,{ATTRIBUTE_WIND,ATTRIBUTE_WATER,ATTRIBUTE_FIRE,ATTRIBUTE_EARTH})
 function c61411502.rclassifier(c)
-	return aux.GetCheckSignature(c,c61411502.rchecks)
+	return aux.GetCheckMask(c,c61411502.rchecks)
 end
 function c61411502.rgoal(g,tp)
 	return Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,g)

--- a/c6309986.lua
+++ b/c6309986.lua
@@ -13,6 +13,9 @@ function c6309986.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c6309986.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
+function c6309986.spclassifier(c,sg,g)
+	return aux.GetCheckSignature(c,c6309986.spchecks)
+end
 function c6309986.cfilter(c,tp)
 	return c:IsFaceup() and c:IsLevel(5) and c:IsReleasable() and Duel.GetMZoneCount(tp,c)>=5
 end
@@ -31,8 +34,11 @@ function c6309986.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		e:SetLabel(0)
 		local g=Duel.GetMatchingGroup(c6309986.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp)
-		return res and not Duel.IsPlayerAffectedByEffect(tp,59822133)
-			and g:CheckSubGroupEach(c6309986.spchecks)
+		if not (res and not Duel.IsPlayerAffectedByEffect(tp,59822133)) then return false end
+		aux.GCheckClassifier=c6309986.spclassifier
+		local ok=g:CheckSubGroupEach(c6309986.spchecks)
+		aux.GCheckClassifier=nil
+		return ok
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,5,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE)
 end
@@ -40,7 +46,9 @@ function c6309986.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c6309986.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		aux.GCheckClassifier=c6309986.spclassifier
 		local sg=g:SelectSubGroupEach(tp,c6309986.spchecks,false)
+		aux.GCheckClassifier=nil
 		if sg then
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			for tc in aux.Next(sg) do

--- a/c6309986.lua
+++ b/c6309986.lua
@@ -14,7 +14,7 @@ function c6309986.initial_effect(c)
 end
 c6309986.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
 function c6309986.spclassifier(c)
-	return aux.GetCheckSignature(c,c6309986.spchecks)
+	return aux.GetCheckMask(c,c6309986.spchecks)
 end
 function c6309986.cfilter(c,tp)
 	return c:IsFaceup() and c:IsLevel(5) and c:IsReleasable() and Duel.GetMZoneCount(tp,c)>=5

--- a/c6309986.lua
+++ b/c6309986.lua
@@ -13,8 +13,8 @@ function c6309986.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c6309986.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
-function c6309986.spclassifier(c,sg,g)
-	return aux.GetCheckSignature(c,c6309986.spchecks)
+function c6309986.spclassifier(c,g)
+	return 1
 end
 function c6309986.cfilter(c,tp)
 	return c:IsFaceup() and c:IsLevel(5) and c:IsReleasable() and Duel.GetMZoneCount(tp,c)>=5

--- a/c6309986.lua
+++ b/c6309986.lua
@@ -35,9 +35,7 @@ function c6309986.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		e:SetLabel(0)
 		local g=Duel.GetMatchingGroup(c6309986.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp)
 		if not (res and not Duel.IsPlayerAffectedByEffect(tp,59822133)) then return false end
-		return aux.WithSubGroupContext(nil,c6309986.spclassifier,function()
-			return g:CheckSubGroupEach(c6309986.spchecks)
-		end)
+		return g:WithSubGroupContext(nil,c6309986.spclassifier):CheckSubGroupEach(c6309986.spchecks)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,5,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE)
 end
@@ -45,9 +43,7 @@ function c6309986.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c6309986.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sg=aux.WithSubGroupContext(nil,c6309986.spclassifier,function()
-			return g:SelectSubGroupEach(tp,c6309986.spchecks,false)
-		end)
+		local sg=g:WithSubGroupContext(nil,c6309986.spclassifier):SelectSubGroupEach(tp,c6309986.spchecks,false)
 		if sg then
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			for tc in aux.Next(sg) do

--- a/c6309986.lua
+++ b/c6309986.lua
@@ -13,7 +13,7 @@ function c6309986.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c6309986.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
-function c6309986.spclassifier(c,sg,g)
+function c6309986.spclassifier(c)
 	return aux.GetCheckSignature(c,c6309986.spchecks)
 end
 function c6309986.cfilter(c,tp)

--- a/c6309986.lua
+++ b/c6309986.lua
@@ -35,10 +35,9 @@ function c6309986.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		e:SetLabel(0)
 		local g=Duel.GetMatchingGroup(c6309986.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp)
 		if not (res and not Duel.IsPlayerAffectedByEffect(tp,59822133)) then return false end
-		aux.GCheckClassifier=c6309986.spclassifier
-		local ok=g:CheckSubGroupEach(c6309986.spchecks)
-		aux.GCheckClassifier=nil
-		return ok
+		return aux.WithSubGroupContext(nil,c6309986.spclassifier,function()
+			return g:CheckSubGroupEach(c6309986.spchecks)
+		end)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,5,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE)
 end
@@ -46,9 +45,9 @@ function c6309986.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c6309986.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		aux.GCheckClassifier=c6309986.spclassifier
-		local sg=g:SelectSubGroupEach(tp,c6309986.spchecks,false)
-		aux.GCheckClassifier=nil
+		local sg=aux.WithSubGroupContext(nil,c6309986.spclassifier,function()
+			return g:SelectSubGroupEach(tp,c6309986.spchecks,false)
+		end)
 		if sg then
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			for tc in aux.Next(sg) do

--- a/c70914287.lua
+++ b/c70914287.lua
@@ -76,10 +76,9 @@ function c70914287.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c70914287.spfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,nil,e,tp)
 	if chk==0 then
 		if not (c:IsAbleToHand() and Duel.GetMZoneCount(tp,c)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133)) then return false end
-		aux.GCheckClassifier=c70914287.spclassifier
-		local res=g:CheckSubGroupEach(c70914287.spchecks)
-		aux.GCheckClassifier=nil
-		return res
+		return aux.WithSubGroupContext(nil,c70914287.spclassifier,function()
+			return g:CheckSubGroupEach(c70914287.spchecks)
+		end)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,c,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,5,tp,LOCATION_HAND+LOCATION_GRAVE)
@@ -90,9 +89,9 @@ function c70914287.spop2(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c70914287.spfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,nil,e,tp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		aux.GCheckClassifier=c70914287.spclassifier
-		local sg=g:SelectSubGroupEach(tp,c70914287.spchecks,false)
-		aux.GCheckClassifier=nil
+		local sg=aux.WithSubGroupContext(nil,c70914287.spclassifier,function()
+			return g:SelectSubGroupEach(tp,c70914287.spchecks,false)
+		end)
 		if sg then
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_ATTACK)
 		end

--- a/c70914287.lua
+++ b/c70914287.lua
@@ -41,7 +41,7 @@ function c70914287.initial_effect(c)
 end
 c70914287.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
 function c70914287.spclassifier(c)
-	return aux.GetCheckSignature(c,c70914287.spchecks)
+	return aux.GetCheckMask(c,c70914287.spchecks)
 end
 function c70914287.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetMatchingGroupCount(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)>Duel.GetMatchingGroupCount(Card.IsType,1-tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)

--- a/c70914287.lua
+++ b/c70914287.lua
@@ -40,7 +40,7 @@ function c70914287.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c70914287.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
-function c70914287.spclassifier(c,sg,g)
+function c70914287.spclassifier(c)
 	return aux.GetCheckSignature(c,c70914287.spchecks)
 end
 function c70914287.spcon1(e,tp,eg,ep,ev,re,r,rp)

--- a/c70914287.lua
+++ b/c70914287.lua
@@ -40,6 +40,9 @@ function c70914287.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c70914287.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
+function c70914287.spclassifier(c,sg,g)
+	return aux.GetCheckSignature(c,c70914287.spchecks)
+end
 function c70914287.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetMatchingGroupCount(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)>Duel.GetMatchingGroupCount(Card.IsType,1-tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)
 end
@@ -71,8 +74,13 @@ end
 function c70914287.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	local g=Duel.GetMatchingGroup(c70914287.spfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,nil,e,tp)
-	if chk==0 then return c:IsAbleToHand() and Duel.GetMZoneCount(tp,c)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
-		and g:CheckSubGroupEach(c70914287.spchecks) end
+	if chk==0 then
+		if not (c:IsAbleToHand() and Duel.GetMZoneCount(tp,c)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133)) then return false end
+		aux.GCheckClassifier=c70914287.spclassifier
+		local res=g:CheckSubGroupEach(c70914287.spchecks)
+		aux.GCheckClassifier=nil
+		return res
+	end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,c,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,5,tp,LOCATION_HAND+LOCATION_GRAVE)
 end
@@ -82,7 +90,9 @@ function c70914287.spop2(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c70914287.spfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,nil,e,tp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		aux.GCheckClassifier=c70914287.spclassifier
 		local sg=g:SelectSubGroupEach(tp,c70914287.spchecks,false)
+		aux.GCheckClassifier=nil
 		if sg then
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_ATTACK)
 		end

--- a/c70914287.lua
+++ b/c70914287.lua
@@ -40,8 +40,8 @@ function c70914287.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 c70914287.spchecks=aux.CreateChecks(Card.IsCode,{44632120,71036835,7021574,34419588,40640057})
-function c70914287.spclassifier(c,sg,g)
-	return aux.GetCheckSignature(c,c70914287.spchecks)
+function c70914287.spclassifier(c,g)
+	return 1
 end
 function c70914287.spcon1(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetMatchingGroupCount(Card.IsType,tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)>Duel.GetMatchingGroupCount(Card.IsType,1-tp,LOCATION_GRAVE,0,nil,TYPE_MONSTER)

--- a/c70914287.lua
+++ b/c70914287.lua
@@ -76,9 +76,7 @@ function c70914287.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c70914287.spfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,nil,e,tp)
 	if chk==0 then
 		if not (c:IsAbleToHand() and Duel.GetMZoneCount(tp,c)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133)) then return false end
-		return aux.WithSubGroupContext(nil,c70914287.spclassifier,function()
-			return g:CheckSubGroupEach(c70914287.spchecks)
-		end)
+		return g:WithSubGroupContext(nil,c70914287.spclassifier):CheckSubGroupEach(c70914287.spchecks)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,c,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,5,tp,LOCATION_HAND+LOCATION_GRAVE)
@@ -89,9 +87,7 @@ function c70914287.spop2(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>=5 and not Duel.IsPlayerAffectedByEffect(tp,59822133) then
 		local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c70914287.spfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,nil,e,tp)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sg=aux.WithSubGroupContext(nil,c70914287.spclassifier,function()
-			return g:SelectSubGroupEach(tp,c70914287.spchecks,false)
-		end)
+		local sg=g:WithSubGroupContext(nil,c70914287.spclassifier):SelectSubGroupEach(tp,c70914287.spchecks,false)
 		if sg then
 			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_ATTACK)
 		end

--- a/c76794549.lua
+++ b/c76794549.lua
@@ -52,7 +52,7 @@ end
 c76794549.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
 function c76794549.hnclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return aux.GetCheckSignature(c,c76794549.hnchecks)
+	return aux.GetCheckMask(c,c76794549.hnchecks)
 end
 function c76794549.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()

--- a/c76794549.lua
+++ b/c76794549.lua
@@ -162,14 +162,10 @@ function c76794549.hncost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if not (c:IsAbleToRemoveAsCost()
 			and Duel.IsExistingMatchingCard(c76794549.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,nil)) then return false end
-		return aux.WithSubGroupContext(nil,c76794549.hnclassifier,function()
-			return mg:CheckSubGroupEach(c76794549.hnchecks,c76794549.hngoal,e,tp,c)
-		end)
+		return mg:WithSubGroupContext(nil,c76794549.hnclassifier):CheckSubGroupEach(c76794549.hnchecks,c76794549.hngoal,e,tp,c)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local sg=aux.WithSubGroupContext(nil,c76794549.hnclassifier,function()
-		return mg:SelectSubGroupEach(tp,c76794549.hnchecks,false,c76794549.hngoal,e,tp,c)
-	end)
+	local sg=mg:WithSubGroupContext(nil,c76794549.hnclassifier):SelectSubGroupEach(tp,c76794549.hnchecks,false,c76794549.hngoal,e,tp,c)
 	sg:AddCard(c)
 	Duel.Remove(sg,POS_FACEUP,REASON_COST)
 end

--- a/c76794549.lua
+++ b/c76794549.lua
@@ -50,9 +50,9 @@ function c76794549.initial_effect(c)
 	end
 end
 c76794549.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
-function c76794549.hnclassifier(c,sg,g)
+function c76794549.hnclassifier(c,g)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return aux.GetCheckSignature(c,c76794549.hnchecks)
+	return 1
 end
 function c76794549.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()

--- a/c76794549.lua
+++ b/c76794549.lua
@@ -50,6 +50,10 @@ function c76794549.initial_effect(c)
 	end
 end
 c76794549.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
+function c76794549.hnclassifier(c,sg,g)
+	if c:IsLocation(LOCATION_MZONE) then return nil end
+	return aux.GetCheckSignature(c,c76794549.hnchecks)
+end
 function c76794549.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=eg:GetFirst()
 	while tc do
@@ -155,11 +159,18 @@ end
 function c76794549.hncost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	local mg=Duel.GetMatchingGroup(c76794549.cfilter,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
-	if chk==0 then return c:IsAbleToRemoveAsCost()
-		and Duel.IsExistingMatchingCard(c76794549.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,nil)
-		and mg:CheckSubGroupEach(c76794549.hnchecks,c76794549.hngoal,e,tp,c) end
+	if chk==0 then
+		if not (c:IsAbleToRemoveAsCost()
+			and Duel.IsExistingMatchingCard(c76794549.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,nil)) then return false end
+		aux.GCheckClassifier=c76794549.hnclassifier
+		local res=mg:CheckSubGroupEach(c76794549.hnchecks,c76794549.hngoal,e,tp,c)
+		aux.GCheckClassifier=nil
+		return res
+	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	aux.GCheckClassifier=c76794549.hnclassifier
 	local sg=mg:SelectSubGroupEach(tp,c76794549.hnchecks,false,c76794549.hngoal,e,tp,c)
+	aux.GCheckClassifier=nil
 	sg:AddCard(c)
 	Duel.Remove(sg,POS_FACEUP,REASON_COST)
 end

--- a/c76794549.lua
+++ b/c76794549.lua
@@ -50,7 +50,7 @@ function c76794549.initial_effect(c)
 	end
 end
 c76794549.hnchecks=aux.CreateChecks(Card.IsSetCard,{0x10f2,0x2073,0x2017,0x1046})
-function c76794549.hnclassifier(c,sg,g)
+function c76794549.hnclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
 	return aux.GetCheckSignature(c,c76794549.hnchecks)
 end

--- a/c76794549.lua
+++ b/c76794549.lua
@@ -162,15 +162,14 @@ function c76794549.hncost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if not (c:IsAbleToRemoveAsCost()
 			and Duel.IsExistingMatchingCard(c76794549.hnfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,nil)) then return false end
-		aux.GCheckClassifier=c76794549.hnclassifier
-		local res=mg:CheckSubGroupEach(c76794549.hnchecks,c76794549.hngoal,e,tp,c)
-		aux.GCheckClassifier=nil
-		return res
+		return aux.WithSubGroupContext(nil,c76794549.hnclassifier,function()
+			return mg:CheckSubGroupEach(c76794549.hnchecks,c76794549.hngoal,e,tp,c)
+		end)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	aux.GCheckClassifier=c76794549.hnclassifier
-	local sg=mg:SelectSubGroupEach(tp,c76794549.hnchecks,false,c76794549.hngoal,e,tp,c)
-	aux.GCheckClassifier=nil
+	local sg=aux.WithSubGroupContext(nil,c76794549.hnclassifier,function()
+		return mg:SelectSubGroupEach(tp,c76794549.hnchecks,false,c76794549.hngoal,e,tp,c)
+	end)
 	sg:AddCard(c)
 	Duel.Remove(sg,POS_FACEUP,REASON_COST)
 end

--- a/c77075360.lua
+++ b/c77075360.lua
@@ -65,8 +65,10 @@ function c77075360.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local ct=math.min(g:GetClassCount(Card.GetLevel),ft)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	aux.GCheckAdditional=aux.dlvcheck
+	aux.GCheckAdditional=aux.dlvcheck_additional
+	aux.GCheckClassifier=aux.dlvcheck_classifier
 	local sg=g:SelectSubGroup(tp,aux.TRUE,false,ct,ct)
+	aux.GCheckClassifier=nil
 	aux.GCheckAdditional=nil
 	Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 end

--- a/c77075360.lua
+++ b/c77075360.lua
@@ -65,7 +65,7 @@ function c77075360.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local ct=math.min(g:GetClassCount(Card.GetLevel),ft)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dlvcheck_spec,aux.TRUE,false,ct,ct)
+	local sg=g:WithCheckSpec(aux.dlvcheck_spec):SelectSubGroup(tp,aux.TRUE,false,ct,ct)
 	Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c77075360.regop(e,tp,eg,ep,ev,re,r,rp)

--- a/c77075360.lua
+++ b/c77075360.lua
@@ -65,11 +65,7 @@ function c77075360.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 	local ct=math.min(g:GetClassCount(Card.GetLevel),ft)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	aux.GCheckAdditional=aux.dlvcheck_additional
-	aux.GCheckClassifier=aux.dlvcheck_classifier
-	local sg=g:SelectSubGroup(tp,aux.TRUE,false,ct,ct)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dlvcheck_spec,aux.TRUE,false,ct,ct)
 	Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function c77075360.regop(e,tp,eg,ep,ev,re,r,rp)

--- a/c7986397.lua
+++ b/c7986397.lua
@@ -19,7 +19,7 @@ end
 function c7986397.rcheck(tp,g,c)
 	return g:FilterCount(Card.IsLocation,nil,LOCATION_DECK)<=1
 end
-function c7986397.rgcheck(g,ec)
+function c7986397.rgcheck(g)
 	return g:FilterCount(Card.IsLocation,nil,LOCATION_DECK)<=1
 end
 function c7986397.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c80033124.lua
+++ b/c80033124.lua
@@ -11,7 +11,7 @@ function c80033124.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c80033124.fchecks=aux.CreateChecks(Card.IsFusionCode,{41230939,77625948,3019642})
-function c80033124.fclassifier(c,sg,g)
+function c80033124.fclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
 	return aux.GetCheckSignature(c,c80033124.fchecks)
 end

--- a/c80033124.lua
+++ b/c80033124.lua
@@ -11,9 +11,9 @@ function c80033124.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c80033124.fchecks=aux.CreateChecks(Card.IsFusionCode,{41230939,77625948,3019642})
-function c80033124.fclassifier(c,sg,g)
+function c80033124.fclassifier(c,g)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return aux.GetCheckSignature(c,c80033124.fchecks)
+	return 1
 end
 function c80033124.ffilter0(c)
 	return c:IsFusionCode(41230939,77625948,3019642) and c:IsCanBeFusionMaterial() and c:IsAbleToDeck()

--- a/c80033124.lua
+++ b/c80033124.lua
@@ -11,6 +11,10 @@ function c80033124.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c80033124.fchecks=aux.CreateChecks(Card.IsFusionCode,{41230939,77625948,3019642})
+function c80033124.fclassifier(c,sg,g)
+	if c:IsLocation(LOCATION_MZONE) then return nil end
+	return aux.GetCheckSignature(c,c80033124.fchecks)
+end
 function c80033124.ffilter0(c)
 	return c:IsFusionCode(41230939,77625948,3019642) and c:IsCanBeFusionMaterial() and c:IsAbleToDeck()
 end
@@ -30,7 +34,10 @@ function c80033124.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if not aux.MustMaterialCheck(nil,tp,EFFECT_MUST_BE_FMATERIAL) then return false end
 		if not Duel.IsExistingMatchingCard(c80033124.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,nil) then return false end
 		local mg=Duel.GetMatchingGroup(c80033124.ffilter0,tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,nil)
-		return mg:CheckSubGroupEach(c80033124.fchecks,c80033124.fgoal,e,tp)
+		aux.GCheckClassifier=c80033124.fclassifier
+		local res=mg:CheckSubGroupEach(c80033124.fchecks,c80033124.fgoal,e,tp)
+		aux.GCheckClassifier=nil
+		return res
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
@@ -44,7 +51,9 @@ function c80033124.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not aux.MustMaterialCheck(nil,tp,EFFECT_MUST_BE_FMATERIAL) then return end
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c80033124.ffilter),tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,nil,e)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	aux.GCheckClassifier=c80033124.fclassifier
 	local sg=mg:SelectSubGroupEach(tp,c80033124.fchecks,false,c80033124.fgoal,e,tp)
+	aux.GCheckClassifier=nil
 	if not sg then return end
 	local cg=sg:Filter(c80033124.cfilter,nil)
 	if cg:GetCount()>0 then

--- a/c80033124.lua
+++ b/c80033124.lua
@@ -34,9 +34,7 @@ function c80033124.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if not aux.MustMaterialCheck(nil,tp,EFFECT_MUST_BE_FMATERIAL) then return false end
 		if not Duel.IsExistingMatchingCard(c80033124.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,nil) then return false end
 		local mg=Duel.GetMatchingGroup(c80033124.ffilter0,tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,nil)
-		return aux.WithSubGroupContext(nil,c80033124.fclassifier,function()
-			return mg:CheckSubGroupEach(c80033124.fchecks,c80033124.fgoal,e,tp)
-		end)
+		return mg:WithSubGroupContext(nil,c80033124.fclassifier):CheckSubGroupEach(c80033124.fchecks,c80033124.fgoal,e,tp)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
@@ -50,9 +48,7 @@ function c80033124.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not aux.MustMaterialCheck(nil,tp,EFFECT_MUST_BE_FMATERIAL) then return end
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c80033124.ffilter),tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,nil,e)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	local sg=aux.WithSubGroupContext(nil,c80033124.fclassifier,function()
-		return mg:SelectSubGroupEach(tp,c80033124.fchecks,false,c80033124.fgoal,e,tp)
-	end)
+	local sg=mg:WithSubGroupContext(nil,c80033124.fclassifier):SelectSubGroupEach(tp,c80033124.fchecks,false,c80033124.fgoal,e,tp)
 	if not sg then return end
 	local cg=sg:Filter(c80033124.cfilter,nil)
 	if cg:GetCount()>0 then

--- a/c80033124.lua
+++ b/c80033124.lua
@@ -13,7 +13,7 @@ end
 c80033124.fchecks=aux.CreateChecks(Card.IsFusionCode,{41230939,77625948,3019642})
 function c80033124.fclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return aux.GetCheckSignature(c,c80033124.fchecks)
+	return aux.GetCheckMask(c,c80033124.fchecks)
 end
 function c80033124.ffilter0(c)
 	return c:IsFusionCode(41230939,77625948,3019642) and c:IsCanBeFusionMaterial() and c:IsAbleToDeck()

--- a/c80033124.lua
+++ b/c80033124.lua
@@ -34,10 +34,9 @@ function c80033124.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		if not aux.MustMaterialCheck(nil,tp,EFFECT_MUST_BE_FMATERIAL) then return false end
 		if not Duel.IsExistingMatchingCard(c80033124.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,nil) then return false end
 		local mg=Duel.GetMatchingGroup(c80033124.ffilter0,tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,nil)
-		aux.GCheckClassifier=c80033124.fclassifier
-		local res=mg:CheckSubGroupEach(c80033124.fchecks,c80033124.fgoal,e,tp)
-		aux.GCheckClassifier=nil
-		return res
+		return aux.WithSubGroupContext(nil,c80033124.fclassifier,function()
+			return mg:CheckSubGroupEach(c80033124.fchecks,c80033124.fgoal,e,tp)
+		end)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
@@ -51,9 +50,9 @@ function c80033124.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not aux.MustMaterialCheck(nil,tp,EFFECT_MUST_BE_FMATERIAL) then return end
 	local mg=Duel.GetMatchingGroup(aux.NecroValleyFilter(c80033124.ffilter),tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,nil,e)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	aux.GCheckClassifier=c80033124.fclassifier
-	local sg=mg:SelectSubGroupEach(tp,c80033124.fchecks,false,c80033124.fgoal,e,tp)
-	aux.GCheckClassifier=nil
+	local sg=aux.WithSubGroupContext(nil,c80033124.fclassifier,function()
+		return mg:SelectSubGroupEach(tp,c80033124.fchecks,false,c80033124.fgoal,e,tp)
+	end)
 	if not sg then return end
 	local cg=sg:Filter(c80033124.cfilter,nil)
 	if cg:GetCount()>0 then

--- a/c81560239.lua
+++ b/c81560239.lua
@@ -20,7 +20,7 @@ end
 function s.rcheck(tp,g,c)
 	return g:GetCount()<3
 end
-function s.rgcheck(g,ec)
+function s.rgcheck(g)
 	return g:GetCount()<3
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/c82428674.lua
+++ b/c82428674.lua
@@ -37,8 +37,10 @@ function c82428674.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c82428674.rmfilter,tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_MZONE,0,nil)
 	if ct==0 or g:GetCount()==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	aux.GCheckAdditional=aux.dlvcheck
+	aux.GCheckAdditional=aux.dlvcheck_additional
+	aux.GCheckClassifier=aux.dlvcheck_classifier
 	local rg=g:SelectSubGroup(tp,aux.TRUE,false,1,ct)
+	aux.GCheckClassifier=nil
 	aux.GCheckAdditional=nil
 	local rc=Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	if rc>0 then

--- a/c82428674.lua
+++ b/c82428674.lua
@@ -37,7 +37,7 @@ function c82428674.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c82428674.rmfilter,tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_MZONE,0,nil)
 	if ct==0 or g:GetCount()==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local rg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dlvcheck_spec,aux.TRUE,false,1,ct)
+	local rg=g:WithCheckSpec(aux.dlvcheck_spec):SelectSubGroup(tp,aux.TRUE,false,1,ct)
 	local rc=Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	if rc>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)

--- a/c82428674.lua
+++ b/c82428674.lua
@@ -37,11 +37,7 @@ function c82428674.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c82428674.rmfilter,tp,LOCATION_HAND+LOCATION_GRAVE+LOCATION_MZONE,0,nil)
 	if ct==0 or g:GetCount()==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	aux.GCheckAdditional=aux.dlvcheck_additional
-	aux.GCheckClassifier=aux.dlvcheck_classifier
-	local rg=g:SelectSubGroup(tp,aux.TRUE,false,1,ct)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local rg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dlvcheck_spec,aux.TRUE,false,1,ct)
 	local rc=Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)
 	if rc>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)

--- a/c87985506.lua
+++ b/c87985506.lua
@@ -39,7 +39,11 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		if ft>0 and #g>0 then
 			if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			aux.GCheckAdditional=aux.dncheck_additional
+			aux.GCheckClassifier=aux.dncheck_classifier
 			local sg=g:SelectSubGroup(tp,aux.dncheck,false,1,math.min(3,ft))
+			aux.GCheckClassifier=nil
+			aux.GCheckAdditional=nil
 			if sg then
 				Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			end

--- a/c87985506.lua
+++ b/c87985506.lua
@@ -39,11 +39,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		if ft>0 and #g>0 then
 			if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-			aux.GCheckAdditional=aux.dncheck_additional
-			aux.GCheckClassifier=aux.dncheck_classifier
-			local sg=g:SelectSubGroup(tp,aux.dncheck,false,1,math.min(3,ft))
-			aux.GCheckClassifier=nil
-			aux.GCheckAdditional=nil
+			local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,math.min(3,ft))
 			if sg then
 				Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			end

--- a/c87985506.lua
+++ b/c87985506.lua
@@ -39,7 +39,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		if ft>0 and #g>0 then
 			if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-			local sg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,1,math.min(3,ft))
+			local sg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,1,math.min(3,ft))
 			if sg then
 				Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
 			end

--- a/c91323605.lua
+++ b/c91323605.lua
@@ -49,11 +49,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.MoveToField(tc,tp,tp,LOCATION_FZONE,POS_FACEUP,true)
 	local g=Duel.GetMatchingGroup(s.sfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	aux.GCheckAdditional=aux.dncheck_additional
-	aux.GCheckClassifier=aux.dncheck_classifier
-	local mg=g:SelectSubGroup(tp,aux.dncheck,false,5,5)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local mg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,5,5)
 	if mg then
 		Duel.BreakEffect()
 		Duel.ConfirmCards(1-tp,mg)

--- a/c91323605.lua
+++ b/c91323605.lua
@@ -49,7 +49,11 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.MoveToField(tc,tp,tp,LOCATION_FZONE,POS_FACEUP,true)
 	local g=Duel.GetMatchingGroup(s.sfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	aux.GCheckAdditional=aux.dncheck_additional
+	aux.GCheckClassifier=aux.dncheck_classifier
 	local mg=g:SelectSubGroup(tp,aux.dncheck,false,5,5)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	if mg then
 		Duel.BreakEffect()
 		Duel.ConfirmCards(1-tp,mg)

--- a/c91323605.lua
+++ b/c91323605.lua
@@ -49,7 +49,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.MoveToField(tc,tp,tp,LOCATION_FZONE,POS_FACEUP,true)
 	local g=Duel.GetMatchingGroup(s.sfilter,tp,LOCATION_DECK,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local mg=aux.SelectSubGroupByCheckSpec(g,tp,aux.dncheck_spec,nil,false,5,5)
+	local mg=g:WithCheckSpec(aux.dncheck_spec):SelectSubGroup(tp,nil,false,5,5)
 	if mg then
 		Duel.BreakEffect()
 		Duel.ConfirmCards(1-tp,mg)

--- a/c93053159.lua
+++ b/c93053159.lua
@@ -42,16 +42,20 @@ function s.initial_effect(c)
 	e4:SetOperation(s.tgop)
 	c:RegisterEffect(e4)
 end
+-- check/spec for materials with different Fusion Codes
+s.dfccheck,s.dfccheck_spec=aux.MakeDistinctCheckSpec(Card.GetFusionCode)
 function s.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
 end
-function s.Alba_System_Drugmata_Fusion_Filter(c,mg,fc,tp,chkf,gc)
-	if not c:IsFusionCode(68468459) and not c:IsHasEffect(EFFECT_FUSION_SUBSTITUTE) then return false end
+-- The custom fusion procedure picks this required Alba/substitute material first,
+-- then checks whether the remaining pool can complete the 6-material fusion.
+function s.IsAlbaSystemDrugmataLeadMaterial(c)
+	return c:IsFusionCode(68468459) or c:IsHasEffect(EFFECT_FUSION_SUBSTITUTE)
+end
+function s.CanCompleteAlbaSystemDrugmataFusion(c,mg,fc,tp,chkf,gc)
+	if not s.IsAlbaSystemDrugmataLeadMaterial(c) then return false end
 	local g=mg:Filter(s.matfilter,c,tp)
-	aux.GCheckAdditional=aux.dncheck
-	local res=g:CheckSubGroup(s.Alba_System_Drugmata_Fusion_Gcheck,6,6,fc,tp,c,chkf,gc)
-	aux.GCheckAdditional=nil
-	return res
+	return g:WithSubGroupContext(s.dfccheck_spec.additional,s.dfccheck_spec.classifier):CheckSubGroup(s.Alba_System_Drugmata_Fusion_Gcheck,6,6,fc,tp,c,chkf,gc)
 end
 function s.matfilter(c,tp)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsControler(tp) and not c:IsHasEffect(6205579)
@@ -73,9 +77,9 @@ function s.Alba_System_Drugmata_Fusion_Condition()
 			local tp=e:GetHandlerPlayer()
 			if gc then
 				if not g:IsContains(gc) then return false end
-				return g:IsExists(s.Alba_System_Drugmata_Fusion_Filter,1,nil,g,fc,tp,chkf,gc)
+				return g:IsExists(s.CanCompleteAlbaSystemDrugmataFusion,1,nil,g,fc,tp,chkf,gc)
 			end
-			return g:IsExists(s.Alba_System_Drugmata_Fusion_Filter,1,nil,g,fc,tp,chkf,nil)
+			return g:IsExists(s.CanCompleteAlbaSystemDrugmataFusion,1,nil,g,fc,tp,chkf,nil)
 		end
 end
 function s.Alba_System_Drugmata_Fusion_Operation()
@@ -90,7 +94,7 @@ function s.Alba_System_Drugmata_Fusion_Operation()
 					fg:AddCard(g:GetFirst())
 				end
 				if gc then
-					if s.Alba_System_Drugmata_Fusion_Filter(gc,fg,fc,tp,chkf) then
+					if s.CanCompleteAlbaSystemDrugmataFusion(gc,fg,fc,tp,chkf) then
 						g=Group.FromCards(gc)
 						fg:RemoveCard(gc)
 						local mg=fg:Filter(s.matfilter,fc,tp)
@@ -98,7 +102,7 @@ function s.Alba_System_Drugmata_Fusion_Operation()
 						sg=mg:SelectSubGroup(tp,s.Alba_System_Drugmata_Fusion_Gcheck,false,6,6,fc,tp,g:GetFirst(),chkf,gc)
 					else
 						Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-						g=fg:FilterSelect(tp,s.Alba_System_Drugmata_Fusion_Filter,1,1,nil,fg,fc,tp,chkf,gc)
+						g=fg:FilterSelect(tp,s.CanCompleteAlbaSystemDrugmataFusion,1,1,nil,fg,fc,tp,chkf,gc)
 						fg:Sub(g)
 						local mg=fg:Filter(s.matfilter,fc,tp)
 						Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
@@ -106,13 +110,11 @@ function s.Alba_System_Drugmata_Fusion_Operation()
 					end
 				else
 					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-					g=fg:FilterSelect(tp,s.Alba_System_Drugmata_Fusion_Filter,1,1,nil,fg,fc,tp,chkf,nil)
+					g=fg:FilterSelect(tp,s.CanCompleteAlbaSystemDrugmataFusion,1,1,nil,fg,fc,tp,chkf,nil)
 					fg:Sub(g)
 					local mg=fg:Filter(s.matfilter,fc,tp)
-					aux.GCheckAdditional=aux.dncheck
 					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-					sg=mg:SelectSubGroup(tp,s.Alba_System_Drugmata_Fusion_Gcheck,true,6,6,fc,tp,g:GetFirst(),chkf)
-					aux.GCheckAdditional=nil
+					sg=mg:WithSubGroupContext(s.dfccheck_spec.additional,s.dfccheck_spec.classifier):SelectSubGroup(tp,s.Alba_System_Drugmata_Fusion_Gcheck,true,6,6,fc,tp,g:GetFirst(),chkf)
 				end
 			end
 			g:Merge(sg)

--- a/c99162753.lua
+++ b/c99162753.lua
@@ -16,7 +16,7 @@ function c99162753.fadditional(sg,c,g)
 end
 function c99162753.fclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return c:GetOriginalRace().."|"..aux.GetCheckSignature(c,c99162753.spchecks)
+	return c:GetOriginalRace().."|"..aux.GetCheckMask(c,c99162753.spchecks)
 end
 function c99162753.rmfilter(c)
 	return (not c:IsLocation(LOCATION_MZONE) or c:IsFaceup()) and c:IsType(TYPE_RITUAL+TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_PENDULUM+TYPE_LINK) and c:IsAbleToRemove()

--- a/c99162753.lua
+++ b/c99162753.lua
@@ -14,9 +14,9 @@ c99162753.spchecks=aux.CreateChecks(Card.IsType,{TYPE_RITUAL,TYPE_FUSION,TYPE_SY
 function c99162753.fadditional(sg,c,g)
 	return sg:GetClassCount(Card.GetOriginalRace)<=1
 end
-function c99162753.fclassifier(c,sg,g)
+function c99162753.fclassifier(c,g)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
-	return c:GetOriginalRace().."|"..aux.GetCheckSignature(c,c99162753.spchecks)
+	return c:GetOriginalRace()
 end
 function c99162753.rmfilter(c)
 	return (not c:IsLocation(LOCATION_MZONE) or c:IsFaceup()) and c:IsType(TYPE_RITUAL+TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_PENDULUM+TYPE_LINK) and c:IsAbleToRemove()

--- a/c99162753.lua
+++ b/c99162753.lua
@@ -11,7 +11,7 @@ function c99162753.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c99162753.spchecks=aux.CreateChecks(Card.IsType,{TYPE_RITUAL,TYPE_FUSION,TYPE_SYNCHRO,TYPE_XYZ,TYPE_PENDULUM,TYPE_LINK})
-function c99162753.fadditional(sg,c,g)
+function c99162753.fadditional(sg)
 	return sg:GetClassCount(Card.GetOriginalRace)<=1
 end
 function c99162753.fclassifier(c)

--- a/c99162753.lua
+++ b/c99162753.lua
@@ -11,6 +11,13 @@ function c99162753.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 c99162753.spchecks=aux.CreateChecks(Card.IsType,{TYPE_RITUAL,TYPE_FUSION,TYPE_SYNCHRO,TYPE_XYZ,TYPE_PENDULUM,TYPE_LINK})
+function c99162753.fadditional(sg,c,g)
+	return sg:GetClassCount(Card.GetOriginalRace)<=1
+end
+function c99162753.fclassifier(c,sg,g)
+	if c:IsLocation(LOCATION_MZONE) then return nil end
+	return c:GetOriginalRace().."|"..aux.GetCheckSignature(c,c99162753.spchecks)
+end
 function c99162753.rmfilter(c)
 	return (not c:IsLocation(LOCATION_MZONE) or c:IsFaceup()) and c:IsType(TYPE_RITUAL+TYPE_FUSION+TYPE_SYNCHRO+TYPE_XYZ+TYPE_PENDULUM+TYPE_LINK) and c:IsAbleToRemove()
 end
@@ -25,14 +32,25 @@ function c99162753.spfilter(c,e,tp,g)
 end
 function c99162753.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c99162753.rmfilter,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
-	if chk==0 then return g:CheckSubGroupEach(c99162753.spchecks,c99162753.fgoal,e,tp) end
+	if chk==0 then
+		aux.GCheckAdditional=c99162753.fadditional
+		aux.GCheckClassifier=c99162753.fclassifier
+		local res=g:CheckSubGroupEach(c99162753.spchecks,c99162753.fgoal,e,tp)
+		aux.GCheckClassifier=nil
+		aux.GCheckAdditional=nil
+		return res
+	end
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,6,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_EXTRA)
 end
 function c99162753.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c99162753.rmfilter),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	aux.GCheckAdditional=c99162753.fadditional
+	aux.GCheckClassifier=c99162753.fclassifier
 	local rg=g:SelectSubGroupEach(tp,c99162753.spchecks,false,c99162753.fgoal,e,tp)
+	aux.GCheckClassifier=nil
+	aux.GCheckAdditional=nil
 	if rg and rg:GetCount()==6 and Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)~=0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local tg=Duel.SelectMatchingCard(tp,c99162753.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,1,nil,e,tp,rg)

--- a/c99162753.lua
+++ b/c99162753.lua
@@ -33,12 +33,9 @@ end
 function c99162753.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c99162753.rmfilter,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
 	if chk==0 then
-		aux.GCheckAdditional=c99162753.fadditional
-		aux.GCheckClassifier=c99162753.fclassifier
-		local res=g:CheckSubGroupEach(c99162753.spchecks,c99162753.fgoal,e,tp)
-		aux.GCheckClassifier=nil
-		aux.GCheckAdditional=nil
-		return res
+		return aux.WithSubGroupContext(c99162753.fadditional,c99162753.fclassifier,function()
+			return g:CheckSubGroupEach(c99162753.spchecks,c99162753.fgoal,e,tp)
+		end)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,6,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_EXTRA)
@@ -46,11 +43,9 @@ end
 function c99162753.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c99162753.rmfilter),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	aux.GCheckAdditional=c99162753.fadditional
-	aux.GCheckClassifier=c99162753.fclassifier
-	local rg=g:SelectSubGroupEach(tp,c99162753.spchecks,false,c99162753.fgoal,e,tp)
-	aux.GCheckClassifier=nil
-	aux.GCheckAdditional=nil
+	local rg=aux.WithSubGroupContext(c99162753.fadditional,c99162753.fclassifier,function()
+		return g:SelectSubGroupEach(tp,c99162753.spchecks,false,c99162753.fgoal,e,tp)
+	end)
 	if rg and rg:GetCount()==6 and Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)~=0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local tg=Duel.SelectMatchingCard(tp,c99162753.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,1,nil,e,tp,rg)

--- a/c99162753.lua
+++ b/c99162753.lua
@@ -14,7 +14,7 @@ c99162753.spchecks=aux.CreateChecks(Card.IsType,{TYPE_RITUAL,TYPE_FUSION,TYPE_SY
 function c99162753.fadditional(sg,c,g)
 	return sg:GetClassCount(Card.GetOriginalRace)<=1
 end
-function c99162753.fclassifier(c,sg,g)
+function c99162753.fclassifier(c)
 	if c:IsLocation(LOCATION_MZONE) then return nil end
 	return c:GetOriginalRace().."|"..aux.GetCheckSignature(c,c99162753.spchecks)
 end

--- a/c99162753.lua
+++ b/c99162753.lua
@@ -33,9 +33,7 @@ end
 function c99162753.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c99162753.rmfilter,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
 	if chk==0 then
-		return aux.WithSubGroupContext(c99162753.fadditional,c99162753.fclassifier,function()
-			return g:CheckSubGroupEach(c99162753.spchecks,c99162753.fgoal,e,tp)
-		end)
+		return g:WithSubGroupContext(c99162753.fadditional,c99162753.fclassifier):CheckSubGroupEach(c99162753.spchecks,c99162753.fgoal,e,tp)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,6,tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_EXTRA)
@@ -43,9 +41,7 @@ end
 function c99162753.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c99162753.rmfilter),tp,LOCATION_HAND+LOCATION_MZONE+LOCATION_GRAVE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local rg=aux.WithSubGroupContext(c99162753.fadditional,c99162753.fclassifier,function()
-		return g:SelectSubGroupEach(tp,c99162753.spchecks,false,c99162753.fgoal,e,tp)
-	end)
+	local rg=g:WithSubGroupContext(c99162753.fadditional,c99162753.fclassifier):SelectSubGroupEach(tp,c99162753.spchecks,false,c99162753.fgoal,e,tp)
 	if rg and rg:GetCount()==6 and Duel.Remove(rg,POS_FACEUP,REASON_EFFECT)~=0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local tg=Duel.SelectMatchingCard(tp,c99162753.spfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,1,nil,e,tp,rg)

--- a/c99426088.lua
+++ b/c99426088.lua
@@ -34,7 +34,7 @@ end
 function c99426088.frcheck(tp,sg,fc)
 	return sg:FilterCount(Card.IsLocation,nil,LOCATION_DECK)<=1
 end
-function c99426088.gcheck(sg,ec)
+function c99426088.gcheck(sg)
 	return sg:FilterCount(Card.IsLocation,nil,LOCATION_DECK)<=1
 end
 function c99426088.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/procedure.lua
+++ b/procedure.lua
@@ -1818,6 +1818,15 @@ function Auxiliary.RitualCheckAdditional(c,lv,greater_or_equal)
 				end
 	end
 end
+function Auxiliary.RitualGetClassifier(c)
+	if c.mat_group_check or Auxiliary.RCheckAdditional or Auxiliary.RGCheckAdditional then
+		return nil
+	end
+	return	function(mc)
+				if mc:IsLocation(LOCATION_MZONE) then return nil end
+				return mc:GetRitualLevel(c)
+			end
+end
 function Auxiliary.RitualUltimateFilter(c,filter,e,tp,m1,m2,level_function,greater_or_equal,chk)
 	if bit.band(c:GetType(),0x81)~=0x81 or (filter and not filter(c,e,tp,chk)) or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,false,true) then return false end
 	local mg=m1:Filter(Card.IsCanBeRitualMaterial,c,c)
@@ -1831,7 +1840,9 @@ function Auxiliary.RitualUltimateFilter(c,filter,e,tp,m1,m2,level_function,great
 	end
 	local lv=level_function(c)
 	Auxiliary.GCheckAdditional=Auxiliary.RitualCheckAdditional(c,lv,greater_or_equal)
+	Auxiliary.GCheckClassifier=Auxiliary.RitualGetClassifier(c)
 	local res=mg:CheckSubGroup(Auxiliary.RitualCheck,1,lv,tp,c,lv,greater_or_equal)
+	Auxiliary.GCheckClassifier=nil
 	Auxiliary.GCheckAdditional=nil
 	return res
 end
@@ -1884,7 +1895,9 @@ function Auxiliary.RitualUltimateOperation(filter,level_function,greater_or_equa
 					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
 					local lv=level_function(tc)
 					Auxiliary.GCheckAdditional=Auxiliary.RitualCheckAdditional(tc,lv,greater_or_equal)
+					Auxiliary.GCheckClassifier=Auxiliary.RitualGetClassifier(tc)
 					mat=mg:SelectSubGroup(tp,Auxiliary.RitualCheck,true,1,lv,tp,tc,lv,greater_or_equal)
+					Auxiliary.GCheckClassifier=nil
 					Auxiliary.GCheckAdditional=nil
 					if not mat then goto RitualUltimateSelectStart end
 					tc:SetMaterial(mat)
@@ -2026,6 +2039,20 @@ function Auxiliary.PendOperationCheck(ft1,ft2,ft)
 				return #g<=ft and #exg<=ft2 and #mg<=ft1
 			end
 end
+function Auxiliary.PendClassifier(c)
+	local lv=0
+	if c.pendulum_level then
+		lv=c.pendulum_level
+	else
+		lv=c:GetLevel()
+	end
+	lv=lv&0x7f
+	if c:IsLocation(LOCATION_EXTRA) then
+		return lv|0x80
+	else
+		return lv
+	end
+end
 function Auxiliary.PendOperation(e,tp,eg,ep,ev,re,r,rp,c,sg,og)
 	local rpz=Duel.GetFieldCard(tp,LOCATION_PZONE,1)
 	local lscale=c:GetLeftScale()
@@ -2076,7 +2103,9 @@ function Auxiliary.PendOperation(e,tp,eg,ep,ev,re,r,rp,c,sg,og)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	Auxiliary.GCheckAdditional=Auxiliary.PendOperationCheck(ft1,ft2,ft)
+	Auxiliary.GCheckClassifier=Auxiliary.PendClassifier
 	local g=tg:SelectSubGroup(tp,Auxiliary.TRUE,true,1,math.min(#tg,ft))
+	Auxiliary.GCheckClassifier=nil
 	Auxiliary.GCheckAdditional=nil
 	if not g then return end
 	if ce then

--- a/procedure.lua
+++ b/procedure.lua
@@ -919,7 +919,10 @@ function Auxiliary.FConditionMix(insf,sub,...)
 					if not mg:IsContains(gc) then return false end
 					Duel.SetSelectedCard(gc)
 				end
-				return mg:CheckSubGroup(Auxiliary.FCheckMixGoal,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
+				Auxiliary.GCheckClassifier=Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs))
+				local res=mg:CheckSubGroup(Auxiliary.FCheckMixGoal,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
+				Auxiliary.GCheckClassifier=nil
+				return res
 			end
 end
 function Auxiliary.FOperationMix(insf,sub,...)
@@ -933,7 +936,9 @@ function Auxiliary.FOperationMix(insf,sub,...)
 				local mg=eg:Filter(Auxiliary.FConditionFilterMix,c,c,sub2,notfusion,table.unpack(funs))
 				if gc then Duel.SetSelectedCard(gc) end
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+				Auxiliary.GCheckClassifier=Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs))
 				local sg=mg:SelectSubGroup(tp,Auxiliary.FCheckMixGoal,cancel,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
+				Auxiliary.GCheckClassifier=nil
 				if sg then
 					Duel.SetFusionMaterial(sg)
 				else
@@ -948,6 +953,70 @@ function Auxiliary.FConditionFilterMix(c,fc,sub,notfusion,...)
 		if f(c,fc,sub) then return true end
 	end
 	return false
+end
+function Auxiliary.FClassifierCheckMixFilter(f,c,fc,sub,mg)
+	local touched_sg=false
+	local sg_probe=setmetatable({},{
+		__len=function()
+			touched_sg=true
+			return 0
+		end,
+		__index=function()
+			touched_sg=true
+			return function() return nil end
+		end,
+		__add=function()
+			touched_sg=true
+			return nil
+		end,
+		__sub=function()
+			touched_sg=true
+			return nil
+		end,
+		__eq=function()
+			touched_sg=true
+			return false
+		end
+	})
+	local ok,res=pcall(f,c,fc,sub,mg,sg_probe)
+	if not ok or touched_sg then return nil end
+	return res and true or false
+end
+function Auxiliary.FGetMixClassifier(tp,mg,fc,sub,chkfnf,...)
+	if Auxiliary.FCheckAdditional or Auxiliary.FGoalCheckAdditional then
+		return nil
+	end
+	local not_fusion=chkfnf&(0x100|0x200)>0
+	if not not_fusion and mg:IsExists(Card.IsHasEffect,1,nil,EFFECT_TUNE_MAGICIAN_F) then
+		return nil
+	end
+	local chkf=chkfnf&0xff
+	local mustg=Duel.GetMustMaterial(tp,EFFECT_MUST_BE_FMATERIAL)
+	local funs={...}
+	return	function(c)
+				if chkf~=PLAYER_NONE and c:IsLocation(LOCATION_MZONE) then
+					return nil
+				end
+				if mustg:IsContains(c) then
+					return nil
+				end
+				local normal_key={}
+				for i,f in ipairs(funs) do
+					local res=Auxiliary.FClassifierCheckMixFilter(f,c,fc,false,mg)
+					if res==nil then return nil end
+					normal_key[i]=res and "1" or "0"
+				end
+				if not sub then
+					return table.concat(normal_key)
+				end
+				local sub_key={}
+				for i,f in ipairs(funs) do
+					local res=Auxiliary.FClassifierCheckMixFilter(f,c,fc,true,mg)
+					if res==nil then return nil end
+					sub_key[i]=res and "1" or "0"
+				end
+				return table.concat(normal_key).."|"..table.concat(sub_key)
+			end
 end
 function Auxiliary.FCheckMix(c,mg,sg,fc,sub,fun1,fun2,...)
 	if fun2 then

--- a/procedure.lua
+++ b/procedure.lua
@@ -1813,7 +1813,7 @@ function Auxiliary.RitualCheckAdditional(c,lv,greater_or_equal)
 					local sum=g:GetSum(Auxiliary.RitualCheckAdditionalLevel,c)
 					if Auxiliary.RGCheckAdditional and not Auxiliary.RGCheckAdditional(g) then return false end
 					local _,minv=g:GetMinGroup(Auxiliary.RitualCheckAdditionalLevel,c)
-					return sum-minv<=lv
+					return sum-minv<lv
 				end
 	end
 end

--- a/procedure.lua
+++ b/procedure.lua
@@ -919,10 +919,7 @@ function Auxiliary.FConditionMix(insf,sub,...)
 					if not mg:IsContains(gc) then return false end
 					Duel.SetSelectedCard(gc)
 				end
-				local res=Auxiliary.WithSubGroupContext(nil,Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs)),function()
-					return mg:CheckSubGroup(Auxiliary.FCheckMixGoal,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
-				end)
-				return res
+				return mg:CheckSubGroup(Auxiliary.FCheckMixGoal,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
 			end
 end
 function Auxiliary.FOperationMix(insf,sub,...)
@@ -936,9 +933,7 @@ function Auxiliary.FOperationMix(insf,sub,...)
 				local mg=eg:Filter(Auxiliary.FConditionFilterMix,c,c,sub2,notfusion,table.unpack(funs))
 				if gc then Duel.SetSelectedCard(gc) end
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-				local sg=Auxiliary.WithSubGroupContext(nil,Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs)),function()
-					return mg:SelectSubGroup(tp,Auxiliary.FCheckMixGoal,cancel,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
-				end)
+				local sg=mg:SelectSubGroup(tp,Auxiliary.FCheckMixGoal,cancel,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
 				if sg then
 					Duel.SetFusionMaterial(sg)
 				else
@@ -953,70 +948,6 @@ function Auxiliary.FConditionFilterMix(c,fc,sub,notfusion,...)
 		if f(c,fc,sub) then return true end
 	end
 	return false
-end
-function Auxiliary.FClassifierCheckMixFilter(f,c,fc,sub,mg)
-	local touched_sg=false
-	local sg_probe=setmetatable({},{
-		__len=function()
-			touched_sg=true
-			return 0
-		end,
-		__index=function()
-			touched_sg=true
-			return function() return nil end
-		end,
-		__add=function()
-			touched_sg=true
-			return nil
-		end,
-		__sub=function()
-			touched_sg=true
-			return nil
-		end,
-		__eq=function()
-			touched_sg=true
-			return false
-		end
-	})
-	local ok,res=pcall(f,c,fc,sub,mg,sg_probe)
-	if not ok or touched_sg then return nil end
-	return res and true or false
-end
-function Auxiliary.FGetMixClassifier(tp,mg,fc,sub,chkfnf,...)
-	if Auxiliary.FCheckAdditional or Auxiliary.FGoalCheckAdditional then
-		return nil
-	end
-	local not_fusion=chkfnf&(0x100|0x200)>0
-	if not not_fusion and mg:IsExists(Card.IsHasEffect,1,nil,EFFECT_TUNE_MAGICIAN_F) then
-		return nil
-	end
-	local chkf=chkfnf&0xff
-	local mustg=Duel.GetMustMaterial(tp,EFFECT_MUST_BE_FMATERIAL)
-	local funs={...}
-	return	function(c)
-				if chkf~=PLAYER_NONE and c:IsLocation(LOCATION_MZONE) then
-					return nil
-				end
-				if mustg:IsContains(c) then
-					return nil
-				end
-				local normal_key={}
-				for i,f in ipairs(funs) do
-					local res=Auxiliary.FClassifierCheckMixFilter(f,c,fc,false,mg)
-					if res==nil then return nil end
-					normal_key[i]=res and "1" or "0"
-				end
-				if not sub then
-					return table.concat(normal_key)
-				end
-				local sub_key={}
-				for i,f in ipairs(funs) do
-					local res=Auxiliary.FClassifierCheckMixFilter(f,c,fc,true,mg)
-					if res==nil then return nil end
-					sub_key[i]=res and "1" or "0"
-				end
-				return table.concat(normal_key).."|"..table.concat(sub_key)
-			end
 end
 function Auxiliary.FCheckMix(c,mg,sg,fc,sub,fun1,fun2,...)
 	if fun2 then
@@ -1878,12 +1809,11 @@ function Auxiliary.RitualCheckAdditional(c,lv,greater_or_equal)
 					return (not Auxiliary.RGCheckAdditional or Auxiliary.RGCheckAdditional(g)) and g:GetSum(Auxiliary.RitualCheckAdditionalLevel,c)<=lv
 				end
 	else
-		return	function(g,ec)
-					if ec then
-						return (not Auxiliary.RGCheckAdditional or Auxiliary.RGCheckAdditional(g,ec)) and g:GetSum(Auxiliary.RitualCheckAdditionalLevel,c)-Auxiliary.RitualCheckAdditionalLevel(ec,c)<=lv
-					else
-						return not Auxiliary.RGCheckAdditional or Auxiliary.RGCheckAdditional(g)
-					end
+		return	function(g)
+					local sum=g:GetSum(Auxiliary.RitualCheckAdditionalLevel,c)
+					if Auxiliary.RGCheckAdditional and not Auxiliary.RGCheckAdditional(g) then return false end
+					local _,minv=g:GetMinGroup(Auxiliary.RitualCheckAdditionalLevel,c)
+					return sum-minv<=lv
 				end
 	end
 end

--- a/procedure.lua
+++ b/procedure.lua
@@ -919,9 +919,9 @@ function Auxiliary.FConditionMix(insf,sub,...)
 					if not mg:IsContains(gc) then return false end
 					Duel.SetSelectedCard(gc)
 				end
-				Auxiliary.GCheckClassifier=Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs))
-				local res=mg:CheckSubGroup(Auxiliary.FCheckMixGoal,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
-				Auxiliary.GCheckClassifier=nil
+				local res=Auxiliary.WithSubGroupContext(nil,Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs)),function()
+					return mg:CheckSubGroup(Auxiliary.FCheckMixGoal,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
+				end)
 				return res
 			end
 end
@@ -936,9 +936,9 @@ function Auxiliary.FOperationMix(insf,sub,...)
 				local mg=eg:Filter(Auxiliary.FConditionFilterMix,c,c,sub2,notfusion,table.unpack(funs))
 				if gc then Duel.SetSelectedCard(gc) end
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-				Auxiliary.GCheckClassifier=Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs))
-				local sg=mg:SelectSubGroup(tp,Auxiliary.FCheckMixGoal,cancel,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
-				Auxiliary.GCheckClassifier=nil
+				local sg=Auxiliary.WithSubGroupContext(nil,Auxiliary.FGetMixClassifier(tp,mg,c,sub2,chkfnf,table.unpack(funs)),function()
+					return mg:SelectSubGroup(tp,Auxiliary.FCheckMixGoal,cancel,#funs,#funs,tp,c,sub2,chkfnf,table.unpack(funs))
+				end)
 				if sg then
 					Duel.SetFusionMaterial(sg)
 				else
@@ -1908,11 +1908,9 @@ function Auxiliary.RitualUltimateFilter(c,filter,e,tp,m1,m2,level_function,great
 		mg:RemoveCard(c)
 	end
 	local lv=level_function(c)
-	Auxiliary.GCheckAdditional=Auxiliary.RitualCheckAdditional(c,lv,greater_or_equal)
-	Auxiliary.GCheckClassifier=Auxiliary.RitualGetClassifier(c)
-	local res=mg:CheckSubGroup(Auxiliary.RitualCheck,1,lv,tp,c,lv,greater_or_equal)
-	Auxiliary.GCheckClassifier=nil
-	Auxiliary.GCheckAdditional=nil
+	local res=Auxiliary.WithSubGroupContext(Auxiliary.RitualCheckAdditional(c,lv,greater_or_equal),Auxiliary.RitualGetClassifier(c),function()
+		return mg:CheckSubGroup(Auxiliary.RitualCheck,1,lv,tp,c,lv,greater_or_equal)
+	end)
 	return res
 end
 function Auxiliary.RitualExtraFilter(c,f)
@@ -1963,11 +1961,9 @@ function Auxiliary.RitualUltimateOperation(filter,level_function,greater_or_equa
 					end
 					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
 					local lv=level_function(tc)
-					Auxiliary.GCheckAdditional=Auxiliary.RitualCheckAdditional(tc,lv,greater_or_equal)
-					Auxiliary.GCheckClassifier=Auxiliary.RitualGetClassifier(tc)
-					mat=mg:SelectSubGroup(tp,Auxiliary.RitualCheck,true,1,lv,tp,tc,lv,greater_or_equal)
-					Auxiliary.GCheckClassifier=nil
-					Auxiliary.GCheckAdditional=nil
+					mat=Auxiliary.WithSubGroupContext(Auxiliary.RitualCheckAdditional(tc,lv,greater_or_equal),Auxiliary.RitualGetClassifier(tc),function()
+						return mg:SelectSubGroup(tp,Auxiliary.RitualCheck,true,1,lv,tp,tc,lv,greater_or_equal)
+					end)
 					if not mat then goto RitualUltimateSelectStart end
 					tc:SetMaterial(mat)
 					Duel.ReleaseRitualMaterial(mat)
@@ -2171,11 +2167,9 @@ function Auxiliary.PendOperation(e,tp,eg,ep,ev,re,r,rp,c,sg,og)
 		tg=tg:Filter(Auxiliary.PConditionExtraFilterSpecific,nil,e,tp,lscale,rscale,ce)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	Auxiliary.GCheckAdditional=Auxiliary.PendOperationCheck(ft1,ft2,ft)
-	Auxiliary.GCheckClassifier=Auxiliary.PendClassifier
-	local g=tg:SelectSubGroup(tp,Auxiliary.TRUE,true,1,math.min(#tg,ft))
-	Auxiliary.GCheckClassifier=nil
-	Auxiliary.GCheckAdditional=nil
+	local g=Auxiliary.WithSubGroupContext(Auxiliary.PendOperationCheck(ft1,ft2,ft),Auxiliary.PendClassifier,function()
+		return tg:SelectSubGroup(tp,Auxiliary.TRUE,true,1,math.min(#tg,ft))
+	end)
 	if not g then return end
 	if ce then
 		Duel.Hint(HINT_CARD,0,ce:GetOwner():GetOriginalCode())

--- a/procedure.lua
+++ b/procedure.lua
@@ -993,7 +993,7 @@ function Auxiliary.FGetMixClassifier(tp,mg,fc,sub,chkfnf,...)
 	local chkf=chkfnf&0xff
 	local mustg=Duel.GetMustMaterial(tp,EFFECT_MUST_BE_FMATERIAL)
 	local funs={...}
-	return	function(c)
+	return	function(c,g)
 				if chkf~=PLAYER_NONE and c:IsLocation(LOCATION_MZONE) then
 					return nil
 				end
@@ -1891,7 +1891,7 @@ function Auxiliary.RitualGetClassifier(c)
 	if c.mat_group_check or Auxiliary.RCheckAdditional or Auxiliary.RGCheckAdditional then
 		return nil
 	end
-	return	function(mc)
+	return	function(mc,g)
 				if mc:IsLocation(LOCATION_MZONE) then return nil end
 				return mc:GetRitualLevel(c)
 			end

--- a/utility.lua
+++ b/utility.lua
@@ -1426,12 +1426,14 @@ function Auxiliary.CreateChecks(f,list)
 	end
 	return checks
 end
-function Auxiliary.GetCheckSignature(c,checks,...)
-	local sig={}
+function Auxiliary.GetCheckMask(c,checks,...)
+	local mask=0
 	for i=1,#checks do
-		sig[i]=checks[i](c,...) and "1" or "0"
+		if checks[i](c,...) then
+			mask=mask|(1<<(#checks-i))
+		end
 	end
-	return table.concat(sig)
+	return mask
 end
 function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 	if not checks[1+#sg](c) then

--- a/utility.lua
+++ b/utility.lua
@@ -1237,24 +1237,6 @@ function Auxiliary.GetGroupClassifier(c)
 	if not Auxiliary.GCheckClassifier then return nil end
 	return Auxiliary.GCheckClassifier(c)
 end
-function Auxiliary.CloneCapturedSubGroup()
-	local cg=Group.CreateGroup()
-	cg:Merge(Auxiliary.SubGroupCaptured)
-	return cg
-end
-function Auxiliary.MergeClassifiedCaptured(cg,entry,c)
-	if not entry.captured then return end
-	local rep=entry.rep
-	if rep==c then
-		cg:Merge(entry.captured)
-		return
-	end
-	local cap=Group.CreateGroup()
-	cap:Merge(entry.captured)
-	cap:RemoveCard(rep)
-	cap:AddCard(c)
-	cg:Merge(cap)
-end
 function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
 	sg:AddCard(c)
 	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c,g) then
@@ -1306,18 +1288,10 @@ function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
 				else
 					local entry=classified[cls]
 					if entry~=nil then
-						res=entry.res
-						if res then
-							Auxiliary.SubGroupCaptured:Clear()
-							Auxiliary.MergeClassifiedCaptured(Auxiliary.SubGroupCaptured,entry,tc)
-						end
+						res=entry
 					else
 						res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
-						entry={res=res,rep=tc}
-						if res then
-							entry.captured=Auxiliary.CloneCapturedSubGroup()
-						end
-						classified[cls]=entry
+						classified[cls]=res
 					end
 				end
 				if res then break end
@@ -1400,19 +1374,19 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 					entry=classified[cls]
 				end
 				if entry~=nil then
-					if entry.res then
-						Auxiliary.MergeClassifiedCaptured(cg,entry,c)
+					if entry then
+						cg:AddCard(c)
 					else
 						eg:RemoveCard(c)
 					end
 				elseif Auxiliary.CheckGroupRecursiveCapture(c,sg,eg,f,min,max,ext_params) then
 					if cls then
-						classified[cls]={res=true,rep=c,captured=Auxiliary.CloneCapturedSubGroup()}
+						classified[cls]=true
 					end
-					cg:Merge(Auxiliary.SubGroupCaptured)
+					cg:AddCard(c)
 				else
 					if cls then
-						classified[cls]={res=false,rep=c}
+						classified[cls]=false
 					end
 					eg:RemoveCard(c)
 				end

--- a/utility.lua
+++ b/utility.lua
@@ -56,11 +56,15 @@ Auxiliary.GCheckAdditional=function(sg) return true end
 ---@param c Card
 ---@return any
 Auxiliary.GCheckClassifier=nil
+-- Per-subgroup-context precomputed classifier lookup: card -> classifier(card).
+Auxiliary.GCheckClassifierCache=nil
 function Auxiliary.WithSubGroupContext(additional,classifier,f)
 	Auxiliary.GCheckAdditional=additional
 	Auxiliary.GCheckClassifier=classifier
+	Auxiliary.GCheckClassifierCache=nil
 	local ok,res=pcall(f)
 	Auxiliary.GCheckClassifier=nil
+	Auxiliary.GCheckClassifierCache=nil
 	Auxiliary.GCheckAdditional=nil
 	if not ok then error(res,0) end
 	return res
@@ -1219,9 +1223,18 @@ function Auxiliary.GetMultiLinkedZone(tp)
 	end
 	return multi_linked_zone
 end
-function Auxiliary.GetGroupClassifier(c)
+function Auxiliary.BuildGroupClassifierCache(g)
 	if not Auxiliary.GCheckClassifier then return nil end
-	return Auxiliary.GCheckClassifier(c)
+	local cache={}
+	for c in Auxiliary.Next(g) do
+		cache[c]=Auxiliary.GCheckClassifier(c)
+	end
+	Auxiliary.GCheckClassifierCache=cache
+	return cache
+end
+function Auxiliary.GetGroupClassifier(c)
+	if not Auxiliary.GCheckClassifierCache then return nil end
+	return Auxiliary.GCheckClassifierCache[c]
 end
 ---Recursive subgroup walker over the current branch state.
 ---Entry usage: call with the current selected subgroup and its remaining pool,
@@ -1280,6 +1293,7 @@ function Group.CheckSubGroup(g,f,min,max,...)
 	max=max or #g
 	if min>max then return false end
 	local ext_params={...}
+	Auxiliary.BuildGroupClassifierCache(g)
 	local sg=Duel.GrabSelectedCard()
 	if #sg>max or #(g+sg)<min then return false end
 	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg)) then return false end
@@ -1299,6 +1313,7 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 	min=min or 1
 	max=max or #g
 	local ext_params={...}
+	Auxiliary.BuildGroupClassifierCache(g)
 	local sg=Group.CreateGroup()
 	local fg=Duel.GrabSelectedCard()
 	if #fg>max or min>max or #(g+fg)<min then return nil end
@@ -1453,6 +1468,7 @@ function Group.CheckSubGroupEach(g,checks,f,...)
 	if f==nil then f=Auxiliary.TRUE end
 	if #g<#checks then return false end
 	local ext_params={...}
+	Auxiliary.BuildGroupClassifierCache(g)
 	local sg=Group.CreateGroup()
 	return Auxiliary.CheckGroupRecursiveEach(sg,g,f,checks,ext_params)
 end
@@ -1469,6 +1485,7 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 	if f==nil then f=Auxiliary.TRUE end
 	local ct=#checks
 	local ext_params={...}
+	Auxiliary.BuildGroupClassifierCache(g)
 	local sg=Group.CreateGroup()
 	local finish=false
 	while #sg<ct do

--- a/utility.lua
+++ b/utility.lua
@@ -56,8 +56,6 @@ end
 Auxiliary.GCheckAdditional=function(sg,c,g) return true end
 ---Subgroup classifier function used to deduplicate equivalent branches on the same recursion layer
 ---@param c Card
----@param sg Group
----@param g Group
 ---@return any
 Auxiliary.GCheckClassifier=nil
 
@@ -1135,7 +1133,7 @@ end
 function Auxiliary.dncheck_additional(sg,c,g)
 	return Auxiliary.dncheck(sg)
 end
-function Auxiliary.dncheck_classifier(c,sg,g)
+function Auxiliary.dncheck_classifier(c)
 	return c:GetCode()
 end
 --check for cards with different levels
@@ -1145,7 +1143,7 @@ end
 function Auxiliary.dlvcheck_additional(sg,c,g)
 	return Auxiliary.dlvcheck(sg)
 end
-function Auxiliary.dlvcheck_classifier(c,sg,g)
+function Auxiliary.dlvcheck_classifier(c)
 	return c:GetLevel()
 end
 --check for cards with different ranks
@@ -1155,7 +1153,7 @@ end
 function Auxiliary.drkcheck_additional(sg,c,g)
 	return Auxiliary.drkcheck(sg)
 end
-function Auxiliary.drkcheck_classifier(c,sg,g)
+function Auxiliary.drkcheck_classifier(c)
 	return c:GetRank()
 end
 --check for cards with different links
@@ -1165,7 +1163,7 @@ end
 function Auxiliary.dlkcheck_additional(sg,c,g)
 	return Auxiliary.dlkcheck(sg)
 end
-function Auxiliary.dlkcheck_classifier(c,sg,g)
+function Auxiliary.dlkcheck_classifier(c)
 	return c:GetLink()
 end
 --check for cards with different attributes
@@ -1175,7 +1173,7 @@ end
 function Auxiliary.dabcheck_additional(sg,c,g)
 	return Auxiliary.dabcheck(sg)
 end
-function Auxiliary.dabcheck_classifier(c,sg,g)
+function Auxiliary.dabcheck_classifier(c)
 	return c:GetAttribute()
 end
 --check for cards with different races
@@ -1185,7 +1183,7 @@ end
 function Auxiliary.drccheck_additional(sg,c,g)
 	return Auxiliary.drccheck(sg)
 end
-function Auxiliary.drccheck_classifier(c,sg,g)
+function Auxiliary.drccheck_classifier(c)
 	return c:GetRace()
 end
 --check for group with 2 cards, each card match f with a1/a2 as argument
@@ -1235,9 +1233,9 @@ function Auxiliary.GetMultiLinkedZone(tp)
 	return multi_linked_zone
 end
 Auxiliary.SubGroupCaptured=nil
-function Auxiliary.GetGroupClassifier(c,sg,g)
+function Auxiliary.GetGroupClassifier(c)
 	if not Auxiliary.GCheckClassifier then return nil end
-	return Auxiliary.GCheckClassifier(c,sg,g)
+	return Auxiliary.GCheckClassifier(c)
 end
 function Auxiliary.CloneCapturedSubGroup()
 	local cg=Group.CreateGroup()
@@ -1268,7 +1266,7 @@ function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
 		local eg=g:Clone()
 		local classified={}
 		for tc in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
+			local cls=Auxiliary.GetGroupClassifier(tc)
 			if not cls then
 				res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
 			else
@@ -1302,7 +1300,7 @@ function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
 			local eg=g:Clone()
 			local classified={}
 			for tc in Auxiliary.Next(g-sg) do
-				local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
+				local cls=Auxiliary.GetGroupClassifier(tc)
 				if not cls then
 					res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
 				else
@@ -1351,7 +1349,7 @@ function Group.CheckSubGroup(g,f,min,max,...)
 	local eg=g:Clone()
 	local classified={}
 	for c in Auxiliary.Next(g-sg) do
-		local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+		local cls=Auxiliary.GetGroupClassifier(c)
 		if not cls then
 			if Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params) then return true end
 		else
@@ -1396,7 +1394,7 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 		local classified={}
 		for c in Auxiliary.Next(g-sg) do
 			if not cg:IsContains(c) then
-				local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+				local cls=Auxiliary.GetGroupClassifier(c)
 				local entry
 				if cls then
 					entry=classified[cls]
@@ -1477,7 +1475,7 @@ function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 		local eg=g:Clone()
 		local classified={}
 		for tc in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
+			local cls=Auxiliary.GetGroupClassifier(tc)
 			if not cls then
 				res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
 			else
@@ -1510,7 +1508,7 @@ function Group.CheckSubGroupEach(g,checks,f,...)
 	local eg=g:Clone()
 	local classified={}
 	for c in Auxiliary.Next(g-sg) do
-		local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+		local cls=Auxiliary.GetGroupClassifier(c)
 		if not cls then
 			if Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params) then return true end
 		else
@@ -1547,7 +1545,7 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 		local eg=g:Clone()
 		local classified={}
 		for c in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+			local cls=Auxiliary.GetGroupClassifier(c)
 			local res
 			if not cls then
 				res=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)

--- a/utility.lua
+++ b/utility.lua
@@ -1153,6 +1153,40 @@ function Auxiliary.MakeDistinctCheckSpec(getter)
 	local check,additional,classifier=Auxiliary.MakeDistinctCheck(getter)
 	return check,{check=check,additional=additional,classifier=classifier}
 end
+local SubGroupContextProxy={}
+function SubGroupContextProxy.CheckSubGroup(self,f,min,max,...)
+	local ext_params={...}
+	return Auxiliary.WithSubGroupContext(self.additional,self.classifier,function()
+		return self.group:CheckSubGroup(f,min,max,table.unpack(ext_params))
+	end)
+end
+function SubGroupContextProxy.SelectSubGroup(self,tp,f,cancelable,min,max,...)
+	local ext_params={...}
+	return Auxiliary.WithSubGroupContext(self.additional,self.classifier,function()
+		return self.group:SelectSubGroup(tp,f,cancelable,min,max,table.unpack(ext_params))
+	end)
+end
+function SubGroupContextProxy.CheckSubGroupEach(self,checks,f,...)
+	local ext_params={...}
+	return Auxiliary.WithSubGroupContext(self.additional,self.classifier,function()
+		return self.group:CheckSubGroupEach(checks,f,table.unpack(ext_params))
+	end)
+end
+function SubGroupContextProxy.SelectSubGroupEach(self,tp,checks,cancelable,f,...)
+	local ext_params={...}
+	return Auxiliary.WithSubGroupContext(self.additional,self.classifier,function()
+		return self.group:SelectSubGroupEach(tp,checks,cancelable,f,table.unpack(ext_params))
+	end)
+end
+-- Syntax sugar for subgroup context chaining, e.g.
+-- g:WithSubGroupContext(additional,classifier):CheckSubGroup(...)
+-- g:WithCheckSpec(spec):SelectSubGroup(...)
+function Group.WithSubGroupContext(g,additional,classifier)
+	return setmetatable({group=g,additional=additional,classifier=classifier},{__index=SubGroupContextProxy})
+end
+function Group.WithCheckSpec(g,spec)
+	return g:WithSubGroupContext(spec.additional,spec.classifier)
+end
 function Auxiliary.CheckSubGroupByCheckSpec(g,spec,f,min,max,...)
 	local ext_params={...}
 	return Auxiliary.WithSubGroupContext(spec.additional,spec.classifier,function()

--- a/utility.lua
+++ b/utility.lua
@@ -54,6 +54,12 @@ end
 ---@param g Group
 ---@return boolean
 Auxiliary.GCheckAdditional=function(sg,c,g) return true end
+---Subgroup classifier function used to deduplicate equivalent branches on the same recursion layer
+---@param c Card
+---@param sg Group
+---@param g Group
+---@return any
+Auxiliary.GCheckClassifier=nil
 
 --the table of xyz number
 Auxiliary.xyz_number={}
@@ -1193,6 +1199,28 @@ function Auxiliary.GetMultiLinkedZone(tp)
 	return multi_linked_zone
 end
 Auxiliary.SubGroupCaptured=nil
+function Auxiliary.GetGroupClassifier(c,sg,g)
+	if not Auxiliary.GCheckClassifier then return nil end
+	return Auxiliary.GCheckClassifier(c,sg,g)
+end
+function Auxiliary.CloneCapturedSubGroup()
+	local cg=Group.CreateGroup()
+	cg:Merge(Auxiliary.SubGroupCaptured)
+	return cg
+end
+function Auxiliary.MergeClassifiedCaptured(cg,entry,c)
+	if not entry.captured then return end
+	local rep=entry.rep
+	if rep==c then
+		cg:Merge(entry.captured)
+		return
+	end
+	local cap=Group.CreateGroup()
+	cap:Merge(entry.captured)
+	cap:RemoveCard(rep)
+	cap:AddCard(c)
+	cg:Merge(cap)
+end
 function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
 	sg:AddCard(c)
 	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c,g) then
@@ -1200,7 +1228,26 @@ function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
 		return false
 	end
 	local res=(#sg>=min and #sg<=max and f(sg,table.unpack(ext_params)))
-		or (#sg<max and g:IsExists(Auxiliary.CheckGroupRecursive,1,sg,sg,g,f,min,max,ext_params))
+	if not res and #sg<max then
+		local eg=g:Clone()
+		local classified={}
+		for tc in Auxiliary.Next(g-sg) do
+			local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
+			if not cls then
+				res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
+			else
+				local entry=classified[cls]
+				if entry~=nil then
+					res=entry
+				else
+					res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
+					classified[cls]=res
+				end
+			end
+			if res then break end
+			eg:RemoveCard(tc)
+		end
+	end
 	sg:RemoveCard(c)
 	return res
 end
@@ -1215,7 +1262,36 @@ function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
 		Auxiliary.SubGroupCaptured:Clear()
 		Auxiliary.SubGroupCaptured:Merge(sg)
 	else
-		res=#sg<max and g:IsExists(Auxiliary.CheckGroupRecursiveCapture,1,sg,sg,g,f,min,max,ext_params)
+		if #sg<max then
+			local eg=g:Clone()
+			local classified={}
+			for tc in Auxiliary.Next(g-sg) do
+				local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
+				if not cls then
+					res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
+				else
+					local entry=classified[cls]
+					if entry~=nil then
+						res=entry.res
+						if res then
+							Auxiliary.SubGroupCaptured:Clear()
+							Auxiliary.MergeClassifiedCaptured(Auxiliary.SubGroupCaptured,entry,tc)
+						end
+					else
+						res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
+						entry={res=res,rep=tc}
+						if res then
+							entry.captured=Auxiliary.CloneCapturedSubGroup()
+						end
+						classified[cls]=entry
+					end
+				end
+				if res then break end
+				eg:RemoveCard(tc)
+			end
+		else
+			res=false
+		end
 	end
 	sg:RemoveCard(c)
 	return res
@@ -1237,8 +1313,21 @@ function Group.CheckSubGroup(g,f,min,max,...)
 	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,nil,g)) then return false end
 	if #sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil,g)) then return true end
 	local eg=g:Clone()
+	local classified={}
 	for c in Auxiliary.Next(g-sg) do
-		if Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params) then return true end
+		local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+		if not cls then
+			if Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params) then return true end
+		else
+			local entry=classified[cls]
+			if entry~=nil then
+				if entry then return true end
+			else
+				entry=Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params)
+				classified[cls]=entry
+				if entry then return true end
+			end
+		end
 		eg:RemoveCard(c)
 	end
 	return false
@@ -1268,11 +1357,29 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 	while #sg<max do
 		local cg=Group.CreateGroup()
 		local eg=g:Clone()
+		local classified={}
 		for c in Auxiliary.Next(g-sg) do
 			if not cg:IsContains(c) then
-				if Auxiliary.CheckGroupRecursiveCapture(c,sg,eg,f,min,max,ext_params) then
+				local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+				local entry
+				if cls then
+					entry=classified[cls]
+				end
+				if entry~=nil then
+					if entry.res then
+						Auxiliary.MergeClassifiedCaptured(cg,entry,c)
+					else
+						eg:RemoveCard(c)
+					end
+				elseif Auxiliary.CheckGroupRecursiveCapture(c,sg,eg,f,min,max,ext_params) then
+					if cls then
+						classified[cls]={res=true,rep=c,captured=Auxiliary.CloneCapturedSubGroup()}
+					end
 					cg:Merge(Auxiliary.SubGroupCaptured)
 				else
+					if cls then
+						classified[cls]={res=false,rep=c}
+					end
 					eg:RemoveCard(c)
 				end
 			end
@@ -1324,7 +1431,24 @@ function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 	if #sg==#checks then
 		res=f(sg,table.unpack(ext_params))
 	else
-		res=g:IsExists(Auxiliary.CheckGroupRecursiveEach,1,sg,sg,g,f,checks,ext_params)
+		local eg=g:Clone()
+		local classified={}
+		for tc in Auxiliary.Next(g-sg) do
+			local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
+			if not cls then
+				res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
+			else
+				local entry=classified[cls]
+				if entry~=nil then
+					res=entry
+				else
+					res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
+					classified[cls]=res
+				end
+			end
+			if res then break end
+			eg:RemoveCard(tc)
+		end
 	end
 	sg:RemoveCard(c)
 	return res
@@ -1340,7 +1464,25 @@ function Group.CheckSubGroupEach(g,checks,f,...)
 	if #g<#checks then return false end
 	local ext_params={...}
 	local sg=Group.CreateGroup()
-	return g:IsExists(Auxiliary.CheckGroupRecursiveEach,1,sg,sg,g,f,checks,ext_params)
+	local eg=g:Clone()
+	local classified={}
+	for c in Auxiliary.Next(g-sg) do
+		local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+		if not cls then
+			if Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params) then return true end
+		else
+			local entry=classified[cls]
+			if entry~=nil then
+				if entry then return true end
+			else
+				entry=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
+				classified[cls]=entry
+				if entry then return true end
+			end
+		end
+		eg:RemoveCard(c)
+	end
+	return false
 end
 ---
 ---@param g Group
@@ -1358,7 +1500,29 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 	local sg=Group.CreateGroup()
 	local finish=false
 	while #sg<ct do
-		local cg=g:Filter(Auxiliary.CheckGroupRecursiveEach,sg,sg,g,f,checks,ext_params)
+		local cg=Group.CreateGroup()
+		local eg=g:Clone()
+		local classified={}
+		for c in Auxiliary.Next(g-sg) do
+			local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
+			local res
+			if not cls then
+				res=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
+			else
+				local entry=classified[cls]
+				if entry~=nil then
+					res=entry
+				else
+					res=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
+					classified[cls]=res
+				end
+			end
+			if res then
+				cg:AddCard(c)
+			else
+				eg:RemoveCard(c)
+			end
+		end
 		if #cg==0 then break end
 		local tc=cg:SelectUnselect(sg,tp,false,cancelable,ct,ct)
 		if not tc then break end

--- a/utility.lua
+++ b/utility.lua
@@ -1348,6 +1348,9 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 		end
 		cg:Sub(sg)
 		finish=(#sg>=min and #sg<=max and f(sg,...))
+		if finish and Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg) then
+			finish=false
+		end
 		if #cg==0 then break end
 		local cancel=not finish and cancelable
 		local tc=cg:SelectUnselect(sg,tp,finish,cancel,min,max)

--- a/utility.lua
+++ b/utility.lua
@@ -1132,25 +1132,61 @@ end
 function Auxiliary.dncheck(g)
 	return g:GetClassCount(Card.GetCode)==#g
 end
+function Auxiliary.dncheck_additional(sg,c,g)
+	return Auxiliary.dncheck(sg)
+end
+function Auxiliary.dncheck_classifier(c,sg,g)
+	return c:GetCode()
+end
 --check for cards with different levels
 function Auxiliary.dlvcheck(g)
 	return g:GetClassCount(Card.GetLevel)==#g
+end
+function Auxiliary.dlvcheck_additional(sg,c,g)
+	return Auxiliary.dlvcheck(sg)
+end
+function Auxiliary.dlvcheck_classifier(c,sg,g)
+	return c:GetLevel()
 end
 --check for cards with different ranks
 function Auxiliary.drkcheck(g)
 	return g:GetClassCount(Card.GetRank)==#g
 end
+function Auxiliary.drkcheck_additional(sg,c,g)
+	return Auxiliary.drkcheck(sg)
+end
+function Auxiliary.drkcheck_classifier(c,sg,g)
+	return c:GetRank()
+end
 --check for cards with different links
 function Auxiliary.dlkcheck(g)
 	return g:GetClassCount(Card.GetLink)==#g
+end
+function Auxiliary.dlkcheck_additional(sg,c,g)
+	return Auxiliary.dlkcheck(sg)
+end
+function Auxiliary.dlkcheck_classifier(c,sg,g)
+	return c:GetLink()
 end
 --check for cards with different attributes
 function Auxiliary.dabcheck(g)
 	return g:GetClassCount(Card.GetAttribute)==#g
 end
+function Auxiliary.dabcheck_additional(sg,c,g)
+	return Auxiliary.dabcheck(sg)
+end
+function Auxiliary.dabcheck_classifier(c,sg,g)
+	return c:GetAttribute()
+end
 --check for cards with different races
 function Auxiliary.drccheck(g)
 	return g:GetClassCount(Card.GetRace)==#g
+end
+function Auxiliary.drccheck_additional(sg,c,g)
+	return Auxiliary.drccheck(sg)
+end
+function Auxiliary.drccheck_classifier(c,sg,g)
+	return c:GetRace()
 end
 --check for group with 2 cards, each card match f with a1/a2 as argument
 function Auxiliary.gfcheck(g,f,a1,a2)
@@ -1417,6 +1453,13 @@ function Auxiliary.CreateChecks(f,list)
 		checks[i]=function(c) return f(c,list[i]) end
 	end
 	return checks
+end
+function Auxiliary.GetCheckSignature(c,checks,...)
+	local sig={}
+	for i=1,#checks do
+		sig[i]=checks[i](c,...) and "1" or "0"
+	end
+	return table.concat(sig)
 end
 function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 	if not checks[1+#sg](c) then

--- a/utility.lua
+++ b/utility.lua
@@ -50,9 +50,8 @@ end
 
 ---Subgroup check function
 ---@param sg Group
----@param c Card|nil
 ---@return boolean
-Auxiliary.GCheckAdditional=function(sg,c) return true end
+Auxiliary.GCheckAdditional=function(sg) return true end
 ---Subgroup classifier function used to deduplicate equivalent branches on the same recursion layer
 ---@param c Card
 ---@return any
@@ -1218,97 +1217,56 @@ function Auxiliary.GetMultiLinkedZone(tp)
 	end
 	return multi_linked_zone
 end
-Auxiliary.SubGroupCaptured=nil
 function Auxiliary.GetGroupClassifier(c)
 	if not Auxiliary.GCheckClassifier then return nil end
 	return Auxiliary.GCheckClassifier(c)
 end
-function Auxiliary.CheckGroupRecursiveStep(sg,rg,eg,f,min,max,ext_params)
-	local classified={}
-	for tc in Auxiliary.Next(rg) do
-		local cls=Auxiliary.GetGroupClassifier(tc)
-		local res
-		if not cls then
-			res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
-		else
-			local entry=classified[cls]
-			if entry~=nil then
-				res=entry
-			else
-				res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
-				classified[cls]=res
-			end
-		end
-		if res then return true end
-		eg:RemoveCard(tc)
-	end
-	return false
-end
-function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
-	sg:AddCard(c)
-	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c) then
-		sg:RemoveCard(c)
-		return false
-	end
+---Recursive subgroup walker over the current branch state.
+---Entry usage: call with the current selected subgroup and its remaining pool,
+---for example `Auxiliary.CheckGroupRecursive(sg,g-sg,f,min,max,ext_params)`.
+---@param sg Group Current subgroup already chosen on this branch.
+---@param rg Group Remaining candidate pool for deeper choices on this branch.
+---@param f function
+---@param min integer
+---@param max integer
+---@param ext_params table
+---@return boolean
+function Auxiliary.CheckGroupRecursive(sg,rg,f,min,max,ext_params)
+	-- Evaluate the current subgroup before exploring any deeper choices. If it already
+	-- satisfies the goal, or we have reached the size cap, this frame is done.
 	local res=(#sg>=min and #sg<=max and f(sg,table.unpack(ext_params)))
-	if not res and #sg<max then
-		local rg=g-sg
-		-- `rg` is already fresh, but `aux.Next(rg)` must iterate a stable group while
-		-- sibling pruning mutates a separate working pool. Mutating the iterated group
-		-- would dirty the core iterator and break `GetNext`.
-		local eg=rg:Clone()
-		res=Auxiliary.CheckGroupRecursiveStep(sg,rg,eg,f,min,max,ext_params)
+	if res or #sg>=max then
+		return res
 	end
-	sg:RemoveCard(c)
-	return res
-end
-function Auxiliary.CheckGroupRecursiveCaptureStep(sg,rg,eg,f,min,max,ext_params)
+	-- Iterate a stable snapshot while `rg` is remove/add-mutated for each child branch.
+	local ig=rg:Clone()
 	local classified={}
-	for tc in Auxiliary.Next(rg) do
+	for tc in Auxiliary.Next(ig) do
 		local cls=Auxiliary.GetGroupClassifier(tc)
-		local res
-		if not cls then
-			res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
+		local entry
+		if cls then
+			entry=classified[cls]
+		end
+		if entry~=nil then
+			res=entry
 		else
-			local entry=classified[cls]
-			if entry~=nil then
-				res=entry
+			sg:AddCard(tc)
+			rg:RemoveCard(tc)
+			if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg) then
+				res=false
 			else
-				res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
+				res=Auxiliary.CheckGroupRecursive(sg,rg,f,min,max,ext_params)
+			end
+			rg:AddCard(tc)
+			sg:RemoveCard(tc)
+			if cls then
 				classified[cls]=res
 			end
 		end
 		if res then return true end
-		eg:RemoveCard(tc)
 	end
 	return false
 end
-function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
-	sg:AddCard(c)
-	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c) then
-		sg:RemoveCard(c)
-		return false
-	end
-	local res=#sg>=min and #sg<=max and f(sg,table.unpack(ext_params))
-	if res then
-		Auxiliary.SubGroupCaptured:Clear()
-		Auxiliary.SubGroupCaptured:Merge(sg)
-	else
-		if #sg<max then
-			local rg=g-sg
-			-- `rg` is already fresh, but `aux.Next(rg)` must iterate a stable group while
-			-- sibling pruning mutates a separate working pool. Mutating the iterated group
-			-- would dirty the core iterator and break `GetNext`.
-			local eg=rg:Clone()
-			res=Auxiliary.CheckGroupRecursiveCaptureStep(sg,rg,eg,f,min,max,ext_params)
-		else
-			res=false
-		end
-	end
-	sg:RemoveCard(c)
-	return res
-end
----
 ---@param g Group
 ---@param f function
 ---@param min? integer
@@ -1322,27 +1280,9 @@ function Group.CheckSubGroup(g,f,min,max,...)
 	local ext_params={...}
 	local sg=Duel.GrabSelectedCard()
 	if #sg>max or #(g+sg)<min then return false end
-	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,nil)) then return false end
-	if #sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil)) then return true end
-	local eg=g:Clone()
-	local classified={}
-	for c in Auxiliary.Next(g-sg) do
-		local cls=Auxiliary.GetGroupClassifier(c)
-		if not cls then
-			if Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params) then return true end
-		else
-			local entry=classified[cls]
-			if entry~=nil then
-				if entry then return true end
-			else
-				entry=Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params)
-				classified[cls]=entry
-				if entry then return true end
-			end
-		end
-		eg:RemoveCard(c)
-	end
-	return false
+	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg)) then return false end
+	if #sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg)) then return true end
+	return Auxiliary.CheckGroupRecursive(sg,g-sg,f,min,max,ext_params)
 end
 ---
 ---@param g Group
@@ -1354,7 +1294,6 @@ end
 ---@param ... any
 ---@return Group
 function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
-	Auxiliary.SubGroupCaptured=Group.CreateGroup()
 	min=min or 1
 	max=max or #g
 	local ext_params={...}
@@ -1366,11 +1305,15 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 	end
 	sg:Merge(fg)
 	local finish=(#sg>=min and #sg<=max and f(sg,...))
+	if finish and Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg) then
+		finish=false
+	end
 	while #sg<max do
 		local cg=Group.CreateGroup()
-		local eg=g:Clone()
 		local classified={}
-		for c in Auxiliary.Next(g-sg) do
+		local rg=g-sg
+		local ig=rg:Clone()
+		for c in Auxiliary.Next(ig) do
 			if not cg:IsContains(c) then
 				local cls=Auxiliary.GetGroupClassifier(c)
 				local entry
@@ -1380,19 +1323,24 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 				if entry~=nil then
 					if entry then
 						cg:AddCard(c)
-					else
-						eg:RemoveCard(c)
 					end
-				elseif Auxiliary.CheckGroupRecursiveCapture(c,sg,eg,f,min,max,ext_params) then
-					if cls then
-						classified[cls]=true
-					end
-					cg:AddCard(c)
 				else
-					if cls then
-						classified[cls]=false
+					sg:AddCard(c)
+					local res
+					rg:RemoveCard(c)
+					if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg) then
+						res=false
+					else
+						res=Auxiliary.CheckGroupRecursive(sg,rg,f,min,max,ext_params)
 					end
-					eg:RemoveCard(c)
+					rg:AddCard(c)
+					sg:RemoveCard(c)
+					if cls then
+						classified[cls]=res
+					end
+					if res then
+						cg:AddCard(c)
+					end
 				end
 			end
 		end
@@ -1439,49 +1387,56 @@ function Auxiliary.GetCheckMask(c,checks,...)
 	end
 	return mask
 end
-function Auxiliary.CheckGroupRecursiveEachStep(sg,rg,eg,f,checks,ext_params)
+---Recursive ordered subgroup walker over the current branch state.
+---Entry usage: call with the current selected subgroup and its remaining pool,
+---normally `Auxiliary.CheckGroupRecursiveEach(sg,g-sg,f,checks,ext_params)`.
+---Current root callers may pass `g` directly only because they always start
+---from an empty `sg`, where `g-sg` is equivalent to `g`.
+---@param sg Group Current subgroup already chosen on this branch.
+---@param rg Group Remaining candidate pool for deeper choices on this branch.
+---@param f function
+---@param checks table
+---@param ext_params table
+---@return boolean
+function Auxiliary.CheckGroupRecursiveEach(sg,rg,f,checks,ext_params)
+	-- Ordered subgroup checks consume exactly one predicate per depth, so once all
+	-- predicates are matched we can evaluate the completed subgroup and stop here.
+	if #sg==#checks then
+		return f(sg,table.unpack(ext_params))
+	end
+	-- Iterate a stable snapshot while `rg` is remove/add-mutated for each child branch.
+	local ig=rg:Clone()
 	local classified={}
-	for tc in Auxiliary.Next(rg) do
-		local cls=Auxiliary.GetGroupClassifier(tc)
-		local res
-		if not cls then
-			res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
-		else
-			local entry=classified[cls]
+	for tc in Auxiliary.Next(ig) do
+		if checks[1+#sg](tc) then
+			local cls=Auxiliary.GetGroupClassifier(tc)
+			local entry
+			local res
+			if cls then
+				entry=classified[cls]
+			end
 			if entry~=nil then
 				res=entry
 			else
-				res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
-				classified[cls]=res
+				sg:AddCard(tc)
+				rg:RemoveCard(tc)
+				if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg) then
+					res=false
+				else
+					res=Auxiliary.CheckGroupRecursiveEach(sg,rg,f,checks,ext_params)
+				end
+				rg:AddCard(tc)
+				sg:RemoveCard(tc)
+				if cls then
+					classified[cls]=res
+				end
+			end
+			if res then
+				return true
 			end
 		end
-		if res then return true end
-		eg:RemoveCard(tc)
 	end
 	return false
-end
-function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
-	if not checks[1+#sg](c) then
-		return false
-	end
-	sg:AddCard(c)
-	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c) then
-		sg:RemoveCard(c)
-		return false
-	end
-	local res
-	if #sg==#checks then
-		res=f(sg,table.unpack(ext_params))
-	else
-		local rg=g-sg
-		-- `rg` is already fresh, but `aux.Next(rg)` must iterate a stable group while
-		-- sibling pruning mutates a separate working pool. Mutating the iterated group
-		-- would dirty the core iterator and break `GetNext`.
-		local eg=rg:Clone()
-		res=Auxiliary.CheckGroupRecursiveEachStep(sg,rg,eg,f,checks,ext_params)
-	end
-	sg:RemoveCard(c)
-	return res
 end
 ---
 ---@param g Group
@@ -1494,25 +1449,7 @@ function Group.CheckSubGroupEach(g,checks,f,...)
 	if #g<#checks then return false end
 	local ext_params={...}
 	local sg=Group.CreateGroup()
-	local eg=g:Clone()
-	local classified={}
-	for c in Auxiliary.Next(g-sg) do
-		local cls=Auxiliary.GetGroupClassifier(c)
-		if not cls then
-			if Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params) then return true end
-		else
-			local entry=classified[cls]
-			if entry~=nil then
-				if entry then return true end
-			else
-				entry=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
-				classified[cls]=entry
-				if entry then return true end
-			end
-		end
-		eg:RemoveCard(c)
-	end
-	return false
+	return Auxiliary.CheckGroupRecursiveEach(sg,g,f,checks,ext_params)
 end
 ---
 ---@param g Group
@@ -1531,26 +1468,36 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 	local finish=false
 	while #sg<ct do
 		local cg=Group.CreateGroup()
-		local eg=g:Clone()
 		local classified={}
-		for c in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(c)
-			local res
-			if not cls then
-				res=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
-			else
-				local entry=classified[cls]
+		local rg=g-sg
+		local ig=rg:Clone()
+		for c in Auxiliary.Next(ig) do
+			if checks[1+#sg](c) then
+				local cls=Auxiliary.GetGroupClassifier(c)
+				local entry
+				local res
+				if cls then
+					entry=classified[cls]
+				end
 				if entry~=nil then
 					res=entry
 				else
-					res=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
-					classified[cls]=res
+					sg:AddCard(c)
+					rg:RemoveCard(c)
+					if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg) then
+						res=false
+					else
+						res=Auxiliary.CheckGroupRecursiveEach(sg,rg,f,checks,ext_params)
+					end
+					rg:AddCard(c)
+					sg:RemoveCard(c)
+					if cls then
+						classified[cls]=res
+					end
 				end
-			end
-			if res then
-				cg:AddCard(c)
-			else
-				eg:RemoveCard(c)
+				if res then
+					cg:AddCard(c)
+				end
 			end
 		end
 		if #cg==0 then break end

--- a/utility.lua
+++ b/utility.lua
@@ -1484,8 +1484,8 @@ function Auxiliary.GetEachBuckets(g,checks)
 	local buckets={}
 	local classified={}
 	local card_to_bucket={}
-	local function new_bucket(c,valid)
-		local bucket={cards=Group.CreateGroup(),rep=c,valid=valid}
+	local function new_bucket(valid)
+		local bucket={cards=Group.CreateGroup(),valid=valid}
 		buckets[#buckets+1]=bucket
 		return bucket
 	end
@@ -1500,7 +1500,7 @@ function Auxiliary.GetEachBuckets(g,checks)
 					bucket=by_sig[sig]
 				end
 				if not bucket then
-					bucket=new_bucket(c,valid)
+					bucket=new_bucket(valid)
 					if not by_sig then
 						by_sig={}
 						classified[cls]=by_sig
@@ -1512,7 +1512,7 @@ function Auxiliary.GetEachBuckets(g,checks)
 			end
 		end
 		if not bucket then
-			bucket=new_bucket(c,valid)
+			bucket=new_bucket(valid)
 			if cls~=nil and #checks==0 then
 				classified[cls]=bucket
 			end
@@ -1536,6 +1536,12 @@ function Auxiliary.GetEachCounts(buckets,card_to_bucket,sg)
 	end
 	return counts
 end
+function Auxiliary.IsNotInGroup(c,g)
+	return not g:IsContains(c)
+end
+function Auxiliary.GetBucketCard(bucket,sg)
+	return bucket.cards:SearchCard(Auxiliary.IsNotInGroup,sg)
+end
 function Auxiliary.GetSubGroupStateKey(size,counts)
 	return size.."|"..table.concat(counts,",")
 end
@@ -1550,14 +1556,16 @@ function Auxiliary.CheckSubGroupState(sg,g,buckets,counts,min,max,f,ext_params,m
 	if not res and #sg<max then
 		for i,bucket in ipairs(buckets) do
 			if counts[i]>0 then
-				local c=bucket.rep
-				sg:AddCard(c)
-				counts[i]=counts[i]-1
-				if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
-					res=Auxiliary.CheckSubGroupState(sg,g,buckets,counts,min,max,f,ext_params,memo)
+				local c=Auxiliary.GetBucketCard(bucket,sg)
+				if c then
+					sg:AddCard(c)
+					counts[i]=counts[i]-1
+					if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
+						res=Auxiliary.CheckSubGroupState(sg,g,buckets,counts,min,max,f,ext_params,memo)
+					end
+					counts[i]=counts[i]+1
+					sg:RemoveCard(c)
 				end
-				counts[i]=counts[i]+1
-				sg:RemoveCard(c)
 				if res then break end
 			end
 		end
@@ -1574,18 +1582,20 @@ function Auxiliary.CheckSubGroupEachState(sg,g,buckets,counts,pos,f,ext_params,m
 	local res=false
 	for i,bucket in ipairs(buckets) do
 		if counts[i]>0 and bucket.valid[pos] then
-			local c=bucket.rep
-			sg:AddCard(c)
-			counts[i]=counts[i]-1
-			if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
-				if pos==#buckets[1].valid then
-					res=f(sg,table.unpack(ext_params))
-				else
-					res=Auxiliary.CheckSubGroupEachState(sg,g,buckets,counts,pos+1,f,ext_params,memo)
+			local c=Auxiliary.GetBucketCard(bucket,sg)
+			if c then
+				sg:AddCard(c)
+				counts[i]=counts[i]-1
+				if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
+					if pos==#buckets[1].valid then
+						res=f(sg,table.unpack(ext_params))
+					else
+						res=Auxiliary.CheckSubGroupEachState(sg,g,buckets,counts,pos+1,f,ext_params,memo)
+					end
 				end
+				counts[i]=counts[i]+1
+				sg:RemoveCard(c)
 			end
-			counts[i]=counts[i]+1
-			sg:RemoveCard(c)
 			if res then break end
 		end
 	end

--- a/utility.lua
+++ b/utility.lua
@@ -56,7 +56,6 @@ end
 Auxiliary.GCheckAdditional=function(sg,c,g) return true end
 ---Subgroup classifier function used to deduplicate equivalent branches on the same recursion layer
 ---@param c Card
----@param sg Group
 ---@param g Group
 ---@return any
 Auxiliary.GCheckClassifier=nil
@@ -1135,7 +1134,7 @@ end
 function Auxiliary.dncheck_additional(sg,c,g)
 	return Auxiliary.dncheck(sg)
 end
-function Auxiliary.dncheck_classifier(c,sg,g)
+function Auxiliary.dncheck_classifier(c,g)
 	return c:GetCode()
 end
 --check for cards with different levels
@@ -1145,7 +1144,7 @@ end
 function Auxiliary.dlvcheck_additional(sg,c,g)
 	return Auxiliary.dlvcheck(sg)
 end
-function Auxiliary.dlvcheck_classifier(c,sg,g)
+function Auxiliary.dlvcheck_classifier(c,g)
 	return c:GetLevel()
 end
 --check for cards with different ranks
@@ -1155,7 +1154,7 @@ end
 function Auxiliary.drkcheck_additional(sg,c,g)
 	return Auxiliary.drkcheck(sg)
 end
-function Auxiliary.drkcheck_classifier(c,sg,g)
+function Auxiliary.drkcheck_classifier(c,g)
 	return c:GetRank()
 end
 --check for cards with different links
@@ -1165,7 +1164,7 @@ end
 function Auxiliary.dlkcheck_additional(sg,c,g)
 	return Auxiliary.dlkcheck(sg)
 end
-function Auxiliary.dlkcheck_classifier(c,sg,g)
+function Auxiliary.dlkcheck_classifier(c,g)
 	return c:GetLink()
 end
 --check for cards with different attributes
@@ -1175,7 +1174,7 @@ end
 function Auxiliary.dabcheck_additional(sg,c,g)
 	return Auxiliary.dabcheck(sg)
 end
-function Auxiliary.dabcheck_classifier(c,sg,g)
+function Auxiliary.dabcheck_classifier(c,g)
 	return c:GetAttribute()
 end
 --check for cards with different races
@@ -1185,7 +1184,7 @@ end
 function Auxiliary.drccheck_additional(sg,c,g)
 	return Auxiliary.drccheck(sg)
 end
-function Auxiliary.drccheck_classifier(c,sg,g)
+function Auxiliary.drccheck_classifier(c,g)
 	return c:GetRace()
 end
 --check for group with 2 cards, each card match f with a1/a2 as argument
@@ -1235,59 +1234,22 @@ function Auxiliary.GetMultiLinkedZone(tp)
 	return multi_linked_zone
 end
 Auxiliary.SubGroupCaptured=nil
-function Auxiliary.GetGroupClassifier(c,sg,g)
+function Auxiliary.GetGroupClassifier(c,g)
 	if not Auxiliary.GCheckClassifier then return nil end
-	return Auxiliary.GCheckClassifier(c,sg,g)
+	return Auxiliary.GCheckClassifier(c,g)
 end
-function Auxiliary.CloneCapturedSubGroup()
-	local cg=Group.CreateGroup()
-	cg:Merge(Auxiliary.SubGroupCaptured)
-	return cg
-end
-function Auxiliary.MergeClassifiedCaptured(cg,entry,c)
-	if not entry.captured then return end
-	local rep=entry.rep
-	if rep==c then
-		cg:Merge(entry.captured)
-		return
-	end
-	local cap=Group.CreateGroup()
-	cap:Merge(entry.captured)
-	cap:RemoveCard(rep)
-	cap:AddCard(c)
-	cg:Merge(cap)
-end
-function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
+function Auxiliary.CheckGroupRecursiveLegacy(c,sg,g,f,min,max,ext_params)
 	sg:AddCard(c)
 	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c,g) then
 		sg:RemoveCard(c)
 		return false
 	end
 	local res=(#sg>=min and #sg<=max and f(sg,table.unpack(ext_params)))
-	if not res and #sg<max then
-		local eg=g:Clone()
-		local classified={}
-		for tc in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
-			if not cls then
-				res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
-			else
-				local entry=classified[cls]
-				if entry~=nil then
-					res=entry
-				else
-					res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
-					classified[cls]=res
-				end
-			end
-			if res then break end
-			eg:RemoveCard(tc)
-		end
-	end
+		or (#sg<max and g:IsExists(Auxiliary.CheckGroupRecursiveLegacy,1,sg,sg,g,f,min,max,ext_params))
 	sg:RemoveCard(c)
 	return res
 end
-function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
+function Auxiliary.CheckGroupRecursiveCaptureLegacy(c,sg,g,f,min,max,ext_params)
 	sg:AddCard(c)
 	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c,g) then
 		sg:RemoveCard(c)
@@ -1298,36 +1260,7 @@ function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
 		Auxiliary.SubGroupCaptured:Clear()
 		Auxiliary.SubGroupCaptured:Merge(sg)
 	else
-		if #sg<max then
-			local eg=g:Clone()
-			local classified={}
-			for tc in Auxiliary.Next(g-sg) do
-				local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
-				if not cls then
-					res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
-				else
-					local entry=classified[cls]
-					if entry~=nil then
-						res=entry.res
-						if res then
-							Auxiliary.SubGroupCaptured:Clear()
-							Auxiliary.MergeClassifiedCaptured(Auxiliary.SubGroupCaptured,entry,tc)
-						end
-					else
-						res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
-						entry={res=res,rep=tc}
-						if res then
-							entry.captured=Auxiliary.CloneCapturedSubGroup()
-						end
-						classified[cls]=entry
-					end
-				end
-				if res then break end
-				eg:RemoveCard(tc)
-			end
-		else
-			res=false
-		end
+		res=#sg<max and g:IsExists(Auxiliary.CheckGroupRecursiveCaptureLegacy,1,sg,sg,g,f,min,max,ext_params)
 	end
 	sg:RemoveCard(c)
 	return res
@@ -1339,7 +1272,7 @@ end
 ---@param max? integer
 ---@param ... any
 ---@return boolean
-function Group.CheckSubGroup(g,f,min,max,...)
+function Group.CheckSubGroupLegacy(g,f,min,max,...)
 	min=min or 1
 	max=max or #g
 	if min>max then return false end
@@ -1349,24 +1282,31 @@ function Group.CheckSubGroup(g,f,min,max,...)
 	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,nil,g)) then return false end
 	if #sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil,g)) then return true end
 	local eg=g:Clone()
-	local classified={}
 	for c in Auxiliary.Next(g-sg) do
-		local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
-		if not cls then
-			if Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params) then return true end
-		else
-			local entry=classified[cls]
-			if entry~=nil then
-				if entry then return true end
-			else
-				entry=Auxiliary.CheckGroupRecursive(c,sg,eg,f,min,max,ext_params)
-				classified[cls]=entry
-				if entry then return true end
-			end
-		end
+		if Auxiliary.CheckGroupRecursiveLegacy(c,sg,eg,f,min,max,ext_params) then return true end
 		eg:RemoveCard(c)
 	end
 	return false
+end
+function Group.CheckSubGroupClassified(g,f,min,max,...)
+	min=min or 1
+	max=max or #g
+	if min>max then return false end
+	local ext_params={...}
+	local sg=Duel.GrabSelectedCard()
+	if #sg>max or #(g+sg)<min then return false end
+	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,nil,g)) then return false end
+	if #sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil,g)) then return true end
+	local buckets,card_to_bucket=Auxiliary.GetEachBuckets(g,{})
+	local counts=Auxiliary.GetEachCounts(buckets,card_to_bucket,sg)
+	local memo={}
+	return Auxiliary.CheckSubGroupState(sg,g,buckets,counts,min,max,f,ext_params,memo)
+end
+function Group.CheckSubGroup(g,f,min,max,...)
+	if Auxiliary.GCheckClassifier then
+		return Group.CheckSubGroupClassified(g,f,min,max,...)
+	end
+	return Group.CheckSubGroupLegacy(g,f,min,max,...)
 end
 ---
 ---@param g Group
@@ -1377,7 +1317,7 @@ end
 ---@param max? integer
 ---@param ... any
 ---@return Group
-function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
+function Group.SelectSubGroupLegacy(g,tp,f,cancelable,min,max,...)
 	Auxiliary.SubGroupCaptured=Group.CreateGroup()
 	min=min or 1
 	max=max or #g
@@ -1393,29 +1333,11 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 	while #sg<max do
 		local cg=Group.CreateGroup()
 		local eg=g:Clone()
-		local classified={}
 		for c in Auxiliary.Next(g-sg) do
 			if not cg:IsContains(c) then
-				local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
-				local entry
-				if cls then
-					entry=classified[cls]
-				end
-				if entry~=nil then
-					if entry.res then
-						Auxiliary.MergeClassifiedCaptured(cg,entry,c)
-					else
-						eg:RemoveCard(c)
-					end
-				elseif Auxiliary.CheckGroupRecursiveCapture(c,sg,eg,f,min,max,ext_params) then
-					if cls then
-						classified[cls]={res=true,rep=c,captured=Auxiliary.CloneCapturedSubGroup()}
-					end
+				if Auxiliary.CheckGroupRecursiveCaptureLegacy(c,sg,eg,f,min,max,ext_params) then
 					cg:Merge(Auxiliary.SubGroupCaptured)
 				else
-					if cls then
-						classified[cls]={res=false,rep=c}
-					end
 					eg:RemoveCard(c)
 				end
 			end
@@ -1443,6 +1365,80 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 		return nil
 	end
 end
+function Group.SelectSubGroupClassified(g,tp,f,cancelable,min,max,...)
+	min=min or 1
+	max=max or #g
+	local ext_params={...}
+	local sg=Group.CreateGroup()
+	local fg=Duel.GrabSelectedCard()
+	if #fg>max or min>max or #(g+fg)<min then return nil end
+	for tc in Auxiliary.Next(fg) do
+		fg:SelectUnselect(sg,tp,false,false,min,max)
+	end
+	sg:Merge(fg)
+	local buckets,card_to_bucket=Auxiliary.GetEachBuckets(g,{})
+	local memo={}
+	local counts=Auxiliary.GetEachCounts(buckets,card_to_bucket,sg)
+	local finish=(#sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil,g)))
+	while #sg<max do
+		local cg=Group.CreateGroup()
+		local class_res={}
+		for c in Auxiliary.Next(g-sg) do
+			local bucket=card_to_bucket[c]
+			local idx=bucket.index
+			local res=class_res[idx]
+			if res==nil then
+				if counts[idx]>0 then
+					sg:AddCard(c)
+					counts[idx]=counts[idx]-1
+					if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
+						res=Auxiliary.CheckSubGroupState(sg,g,buckets,counts,min,max,f,ext_params,memo)
+					else
+						res=false
+					end
+					counts[idx]=counts[idx]+1
+					sg:RemoveCard(c)
+				else
+					res=false
+				end
+				class_res[idx]=res
+			end
+			if res then
+				cg:AddCard(c)
+			end
+		end
+		cg:Sub(sg)
+		finish=(#sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil,g)))
+		if #cg==0 then break end
+		local cancel=not finish and cancelable
+		local tc=cg:SelectUnselect(sg,tp,finish,cancel,min,max)
+		if not tc then break end
+		if not fg:IsContains(tc) then
+			local idx=card_to_bucket[tc].index
+			if not sg:IsContains(tc) then
+				sg:AddCard(tc)
+				counts[idx]=counts[idx]-1
+				if #sg==max then finish=true end
+			else
+				sg:RemoveCard(tc)
+				counts[idx]=counts[idx]+1
+			end
+		elseif cancelable then
+			return nil
+		end
+	end
+	if finish then
+		return sg
+	else
+		return nil
+	end
+end
+function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
+	if Auxiliary.GCheckClassifier then
+		return Group.SelectSubGroupClassified(g,tp,f,cancelable,min,max,...)
+	end
+	return Group.SelectSubGroupLegacy(g,tp,f,cancelable,min,max,...)
+end
 ---Create a table of filter functions
 ---@param f function
 ---@param list table
@@ -1454,14 +1450,149 @@ function Auxiliary.CreateChecks(f,list)
 	end
 	return checks
 end
-function Auxiliary.GetCheckSignature(c,checks,...)
-	local sig={}
-	for i=1,#checks do
-		sig[i]=checks[i](c,...) and "1" or "0"
+function Auxiliary.GetCheckSignatureAndValid(c,checks,...)
+	if #checks==0 then
+		return nil,{}
 	end
-	return table.concat(sig)
+	local base32="0123456789abcdefghijklmnopqrstuv"
+	local sig={}
+	local valid={}
+	local chunk=0
+	local chunk_pos=0
+	for i=1,#checks do
+		local res=checks[i](c,...)
+		valid[i]=res
+		if res then
+			chunk=chunk|(1<<chunk_pos)
+		end
+		chunk_pos=chunk_pos+1
+		if chunk_pos==5 then
+			sig[#sig+1]=base32:sub(chunk+1,chunk+1)
+			chunk=0
+			chunk_pos=0
+		end
+	end
+	if chunk_pos>0 then
+		sig[#sig+1]=base32:sub(chunk+1,chunk+1)
+	end
+	return table.concat(sig),valid
 end
-function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
+function Auxiliary.GetEachStateKey(pos,counts)
+	return pos.."|"..table.concat(counts,",")
+end
+function Auxiliary.GetEachBuckets(g,checks)
+	local buckets={}
+	local classified={}
+	local card_to_bucket={}
+	local function new_bucket(c,valid)
+		local bucket={cards=Group.CreateGroup(),rep=c,valid=valid}
+		buckets[#buckets+1]=bucket
+		return bucket
+	end
+	for c in Auxiliary.Next(g) do
+		local cls=Auxiliary.GetGroupClassifier(c,g)
+		local bucket
+		local sig,valid=Auxiliary.GetCheckSignatureAndValid(c,checks)
+		if cls~=nil then
+			if #checks>0 then
+				local by_sig=classified[cls]
+				if by_sig then
+					bucket=by_sig[sig]
+				end
+				if not bucket then
+					bucket=new_bucket(c,valid)
+					if not by_sig then
+						by_sig={}
+						classified[cls]=by_sig
+					end
+					by_sig[sig]=bucket
+				end
+			else
+				bucket=classified[cls]
+			end
+		end
+		if not bucket then
+			bucket=new_bucket(c,valid)
+			if cls~=nil and #checks==0 then
+				classified[cls]=bucket
+			end
+		end
+		bucket.cards:AddCard(c)
+		card_to_bucket[c]=bucket
+	end
+	return buckets,card_to_bucket
+end
+function Auxiliary.GetEachCounts(buckets,card_to_bucket,sg)
+	local counts={}
+	for i,bucket in ipairs(buckets) do
+		counts[i]=#bucket.cards
+		bucket.index=i
+	end
+	for c in Auxiliary.Next(sg) do
+		local bucket=card_to_bucket[c]
+		if bucket then
+			counts[bucket.index]=counts[bucket.index]-1
+		end
+	end
+	return counts
+end
+function Auxiliary.GetSubGroupStateKey(size,counts)
+	return size.."|"..table.concat(counts,",")
+end
+function Auxiliary.CheckSubGroupState(sg,g,buckets,counts,min,max,f,ext_params,memo)
+	local key=Auxiliary.GetSubGroupStateKey(#sg,counts)
+	local cached=memo[key]
+	if cached~=nil then
+		return cached
+	end
+	local res=(#sg>=min and #sg<=max and f(sg,table.unpack(ext_params))
+		and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil,g)))
+	if not res and #sg<max then
+		for i,bucket in ipairs(buckets) do
+			if counts[i]>0 then
+				local c=bucket.rep
+				sg:AddCard(c)
+				counts[i]=counts[i]-1
+				if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
+					res=Auxiliary.CheckSubGroupState(sg,g,buckets,counts,min,max,f,ext_params,memo)
+				end
+				counts[i]=counts[i]+1
+				sg:RemoveCard(c)
+				if res then break end
+			end
+		end
+	end
+	memo[key]=res
+	return res
+end
+function Auxiliary.CheckSubGroupEachState(sg,g,buckets,counts,pos,f,ext_params,memo)
+	local key=Auxiliary.GetEachStateKey(pos,counts)
+	local cached=memo[key]
+	if cached~=nil then
+		return cached
+	end
+	local res=false
+	for i,bucket in ipairs(buckets) do
+		if counts[i]>0 and bucket.valid[pos] then
+			local c=bucket.rep
+			sg:AddCard(c)
+			counts[i]=counts[i]-1
+			if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
+				if pos==#buckets[1].valid then
+					res=f(sg,table.unpack(ext_params))
+				else
+					res=Auxiliary.CheckSubGroupEachState(sg,g,buckets,counts,pos+1,f,ext_params,memo)
+				end
+			end
+			counts[i]=counts[i]+1
+			sg:RemoveCard(c)
+			if res then break end
+		end
+	end
+	memo[key]=res
+	return res
+end
+function Auxiliary.CheckGroupRecursiveEachLegacy(c,sg,g,f,checks,ext_params)
 	if not checks[1+#sg](c) then
 		return false
 	end
@@ -1474,24 +1605,7 @@ function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 	if #sg==#checks then
 		res=f(sg,table.unpack(ext_params))
 	else
-		local eg=g:Clone()
-		local classified={}
-		for tc in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(tc,sg,eg)
-			if not cls then
-				res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
-			else
-				local entry=classified[cls]
-				if entry~=nil then
-					res=entry
-				else
-					res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
-					classified[cls]=res
-				end
-			end
-			if res then break end
-			eg:RemoveCard(tc)
-		end
+		res=g:IsExists(Auxiliary.CheckGroupRecursiveEachLegacy,1,sg,sg,g,f,checks,ext_params)
 	end
 	sg:RemoveCard(c)
 	return res
@@ -1502,30 +1616,28 @@ end
 ---@param f? function
 ---@param ... any
 ---@return boolean
-function Group.CheckSubGroupEach(g,checks,f,...)
+function Group.CheckSubGroupEachLegacy(g,checks,f,...)
 	if f==nil then f=Auxiliary.TRUE end
 	if #g<#checks then return false end
 	local ext_params={...}
 	local sg=Group.CreateGroup()
-	local eg=g:Clone()
-	local classified={}
-	for c in Auxiliary.Next(g-sg) do
-		local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
-		if not cls then
-			if Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params) then return true end
-		else
-			local entry=classified[cls]
-			if entry~=nil then
-				if entry then return true end
-			else
-				entry=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
-				classified[cls]=entry
-				if entry then return true end
-			end
-		end
-		eg:RemoveCard(c)
+	return g:IsExists(Auxiliary.CheckGroupRecursiveEachLegacy,1,sg,sg,g,f,checks,ext_params)
+end
+function Group.CheckSubGroupEachClassified(g,checks,f,...)
+	if f==nil then f=Auxiliary.TRUE end
+	if #g<#checks then return false end
+	local ext_params={...}
+	local buckets,card_to_bucket=Auxiliary.GetEachBuckets(g,checks)
+	local sg=Group.CreateGroup()
+	local counts=Auxiliary.GetEachCounts(buckets,card_to_bucket,sg)
+	local memo={}
+	return Auxiliary.CheckSubGroupEachState(sg,g,buckets,counts,1,f,ext_params,memo)
+end
+function Group.CheckSubGroupEach(g,checks,f,...)
+	if Auxiliary.GCheckClassifier then
+		return Group.CheckSubGroupEachClassified(g,checks,f,...)
 	end
-	return false
+	return Group.CheckSubGroupEachLegacy(g,checks,f,...)
 end
 ---
 ---@param g Group
@@ -1535,7 +1647,7 @@ end
 ---@param f? function
 ---@param ... any
 ---@return Group
-function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
+function Group.SelectSubGroupEachLegacy(g,tp,checks,cancelable,f,...)
 	if cancelable==nil then cancelable=false end
 	if f==nil then f=Auxiliary.TRUE end
 	local ct=#checks
@@ -1543,29 +1655,7 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 	local sg=Group.CreateGroup()
 	local finish=false
 	while #sg<ct do
-		local cg=Group.CreateGroup()
-		local eg=g:Clone()
-		local classified={}
-		for c in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(c,sg,eg)
-			local res
-			if not cls then
-				res=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
-			else
-				local entry=classified[cls]
-				if entry~=nil then
-					res=entry
-				else
-					res=Auxiliary.CheckGroupRecursiveEach(c,sg,eg,f,checks,ext_params)
-					classified[cls]=res
-				end
-			end
-			if res then
-				cg:AddCard(c)
-			else
-				eg:RemoveCard(c)
-			end
-		end
+		local cg=g:Filter(Auxiliary.CheckGroupRecursiveEachLegacy,sg,sg,g,f,checks,ext_params)
 		if #cg==0 then break end
 		local tc=cg:SelectUnselect(sg,tp,false,cancelable,ct,ct)
 		if not tc then break end
@@ -1581,6 +1671,78 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 	else
 		return nil
 	end
+end
+function Group.SelectSubGroupEachClassified(g,tp,checks,cancelable,f,...)
+	if cancelable==nil then cancelable=false end
+	if f==nil then f=Auxiliary.TRUE end
+	local ct=#checks
+	local ext_params={...}
+	local sg=Group.CreateGroup()
+	local buckets,card_to_bucket=Auxiliary.GetEachBuckets(g,checks)
+	local memo={}
+	local counts=Auxiliary.GetEachCounts(buckets,card_to_bucket,sg)
+	local initial_counts={}
+	for i=1,#counts do
+		initial_counts[i]=counts[i]
+	end
+	local finish=false
+	while #sg<ct do
+		local cg=Group.CreateGroup()
+		local class_res={}
+		for c in Auxiliary.Next(g-sg) do
+			local bucket=card_to_bucket[c]
+			local idx=bucket.index
+			local res=class_res[idx]
+			if res==nil then
+				if counts[idx]>0 and bucket.valid[1+#sg] then
+					sg:AddCard(c)
+					counts[idx]=counts[idx]-1
+					if not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,c,g) then
+						if #sg==ct then
+							res=f(sg,table.unpack(ext_params))
+						else
+							res=Auxiliary.CheckSubGroupEachState(sg,g,buckets,counts,#sg+1,f,ext_params,memo)
+						end
+					else
+						res=false
+					end
+					counts[idx]=counts[idx]+1
+					sg:RemoveCard(c)
+				else
+					res=false
+				end
+				class_res[idx]=res
+			end
+			if res then
+				cg:AddCard(c)
+			end
+		end
+		if #cg==0 then break end
+		local tc=cg:SelectUnselect(sg,tp,false,cancelable,ct,ct)
+		if not tc then break end
+		local idx=card_to_bucket[tc].index
+		if not sg:IsContains(tc) then
+			sg:AddCard(tc)
+			counts[idx]=counts[idx]-1
+			if #sg==ct then finish=true end
+		else
+			sg:Clear()
+			for i=1,#counts do
+				counts[i]=initial_counts[i]
+			end
+		end
+	end
+	if finish then
+		return sg
+	else
+		return nil
+	end
+end
+function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
+	if Auxiliary.GCheckClassifier then
+		return Group.SelectSubGroupEachClassified(g,tp,checks,cancelable,f,...)
+	end
+	return Group.SelectSubGroupEachLegacy(g,tp,checks,cancelable,f,...)
 end
 --for effects that player usually select card from field, avoid showing panel
 function Auxiliary.SelectCardFromFieldFirst(tp,f,player,s,o,min,max,ex,...)

--- a/utility.lua
+++ b/utility.lua
@@ -51,13 +51,21 @@ end
 ---Subgroup check function
 ---@param sg Group
 ---@param c Card|nil
----@param g Group
 ---@return boolean
-Auxiliary.GCheckAdditional=function(sg,c,g) return true end
+Auxiliary.GCheckAdditional=function(sg,c) return true end
 ---Subgroup classifier function used to deduplicate equivalent branches on the same recursion layer
 ---@param c Card
 ---@return any
 Auxiliary.GCheckClassifier=nil
+function Auxiliary.WithSubGroupContext(additional,classifier,f)
+	Auxiliary.GCheckAdditional=additional
+	Auxiliary.GCheckClassifier=classifier
+	local ok,res=pcall(f)
+	Auxiliary.GCheckClassifier=nil
+	Auxiliary.GCheckAdditional=nil
+	if not ok then error(res,0) end
+	return res
+end
 
 --the table of xyz number
 Auxiliary.xyz_number={}
@@ -1126,66 +1134,44 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end
+function Auxiliary.MakeDistinctCheck(getter)
+	local group_check=function(g)
+		return g:GetClassCount(getter)==#g
+	end
+	local additional_check=function(sg,c)
+		return group_check(sg)
+	end
+	local classifier=function(c)
+		return getter(c)
+	end
+	return group_check,additional_check,classifier
+end
+function Auxiliary.MakeDistinctCheckSpec(getter)
+	local check,additional,classifier=Auxiliary.MakeDistinctCheck(getter)
+	return check,{check=check,additional=additional,classifier=classifier}
+end
+function Auxiliary.CheckSubGroupByCheckSpec(g,spec,f,min,max,...)
+	return Auxiliary.WithSubGroupContext(spec.additional,spec.classifier,function()
+		return g:CheckSubGroup(f or spec.check,min,max,...)
+	end)
+end
+function Auxiliary.SelectSubGroupByCheckSpec(g,tp,spec,f,cancelable,min,max,...)
+	return Auxiliary.WithSubGroupContext(spec.additional,spec.classifier,function()
+		return g:SelectSubGroup(tp,f or spec.check,cancelable,min,max,...)
+	end)
+end
 --check for cards with different names
-function Auxiliary.dncheck(g)
-	return g:GetClassCount(Card.GetCode)==#g
-end
-function Auxiliary.dncheck_additional(sg,c,g)
-	return Auxiliary.dncheck(sg)
-end
-function Auxiliary.dncheck_classifier(c)
-	return c:GetCode()
-end
+Auxiliary.dncheck,Auxiliary.dncheck_spec=Auxiliary.MakeDistinctCheckSpec(Card.GetCode)
 --check for cards with different levels
-function Auxiliary.dlvcheck(g)
-	return g:GetClassCount(Card.GetLevel)==#g
-end
-function Auxiliary.dlvcheck_additional(sg,c,g)
-	return Auxiliary.dlvcheck(sg)
-end
-function Auxiliary.dlvcheck_classifier(c)
-	return c:GetLevel()
-end
+Auxiliary.dlvcheck,Auxiliary.dlvcheck_spec=Auxiliary.MakeDistinctCheckSpec(Card.GetLevel)
 --check for cards with different ranks
-function Auxiliary.drkcheck(g)
-	return g:GetClassCount(Card.GetRank)==#g
-end
-function Auxiliary.drkcheck_additional(sg,c,g)
-	return Auxiliary.drkcheck(sg)
-end
-function Auxiliary.drkcheck_classifier(c)
-	return c:GetRank()
-end
+Auxiliary.drkcheck,Auxiliary.drkcheck_spec=Auxiliary.MakeDistinctCheckSpec(Card.GetRank)
 --check for cards with different links
-function Auxiliary.dlkcheck(g)
-	return g:GetClassCount(Card.GetLink)==#g
-end
-function Auxiliary.dlkcheck_additional(sg,c,g)
-	return Auxiliary.dlkcheck(sg)
-end
-function Auxiliary.dlkcheck_classifier(c)
-	return c:GetLink()
-end
+Auxiliary.dlkcheck,Auxiliary.dlkcheck_spec=Auxiliary.MakeDistinctCheckSpec(Card.GetLink)
 --check for cards with different attributes
-function Auxiliary.dabcheck(g)
-	return g:GetClassCount(Card.GetAttribute)==#g
-end
-function Auxiliary.dabcheck_additional(sg,c,g)
-	return Auxiliary.dabcheck(sg)
-end
-function Auxiliary.dabcheck_classifier(c)
-	return c:GetAttribute()
-end
+Auxiliary.dabcheck,Auxiliary.dabcheck_spec=Auxiliary.MakeDistinctCheckSpec(Card.GetAttribute)
 --check for cards with different races
-function Auxiliary.drccheck(g)
-	return g:GetClassCount(Card.GetRace)==#g
-end
-function Auxiliary.drccheck_additional(sg,c,g)
-	return Auxiliary.drccheck(sg)
-end
-function Auxiliary.drccheck_classifier(c)
-	return c:GetRace()
-end
+Auxiliary.drccheck,Auxiliary.drccheck_spec=Auxiliary.MakeDistinctCheckSpec(Card.GetRace)
 --check for group with 2 cards, each card match f with a1/a2 as argument
 function Auxiliary.gfcheck(g,f,a1,a2)
 	if #g~=2 then return false end
@@ -1237,39 +1223,69 @@ function Auxiliary.GetGroupClassifier(c)
 	if not Auxiliary.GCheckClassifier then return nil end
 	return Auxiliary.GCheckClassifier(c)
 end
+function Auxiliary.CheckGroupRecursiveStep(sg,rg,eg,f,min,max,ext_params)
+	local classified={}
+	for tc in Auxiliary.Next(rg) do
+		local cls=Auxiliary.GetGroupClassifier(tc)
+		local res
+		if not cls then
+			res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
+		else
+			local entry=classified[cls]
+			if entry~=nil then
+				res=entry
+			else
+				res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
+				classified[cls]=res
+			end
+		end
+		if res then return true end
+		eg:RemoveCard(tc)
+	end
+	return false
+end
 function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
 	sg:AddCard(c)
-	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c,g) then
+	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c) then
 		sg:RemoveCard(c)
 		return false
 	end
 	local res=(#sg>=min and #sg<=max and f(sg,table.unpack(ext_params)))
 	if not res and #sg<max then
-		local eg=g:Clone()
-		local classified={}
-		for tc in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(tc)
-			if not cls then
-				res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
-			else
-				local entry=classified[cls]
-				if entry~=nil then
-					res=entry
-				else
-					res=Auxiliary.CheckGroupRecursive(tc,sg,eg,f,min,max,ext_params)
-					classified[cls]=res
-				end
-			end
-			if res then break end
-			eg:RemoveCard(tc)
-		end
+		local rg=g-sg
+		-- `rg` is already fresh, but `aux.Next(rg)` must iterate a stable group while
+		-- sibling pruning mutates a separate working pool. Mutating the iterated group
+		-- would dirty the core iterator and break `GetNext`.
+		local eg=rg:Clone()
+		res=Auxiliary.CheckGroupRecursiveStep(sg,rg,eg,f,min,max,ext_params)
 	end
 	sg:RemoveCard(c)
 	return res
 end
+function Auxiliary.CheckGroupRecursiveCaptureStep(sg,rg,eg,f,min,max,ext_params)
+	local classified={}
+	for tc in Auxiliary.Next(rg) do
+		local cls=Auxiliary.GetGroupClassifier(tc)
+		local res
+		if not cls then
+			res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
+		else
+			local entry=classified[cls]
+			if entry~=nil then
+				res=entry
+			else
+				res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
+				classified[cls]=res
+			end
+		end
+		if res then return true end
+		eg:RemoveCard(tc)
+	end
+	return false
+end
 function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
 	sg:AddCard(c)
-	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c,g) then
+	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c) then
 		sg:RemoveCard(c)
 		return false
 	end
@@ -1279,24 +1295,12 @@ function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
 		Auxiliary.SubGroupCaptured:Merge(sg)
 	else
 		if #sg<max then
-			local eg=g:Clone()
-			local classified={}
-			for tc in Auxiliary.Next(g-sg) do
-				local cls=Auxiliary.GetGroupClassifier(tc)
-				if not cls then
-					res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
-				else
-					local entry=classified[cls]
-					if entry~=nil then
-						res=entry
-					else
-						res=Auxiliary.CheckGroupRecursiveCapture(tc,sg,eg,f,min,max,ext_params)
-						classified[cls]=res
-					end
-				end
-				if res then break end
-				eg:RemoveCard(tc)
-			end
+			local rg=g-sg
+			-- `rg` is already fresh, but `aux.Next(rg)` must iterate a stable group while
+			-- sibling pruning mutates a separate working pool. Mutating the iterated group
+			-- would dirty the core iterator and break `GetNext`.
+			local eg=rg:Clone()
+			res=Auxiliary.CheckGroupRecursiveCaptureStep(sg,rg,eg,f,min,max,ext_params)
 		else
 			res=false
 		end
@@ -1318,8 +1322,8 @@ function Group.CheckSubGroup(g,f,min,max,...)
 	local ext_params={...}
 	local sg=Duel.GrabSelectedCard()
 	if #sg>max or #(g+sg)<min then return false end
-	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,nil,g)) then return false end
-	if #sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil,g)) then return true end
+	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,nil)) then return false end
+	if #sg>=min and #sg<=max and f(sg,...) and (not Auxiliary.GCheckAdditional or Auxiliary.GCheckAdditional(sg,nil)) then return true end
 	local eg=g:Clone()
 	local classified={}
 	for c in Auxiliary.Next(g-sg) do
@@ -1435,12 +1439,33 @@ function Auxiliary.GetCheckMask(c,checks,...)
 	end
 	return mask
 end
+function Auxiliary.CheckGroupRecursiveEachStep(sg,rg,eg,f,checks,ext_params)
+	local classified={}
+	for tc in Auxiliary.Next(rg) do
+		local cls=Auxiliary.GetGroupClassifier(tc)
+		local res
+		if not cls then
+			res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
+		else
+			local entry=classified[cls]
+			if entry~=nil then
+				res=entry
+			else
+				res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
+				classified[cls]=res
+			end
+		end
+		if res then return true end
+		eg:RemoveCard(tc)
+	end
+	return false
+end
 function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 	if not checks[1+#sg](c) then
 		return false
 	end
 	sg:AddCard(c)
-	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c,g) then
+	if Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,c) then
 		sg:RemoveCard(c)
 		return false
 	end
@@ -1448,24 +1473,12 @@ function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 	if #sg==#checks then
 		res=f(sg,table.unpack(ext_params))
 	else
-		local eg=g:Clone()
-		local classified={}
-		for tc in Auxiliary.Next(g-sg) do
-			local cls=Auxiliary.GetGroupClassifier(tc)
-			if not cls then
-				res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
-			else
-				local entry=classified[cls]
-				if entry~=nil then
-					res=entry
-				else
-					res=Auxiliary.CheckGroupRecursiveEach(tc,sg,eg,f,checks,ext_params)
-					classified[cls]=res
-				end
-			end
-			if res then break end
-			eg:RemoveCard(tc)
-		end
+		local rg=g-sg
+		-- `rg` is already fresh, but `aux.Next(rg)` must iterate a stable group while
+		-- sibling pruning mutates a separate working pool. Mutating the iterated group
+		-- would dirty the core iterator and break `GetNext`.
+		local eg=rg:Clone()
+		res=Auxiliary.CheckGroupRecursiveEachStep(sg,rg,eg,f,checks,ext_params)
 	end
 	sg:RemoveCard(c)
 	return res

--- a/utility.lua
+++ b/utility.lua
@@ -1150,13 +1150,15 @@ function Auxiliary.MakeDistinctCheckSpec(getter)
 	return check,{check=check,additional=additional,classifier=classifier}
 end
 function Auxiliary.CheckSubGroupByCheckSpec(g,spec,f,min,max,...)
+	local ext_params={...}
 	return Auxiliary.WithSubGroupContext(spec.additional,spec.classifier,function()
-		return g:CheckSubGroup(f or spec.check,min,max,...)
+		return g:CheckSubGroup(f or spec.check,min,max,table.unpack(ext_params))
 	end)
 end
 function Auxiliary.SelectSubGroupByCheckSpec(g,tp,spec,f,cancelable,min,max,...)
+	local ext_params={...}
 	return Auxiliary.WithSubGroupContext(spec.additional,spec.classifier,function()
-		return g:SelectSubGroup(tp,f or spec.check,cancelable,min,max,...)
+		return g:SelectSubGroup(tp,f or spec.check,cancelable,min,max,table.unpack(ext_params))
 	end)
 end
 --check for cards with different names


### PR DESCRIPTION
## Summary
- refactor subgroup recursive selection/check logic and same-layer dedupe around subgroup contexts and check specs
- simplify ritual additional-hook handling and align custom ATK-based ritual checks with the same subgroup/classifier model
- migrate card-script subgroup call sites to the new chain syntax and keep the branch aligned with origin/patch-gcheck-classifier

## API changes
- `GCheckAdditional` now receives only the current subgroup; utility-side subgroup checks no longer pass the selected card or branch pool
- `RGCheckAdditional` now receives only the current ritual material subgroup; ritual-side additional checks no longer pass a singled-out material
- distinct-check helpers are exposed as `*_check` plus `*_check_spec` pairs (for example `dncheck` / `dncheck_spec`), and the older exported `*_additional` / `*_classifier` helpers are removed from the utility surface
- subgroup classifiers are now treated as `classifier(c)` values and are precomputed once per subgroup context
- subgroup contexts now also have chain syntax sugar on `Group`, e.g. `g:WithSubGroupContext(additional, classifier):CheckSubGroup(...)` and `g:WithCheckSpec(spec):SelectSubGroup(...)`

## Notes
- includes merge/resolution commits needed to integrate origin/patch-gcheck-classifier and follow-up local fixes
- touched ritual helper cards and subgroup-helper card scripts were updated to match the subgroup-only hook contract and the new chain-style subgroup API
