### PR TITLE
fix vararg loss caused by nil holes

### DIFF
--- a/procedure.lua
+++ b/procedure.lua
@@ -40,15 +40,15 @@ end
 
 --Synchro Summon
 function Auxiliary.Tuner(f,...)
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	return	function(target,syncard)
-				return target:IsTuner(syncard) and (not f or f(target,table.unpack(ext_params)))
+				return target:IsTuner(syncard) and (not f or f(target,table.unpack(ext_params,1,ext_params.n)))
 			end
 end
 function Auxiliary.NonTuner(f,...)
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	return	function(target,syncard)
-				return target:IsNotTuner(syncard) and (not f or f(target,table.unpack(ext_params)))
+				return target:IsNotTuner(syncard) and (not f or f(target,table.unpack(ext_params,1,ext_params.n)))
 			end
 end
 ---Synchro monster, 1 tuner + min to max monsters

--- a/utility.lua
+++ b/utility.lua
@@ -446,27 +446,27 @@ function Auxiliary.EnableChangeCode(c,code,location,condition)
 	return e1
 end
 function Auxiliary.TargetEqualFunction(f,value,...)
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	return	function(effect,target)
-				return f(target,table.unpack(ext_params))==value
+				return f(target,table.unpack(ext_params,1,ext_params.n))==value
 			end
 end
 function Auxiliary.TargetBoolFunction(f,...)
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	return	function(effect,target)
-				return f(target,table.unpack(ext_params))
+				return f(target,table.unpack(ext_params,1,ext_params.n))
 			end
 end
 function Auxiliary.FilterEqualFunction(f,value,...)
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	return	function(target)
-				return f(target,table.unpack(ext_params))==value
+				return f(target,table.unpack(ext_params,1,ext_params.n))==value
 			end
 end
 function Auxiliary.FilterBoolFunction(f,...)
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	return	function(target)
-				return f(target,table.unpack(ext_params))
+				return f(target,table.unpack(ext_params,1,ext_params.n))
 			end
 end
 function Auxiliary.GetValueType(v)

--- a/utility.lua
+++ b/utility.lua
@@ -1377,8 +1377,7 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 end
 --for effects that player usually select card from field, avoid showing panel
 function Auxiliary.SelectCardFromFieldFirst(tp,f,player,s,o,min,max,ex,...)
-	local ext_params={...}
-	local g=Duel.GetMatchingGroup(f,player,s,o,ex,table.unpack(ext_params))
+	local g=Duel.GetMatchingGroup(f,player,s,o,ex,...)
 	local fg=g:Filter(Card.IsOnField,nil)
 	g:Sub(fg)
 	if #fg>=min and #g>0 then
@@ -1391,11 +1390,10 @@ function Auxiliary.SelectCardFromFieldFirst(tp,f,player,s,o,min,max,ex,...)
 			Duel.Hint(HINT_SELECTMSG,tp,last_hint)
 		end
 	end
-	return Duel.SelectMatchingCard(tp,f,player,s,o,min,max,ex,table.unpack(ext_params))
+	return Duel.SelectMatchingCard(tp,f,player,s,o,min,max,ex,...)
 end
 function Auxiliary.SelectTargetFromFieldFirst(tp,f,player,s,o,min,max,ex,...)
-	local ext_params={...}
-	local g=Duel.GetMatchingGroup(f,player,s,o,ex,table.unpack(ext_params)):Filter(Card.IsCanBeEffectTarget,nil)
+	local g=Duel.GetMatchingGroup(f,player,s,o,ex,...):Filter(Card.IsCanBeEffectTarget,nil)
 	local fg=g:Filter(Card.IsOnField,nil)
 	g:Sub(fg)
 	if #fg>=min and #g>0 then
@@ -1409,7 +1407,7 @@ function Auxiliary.SelectTargetFromFieldFirst(tp,f,player,s,o,min,max,ex,...)
 			Duel.Hint(HINT_SELECTMSG,tp,last_hint)
 		end
 	end
-	return Duel.SelectTarget(tp,f,player,s,o,min,max,ex,table.unpack(ext_params))
+	return Duel.SelectTarget(tp,f,player,s,o,min,max,ex,...)
 end
 ---
 ---Select the same number of cards from each group.

