### PR TITLE
Fix 海皇精 アビスライン

### DIFF
--- a/c17080584.lua
+++ b/c17080584.lua
@@ -28,14 +28,14 @@ function s.initial_effect(c)
 	e2:SetOperation(s.drop)
 	c:RegisterEffect(e2)
 end
-function s.cfilter(c,tp)
+function s.cfilter(c)
 	return c:IsSetCard(0x77,0x74)
 end
 function s.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	e:SetLabel(100)
-	if chk==0 then return c:IsReleasable() and Duel.CheckReleaseGroupEx(tp,s.cfilter,1,REASON_COST,true,c,tp) end
-	local g=Duel.SelectReleaseGroupEx(tp,s.cfilter,1,1,REASON_COST,true,c,tp)
+	if chk==0 then return c:IsReleasable() and Duel.CheckReleaseGroupEx(tp,s.cfilter,1,REASON_COST,true,c) end
+	local g=Duel.SelectReleaseGroupEx(tp,s.cfilter,1,1,REASON_COST,true,c)
 	g:AddCard(c)
 	Duel.Release(g,REASON_COST)
 end

--- a/c17080584.lua
+++ b/c17080584.lua
@@ -29,7 +29,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.cfilter(c,tp)
-	return c:IsSetCard(0x77,0x74) and Duel.GetMZoneCount(tp,c)>0
+	return c:IsSetCard(0x77,0x74)
 end
 function s.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()


### PR DESCRIPTION
修复①效果在自己场上没有可用的怪兽区域且场上不存在可以解放的「海皇」或「水精鳞」怪兽时应也能选择解放手卡的「海皇」或「水精鳞」怪兽来发动的问题。 
效果处理的描述为“加入手卡或特殊召唤”，并不必需要检查是否存在可用怪兽区域。

效果描述：把手卡的这张卡和自己的手卡·场上1只「海皇」怪兽或「水精鳞」怪兽解放才能发动。从卡组选1只7星的鱼族·海龙族·水族怪兽加入手卡或特殊召唤。
 （手札のこのカードと自分の手札・フィールドの、「海皇」モンスターか「水精鱗」モンスター１体をリリースして発動できる。デッキからレベル７の魚族・海竜族・水族モンスター１体を選び、手札に加えるか特殊召喚する。）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6661&request_locale=ja