### PR TITLE
Fix Lua precedence bug in c2606417 and check SendtoGrave return value in c43419178

### DIFF
--- a/c2606417.lua
+++ b/c2606417.lua
@@ -71,7 +71,7 @@ function s.ctop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.mfilter(c)
 	return c:IsOnField() and c:IsFaceup() and c:IsType(TYPE_MONSTER)
-		and (not c:GetAttack()==0 or not c:IsDisabled())
+		and (c:GetAttack()~=0 or not c:IsDisabled())
 end
 function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()

--- a/c43419178.lua
+++ b/c43419178.lua
@@ -40,7 +40,7 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,s.tgfilter,tp,LOCATION_DECK,0,1,1,nil)
 	local tc=g:GetFirst()
-	if tc and Duel.SendtoGrave(tc,REASON_EFFECT) and tc:IsLocation(LOCATION_GRAVE) then
+	if tc and Duel.SendtoGrave(tc,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_GRAVE) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local sg=Duel.SelectMatchingCard(tp,Card.IsAbleToGrave,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
 		if sg:GetCount()>0 then


### PR DESCRIPTION
Fixes two script logic bugs:
1. **`c2606417.lua`**: Fixed a Lua operator precedence issue where `not c:GetAttack()==0` was parsed as `(not c:GetAttack()) == 0` (evaluating to `false == 0`, which is always `false`). Updated to `c:GetAttack() ~= 0`.
2. **`c43419178.lua`**: Added a `> 0` check for `Duel.SendtoGrave(tc, REASON_EFFECT)`. Because `0` is truthy in Lua, omitting `> 0` resulted in evaluating the `if` condition as `true` even when 0 cards were sent to the graveyard.