### PR TITLE
Fix c90091224 subgroup selection hang, add aux.SelectSameCount

### DIFF
--- a/c14529511.lua
+++ b/c14529511.lua
@@ -61,12 +61,12 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SendtoGrave(g,REASON_EFFECT)
 end
 function s.desfilter(c,e)
-	return c:IsFaceup() and c:IsSetCard(0x1a1) and (not e or c:IsCanBeEffectTarget(e))
+	return c:IsFaceup() and c:IsSetCard(0x1a1) and c:IsCanBeEffectTarget(e)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
 	local g1=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_MZONE,0,nil,e)
 	local g2=Duel.GetMatchingGroup(Card.IsCanBeEffectTarget,tp,0,LOCATION_ONFIELD,nil,e)
-	if chkc then return false end
 	if chk==0 then return Duel.GetFlagEffect(tp,id)==0
 		and #g1>0 and #g2>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)

--- a/c14529511.lua
+++ b/c14529511.lua
@@ -60,22 +60,19 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK+LOCATION_EXTRA,0,3,3,nil)
 	Duel.SendtoGrave(g,REASON_EFFECT)
 end
-function s.desfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x1a1)
+function s.desfilter(c,e)
+	return c:IsFaceup() and c:IsSetCard(0x1a1) and (not e or c:IsCanBeEffectTarget(e))
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local g1=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_MZONE,0,nil,e)
+	local g2=Duel.GetMatchingGroup(Card.IsCanBeEffectTarget,tp,0,LOCATION_ONFIELD,nil,e)
 	if chkc then return false end
 	if chk==0 then return Duel.GetFlagEffect(tp,id)==0
-		and Duel.IsExistingTarget(s.desfilter,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.IsExistingTarget(nil,tp,0,LOCATION_ONFIELD,1,nil) end
-	local ct=Duel.GetMatchingGroupCount(Card.IsCanBeEffectTarget,tp,0,LOCATION_ONFIELD,nil,e)
+		and #g1>0 and #g2>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g1=Duel.SelectTarget(tp,s.desfilter,tp,LOCATION_MZONE,0,1,ct,nil)
-	local ect=g1:GetCount()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g2=Duel.SelectTarget(tp,nil,tp,0,LOCATION_ONFIELD,ect,ect,nil)
-	g1:Merge(g2)
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g1,g1:GetCount(),0,0)
+	local sg=aux.SelectSameCount(tp,g1,g2)
+	Duel.SetTargetCard(sg)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 	Duel.RegisterFlagEffect(tp,id,RESET_CHAIN,EFFECT_FLAG_OATH,1)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)

--- a/c34433770.lua
+++ b/c34433770.lua
@@ -33,51 +33,13 @@ end
 function s.mfilter(c,e)
 	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x1115) and (not e or c:IsCanBeEffectTarget(e))
 end
