### PR TITLE
Fix monster special summon check from GY

### DIFF
--- a/c2645637.lua
+++ b/c2645637.lua
@@ -38,7 +38,7 @@ function c2645637.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_MONSTER) and Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)==LOCATION_GRAVE
 end
 function c2645637.spfilter(c)
-	return c:IsSummonLocation(LOCATION_GRAVE)
+	return c:IsSummonLocation(LOCATION_GRAVE) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function c2645637.atkcon2(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c2645637.spfilter,1,nil) and not eg:IsContains(e:GetHandler())

--- a/c29081251.lua
+++ b/c29081251.lua
@@ -66,7 +66,7 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.spfilter(c)
-	return c:IsSummonLocation(LOCATION_GRAVE)
+	return c:IsSummonLocation(LOCATION_GRAVE) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.spfilter,1,nil) and not eg:IsContains(e:GetHandler())

--- a/c44088353.lua
+++ b/c44088353.lua
@@ -54,7 +54,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.cfilter(c,tp)
-	return c:IsSummonLocation(LOCATION_GRAVE) and c:GetPreviousControler()==tp
+	return c:IsSummonLocation(LOCATION_GRAVE) and c:GetPreviousControler()==tp and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.cfilter,1,nil,tp)

--- a/c45133463.lua
+++ b/c45133463.lua
@@ -12,7 +12,7 @@ function c45133463.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c45133463.cfiltetr(c,tp)
-	return c:IsPreviousLocation(LOCATION_GRAVE) and c:IsPreviousControler(tp)
+	return c:IsPreviousLocation(LOCATION_GRAVE) and c:IsPreviousControler(tp) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function c45133463.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c45133463.cfiltetr,1,nil,tp)

--- a/c4918855.lua
+++ b/c4918855.lua
@@ -92,7 +92,7 @@ function c4918855.negop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateActivation(ev)
 end
 function c4918855.cfilter(c,tp)
-	return c:IsSummonLocation(LOCATION_GRAVE) and c:IsPreviousControler(1-tp)
+	return c:IsSummonLocation(LOCATION_GRAVE) and c:IsPreviousControler(1-tp) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function c4918855.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c4918855.cfilter,1,nil,tp)

--- a/c53855409.lua
+++ b/c53855409.lua
@@ -24,7 +24,7 @@ function c53855409.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c53855409.gfilter(c,tp)
-	return c:IsPreviousLocation(LOCATION_GRAVE) and c:IsPreviousControler(tp)
+	return c:IsPreviousLocation(LOCATION_GRAVE) and c:IsPreviousControler(tp) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function c53855409.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c53855409.gfilter,1,nil,tp)

--- a/c57458399.lua
+++ b/c57458399.lua
@@ -25,7 +25,7 @@ function c57458399.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c57458399.spfilter(c,tp)
-	return c:IsSummonLocation(LOCATION_GRAVE) and c:IsPreviousControler(tp)
+	return c:IsSummonLocation(LOCATION_GRAVE) and c:IsPreviousControler(tp) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function c57458399.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c57458399.spfilter,1,nil,tp)

--- a/c65187687.lua
+++ b/c65187687.lua
@@ -53,7 +53,7 @@ function c65187687.rmop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c65187687.spfilter(c)
-	return c:IsSummonLocation(LOCATION_GRAVE)
+	return c:IsSummonLocation(LOCATION_GRAVE) and c:GetOriginalType()&TYPE_MONSTER~=0
 end
 function c65187687.discon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c65187687.spfilter,1,nil) and not eg:IsContains(e:GetHandler())


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23154&keyword=&tag=-1&request_locale=ja

> Question
相手の墓地の「バージェストマ・ディノミスクス」が、『②：罠カードが発動した時、その発動にチェーンしてこの効果を墓地で発動できる。このカードは通常モンスター（水族・水・星２・攻１２００／守０）となり、モンスターゾーンに特殊召喚する（罠カードとしては扱わない）。この効果で特殊召喚したこのカードはモンスターの効果を受けず、フィールドから離れた場合に除外される』効果により特殊召喚されました。
自分は墓地の「竜血公ヴァンパイア」の『③：相手の墓地からモンスターが特殊召喚された場合、自分フィールドのモンスター２体をリリースして発動できる。このカードを墓地から特殊召喚する』効果を発動できますか？
Answer
その状況は、相手の墓地からモンスターが特殊召喚された状況としては扱いませんので、自分の墓地の「竜血公ヴァンパイア」の『③』の効果を発動することはできません。