### PR TITLE
Fix 影霊衣の魔剣士 アバンス

### DIFF
--- a/c51618973.lua
+++ b/c51618973.lua
@@ -68,7 +68,9 @@ end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_REMOVED,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local tg=g:SelectSubGroup(tp,aux.dncheck,false,1,g:GetCount())
+	aux.GCheckAdditional=aux.dncheck
+	local tg=g:SelectSubGroup(tp,aux.TRUE,false,1,g:GetCount())
+	aux.GCheckAdditional=nil
 	if tg and tg:GetCount()>0 then
 		Duel.SendtoHand(tg,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,tg)


### PR DESCRIPTION
Fix when there're too many cards to choose, the game will stuck.

Test puzzle:
```lua
--[[message TEST]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_TEST_MODE)
Debug.SetPlayerInfo(0,2000,0,0)
Debug.SetPlayerInfo(1,2000,0,0)

Debug.AddCard(51618973,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)

Debug.AddCard(18176525,0,0,LOCATION_GRAVE,2,POS_FACEUP_ATTACK,true)
Debug.AddCard(17954937,0,0,LOCATION_GRAVE,2,POS_FACEUP_ATTACK,true)

local cid={90307777,27796375,53180020,99185129,26674724,52068432,89463537,25857246,52846880,88240999,14735698,51124303,52738610,74122412,97211663}
for _,id in ipairs(cid) do
	Debug.AddCard(id,0,0,LOCATION_REMOVED,3,POS_FACEUP_ATTACK)
	Debug.AddCard(id,0,0,LOCATION_REMOVED,3,POS_FACEUP_ATTACK)
end

Debug.ReloadFieldEnd()
```