### PR TITLE
Fix 閃刀姫＝ゼロ

### DIFF
--- a/c76072561.lua
+++ b/c76072561.lua
@@ -9,7 +9,7 @@ function s.initial_effect(c)
 	--link limit
 	local e0=Effect.CreateEffect(c)
 	e0:SetType(EFFECT_TYPE_SINGLE)
-	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e0:SetCode(EFFECT_CANNOT_BE_LINK_MATERIAL)
 	e0:SetValue(1)
 	c:RegisterEffect(e0)


### PR DESCRIPTION
修复「霸王眷龙 凶饿毒」的效果获得「闪刀姬=零露」的效果时，应不会适用“这张卡不能作为连接素材”的问题。