### PR TITLE
Fix 糾罪都市－エニアポリス

### DIFF
--- a/c17621695.lua
+++ b/c17621695.lua
@@ -81,6 +81,7 @@ function s.pthop(e,tp,eg,ep,ev,re,r,rp)
 	if mg:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 		local og=mg:Select(tp,1,1,nil)
+		Duel.HintSelection(og)
 		local tc=og:GetFirst()
 		local b1=Duel.CheckLocation(tp,LOCATION_PZONE,0) or Duel.CheckLocation(tp,LOCATION_PZONE,1)
 		local b2=tc:IsAbleToHand()
@@ -92,7 +93,6 @@ function s.pthop(e,tp,eg,ep,ev,re,r,rp)
 				Duel.MoveToField(tc,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
 			end
 		else
-			Duel.HintSelection(og)
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)
 		end
 	end

--- a/c17621695.lua
+++ b/c17621695.lua
@@ -87,7 +87,7 @@ function s.pthop(e,tp,eg,ep,ev,re,r,rp)
 		local op=aux.SelectFromOptions(tp,
 			{b1,aux.Stringid(id,3),1},
 			{b2,aux.Stringid(id,4),2})
-		if op==1 then
+		if op==1 and not tc:IsImmuneToEffect(e) then
 			Duel.MoveToField(tc,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
 		else
 			Duel.HintSelection(og)

--- a/c17621695.lua
+++ b/c17621695.lua
@@ -87,8 +87,10 @@ function s.pthop(e,tp,eg,ep,ev,re,r,rp)
 		local op=aux.SelectFromOptions(tp,
 			{b1,aux.Stringid(id,3),1},
 			{b2,aux.Stringid(id,4),2})
-		if op==1 and not tc:IsImmuneToEffect(e) then
-			Duel.MoveToField(tc,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+		if op==1 then
+			if not not tc:IsImmuneToEffect(e) then
+				Duel.MoveToField(tc,tp,tp,LOCATION_PZONE,POS_FACEUP,true)
+			end
 		else
 			Duel.HintSelection(og)
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)


### PR DESCRIPTION
修复②效果在适用后，若所选择的怪兽被赋予「不受自身以外的卡发动的效果影响」（如「禁忌的圣冠」等）的效果，在选择【放置灵摆区域】的处理时应不会执行放置灵摆区处理的问题。

效果描述：自己场上的「纠罪巧」灵摆怪兽在主要阶段反转的场合才能发动。选那之内的1只回到手卡或在自己的灵摆区域放置。
 （自分フィールドの「糾罪巧」Pモンスターがメインフェイズにリバースした場合に発動できる。その内の１体を選び、手札に戻すか自分のPゾーンに置く。）

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=21950&request_locale=ja