### PR TITLE
fix Mulcharmy monsters

### DIFF
--- a/c42141493.lua
+++ b/c42141493.lua
@@ -1,6 +1,7 @@
 --マルチャミー・フワロス
 local s,id,o=GetID()
 function s.initial_effect(c)
+	aux.EnableMulcharmyGlobalCheck()
 	--draw
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
@@ -13,33 +14,13 @@ function s.initial_effect(c)
 	e1:SetCost(s.drcost)
 	e1:SetOperation(s.drop)
 	c:RegisterEffect(e1)
-	Duel.AddCustomActivityCounter(id,ACTIVITY_CHAIN,s.chainfilter)
 end
 function s.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)<2
+	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetFlagEffect(tp,84192580)<=1
 end
 function s.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
-	local e3=Effect.CreateEffect(e:GetHandler())
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
-	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
-	e3:SetTargetRange(1,0)
-	e3:SetCondition(s.actcon)
-	e3:SetValue(s.aclimit)
-	e3:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e3,tp)
-end
-function s.chainfilter(re,tp,cid)
-	return not (re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2))
-end
-function s.actcon(e)
-	local tp=e:GetHandlerPlayer()
-	return Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)>1
-end
-function s.aclimit(e,re,tp)
-	return re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2)
 end
 function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c84192580.lua
+++ b/c84192580.lua
@@ -1,7 +1,8 @@
 --マルチャミー・プルリア
 local s,id,o=GetID()
 function s.initial_effect(c)
-	--
+	aux.EnableMulcharmyGlobalCheck()
+	--draw
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DRAW)
@@ -13,33 +14,13 @@ function s.initial_effect(c)
 	e1:SetCost(s.drcost)
 	e1:SetOperation(s.drop)
 	c:RegisterEffect(e1)
-	Duel.AddCustomActivityCounter(id,ACTIVITY_CHAIN,s.chainfilter)
 end
 function s.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)<2
+	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetFlagEffect(tp,84192580)<=1
 end
 function s.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
-	local e3=Effect.CreateEffect(e:GetHandler())
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
-	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
-	e3:SetTargetRange(1,0)
-	e3:SetCondition(s.actcon)
-	e3:SetValue(s.aclimit)
-	e3:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e3,tp)
-end
-function s.chainfilter(re,tp,cid)
-	return not (re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2))
-end
-function s.actcon(e)
-	local tp=e:GetHandlerPlayer()
-	return Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)>1
-end
-function s.aclimit(e,re,tp)
-	return re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2)
 end
 function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c87126721.lua
+++ b/c87126721.lua
@@ -1,6 +1,7 @@
 --マルチャミー・ニャルス
 local s,id,o=GetID()
 function s.initial_effect(c)
+	aux.EnableMulcharmyGlobalCheck()
 	--draw
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
@@ -13,33 +14,13 @@ function s.initial_effect(c)
 	e1:SetCost(s.drcost)
 	e1:SetOperation(s.drop)
 	c:RegisterEffect(e1)
-	Duel.AddCustomActivityCounter(id,ACTIVITY_CHAIN,s.chainfilter)
 end
 function s.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)<2
+	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetFlagEffect(tp,84192580)<=1
 end
 function s.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDiscardable() end
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
-	local e3=Effect.CreateEffect(e:GetHandler())
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
-	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
-	e3:SetTargetRange(1,0)
-	e3:SetCondition(s.actcon)
-	e3:SetValue(s.aclimit)
-	e3:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e3,tp)
-end
-function s.chainfilter(re,tp,cid)
-	return not (re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2))
-end
-function s.actcon(e)
-	local tp=e:GetHandlerPlayer()
-	return Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)>1
-end
-function s.aclimit(e,re,tp)
-	return re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2)
 end
 function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/utility.lua
+++ b/utility.lua
@@ -2039,3 +2039,18 @@ end
 function Auxiliary.PhantasmsSpSummonType(c)
 	return c:IsType(TYPE_SPSUMMON)
 end
+---Count for the activation of "Mulcharmy" monsters
+function Auxiliary.EnableMulcharmyGlobalCheck()
+	if Auxiliary.MulcharmyGlobalFlag then return end
+	Auxiliary.MulcharmyGlobalFlag=true
+	local ge1=Effect.GlobalEffect()
+	ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	ge1:SetCode(EVENT_CHAINING)
+	ge1:SetOperation(Auxiliary.MulcharmyGlobalCheck)
+	Duel.RegisterEffect(ge1,0)
+end
+function Auxiliary.MulcharmyGlobalCheck(e,tp,eg,ep,ev,re,r,rp)
+	if re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2) then
+		Duel.RegisterFlagEffect(ep,84192580,RESET_PHASE+PHASE_END,0,1)
+	end
+end


### PR DESCRIPTION
According to the [ruling](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7813&keyword=&tag=-1&request_locale=ja), the activation count limit of _Mulcharmy_ monsters' effects is still counted even if the activation is negated. But `ACTIVITY_CHAIN` reduces its count when the activation is negated.
