### PR TITLE
Fix カップ・オブ・エース

### DIFF
--- a/c37812118.lua
+++ b/c37812118.lua
@@ -10,7 +10,7 @@ function c37812118.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c37812118.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) and Duel.IsPlayerCanDraw(1-tp,2) end
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) or Duel.IsPlayerCanDraw(1-tp,2) end
 	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
 end
 function c37812118.activate(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
现裁定：至少一方的玩家，2张抽卡可以的状况（卡组有2张以上，抽卡没有限制的效果和条件的状况）发动。双方不能进行2张抽卡的情况下不能发动。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7623&request_locale=ja