### PR TITLE
Fix EFFECT_DOUBLE_TRIBUTE

### DIFF
--- a/c11662742.lua
+++ b/c11662742.lua
@@ -51,7 +51,8 @@ function c11662742.initial_effect(c)
 	c:RegisterEffect(e6)
 end
 function c11662742.dtcon(e,c)
-	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c11662742.dmop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/c15090429.lua
+++ b/c15090429.lua
@@ -8,5 +8,6 @@ function c15090429.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c15090429.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_WIND)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_WIND) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c17444133.lua
+++ b/c17444133.lua
@@ -8,5 +8,6 @@ function c17444133.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c17444133.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_LIGHT)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c23087070.lua
+++ b/c23087070.lua
@@ -8,5 +8,6 @@ function c23087070.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c23087070.condition(e,c)
-	return c:IsRace(RACE_PLANT)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_PLANT) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c25163248.lua
+++ b/c25163248.lua
@@ -8,5 +8,6 @@ function c25163248.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c25163248.condition(e,c)
-	return c:IsRace(RACE_MACHINE)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_MACHINE) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c27107590.lua
+++ b/c27107590.lua
@@ -42,7 +42,8 @@ function c27107590.sprcon(e,c)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 end
 function c27107590.dtcon(e,c)
-	return c:IsSetCard(0x4a)
+	local ec=e:GetHandler()
+	return c:IsSetCard(0x4a) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c27107590.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsReleasable() end

--- a/c33750025.lua
+++ b/c33750025.lua
@@ -19,7 +19,8 @@ function c33750025.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c33750025.tricon(e,c)
-	return c:IsRace(RACE_DRAGON)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_DRAGON) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c33750025.thfilter(c)
 	return c:IsRace(RACE_DRAGON) and c:IsLevelAbove(5) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()

--- a/c36523152.lua
+++ b/c36523152.lua
@@ -36,5 +36,6 @@ function c36523152.splimit(e,c,sump,sumtype,sumpos,targetp,se)
 	return not c:IsSetCard(0x9a)
 end
 function c36523152.condition(e,c)
-	return c:IsRace(RACE_MACHINE)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_MACHINE) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c36527535.lua
+++ b/c36527535.lua
@@ -23,5 +23,6 @@ function c36527535.sprcon(e,c)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 end
 function c36527535.dtcon(e,c)
-	return c:IsSetCard(0x9f)
+	local ec=e:GetHandler()
+	return c:IsSetCard(0x9f) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c38479725.lua
+++ b/c38479725.lua
@@ -8,5 +8,6 @@ function c38479725.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c38479725.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_EARTH)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_EARTH) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c41089128.lua
+++ b/c41089128.lua
@@ -8,5 +8,6 @@ function c41089128.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c41089128.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_FIRE)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_FIRE) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c42029847.lua
+++ b/c42029847.lua
@@ -14,7 +14,8 @@ function c42029847.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c42029847.condition(e,c)
-	return c:IsRace(RACE_FAIRY)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_FAIRY) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c42029847.regop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetFlagEffect(tp,42029847)~=0 then return end

--- a/c42388271.lua
+++ b/c42388271.lua
@@ -17,7 +17,7 @@ function c42388271.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_DOUBLE_TRIBUTE)
-	e2:SetValue(1)
+	e2:SetValue(c42388271.condition)
 	c:RegisterEffect(e2)
 	--tograve
 	local e3=Effect.CreateEffect(c)
@@ -32,6 +32,10 @@ function c42388271.initial_effect(c)
 	e3:SetTarget(c42388271.tgtg)
 	e3:SetOperation(c42388271.tgop)
 	c:RegisterEffect(e3)
+end
+function c42388271.condition(e,c)
+	local ec=e:GetHandler()
+	return ec:IsFaceup() or c:GetControler()==ec:GetControler()
 end
 function c42388271.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end

--- a/c44436472.lua
+++ b/c44436472.lua
@@ -8,5 +8,6 @@ function c44436472.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c44436472.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_DARK)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_DARK) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c50354944.lua
+++ b/c50354944.lua
@@ -53,7 +53,8 @@ function c50354944.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 end
 function c50354944.condition(e,c)
-	return c:IsRace(RACE_WARRIOR)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_WARRIOR) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c50354944.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()

