### PR TITLE
Add EFFECT_CANNOT_DISABLE effects

### DIFF
--- a/c15866454.lua
+++ b/c15866454.lua
@@ -9,6 +9,12 @@ function c15866454.initial_effect(c)
 	e1:SetTarget(c15866454.target)
 	e1:SetOperation(c15866454.activate)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 end
 function c15866454.filter(c)
 	return c:IsAbleToHand() and c:IsType(TYPE_SPELL+TYPE_TRAP)

--- a/c18563744.lua
+++ b/c18563744.lua
@@ -12,6 +12,12 @@ function c18563744.initial_effect(c)
 	e1:SetTarget(c18563744.target)
 	e1:SetOperation(c18563744.activate)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 	--to hand
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(18563744,1))

--- a/c4059313.lua
+++ b/c4059313.lua
@@ -10,6 +10,12 @@ function c4059313.initial_effect(c)
 	e1:SetTarget(c4059313.target)
 	e1:SetOperation(c4059313.activate)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 end
 function c4059313.filter(c)
 	return c:IsFaceup() and c:IsCode(10000010) and c:GetFlagEffect(4059313)==0

--- a/c42469671.lua
+++ b/c42469671.lua
@@ -13,6 +13,12 @@ function c42469671.initial_effect(c)
 	e1:SetTarget(c42469671.destg)
 	e1:SetOperation(c42469671.desop)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 end
 function c42469671.actfilter(c)
 	return c:IsFaceup() and c:IsOriginalCodeRule(10000020)

--- a/c44968459.lua
+++ b/c44968459.lua
@@ -11,6 +11,12 @@ function c44968459.initial_effect(c)
 	e1:SetTarget(c44968459.target)
 	e1:SetOperation(c44968459.activate)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 	--to hand
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(44968459,1))

--- a/c66236707.lua
+++ b/c66236707.lua
@@ -12,6 +12,12 @@ function s.initial_effect(c)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp

--- a/c7373632.lua
+++ b/c7373632.lua
@@ -10,6 +10,12 @@ function c7373632.initial_effect(c)
 	e1:SetTarget(c7373632.target)
 	e1:SetOperation(c7373632.activate)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 end
 function c7373632.filter(c)
 	return c:IsFaceup() and (c:GetOriginalRace()&RACE_DIVINE~=0 or c:IsOriginalCodeRule(21208154,62180201,57793869)) and c:GetFlagEffect(7373632)==0

--- a/c79868386.lua
+++ b/c79868386.lua
@@ -13,6 +13,12 @@ function c79868386.initial_effect(c)
 	e1:SetTarget(c79868386.target)
 	e1:SetOperation(c79868386.activate)
 	c:RegisterEffect(e1)
+	--cannot disable
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetCode(EFFECT_CANNOT_DISABLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e0)
 end
 function c79868386.actfilter(c)
 	return c:IsFaceup() and c:IsOriginalCodeRule(10000000)


### PR DESCRIPTION
> 『そのカードの効果をターン終了時まで無効にする』処理に成功した場合、『自分はデッキから１枚ドローする』処理が行われます。これらは同時に行われません。

> 记述『这张卡的发动和效果不会被无效化』的「沉默之剑」发动时，连锁对这张「沉默之剑」为对象发动「帝王的轰毅」的场合，不能无效，不能抽卡。