### PR TITLE
Fix 妖精伝姫－シラユキ

### DIFF
--- a/c55623480.lua
+++ b/c55623480.lua
@@ -41,24 +41,21 @@ function c55623480.posop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ChangePosition(tc,POS_FACEDOWN_DEFENSE)
 	end
 end
-function c55623480.mainfilter(c)
-	return c:IsLocation(LOCATION_MZONE) and c:GetSequence()<=4
+function c55623480.mainfilter(c,tp)
+	return Duel.GetMZoneCount(tp,c)>0
 end
 function c55623480.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	local ct=-ft+1
 	local sg=Duel.GetMatchingGroup(Card.IsAbleToRemoveAsCost,tp,LOCATION_HAND+LOCATION_ONFIELD+LOCATION_GRAVE,0,e:GetHandler())
-	if chk==0 then return sg:GetCount()>=7 and (ft>0 or sg:IsExists(c55623480.mainfilter,ct,nil)) end
+	if chk==0 then return sg:GetCount()>=7 and (ft>0 or sg:IsExists(c55623480.mainfilter,1,nil,tp)) end
 	local g=nil
 	if ft<=0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-		g=sg:FilterSelect(tp,c55623480.mainfilter,ct,ct,nil)
-		if ct<7 then
-			sg:Sub(g)
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-			local g1=sg:Select(tp,7-ct,7-ct,nil)
-			g:Merge(g1)
-		end
+		g=sg:FilterSelect(tp,c55623480.mainfilter,1,1,nil,tp)
+		sg:Sub(g)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local g1=sg:Select(tp,6,6,nil)
+		g:Merge(g1)
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 		g=sg:Select(tp,7,7,nil)
@@ -71,7 +68,7 @@ function c55623480.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c55623480.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
+	if c:IsRelateToChain() then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
When you have no available monster zone and activate ``妖精伝姫－シラユキ``'s effect, it should not remove the only monster in zones that cannot be used on the field without other monsters.

It usually occurs in such situation:

Chain1: ``クシャトリラ・シャングリラ`` choose a zone.
Chain2: Special Summon a monster to that zone.