### PR TITLE
Fix ヴァレット・リチャージャー

### DIFF
--- a/c5969957.lua
+++ b/c5969957.lua
@@ -47,7 +47,7 @@ end
 function c5969957.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local g=eg:Filter(c5969957.tgfilter,nil,e,tp)
 	if chkc then return g:IsContains(chkc) end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and g:GetCount()>0 end
+	if chk==0 then return Duel.GetMZoneCount(tp,c)>0 and g:GetCount()>0 end
 	local c=nil
 	if g:GetCount()>1 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)


### PR DESCRIPTION
修复此卡在怪兽区域存在，其他怪兽区域都有怪兽存在的场合，若在额外怪兽区域的自身怪兽被战斗·效果破坏的场合，应能通过解放场上的此卡来发动①效果的问题。

效果描述：从额外卡组特殊召唤的自己场上的表侧表示的暗属性怪兽被战斗·效果破坏的场合，把手卡·场上的这张卡送去墓地，以那些破坏的怪兽之内的1只为对象才能发动。原本卡名和那只怪兽不同的1只暗属性怪兽从自己墓地特殊召唤。（EXデッキから特殊召喚された自分フィールドの表側表示の闇属性モンスターが戦闘・効果で破壊された場合、手札・フィールドのこのカードを墓地へ送り、その破壊されたモンスターの内の１体を対象として発動できる。そのモンスターとは元々のカード名が異なる闇属性モンスター１体を自分の墓地から特殊召喚する。）

https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=14616