### PR TITLE
Fix 原質の炉心貫通

### DIFF
--- a/c66059345.lua
+++ b/c66059345.lua
@@ -108,10 +108,10 @@ function s.ovtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.ovop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetDecktopGroup(tp,1)
-	if g:GetCount()==1 then
+	if Duel.IsExistingMatchingCard(s.matfilter,tp,LOCATION_MZONE,0,1,nil) and g:GetCount()==1 then
 		local tc=g:GetFirst()
 		Duel.DisableShuffleCheck()
-		if Duel.IsExistingMatchingCard(s.matfilter,tp,LOCATION_MZONE,0,1,nil) and tc:IsCanOverlay() then
+		if tc:IsCanOverlay() then
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 			local sg=Duel.SelectMatchingCard(tp,s.matfilter,tp,LOCATION_MZONE,0,1,1,nil)
 			Duel.HintSelection(sg)


### PR DESCRIPTION
When you control no ``マテリアクトル`` xyz monster, deck top should not be sent to GY.