### PR TITLE
Update Possessed Dark Soul

### DIFF
--- a/c52860176.lua
+++ b/c52860176.lua
@@ -20,7 +20,8 @@ function c52860176.filter(c)
 end
 function c52860176.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c52860176.filter,tp,0,LOCATION_MZONE,nil)
-	if chk==0 then return g:GetCount()>0 end
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if chk==0 then return ft+1>=g:GetCount() and g:GetCount()>0 end
 	Duel.SetOperationInfo(0,CATEGORY_CONTROL,g,g:GetCount(),0,0)
 end
 function c52860176.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/c52860176.lua
+++ b/c52860176.lua
@@ -20,8 +20,8 @@ function c52860176.filter(c)
 end
 function c52860176.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c52860176.filter,tp,0,LOCATION_MZONE,nil)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if chk==0 then return ft+1>=g:GetCount() and g:GetCount()>0 end
+	local ft=Duel.GetMZoneCount(tp,e:GetHandler())
+	if chk==0 then return ft>=g:GetCount() and g:GetCount()>0 end
 	Duel.SetOperationInfo(0,CATEGORY_CONTROL,g,g:GetCount(),0,0)
 end
 function c52860176.operation(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Update script to match new rulings from Konami stating you must have enough open MZones to take control of all of the opponents level 3 or lower monsters, including the MZone that will be open once Possessed Dark Soul tributes itself.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9129&request_locale=ja