### PR TITLE
Fix 時空の渦

### DIFF
--- a/c42138622.lua
+++ b/c42138622.lua
@@ -1,4 +1,4 @@
---Vortex of Time
+--時空の渦
 local s,id,o=GetID()
 function s.initial_effect(c)
 	aux.AddCodeList(c,97077563)
@@ -14,9 +14,12 @@ function s.initial_effect(c)
 	e1:SetOperation(s.chop)
 	c:RegisterEffect(e1)
 end
+function s.mfilter(c)
+	return c:IsRace(RACE_ZOMBIE) and c:IsType(TYPE_MONSTER) and c:IsFaceup()
+end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_ONFIELD,0,nil)
-	local check=g:IsExists(Card.IsRace,1,nil,RACE_ZOMBIE) and g:IsExists(Card.IsCode,1,nil,97077563)
+	local check=g:IsExists(s.mfilter,1,nil) and g:IsExists(Card.IsCode,1,nil,97077563)
 	return rp==1-tp and check and
 		(re:IsActiveType(TYPE_MONSTER) or re:GetActiveType()==TYPE_SPELL or re:IsActiveType(TYPE_QUICKPLAY))
 end


### PR DESCRIPTION
Should not be able to activate when zombie monsters exist only in S&T zones(``彷徨える幽霊船`` etc).