### PR TITLE
Fix 古代の機械暗黒巨人

### DIFF
--- a/c64603182.lua
+++ b/c64603182.lua
@@ -39,9 +39,11 @@ function c64603182.thop(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
-		Duel.ShuffleHand(tp)
 		Duel.BreakEffect()
-		Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISCARD)
+		local dg=Duel.SelectMatchingCard(tp,Card.IsDiscardable,tp,LOCATION_HAND,0,1,1,nil,REASON_EFFECT)
+		Duel.ShuffleHand(tp)
+		Duel.SendtoGrave(dg,REASON_EFFECT+REASON_DISCARD)
 	end
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)


### PR DESCRIPTION
Move shufflehand after select

Test puzzle:

```lua
--[[message TEST]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_TEST_MODE)
Debug.SetPlayerInfo(0,2000,0,0)
Debug.SetPlayerInfo(1,2000,0,0)

Debug.AddCard(60953949,0,0,LOCATION_HAND,0,POS_FACEUP_ATTACK,true)

Debug.AddCard(47482043,0,0,LOCATION_SZONE,0,POS_FACEUP)

Debug.AddCard(64603182,0,0,LOCATION_GRAVE,2,POS_FACEUP_ATTACK,true)

Debug.AddCard(60953949,0,0,LOCATION_DECK,2,POS_FACEDOWN)
Debug.AddCard(43471513,0,0,LOCATION_DECK,2,POS_FACEDOWN)


Debug.ReloadFieldEnd()
```