-function s.fselect(g)
-	return g:FilterCount(s.sfilter,nil)==g:FilterCount(s.mfilter,nil)
-end
-function s.SelectSub(g1,g2,tp)
-	local max=math.min(#g1,#g2)
-	local sg1=Group.CreateGroup()
-	local sg2=Group.CreateGroup()
-	local sg=sg1+sg2
-	local fg=g1+g2
-	local finish=false
-	while true do
-		finish=#sg1==#sg2 and #sg>0
-		local sc=fg:SelectUnselect(sg,tp,finish,finish,2,max*2)
-		if not sc then break end
-		if sg:IsContains(sc) then
-			if g1:IsContains(sc) then
-				sg1:RemoveCard(sc)
-			else
-				sg2:RemoveCard(sc)
-			end
-		else
-			if g1:IsContains(sc) then
-				sg1:AddCard(sc)
-			else
-				sg2:AddCard(sc)
-			end
-		end
-		sg=sg1+sg2
-		fg=g1+g2-sg
-		if #sg1>=max then
-			fg=fg-g1
-		end
-		if #sg2>=max then
-			fg=fg-g2
-		end
-	end
-	return sg
-end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
 	local g1=Duel.GetMatchingGroup(s.sfilter,tp,LOCATION_GRAVE,0,nil,e)
 	local g2=Duel.GetMatchingGroup(s.mfilter,tp,LOCATION_GRAVE,0,nil,e)
 	if chkc then return false end
 	if chk==0 then return g1:GetCount()>0 and g2:GetCount()>0 end
-	local tg=s.SelectSub(g1,g2,tp)
+	local tg=aux.SelectSameCount(g1,g2,tp,1,64)
 	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,tg,#tg,0,0)
 end

--- a/c34433770.lua
+++ b/c34433770.lua
@@ -39,7 +39,7 @@ function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g2=Duel.GetMatchingGroup(s.mfilter,tp,LOCATION_GRAVE,0,nil,e)
 	if chkc then return false end
 	if chk==0 then return g1:GetCount()>0 and g2:GetCount()>0 end
-	local tg=aux.SelectSameCount(g1,g2,tp,1,64)
+	local tg=aux.SelectSameCount(tp,g1,g2)
 	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,tg,#tg,0,0)
 end

--- a/c34433770.lua
+++ b/c34433770.lua
@@ -34,11 +34,11 @@ function s.mfilter(c,e)
 	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x1115) and (not e or c:IsCanBeEffectTarget(e))
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local c=e:GetHandler()
+	if chkc then return false end
 	local g1=Duel.GetMatchingGroup(s.sfilter,tp,LOCATION_GRAVE,0,nil,e)
 	local g2=Duel.GetMatchingGroup(s.mfilter,tp,LOCATION_GRAVE,0,nil,e)
-	if chkc then return false end
 	if chk==0 then return g1:GetCount()>0 and g2:GetCount()>0 end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 	local tg=aux.SelectSameCount(tp,g1,g2)
 	Duel.SetTargetCard(tg)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,tg,#tg,0,0)

--- a/c79561872.lua
+++ b/c79561872.lua
@@ -41,14 +41,17 @@ end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_FUSION)
 end
-function s.thfilter(c,e,tp)
+function s.thfilter1(c,e)
 	return c:IsCanBeEffectTarget(e) and c:IsAbleToHand()
-		and (c:IsControler(1-tp) or c:IsFaceup() and c:IsSetCard(0x146))
+		and c:IsFaceup() and c:IsSetCard(0x146)
+end
+function s.thfilter2(c,e)
+	return c:IsCanBeEffectTarget(e) and c:IsAbleToHand()
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local g1=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_ONFIELD,0,nil,e,tp)
-	local g2=Duel.GetMatchingGroup(s.thfilter,tp,0,LOCATION_ONFIELD,nil,e,tp)
 	if chkc then return false end
+	local g1=Duel.GetMatchingGroup(s.thfilter1,tp,LOCATION_ONFIELD,0,nil,e)
+	local g2=Duel.GetMatchingGroup(s.thfilter2,tp,0,LOCATION_ONFIELD,nil,e)
 	if chk==0 then return #g1>0 and #g2>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
 	local sg=aux.SelectSameCount(tp,g1,g2)

--- a/c79561872.lua
+++ b/c79561872.lua
@@ -45,15 +45,13 @@ function s.thfilter(c,e,tp)
 	return c:IsCanBeEffectTarget(e) and c:IsAbleToHand()
 		and (c:IsControler(1-tp) or c:IsFaceup() and c:IsSetCard(0x146))
 end
-function s.gcheck(g,tp)
-	return g:FilterCount(Card.IsControler,nil,tp)==g:FilterCount(Card.IsControler,nil,1-tp)
-end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e,tp)
+	local g1=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_ONFIELD,0,nil,e,tp)
+	local g2=Duel.GetMatchingGroup(s.thfilter,tp,0,LOCATION_ONFIELD,nil,e,tp)
 	if chkc then return false end
-	if chk==0 then return g:CheckSubGroup(s.gcheck,2,2,tp) end
+	if chk==0 then return #g1>0 and #g2>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local sg=g:SelectSubGroup(tp,s.gcheck,false,2,g:GetCount(),tp)
+	local sg=aux.SelectSameCount(tp,g1,g2)
 	Duel.SetTargetCard(sg)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,sg,sg:GetCount(),0,0)
 end

--- a/c90091224.lua
+++ b/c90091224.lua
@@ -32,15 +32,37 @@ end
 function s.desfilter(c,e)
 	return c:IsCanBeEffectTarget(e)
 end
