### PR TITLE
Merge delayed events for Set cards in RegisterMergedDelayedEvent_ToSingleCard

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1734,15 +1734,17 @@ function Auxiliary.RegisterMergedDelayedEvent_ToSingleCard_AddOperation(c,g,even
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(event)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_SET_AVAILABLE)
-	e1:SetRange(0xff)
 	e1:SetLabel(event_code_single,event)
 	e1:SetLabelObject(g)
 	e1:SetOperation(Auxiliary.MergedDelayEventCheck1_ToSingleCard)
-	c:RegisterEffect(e1)
+	-- Card-registered FIELD continuous effects fail is_activateable while the handler is Set.
+	-- Duel.RegisterEffect is FIELD_ONLY, so Check1 still merges when this card is face-down,
+	-- which is required for cteffect. EVENT_MOVE still clears g if this copy becomes public.
+	Duel.RegisterEffect(e1,0)
 	local e2=e1:Clone()
 	e2:SetCode(EVENT_CHAIN_END)
 	e2:SetOperation(Auxiliary.MergedDelayEventCheck2_ToSingleCard)
-	c:RegisterEffect(e2)
+	Duel.RegisterEffect(e2,0)
 end
 function Auxiliary.ThisCardMovedToPublicResetCheck_ToSingleCard(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetOwner()


### PR DESCRIPTION
## 中文
### 摘要
`RegisterMergedDelayedEvent_ToSingleCard` 原先把 Check1/Check2 注册在卡片上。盖放的永续陷阱/魔法因此听不到诱发事件，翻开时无法同时发动（cteffect）。全局 `RegisterMergedDelayedEvent` 能翻开同时发动，但会在「连锁 1 把这张卡表侧放到场上、连锁 2 满足条件」时误发。
本次只改注册方式：Check1/Check2 改为 `Duel.RegisterEffect`（`FIELD_ONLY`），盖放时仍合并事件。每张卡自己的 `g`、`EVENT_MOVE` 清组、以及「自身出现在事件组则清组」均保持不变。
### 问题
两套 helper 行为不一致：
| Helper | 盖放翻开同时发动 | 连锁 1 表侧上场 + 连锁 2 条件 |
| --- | --- | --- |
| `RegisterMergedDelayedEvent` | 可以 | 会误发 |
| `RegisterMergedDelayedEvent_ToSingleCard`（改前） | 不可以 | 不会误发 |
典型卡：`6547248` 道化の一座『新加入』、`94384774` 海老須神鮮まつり，以及同类永续陷阱。
### 原因
Check1/Check2 原先是：
```lua
e1:SetRange(0xff)
c:RegisterEffect(e1)
```
这是挂在卡上的 `EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS`。ocgcore 对场上里侧 handler 会让 `is_activateable` 直接失败，`EFFECT_FLAG_SET_AVAILABLE` 管不到这条。盖放时 Check1 不会把事件写入这张卡的 `g`，`get_cteffect` 也就看不到私有 `EVENT_CUSTOM`。
全局 helper 使用 `Duel.RegisterEffect`。handler 为空时内核会加上 `EFFECT_FLAG_FIELD_ONLY`，与表里无关，所以能 cteffect；但它共用 `g`，也没有「这张卡变成公开时清组」。
### 改动
`RegisterMergedDelayedEvent_ToSingleCard_AddOperation`：去掉 `SetRange(0xff)` 和 `c:RegisterEffect`，改为与全局 helper 相同的 `Duel.RegisterEffect(e, 0)`。
未改动：
- 每张卡一份 `g`、一份私有 `event_code_single`
- `EVENT_MOVE`：这张卡变成表侧/公开则 `g:Clear()`
- Check1：`eg:IsContains(c)` 则清组（[#3118](https://github.com/Fluorohydride/ygopro-scripts/pull/3118)）
- Check2 在 `EVENT_CHAIN_END` 对本次 `EVENT_MOVE` 的公开检查
### 测试计划
#### `6547248` 道化の一座『新加入』
② 是「自己上级召唤成功后破坏魔陷」的 DELAY 诱发，由 `RegisterMergedDelayedEvent_ToSingleCard` 监听 `EVENT_SUMMON_SUCCESS`。③ 是从墓地 `MoveToField` 表侧放置到魔陷区。以下 e2e 均已通过。
1. **盖放翻开同时发动②（cteffect）**  
   这张卡里侧盖放在魔陷区。解放「圣精灵」上级召唤「恶魔召唤」。出现 `SelectEffectYn`（`desc === 94`），翻开同时发动②，对象只能选对方「旋风」，不能选这张卡自己或「星尘龙」。连锁上「星尘龙」可以连锁。处理后「旋风」离场，这张卡表侧留在场上。
2. **连锁 1 发动③、连锁 2 上级召唤 → 连锁结束后不能发动②**  
   「愚蠢的副葬」把这张卡从卡组送墓（「灰流丽」可以连锁）。③ 从墓地发动作为连锁 1（`MoveToField` 表侧上场），「血之代偿」作为连锁 2 上级召唤「恶魔召唤」。连锁结束后没有 `SelectEffectYn`，这张卡虽已表侧在场，但不能发动②。这是全局 helper 会误发、ToSingleCard 必须保住的路径。
3. **同回合先上级召唤不发②，再离场进墓后连锁③与上级召唤，仍不能发动②**  
   这张卡已经表侧在场。先上级召唤「恶魔召唤」并**拒绝**②。再把这张卡弹回手卡、用「暗黑界的交易」丢弃进墓地，然后同一连锁里再发动③与另一次上级召唤。连锁结束后仍然不能发动②：当回合已经用过的次数限制，以及「事后表侧上场」两条都不能让②再出现。
4. **发动「水泡幻象」后，上级召唤时可以从手卡发动这张卡并同时使用②**  
   「水泡幻象」盖放（非盖放回合）。先翻开「水泡幻象」，再上级召唤「恶魔召唤」。这张卡在手卡可以发动，并出现 cteffect（`desc === 94`）同时使用②。破坏「旋风」后这张卡表侧在场。
5. **「王家的神殿」适用中，连锁 1 盖放这张卡、连锁 2 上级召唤 → 可以发动②**  
   「王家的神殿」表侧在场。连锁 1 用「ディアボロ」(31533473) 从卡组**里侧盖放**这张卡，连锁 2「血之代偿」上级召唤。盖放是里侧不是表侧公开，不会清掉这张卡的事件组。连锁结束后可以发动②（当回合盖放由神殿允许），并走 cteffect。
6. **「水泡幻象」适用中，连锁 1 抽到这张卡、连锁 2 上级召唤 → 可以从手卡发动并使用②**  
   「水泡幻象」已适用。「强欲之壶」作为连锁 1 把这张卡抽到手卡，连锁 2 上级召唤。抽进手卡时这张卡不是表侧/公开，事件组保留。连锁结束后可以从手卡发动这张卡，并 cteffect 使用②。
- [x] `94384774`：盖放翻开同时发动①；连锁 1 表侧放置到场上、连锁 2 特殊召唤后不能发动①
- [x] [#3118](https://github.com/Fluorohydride/ygopro-scripts/pull/3118) 五个场景：
  1. 世海龍ジーランティス表侧特召全场 → 相剑大邪合并诱发不发动
  2. 死者蘇生特召 CX ファナティクス・マキナ后，ファンタジクス・マキナ特召到对方场 → CX 可以诱发
  3. 浅すぎた墓穴同时里侧特召双方 CX → 不诱发
  4. 悲劇のデスピアン除外自身并盖放復烙印，再发动復烙印 → ①不诱发
  5. RUM－ソウル・シェイブ・フォース特召クシャトリラ・アライズハート → ②可以诱发
---
## English
### Summary
`RegisterMergedDelayedEvent_ToSingleCard` previously registered Check1/Check2 on the card. Set Continuous Traps/Spells therefore never saw the delayed event, so they could not activate together with their flip (cteffect). The global `RegisterMergedDelayedEvent` allows cteffect, but it falsely triggers when Chain Link 1 places the card face-up and Chain Link 2 meets the trigger condition.
This change only switches registration: Check1/Check2 now use `Duel.RegisterEffect` (`FIELD_ONLY`) so Set cards still merge events. Per-card `g`, the `EVENT_MOVE` reset, and “clear if this card is in the event group” are unchanged.
### Problem
The two helpers disagreed:
| Helper | cteffect while flipping a Set card | CL1 place face-up + CL2 condition |
| --- | --- | --- |
| `RegisterMergedDelayedEvent` | yes | false trigger |
| `RegisterMergedDelayedEvent_ToSingleCard` (before) | no | no false trigger |
Typical cards: `6547248` Clown's Theater "Newcomer", `94384774` Ebisu Shinsen Festival, and similar Continuous Traps.
### Root cause
Check1/Check2 used to be:
```lua
e1:SetRange(0xff)
c:RegisterEffect(e1)
```
That is a card-registered `EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS`. ocgcore rejects `is_activateable` when the handler is face-down on the field; `EFFECT_FLAG_SET_AVAILABLE` does not cover this path. Check1 never merged into that card's `g` while Set, so `get_cteffect` never saw the private `EVENT_CUSTOM`.
The global helper uses `Duel.RegisterEffect`. With a null handler the core sets `EFFECT_FLAG_FIELD_ONLY`, so it runs regardless of position and cteffect works. It also shares one `g` and does not clear when this copy becomes public.
### Change
In `RegisterMergedDelayedEvent_ToSingleCard_AddOperation`, drop `SetRange(0xff)` / `c:RegisterEffect` and register with `Duel.RegisterEffect(e, 0)`, same as the global helper.
Unchanged:
- One `g` and one private `event_code_single` per card
- `EVENT_MOVE`: `g:Clear()` when this copy becomes face-up/public
- Check1: clear when `eg:IsContains(c)` ([#3118](https://github.com/Fluorohydride/ygopro-scripts/pull/3118))
- Check2 public-move check at `EVENT_CHAIN_END`
### Test plan
#### `6547248` Clown's Theater "Newcomer"
Effect ② is a DELAY trigger that destroys Spells/Traps after you Tribute Summon. It listens to `EVENT_SUMMON_SUCCESS` via `RegisterMergedDelayedEvent_ToSingleCard`. Effect ③ `MoveToField`s this card from the GY face-up. All of the following e2e cases passed.
1. **Flip a Set copy and activate ② together (cteffect)**  
   This card is Set in the Spell/Trap Zone. Tribute Summon "Summoned Skull" by Tributing "La Jinn the Mystical Genie of the Lamp". `SelectEffectYn` appears (`desc === 94`). Flipping also activates ②. The only legal target is the opponent's "Mystical Space Typhoon"; this card itself and "Stardust Dragon" are not selectable. "Stardust Dragon" can chain. After resolution MST is gone and this card stays face-up.
2. **CL1 effect ③, CL2 Tribute Summon → ② cannot activate after the chain**  
   "Foolish Burial Goods" sends this card from the Deck to the GY ("Ash Blossom" can chain). Effect ③ activates from the GY as CL1 (`MoveToField` face-up). "Ultimate Offering" Tribute Summons "Summoned Skull" as CL2. After the chain there is no `SelectEffectYn`. The card is face-up on the field but ② is not available. This is the false-trigger path of the global helper, which ToSingleCard must keep blocking.
3. **Same turn: skip ② on a Tribute Summon, leave the field, then CL ③ + another Tribute Summon → still no ②**  
   This card is already face-up. Tribute Summon "Summoned Skull" and **decline** ②. Bounce this card to the hand, discard it with "Dark World Dealings", then in one chain activate ③ and Tribute Summon again. After the chain ② still cannot activate: the once-per-turn lock and the "placed face-up after the fact" rule both still apply.
4. **After "Bubble Illusion", Tribute Summon → activate this card from the hand and use ② together**  
   "Bubble Illusion" is Set (not Set this turn). Flip it, then Tribute Summon "Summoned Skull". This card can be activated from the hand, and cteffect (`desc === 94`) lets ② be used together. After destroying MST this card stays face-up.
5. **"Temple of the Kings" is applying: CL1 Sets this card, CL2 Tribute Summons → ② can activate**  
   "Temple of the Kings" is face-up. CL1 uses Diabolo (31533473) to **Set** this card from the Deck face-down. CL2 "Ultimate Offering" Tribute Summons. A face-down Set is not public, so this card's event group is not cleared. After the chain ② can activate (Temple allows activating a Trap Set this turn) and uses cteffect.
6. **"Bubble Illusion" is applying: CL1 draws this card, CL2 Tribute Summons → activate from the hand and use ②**  
   "Bubble Illusion" is already applying. "Pot of Greed" as CL1 draws this card. CL2 Tribute Summons. Drawing to the hand does not make the card face-up/public, so the event group is kept. After the chain this card can be activated from the hand, and cteffect uses ②.
- [x] `94384774`: cteffect for effect ① when flipping; no ① after CL1 place face-up + CL2 Special Summon
- [x] The five scenarios from [#3118](https://github.com/Fluorohydride/ygopro-scripts/pull/3118):
  1. Worldsea Dragon Zealantis Special Summons everything face-up → Swordsoul Sinister Sovereign no merged trigger
  2. Monster Reborn Special Summons CXyz Gimmick Puppet Fanatix Machina, then Fantasix Machina Special Summons itself to the opponent's field → the CX can trigger
  3. The Shallow Grave Special Summons both CX face-down → no trigger
  4. Dramaturge of Despia banishes itself and Sets Branded in Red, then Branded in Red is activated → effect ① does not trigger
  5. Rank-Up-Magic Soul Shave Force Special Summons Kashtira Arise-Heart → effect ② can trigger