### PR TITLE
Fix 未来への沈黙

### DIFF
--- a/c78679226.lua
+++ b/c78679226.lua
@@ -65,10 +65,12 @@ function s.dactivate(e,tp,eg,ep,ev,re,r,rp)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
+		if g:IsExists(Card.IsLocation,1,nil,LOCATION_HAND) then
+			local ct1=6-Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)
+			local ct2=6-Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)
+			if ct1>0 or ct2>0 then Duel.BreakEffect() end
+			if ct1>0 then Duel.Draw(tp,ct1,REASON_EFFECT) end
+			if ct2>0 then Duel.Draw(1-tp,ct2,REASON_EFFECT) end
+		end
 	end
-	local ct1=6-Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)
-	local ct2=6-Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)
-	if ct1>0 or ct2>0 then Duel.BreakEffect() end
-	if ct1>0 then Duel.Draw(tp,ct1,REASON_EFFECT) end
-	if ct2>0 then Duel.Draw(1-tp,ct2,REASON_EFFECT) end
 end


### PR DESCRIPTION
【效果描述：从卡组把有「光之黄金柜」的卡名记述的1只怪兽加入手卡。自己场上有着「光之黄金柜」以及有那个卡名记述的怪兽存在的状态，把这张卡在自己·对方的战斗阶段发动的场合，再让双方各自直到手卡变成6张为止抽卡。】

修复该卡在满足“后续抽卡”条件的情况下发动后若没有把前述的怪兽加入手卡的场合，应不能执行后续的抽卡的处理的问题。