### PR TITLE
Fix ウィッチクラフト・ドレーピング&ウィッチクラフト・コラボレーション

### DIFF
--- a/c10805153.lua
+++ b/c10805153.lua
@@ -26,7 +26,7 @@ function c10805153.filter(c)
 	return c:IsSetCard(0x128) and c:IsFaceup() and not c:IsHasEffect(EFFECT_EXTRA_ATTACK)
 end
 function c10805153.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc,exc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c10805153.filter(chkc) end
 	if chk==0 then return aux.bpcon(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.IsExistingTarget(c10805153.filter,tp,LOCATION_MZONE,0,1,exc) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)

--- a/c56894757.lua
+++ b/c56894757.lua
@@ -30,7 +30,7 @@ function c56894757.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x128)
 end
 function c56894757.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc,exc)
-	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and chkc:IsAbleToHand() end
+	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and chkc:IsAbleToHand() and c56894757.filter(chkc) end
 	if chk==0 then return Duel.IsExistingMatchingCard(c56894757.cfilter,tp,LOCATION_MZONE,0,1,exc)
 		and Duel.IsExistingTarget(Card.IsAbleToHand,tp,0,LOCATION_SZONE,1,nil) end
 	local ct=Duel.GetMatchingGroupCount(c56894757.cfilter,tp,LOCATION_MZONE,0,nil)


### PR DESCRIPTION
修复这类卡被「暗迁士 黑蛇晶」的效果进行对象转移时，能选择不符合要求的卡片的问题。

「魔女术的合作」：以自己场上1只「魔女术」怪兽为对象才能发动。
「魔女术的裁剪」：以最多有自己场上的「魔女术」怪兽数量的对方场上的魔法·陷阱卡为对象才能发动。