### PR TITLE
fix SelectSubGroup nil check for 2 cards

### DIFF
--- a/c44175358.lua
+++ b/c44175358.lua
@@ -33,7 +33,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil,e,tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local sg=g:SelectSubGroup(tp,s.fselect,false,2,2)
-	if sg:GetCount()==2 then
+	if sg and sg:GetCount()==2 then
 		local fid=e:GetHandler():GetFieldID()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		for tc in aux.Next(sg) do

--- a/c7337976.lua
+++ b/c7337976.lua
@@ -69,7 +69,7 @@ function c7337976.tgop2(e,tp,eg,ep,ev,re,r,rp)
 	aux.GCheckAdditional=aux.dncheck
 	local sg=g:SelectSubGroup(tp,aux.TRUE,false,1,ct)
 	aux.GCheckAdditional=nil
-	if sg:GetCount()>0 then
+	if sg and sg:GetCount()>0 then
 		Duel.SendtoGrave(sg,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
Group.SelectSubGroup (utility.lua) returns nil when its pre-check fails (#group<min), regardless of the cancelable flag. Both scripts re-fetch the candidate pool at resolution time without re-validating it, so card movement during the chain (e.g. deck search/shuffle, Macro Cosmos) can empty the pool and make SelectSubGroup return nil, crashing on sg:GetCount() with 'attempt to index a nil value'.

- c44175358: re-check via nil guard before sg:GetCount()==2
- c7337976: nil guard before sg:GetCount()>0 (matches the guard style already used in c8602351/c7511613)