--- a/utility.lua
+++ b/utility.lua
@@ -1199,7 +1199,7 @@ function Auxiliary.CheckGroupRecursive(c,sg,g,f,min,max,ext_params)
 		sg:RemoveCard(c)
 		return false
 	end
-	local res=(#sg>=min and #sg<=max and f(sg,table.unpack(ext_params)))
+	local res=(#sg>=min and #sg<=max and f(sg,table.unpack(ext_params,1,ext_params.n)))
 		or (#sg<max and g:IsExists(Auxiliary.CheckGroupRecursive,1,sg,sg,g,f,min,max,ext_params))
 	sg:RemoveCard(c)
 	return res
@@ -1210,7 +1210,7 @@ function Auxiliary.CheckGroupRecursiveCapture(c,sg,g,f,min,max,ext_params)
 		sg:RemoveCard(c)
 		return false
 	end
-	local res=#sg>=min and #sg<=max and f(sg,table.unpack(ext_params))
+	local res=#sg>=min and #sg<=max and f(sg,table.unpack(ext_params,1,ext_params.n))
 	if res then
 		Auxiliary.SubGroupCaptured:Clear()
 		Auxiliary.SubGroupCaptured:Merge(sg)
@@ -1231,7 +1231,7 @@ function Group.CheckSubGroup(g,f,min,max,...)
 	min=min or 1
 	max=max or #g
 	if min>max then return false end
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	local sg=Duel.GrabSelectedCard()
 	if #sg>max or #(g+sg)<min then return false end
 	if #sg==max and (not f(sg,...) or Auxiliary.GCheckAdditional and not Auxiliary.GCheckAdditional(sg,nil,g)) then return false end
@@ -1256,7 +1256,7 @@ function Group.SelectSubGroup(g,tp,f,cancelable,min,max,...)
 	Auxiliary.SubGroupCaptured=Group.CreateGroup()
 	min=min or 1
 	max=max or #g
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	local sg=Group.CreateGroup()
 	local fg=Duel.GrabSelectedCard()
 	if #fg>max or min>max or #(g+fg)<min then return nil end
@@ -1322,7 +1322,7 @@ function Auxiliary.CheckGroupRecursiveEach(c,sg,g,f,checks,ext_params)
 	end
 	local res
 	if #sg==#checks then
-		res=f(sg,table.unpack(ext_params))
+		res=f(sg,table.unpack(ext_params,1,ext_params.n))
 	else
 		res=g:IsExists(Auxiliary.CheckGroupRecursiveEach,1,sg,sg,g,f,checks,ext_params)
 	end
@@ -1338,7 +1338,7 @@ end
 function Group.CheckSubGroupEach(g,checks,f,...)
 	if f==nil then f=Auxiliary.TRUE end
 	if #g<#checks then return false end
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	local sg=Group.CreateGroup()
 	return g:IsExists(Auxiliary.CheckGroupRecursiveEach,1,sg,sg,g,f,checks,ext_params)
 end
@@ -1354,7 +1354,7 @@ function Group.SelectSubGroupEach(g,tp,checks,cancelable,f,...)
 	if cancelable==nil then cancelable=false end
 	if f==nil then f=Auxiliary.TRUE end
 	local ct=#checks
-	local ext_params={...}
+	local ext_params=table.pack(...)
 	local sg=Group.CreateGroup()
 	local finish=false
 	while #sg<ct do


### PR DESCRIPTION
**Problem:**

Lua's table implementation has a well-known limitation when handling tables containing `nil` values, commonly referred to as the "hole" problem. Using `#` to get the length of a table with holes (e.g., `#{9,nil,8}`) results in **undefined behavior** — the result may be `1` or `3`. Since `table.unpack` uses `#` by default, it may return either `1` or `3` elements accordingly.

In practice, this can lead to the issue in #3041. In `c30998403.lua`, `nil` values are passed as varargs to `CheckSubGroup` and then forwarded to `aux.gffcheck`. During this process, some arguments may be lost.

**Solution:**

Use `table.pack` (introduced in Lua 5.2) to preserve the original vararg count and avoid issues caused by holes. When unpacking, explicitly pass the stored count (`table.unpack(t, 1, t.n)`), and avoid unnecessary pack/unpack operations where possible.

The `FusionProcMix` family of functions is left unchanged for now, since their varargs are not expected to contain `nil` values semantically.