### PR TITLE
Fix Mischief of the Wolves

### DIFF
--- a/c95589901.lua
+++ b/c95589901.lua
@@ -35,7 +35,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		or Duel.IsExistingMatchingCard(s.lvfilter2,tp,LOCATION_MZONE,0,1,nil) end
 end
 function s.lvfilter(c)
-	return c:IsFaceup() and c:IsLevelAbove(3)
+	return c:IsFaceup() and c:IsLevelAbove(2)
 end
 function s.lvfilter2(c)
 	return c:IsFaceup() and c:IsLevelAbove(1)


### PR DESCRIPTION
> 自分のモンスターゾーンにレベルを持つモンスターが表側表示で存在せず、相手のモンスターゾーンにレベル２以上のモンスターが表側表示で存在しない場合には発動できません。