### PR TITLE
Fix クリスタルクリアウィング・オーバー・シンクロ・ドラゴン

### DIFF
--- a/c84343351.lua
+++ b/c84343351.lua
@@ -1,6 +1,7 @@
 --クリスタルクリアウィング・オーバー・シンクロ・ドラゴン
 local s,id,o=GetID()
 function s.initial_effect(c)
+	aux.AddMaterialCodeList(c,82044279)
 	c:EnableReviveLimit()
 	--material
 	aux.AddSynchroMixProcedure(c,aux.FilterBoolFunction(Card.IsCode,82044279),nil,nil,aux.Tuner(nil),1,99,s.syncheck)


### PR DESCRIPTION
修复使用「同调超车」时不能展示该卡而把墓地的「幻透翼同调龙」加入手卡或特殊召唤的问题。

チューナー２体以上またはSモンスターのチューナー＋「クリアウィング・シンクロ・ドラゴン」
https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=20776