### PR TITLE
Fix War Rock Meteoragon

### DIFF
--- a/c10497636.lua
+++ b/c10497636.lua
@@ -62,13 +62,21 @@ function c10497636.discon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c10497636.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ac=e:GetLabelObject()
-	if chk==0 then return true end
+	if chk==0 then
+		if not ac:IsFaceup() then return false end
+		local code=ac:GetOriginalCodeRule()
+		local labels={Duel.GetFlagEffectLabel(0,10497636)}
+		for _,v in ipairs(labels) do
+			if v==code then return false end
+		end
+		return true
+	end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,ac,1,0,0)
 end
 function c10497636.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local ac=e:GetLabelObject()
-	if ac:IsFaceup() and ac:IsRelateToBattle() and ac:IsCanBeDisabledByEffect(e) and ac:IsControler(1-tp) then
+	if ac:IsFaceup() and ac:IsRelateToBattle() and ac:IsControler(1-tp) then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_DISABLE)
@@ -94,6 +102,7 @@ function c10497636.disop(e,tp,eg,ep,ev,re,r,rp)
 		e4:SetLabelObject(ac)
 		e4:SetReset(RESET_PHASE+PHASE_END)
 		Duel.RegisterEffect(e4,tp)
+		Duel.RegisterFlagEffect(0,10497636,RESET_PHASE+PHASE_END,0,1,ac:GetOriginalCodeRule())
 	end
 end
 function c10497636.distg2(e,c)


### PR DESCRIPTION
Fixed disable check.
Q.
「ウォークライ・メテオラゴン」と「デブリ・ドラゴン」の効果によって特殊召喚された「ダンディライオン」はフィールドに存在する。自分の「ウォークライ・メテオラゴン」が無効化された相手の「デブリ・ドラゴン」と戦闘を行う攻撃宣言時、「ウォークライ・メテオラゴン」の「②：このカードが相手モンスターと戦闘を行う攻撃宣言時に発動できる。このターン、その相手モンスター及びその相手モンスターと元々のカード名が同じモンスターの効果は無効化される。」効果を発動する事はできますか？
自分の「ウォークライ・メテオラゴン」が相手の「青眼の白龍」と戦闘を行う攻撃宣言時、「ウォークライ・メテオラゴン」の「②：このカードが相手モンスターと戦闘を行う攻撃宣言時に発動できる。このターン、その相手モンスター及びその相手モンスターと元々のカード名が同じモンスターの効果は無効化される。」効果を発動する事はできますか？
A.
どちらの場合でも、発動できます。
Q.
自分フィールドが「ウォークライ・メテオラゴン」のみ、相手フィールドが「キラー・トマト」2体のみ。自分の「ウォークライ・メテオラゴン」が相手の1体目の「キラー・トマト」と戦闘を行う攻撃宣言時、その「②：このカードが相手モンスターと戦闘を行う攻撃宣言時に発動できる。このターン、その相手モンスター及びその相手モンスターと元々のカード名が同じモンスターの効果は無効化される。」効果を発動しました。
その「ウォークライ・メテオラゴン」が③の効果で、２回までモンスターに攻撃できる。その「ウォークライ・メテオラゴン」が相手の2体目の「キラー・トマト」と戦闘を行う攻撃宣言時、その②の効果を発動できますか？
A.
ご質問の場合、２体目の「キラー・トマト」への攻撃宣言時には「ウォークライ・メテオラゴン」の『②』の効果は発動できません。