### PR TITLE
Fix ウォーター・ドラゴン

### DIFF
--- a/c85066822.lua
+++ b/c85066822.lua
@@ -10,7 +10,7 @@ function c85066822.initial_effect(c)
 	--atkchange
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_SET_ATTACK)
+	e2:SetCode(EFFECT_SET_ATTACK_FINAL)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
 	e2:SetTarget(c85066822.atfilter)


### PR DESCRIPTION
Ｑ：このカードの(1)の効果で攻撃力０になったモンスターに対して、《突進》や《サイバネティック・マジシャン》の効果を発動しました。
       そのモンスターの攻撃力はいくらになりますか？
Ａ：いずれの場合も攻撃力０になります。(15/07/03)

https://yugioh-wiki.net/index.php?%A1%D4%A5%A6%A5%A9%A1%BC%A5%BF%A1%BC%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5