### PR TITLE
Fix 武器庫整理

### DIFF
--- a/c49652661.lua
+++ b/c49652661.lua
@@ -15,7 +15,6 @@ function s.initial_effect(c)
 	--equip
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,1))
-	e2:SetCategory(CATEGORY_EQUIP)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_FREE_CHAIN)
 	e2:SetRange(LOCATION_GRAVE)


### PR DESCRIPTION
修复该卡应不属于「学习精灵」①效果（把持有把自身当作装备卡使用来装备效果的1张陷阱卡从卡组到自己场上盖放）适用的范围。

「武器库整理」效果描述：
①：从卡组把最多2张装备魔法卡送去墓地（同名卡最多1张）。
②：把墓地的这张卡除外，以自己场上1只表侧表示怪兽为对象才能发动。把最多2张那只怪兽可以装备的装备魔法卡从自己的手卡·墓地给那只怪兽装备（同名卡最多1张）。只要这个效果把装备魔法卡装备中，那只怪兽给与对方的战斗伤害变成一半。