### PR TITLE
fix incorrect use of aux.NecroValleyFilter with card argument

### DIFF
--- a/c33760966.lua
+++ b/c33760966.lua
@@ -180,7 +180,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) and aux.NecroValleyFilter(c)
+	if c:IsRelateToEffect(e) and aux.NecroValleyFilter()(c)
 		and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/c49451215.lua
+++ b/c49451215.lua
@@ -54,7 +54,7 @@ function s.settg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToChain() and aux.NecroValleyFilter(tc) then
+	if tc and tc:IsRelateToChain() and aux.NecroValleyFilter()(tc) then
 		Duel.SSet(tp,tc)
 	end
 end

--- a/c49904658.lua
+++ b/c49904658.lua
@@ -90,7 +90,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if c:IsRelateToChain() and aux.NecroValleyFilter(c) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
+	if c:IsRelateToChain() and aux.NecroValleyFilter()(c) and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)>0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)

--- a/c75493362.lua
+++ b/c75493362.lua
@@ -56,7 +56,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and aux.NecroValleyFilter(tc) and tc:IsRelateToChain() then
+	if tc and tc:IsRelateToChain() and aux.NecroValleyFilter()(tc) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/c8852158.lua
+++ b/c8852158.lua
@@ -78,7 +78,7 @@ function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToChain() and aux.NecroValleyFilter(tc) then
+	if tc:IsRelateToChain() and aux.NecroValleyFilter()(tc) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
function Auxiliary.NecroValleyFilter(f)
    return function(target,...)
        return (not f or f(target,...)) and not target:IsHasEffect(EFFECT_NECRO_VALLEY)
    end
end

aux.NecroValleyFilter takes a function and returns a function.
taking a Card object is not the supposed usage.