### PR TITLE
Fix シューティング・ソニック

### DIFF
--- a/c30983281.lua
+++ b/c30983281.lua
@@ -88,7 +88,8 @@ function c30983281.sccost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ect1=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
 	local ect2=aux.ExtraDeckSummonCountLimit and Duel.IsPlayerAffectedByEffect(tp,92345028)
 		and aux.ExtraDeckSummonCountLimit[tp]
-	local g=Duel.GetMatchingGroup(c30983281.excostfilter,tp,LOCATION_GRAVE,0,nil,tp)
+	local g=Group.CreateGroup()
+	if c:IsSetCard(0xa3) then g:Merge(Duel.GetMatchingGroup(c30983281.excostfilter,tp,LOCATION_GRAVE,0,nil,tp)) end
 	local chkrel=c:IsReleasable()
 	local chknotrel=g:GetCount()>0
 	local b1=chkrel and Duel.IsExistingMatchingCard(c30983281.scfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,chkrel,nil)

--- a/c44508094.lua
+++ b/c44508094.lua
@@ -39,8 +39,10 @@ function c44508094.excostfilter(c,tp)
 	return c:IsAbleToRemoveAsCost() and c:IsHasEffect(84012625,tp)
 end
 function c44508094.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local g=Duel.GetMatchingGroup(c44508094.excostfilter,tp,LOCATION_GRAVE,0,nil,tp)
-	if e:GetHandler():IsReleasable() then g:AddCard(e:GetHandler()) end
+	local g=Group.CreateGroup()
+	local c=e:GetHandler()
+	if c:IsReleasable() then g:AddCard(c) end
+	if c:IsSetCard(0xa3) then g:Merge(Duel.GetMatchingGroup(s.excostfilter,tp,LOCATION_GRAVE,0,nil,tp)) end
 	if chk==0 then return #g>0 end
 	local tc
 	if #g>1 then

--- a/c76636978.lua
+++ b/c76636978.lua
@@ -48,9 +48,10 @@ function s.excostfilter(c,tp)
 	return c:IsAbleToRemoveAsCost() and c:IsHasEffect(84012625,tp)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local g=Duel.GetMatchingGroup(s.excostfilter,tp,LOCATION_GRAVE,0,nil,tp)
+	local g=Group.CreateGroup()
 	local c=e:GetHandler()
-	if c:IsReleasable() and c:IsSetCard(0xa3) then g:AddCard(c) end
+	if c:IsReleasable() then g:AddCard(c) end
+	if c:IsSetCard(0xa3) then g:Merge(Duel.GetMatchingGroup(s.excostfilter,tp,LOCATION_GRAVE,0,nil,tp)) end
 	if chk==0 then return #g>0 end
 	local tc
 	if #g>1 then


### PR DESCRIPTION
Fix when stardust monster's name is changed, they should not be able to apply the effect of ``シューティング・ソニック``.