### PR TITLE
Destiny Board Bug Fix

### DIFF
--- a/c94212438.lua
+++ b/c94212438.lua
@@ -28,6 +28,7 @@ function c94212438.initial_effect(c)
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e4:SetCode(EVENT_LEAVE_FIELD)
+	e4:SetCondition(c94212438.tgcon2)
 	e4:SetOperation(c94212438.tgop)
 	c:RegisterEffect(e4)
 	--win
@@ -83,13 +84,17 @@ function c94212438.plop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c94212438.cfilter1(c,tp)
-	return c:IsControler(tp) and (c:IsCode(94212438) or c:IsSetCard(0x1c))
+	return c:IsPreviousControler(tp) and (c:IsCode(94212438) or c:IsSetCard(0x1c)) and (c:IsPreviousPosition(POS_FACEUP) or (c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED) and c:IsFaceup()) or (c:IsLocation(LOCATION_HAND) and c:IsPublic()))
 end
 function c94212438.cfilter2(c)
 	return c:IsFaceup() and (c:IsCode(94212438) or c:IsSetCard(0x1c))
 end
 function c94212438.tgcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c94212438.cfilter1,1,nil,tp)
+end
+function c94212438.tgcon2(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousControler(tp) and (c:IsPreviousPosition(POS_FACEUP) or (c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED) and c:IsFaceup()) or (c:IsLocation(LOCATION_HAND) and c:IsPublic()))
 end
 function c94212438.tgop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c94212438.cfilter2,tp,LOCATION_ONFIELD,0,nil)


### PR DESCRIPTION
These bugs are fixed based on the OCG official ruling or based on interpretation of card text.
1. When a face-down "Spirit Message" card or "Destiny Board"  leaves the field of the controler of "Destiny Board" (Same for Destiny Board itself), but sent to deck, or hand (not public), the second effect of Destiny Board should not be triggered (based on official ruling).
2. When a "Spirit Message" card or "Destiny Board" leaves the opponent's field of the controler of "Destiny Board" (Which means the controler was changed), but sent to the controler's GY, the second effect of Destiny Board should not be triggered (based on card text: When any "Spirit Message" card or "Destiny Board" you control leaves the field/自分フィールドの「ウィジャ盤」または「死のメッセージ」カードがフィールドから離れた時に).