### PR TITLE
Fix フィリアス・ディアベル

### DIFF
--- a/c78293584.lua
+++ b/c78293584.lua
@@ -61,7 +61,6 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 		for tc in aux.Next(g) do
 			local e1=Effect.CreateEffect(c)
 			e1:SetType(EFFECT_TYPE_SINGLE)
-			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 			e1:SetCode(EFFECT_UPDATE_ATTACK)
 			e1:SetValue(500)
 			e1:SetReset(RESET_EVENT+RESETS_STANDARD)


### PR DESCRIPTION
Fix the issue where  ⌈フィリアス・ディアベル⌋ would prevent ⌈ディアベル⌋ monsters from being affected by other continuous attack-changing effects under specific situations.