### PR TITLE
Fix 超銀河眼の光子龍－フォトン・ハウリング

### DIFF
--- a/c28331069.lua
+++ b/c28331069.lua
@@ -90,6 +90,7 @@ function s.disop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.Release(rg,REASON_EFFECT)~=0 then
 		local g=Duel.GetMatchingGroup(aux.NegateAnyFilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,aux.ExceptThisCard(e))
 		for tc in aux.Next(g) do
+			Duel.NegateRelatedChain(tc,RESET_TURN_SET)
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)


### PR DESCRIPTION
对方场上c1发动怪兽效果，我方c2连锁「幽鬼兔」，对方连锁c3「超银河眼光子龙-光子咆哮」②效果，结算时c1的怪兽效果能正常适用。

修复以上反馈的问题。