### PR TITLE
Fix GMX - VELOX

### DIFF
--- a/c82706696.lua
+++ b/c82706696.lua
@@ -92,11 +92,9 @@ function s.desop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.SendtoGrave(hc,REASON_RULE)
 		end
 		Duel.ShuffleDeck(tp)
-		if tc:IsRelateToChain() and tc:IsOnField() then
-			Duel.BreakEffect()
-			Duel.Destroy(tc,REASON_EFFECT)
-		end
-	else
-		Duel.ConfirmDecktop(tp,dct)
+	end
+	if tc:IsRelateToChain() and tc:IsOnField() then
+		Duel.BreakEffect()
+		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
> 処理時に、自分のデッキに「GMX」モンスター及び恐竜族モンスターが１体も存在しなくなった場合、処理は何も行われません。

> 処理時に、２つの『●』の処理を行います。片方の『●』の処理を行えなくなった場合、もう片方の『●』の処理だけ行います。両方の『●』の処理を行う場合、それらは同時に行われません。