-function s.gcheck(g,tp)
-	return g:FilterCount(Card.IsControler,nil,tp)==g:FilterCount(Card.IsControler,nil,1-tp)
+function s.gcheck(g)
+	local ct=#g
+	if ct%2~=0 then return false end
+	local diff=0
+	for tc in aux.Next(g) do
+		ct=ct-1
+		diff=diff+(tc:IsControler(0) and 1 or -1)
+		if math.abs(diff)>ct then return false end
+	end
+	return diff==0
+end
+function s.gcheckadd(g)
+	local ct=#g
+	local diff=0
+	for tc in aux.Next(g) do
+		ct=ct-1
+		diff=diff+(tc:IsControler(0) and 1 or -1)
+		if math.abs(diff)>ct+1 then return false end
+	end
+	return math.abs(diff)<=1
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e)
 	if chkc then return false end
-	if chk==0 then return g:CheckSubGroup(s.gcheck,2,2,tp) end
+	if chk==0 then
+		return g:IsExists(Card.IsControler,1,nil,tp) and g:IsExists(Card.IsControler,1,nil,1-tp)
+	end
+	aux.GCheckAdditional=s.gcheckadd
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local sg=g:SelectSubGroup(tp,s.gcheck,false,2,24,tp)
+	local sg=g:SelectSubGroup(tp,s.gcheck,false,2,24)
+	aux.GCheckAdditional=nil
 	Duel.SetTargetCard(sg)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 end

--- a/c90091224.lua
+++ b/c90091224.lua
@@ -32,49 +32,6 @@ end
 function s.desfilter(c,e)
 	return c:IsCanBeEffectTarget(e)
 end
-function s.selecttg(g,tp)
-	local g1=Group.CreateGroup()
-	local g2=Group.CreateGroup()
-	for tc in aux.Next(g) do
-		if tc:IsControler(tp) then
-			g1:AddCard(tc)
-		else
-			g2:AddCard(tc)
-		end
-	end
-	local max=math.min(#g1,#g2,12)
-	local sg1=Group.CreateGroup()
-	local sg2=Group.CreateGroup()
-	local sg=sg1+sg2
-	local fg=g1+g2
-	while true do
-		local finish=#sg1==#sg2 and #sg>0
-		local tc=fg:SelectUnselect(sg,tp,finish,false,2,max*2)
-		if not tc then break end
-		if sg:IsContains(tc) then
-			if g1:IsContains(tc) then
-				sg1:RemoveCard(tc)
-			else
-				sg2:RemoveCard(tc)
-			end
-		else
-			if g1:IsContains(tc) then
-				sg1:AddCard(tc)
-			else
-				sg2:AddCard(tc)
-			end
-		end
-		sg=sg1+sg2
-		fg=g1+g2-sg
-		if #sg1>=max then
-			fg=fg-g1
-		end
-		if #sg2>=max then
-			fg=fg-g2
-		end
-	end
-	return sg
-end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e)
 	if chkc then return false end
@@ -82,7 +39,9 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		return g:IsExists(Card.IsControler,1,nil,tp) and g:IsExists(Card.IsControler,1,nil,1-tp)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local sg=s.selecttg(g,tp)
+	local g1=g:Filter(Card.IsControler,nil,tp)
+	local g2=g:Filter(Card.IsControler,nil,1-tp)
+	local sg=aux.SelectSameCount(g1,g2,tp,1,13)
 	Duel.SetTargetCard(sg)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 end

--- a/c90091224.lua
+++ b/c90091224.lua
@@ -33,14 +33,14 @@ function s.desfilter(c,e)
 	return c:IsCanBeEffectTarget(e)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local g=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e)
 	if chkc then return false end
+	local g=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e)
 	if chk==0 then
 		return g:IsExists(Card.IsControler,1,nil,tp) and g:IsExists(Card.IsControler,1,nil,1-tp)
 	end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g1=g:Filter(Card.IsControler,nil,tp)
 	local g2=g:Filter(Card.IsControler,nil,1-tp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local sg=aux.SelectSameCount(tp,g1,g2)
 	Duel.SetTargetCard(sg)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)

