### PR TITLE
Fix 始まりの神ファーラ

### DIFF
--- a/c82344137.lua
+++ b/c82344137.lua
@@ -59,7 +59,9 @@ function s.ncop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterEffect(e1,tp)
 end
 function s.actop(e,tp,eg,ep,ev,re,r,rp)
-	if re:GetHandler():IsCode(e:GetLabel()) then
+	local code=e:GetLabel()
+	local code1,code2=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CODE,CHAININFO_TRIGGERING_CODE2)
+	if code==code1 or code==code2 then
 		Duel.SetChainLimit(aux.FALSE)
 	end
 end


### PR DESCRIPTION
## Summary / 摘要
- **EN:** Fix Phara the Primordial Goddess (82344137) ① so the chain lock compares the **name at activation**, not the card's current name after cost.
- **ZH:** 修正「初始之神 法拉」(82344137) 的①效果：连锁封锁改为比较**发动时的卡名**，而不是支付代价之后的当前卡名。
## Background / 背景
Phara ①: reveal this card and 1 Spell/Trap from the hand; until the end of the next turn, neither player can activate effects in response to the revealed Spell/Trap or cards with the same name.
法拉①：把手卡的这张卡和手卡1张魔法·陷阱卡给对方观看；直到下个回合结束时，双方不能对应给人观看的魔法·陷阱卡以及那些同名卡的效果的发动把效果发动。
Database ruling (2026-07-17): the restriction applies when the **name of the revealed card in the hand** matches the **name of the activating card at activation**. Original name and card type (Monster / Spell / Trap) do not matter. Cards treated as "Umi" by rule (e.g. A Legendary Ocean) or by effect (e.g. Azure Ocean Dragon Lord - Neo-Daedalus Rage) are included.
数据库裁定（2026-07-17）：只要「展示时手卡中的卡名」与「效果发动时的卡名」相同，就不能连锁。不考虑原本卡名，也不考虑卡的种类（怪兽 / 魔法 / 陷阱）。规则上当作「海」的卡（如「传说之都 亚特兰蒂斯」），以及效果上当作「海」的卡（如「苍海龙神-尼奥泰达路斯·怒」）都适用。
## Problem / 问题
Official script:
```lua
function s.actop(e,tp,eg,ep,ev,re,r,rp)
	if re:GetHandler():IsCode(e:GetLabel()) then
		Duel.SetChainLimit(aux.FALSE)
	end
end
```
`Card.IsCode` reads the **current** name. That is wrong when the activating card leaves the zone that grants the name.
`Card.IsCode` 读取的是**当前**卡名。当发动的卡离开赋予该卡名的区域后，判断就会出错。
Typical failure: after Phara reveals A Legendary Ocean (`295517`, treated as Umi `22702055` by rule), Neo-Daedalus Rage (`41570943`) activates ③ and sends **itself** to the GY as cost (its on-field name is Umi). Cost is paid before `EVENT_CHAINING`. `EFFECT_CHANGE_CODE` only applies in the Monster Zone, so in the GY `IsCode(22702055)` is false and the lock does not apply.
典型失败例：法拉展示亚特兰蒂斯（`295517`，规则上当作「海」`22702055`）后，苍海龙神（`41570943`）发动③并把**自己**作为「海」送墓。代价在 `EVENT_CHAINING` 之前支付。`EFFECT_CHANGE_CODE` 只在怪兽区适用，送墓后 `IsCode(22702055)` 为 false，连锁封锁不会生效。
## Fix / 修正
Compare the revealed name with `CHAININFO_TRIGGERING_CODE` / `CHAININFO_TRIGGERING_CODE2`, which are snapshotted at activation (for a monster Quick Effect, before cost).
改为与 `CHAININFO_TRIGGERING_CODE` / `CHAININFO_TRIGGERING_CODE2` 比较。这两个值在发动时快照（怪兽诱发即时效果是在支付代价之前）。
```lua
function s.actop(e,tp,eg,ep,ev,re,r,rp)
	local code=e:GetLabel()
	local code1,code2=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CODE,CHAININFO_TRIGGERING_CODE2)
	if code==code1 or code==code2 then
		Duel.SetChainLimit(aux.FALSE)
	end
end
```
`nccost` still stores `sc:GetCode()`. For A Legendary Ocean that is `22702055` via `rule_code`, which matches the ruling.
`nccost` 仍保存 `sc:GetCode()`。亚特兰蒂斯因 `rule_code` 得到 `22702055`，与裁定一致。
