### PR TITLE
Fix EMポップアップ

### DIFF
--- a/c11481610.lua
+++ b/c11481610.lua
@@ -55,6 +55,7 @@ function c11481610.activate(e,tp,eg,ep,ev,re,r,rp)
 		end
 	end
 	if not res then
+		Duel.BreakEffect()
 		local lp=Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)
 		Duel.SetLP(tp,Duel.GetLP(tp)-lp*1000)
 	end


### PR DESCRIPTION
> 自分のペンデュラムゾーンにカードが存在しない場合でも発動する事ができます。（『自分はその数だけデッキからドローする』処理を行った後、『自分は自分の手札の数×１０００LPを失う』処理を行う事になります。）