--- a/c90091224.lua
+++ b/c90091224.lua
@@ -41,7 +41,7 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g1=g:Filter(Card.IsControler,nil,tp)
 	local g2=g:Filter(Card.IsControler,nil,1-tp)
-	local sg=aux.SelectSameCount(g1,g2,tp,1,13)
+	local sg=aux.SelectSameCount(tp,g1,g2)
 	Duel.SetTargetCard(sg)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 end

--- a/c90091224.lua
+++ b/c90091224.lua
@@ -32,26 +32,48 @@ end
 function s.desfilter(c,e)
 	return c:IsCanBeEffectTarget(e)
 end
-function s.gcheck(g)
-	local ct=#g
-	if ct%2~=0 then return false end
-	local diff=0
+function s.selecttg(g,tp)
+	local g1=Group.CreateGroup()
+	local g2=Group.CreateGroup()
 	for tc in aux.Next(g) do
-		ct=ct-1
-		diff=diff+(tc:IsControler(0) and 1 or -1)
-		if math.abs(diff)>ct then return false end
+		if tc:IsControler(tp) then
+			g1:AddCard(tc)
+		else
+			g2:AddCard(tc)
+		end
 	end
-	return diff==0
-end
-function s.gcheckadd(g)
-	local ct=#g
-	local diff=0
-	for tc in aux.Next(g) do
-		ct=ct-1
-		diff=diff+(tc:IsControler(0) and 1 or -1)
-		if math.abs(diff)>ct+1 then return false end
+	local max=math.min(#g1,#g2,12)
+	local sg1=Group.CreateGroup()
+	local sg2=Group.CreateGroup()
+	local sg=sg1+sg2
+	local fg=g1+g2
+	while true do
+		local finish=#sg1==#sg2 and #sg>0
+		local tc=fg:SelectUnselect(sg,tp,finish,false,2,max*2)
+		if not tc then break end
+		if sg:IsContains(tc) then
+			if g1:IsContains(tc) then
+				sg1:RemoveCard(tc)
+			else
+				sg2:RemoveCard(tc)
+			end
+		else
+			if g1:IsContains(tc) then
+				sg1:AddCard(tc)
+			else
+				sg2:AddCard(tc)
+			end
+		end
+		sg=sg1+sg2
+		fg=g1+g2-sg
+		if #sg1>=max then
+			fg=fg-g1
+		end
+		if #sg2>=max then
+			fg=fg-g2
+		end
 	end
-	return math.abs(diff)<=1
+	return sg
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=Duel.GetMatchingGroup(s.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil,e)
@@ -59,10 +81,8 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then
 		return g:IsExists(Card.IsControler,1,nil,tp) and g:IsExists(Card.IsControler,1,nil,1-tp)
 	end
-	aux.GCheckAdditional=s.gcheckadd
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local sg=g:SelectSubGroup(tp,s.gcheck,false,2,24)
-	aux.GCheckAdditional=nil
+	local sg=s.selecttg(g,tp)
 	Duel.SetTargetCard(sg)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
 end

--- a/c91703676.lua
+++ b/c91703676.lua
@@ -26,9 +26,9 @@ function s.filter(c,e)
 	return c:IsSetCard(0x81) and c:IsFaceup() and c:IsCanBeEffectTarget(e)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
 	local g1=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,0,nil,e)
 	local g2=Duel.GetMatchingGroup(Card.IsCanBeEffectTarget,tp,0,LOCATION_ONFIELD,nil,e)
-	if chkc then return false end
 	if chk==0 then return #g1>0 and #g2>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local sg=aux.SelectSameCount(tp,g1,g2)

--- a/c91703676.lua
+++ b/c91703676.lua
@@ -26,18 +26,14 @@ function s.filter(c,e)
 	return c:IsSetCard(0x81) and c:IsFaceup() and c:IsCanBeEffectTarget(e)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local g1=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,0,nil,e)
+	local g2=Duel.GetMatchingGroup(Card.IsCanBeEffectTarget,tp,0,LOCATION_ONFIELD,nil,e)
 	if chkc then return false end