--- a/c53461122.lua
+++ b/c53461122.lua
@@ -8,5 +8,6 @@ function c53461122.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c53461122.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_EARTH) and c:IsType(TYPE_NORMAL)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_EARTH) and c:IsType(TYPE_NORMAL) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c54766667.lua
+++ b/c54766667.lua
@@ -8,5 +8,6 @@ function c54766667.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c54766667.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsType(TYPE_NORMAL)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsType(TYPE_NORMAL) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c564541.lua
+++ b/c564541.lua
@@ -20,7 +20,8 @@ function c564541.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c564541.dccon(e,c)
-	return c:IsRace(RACE_DRAGON)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_DRAGON) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c564541.cfilter(c)
 	return c:IsType(TYPE_MONSTER) and not c:IsRace(RACE_DRAGON)

--- a/c62729173.lua
+++ b/c62729173.lua
@@ -8,5 +8,6 @@ function c62729173.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c62729173.condition(e,c)
-	return c:IsSetCard(0x100a)
+	local ec=e:GetHandler()
+	return c:IsSetCard(0x100a) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c64450427.lua
+++ b/c64450427.lua
@@ -38,5 +38,6 @@ function c64450427.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 end
 function c64450427.dtcon(e,c)
-	return c:IsType(TYPE_PENDULUM)
+	local ec=e:GetHandler()
+	return c:IsType(TYPE_PENDULUM) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c66752837.lua
+++ b/c66752837.lua
@@ -20,7 +20,8 @@ function c66752837.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c66752837.tricon(e,c)
-	return c:IsRace(RACE_DRAGON)
+	local ec=e:GetHandler()
+	return c:IsRace(RACE_DRAGON) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c66752837.cfilter(c)
 	return c:IsRace(RACE_DRAGON) and c:GetPreviousRaceOnField()==RACE_DRAGON

--- a/c81755371.lua
+++ b/c81755371.lua
@@ -8,5 +8,6 @@ function c81755371.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c81755371.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_NORMAL)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_NORMAL) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c8522996.lua
+++ b/c8522996.lua
@@ -74,7 +74,8 @@ function c8522996.chop(e,tp,eg,ep,ev,re,r,rp)
 	c:RegisterEffect(e2)
 end
 function c8522996.condition(e,c)
-	return c:IsAttribute(e:GetHandler():GetAttribute())
+	local ec=e:GetHandler()
+	return c:IsAttribute(ec:GetAttribute()) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c8522996.splimit(e,c,tp,sumtp,sumpos)
 	return not c:IsAttribute(e:GetHandler():GetAttribute())

--- a/c92084010.lua
+++ b/c92084010.lua
@@ -8,5 +8,6 @@ function c92084010.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c92084010.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_WATER)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_WATER) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end

--- a/c97574404.lua
+++ b/c97574404.lua
@@ -27,7 +27,8 @@ function c97574404.dtcon(e)
 	return e:GetHandler():GetFlagEffectLabel(FLAG_ID_ARCANA_COIN)==1
 end
 function c97574404.dtval(e,c)
-	return c:IsSetCard(0x5)
+	local ec=e:GetHandler()
+	return c:IsSetCard(0x5) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end
 function c97574404.sumcon(e)
 	return e:GetHandler():GetFlagEffectLabel(FLAG_ID_ARCANA_COIN)==0

--- a/c99865167.lua
+++ b/c99865167.lua
@@ -8,5 +8,6 @@ function c99865167.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c99865167.condition(e,c)
-	return c:IsAttribute(ATTRIBUTE_WIND) and c:IsType(TYPE_NORMAL)
+	local ec=e:GetHandler()
+	return c:IsAttribute(ATTRIBUTE_WIND) and c:IsType(TYPE_NORMAL) and (ec:IsFaceup() or c:GetControler()==ec:GetControler())
 end


### PR DESCRIPTION
Facedown monster should not apply EFFECT_DOUBLE_TRIBUTE for opponent's monster.

Test puzzle:
```lua
--[[message TEST]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_TEST_MODE)
Debug.SetPlayerInfo(0,2000,0,0)
Debug.SetPlayerInfo(1,2000,0,0)

Debug.AddCard(89631139,0,0,LOCATION_HAND,0,POS_FACEUP_ATTACK,true)
Debug.AddCard(79844764,0,0,LOCATION_HAND,0,POS_FACEUP_ATTACK,true)
Debug.AddCard(4031928,0,0,LOCATION_HAND,0,POS_FACEUP_ATTACK,true)

Debug.AddCard(564541,1,1,LOCATION_MZONE,0,POS_FACEDOWN)
Debug.AddCard(42388271,1,1,LOCATION_MZONE,1,POS_FACEDOWN)

Debug.ReloadFieldEnd()
```