### PR TITLE
Fix ミミグル・フォーク

### DIFF
--- a/c19338434.lua
+++ b/c19338434.lua
@@ -49,8 +49,10 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ChangePosition(tc,pos)
 	else
 		Duel.SendtoGrave(tc,REASON_EFFECT)
-		Duel.BreakEffect()
-		Duel.Draw(p,2,REASON_EFFECT)
+		if tc:IsLocation(LOCATION_GRAVE) then
+			Duel.BreakEffect()
+			Duel.Draw(p,2,REASON_EFFECT)
+		end
 	end
 end
 function s.thfilter(c)


### PR DESCRIPTION
修复以下问题：「大宇宙」适用中，「迷拟宝箱鬼·岔路」的①的第2个『●』适用时，仍会抽卡。
（●作为对象的怪兽送去墓地。那之后，这个效果送去墓地的怪兽的持有者抽2张）