-	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil)
-		and Duel.IsExistingTarget(s.filter,tp,LOCATION_MZONE,0,1,nil,e) end
-	local ct1=Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_MZONE,0,nil,e)
-	local ct2=Duel.GetMatchingGroupCount(Card.IsCanBeEffectTarget,tp,0,LOCATION_ONFIELD,nil,e)
-	local mc=math.min(ct1,ct2)
+	if chk==0 then return #g1>0 and #g2>0 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g1=Duel.SelectTarget(tp,s.filter,tp,LOCATION_MZONE,0,1,mc,nil,e)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g2=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,#g1,#g1,nil)
-	g1:Merge(g2)
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g1,#g1,0,0)
+	local sg=aux.SelectSameCount(tp,g1,g2)
+	Duel.SetTargetCard(sg)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,#sg,0,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)

--- a/utility.lua
+++ b/utility.lua
@@ -1429,10 +1429,17 @@ function Auxiliary.SelectSameCount(g1,g2,tp,min,max,except)
 	max=math.min(max or math.min(#g1,#g2),#g1,#g2)
 	if min>max then return nil end
 	local sg=Group.CreateGroup()
-	local fg=g1+g2
 	local ct1=0
 	local ct2=0
 	while true do
+		local fg=Group.CreateGroup()
+		if ct1<max then
+			fg:Merge(g1)
+		end
+		if ct2<max then
+			fg:Merge(g2)
+		end
+		fg:Sub(sg)
 		local finish=ct1==ct2 and ct1>=min and ct1<=max
 		local tc=fg:SelectUnselect(sg,tp,finish,false,min*2,max*2)
 		if not tc then break end
@@ -1451,14 +1458,7 @@ function Auxiliary.SelectSameCount(g1,g2,tp,min,max,except)
 				ct2=ct2+1
 			end
 		end
-		fg=Group.CreateGroup()
-		if ct1<max then
-			fg:Merge(g1)
-		end
-		if ct2<max then
-			fg:Merge(g2)
-		end
-		fg:Sub(sg)
+		if ct1==max and ct2==max then break end
 	end
 	return sg
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1419,7 +1419,7 @@ end
 ---@param min? integer Cards to select from each group, minimum
 ---@param max? integer Cards to select from each group, maximum
 ---@param except? Card|Group
----@return Group|nil
+---@return Group
 function Auxiliary.SelectSameCount(tp,g1,g2,min,max,except)
 	if except then
 		g1=g1-except

--- a/utility.lua
+++ b/utility.lua
@@ -1411,6 +1411,55 @@ function Auxiliary.SelectTargetFromFieldFirst(tp,f,player,s,o,min,max,ex,...)
 	end
 	return Duel.SelectTarget(tp,f,player,s,o,min,max,ex,table.unpack(ext_params))
 end
+---
+---Select the same number of cards from each group.
+---@param g1 Group
+---@param g2 Group
+---@param tp integer
+---@param min integer Cards to select from each group, minimum
+---@param max integer Cards to select from each group, maximum
+---@param except? Card|Group
+---@return Group|nil
+function Auxiliary.SelectSameCount(g1,g2,tp,min,max,except)
+	if except then
+		g1=g1-except
+		g2=g2-except
+	end
+	min=min or 1
+	max=math.min(max or math.min(#g1,#g2),#g1,#g2)
+	if min>max then return nil end
+	local sg1=Group.CreateGroup()
+	local sg2=Group.CreateGroup()
+	local sg=sg1+sg2
+	local fg=g1+g2
+	while true do
+		local finish=#sg1==#sg2 and #sg1>=min and #sg1<=max
+		local tc=fg:SelectUnselect(sg,tp,finish,false,min*2,max*2)
+		if not tc then break end
+		if sg:IsContains(tc) then
+			if g1:IsContains(tc) then
+				sg1:RemoveCard(tc)
+			else
+				sg2:RemoveCard(tc)
+			end
+		else
+			if g1:IsContains(tc) then
+				sg1:AddCard(tc)
+			else
+				sg2:AddCard(tc)
+			end
+		end
+		sg=sg1+sg2
+		fg=g1+g2-sg
+		if #sg1>=max then
+			fg=fg-g1
+		end
+		if #sg2>=max then
+			fg=fg-g2
+		end
+	end
+	return sg
+end
 --condition of "negate activation and banish"
 function Auxiliary.nbcon(tp,re)
 	local rc=re:GetHandler()

--- a/utility.lua
+++ b/utility.lua
@@ -1413,14 +1413,14 @@ function Auxiliary.SelectTargetFromFieldFirst(tp,f,player,s,o,min,max,ex,...)
 end
 ---
 ---Select the same number of cards from each group.
+---@param tp integer
 ---@param g1 Group
 ---@param g2 Group
----@param tp integer
 ---@param min integer Cards to select from each group, minimum
 ---@param max integer Cards to select from each group, maximum
 ---@param except? Card|Group
 ---@return Group|nil
-function Auxiliary.SelectSameCount(g1,g2,tp,min,max,except)
+function Auxiliary.SelectSameCount(tp,g1,g2,min,max,except)
 	if except then
 		g1=g1-except
 		g2=g2-except

--- a/utility.lua
+++ b/utility.lua
@@ -1428,35 +1428,37 @@ function Auxiliary.SelectSameCount(g1,g2,tp,min,max,except)
 	min=min or 1
 	max=math.min(max or math.min(#g1,#g2),#g1,#g2)
 	if min>max then return nil end
-	local sg1=Group.CreateGroup()
-	local sg2=Group.CreateGroup()
-	local sg=sg1+sg2
+	local sg=Group.CreateGroup()
 	local fg=g1+g2
+	local ct1=0
+	local ct2=0
 	while true do
-		local finish=#sg1==#sg2 and #sg1>=min and #sg1<=max
+		local finish=ct1==ct2 and ct1>=min and ct1<=max
 		local tc=fg:SelectUnselect(sg,tp,finish,false,min*2,max*2)
 		if not tc then break end
 		if sg:IsContains(tc) then
+			sg:RemoveCard(tc)
 			if g1:IsContains(tc) then
-				sg1:RemoveCard(tc)
+				ct1=ct1-1
 			else
-				sg2:RemoveCard(tc)
+				ct2=ct2-1
 			end
 		else
+			sg:AddCard(tc)
 			if g1:IsContains(tc) then
-				sg1:AddCard(tc)
+				ct1=ct1+1
 			else
-				sg2:AddCard(tc)
+				ct2=ct2+1
 			end
 		end
-		sg=sg1+sg2
-		fg=g1+g2-sg
-		if #sg1>=max then
-			fg=fg-g1
+		fg=Group.CreateGroup()
+		if ct1<max then
+			fg:Merge(g1)
 		end
-		if #sg2>=max then
-			fg=fg-g2
+		if ct2<max then
+			fg:Merge(g2)
 		end
+		fg:Sub(sg)
 	end
 	return sg
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1426,7 +1426,7 @@ function Auxiliary.SelectSameCount(g1,g2,tp,min,max,except)
 		g2=g2-except
 	end
 	min=min or 1
-	max=math.min(max or math.min(#g1,#g2),#g1,#g2)
+	max=math.min(max or 127,#g1,#g2)
 	if min>max then return nil end
 	local sg=Group.CreateGroup()
 	local ct1=0

--- a/utility.lua
+++ b/utility.lua
@@ -1416,8 +1416,8 @@ end
 ---@param tp integer
 ---@param g1 Group
 ---@param g2 Group
----@param min integer Cards to select from each group, minimum
----@param max integer Cards to select from each group, maximum
+---@param min? integer Cards to select from each group, minimum
+---@param max? integer Cards to select from each group, maximum
 ---@param except? Card|Group
 ---@return Group|nil
 function Auxiliary.SelectSameCount(tp,g1,g2,min,max,except)


### PR DESCRIPTION
## Summary

Fixes the target selection logic for `c90091224.lua`.

The previous implementation used `CheckSubGroup` / `SelectSubGroup` with a final equality check, which could trigger an extremely large subgroup search when many cards were targetable on the field. In practice, this could make the server hang and eventually crash while processing a replay or duel state.

This change replaces the recursive subgroup search with an explicit `SelectUnselect` loop, inspired by the selection pattern used in `c34433770.lua`.

The new selection flow:

- splits valid targets by controller
- allows finishing only when both players have the same number of selected cards
- preserves the original selection experience, including selecting several cards from one side before selecting matching cards from the other side
- keeps the original total target cap of 24 by allowing up to 12 cards from each player