### PR TITLE
Fix キラーチューン・クラックル

### DIFF
--- a/c39576656.lua
+++ b/c39576656.lua
@@ -80,11 +80,24 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ShuffleExtra(1-tp)
 	end
 end
+function s.retexfilter(c)
+	return c:IsPreviousLocation(LOCATION_EXTRA) and c:IsPreviousPosition(POS_FACEUP)
+end
+function s.returnremoved(g)
+	local pg=g:Filter(s.retexfilter,nil)
+	local dg=g:Filter(aux.NOT(s.retexfilter),nil)
+	if #pg>0 then
+		Duel.SendtoExtraP(pg,nil,REASON_EFFECT)
+	end
+	if #dg>0 then
+		Duel.SendtoDeck(dg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+	end
+end
 function s.retop(e,tp,eg,ep,ev,re,r,rp)
 	local fid=e:GetLabel()
 	local tc=e:GetLabelObject()
 	if tc and tc:GetFlagEffectLabel(id)==fid then
-		Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+		s.returnremoved(Group.FromCards(tc))
 	end
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
@@ -134,6 +147,8 @@ function s.retfilter(c,fid)
 end
 function s.retop2(e,tp,eg,ep,ev,re,r,rp)
 	local fid=e:GetLabel()
-	local tg=e:GetLabelObject():Filter(s.retfilter,nil,fid)
-	Duel.SendtoDeck(tg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+	local g=e:GetLabelObject()
+	local tg=g:Filter(s.retfilter,nil,fid)
+	g:DeleteGroup()
+	s.returnremoved(tg)
 end


### PR DESCRIPTION
## Summary / 摘要

- **EN:** Fix Kewl Tune Crackle (39576656) so Extra Deck monsters banished face-up until the End Phase return **face-up to the Extra Deck**, instead of being sent to the Main Deck (or Extra face-down).
- **ZH:** 修正「杀手级调整曲·噼啪削波手」(39576656)：直到结束阶段除外的额外卡组表侧卡，结束阶段应**表侧回到额外卡组**，而不是进主卡组（或里侧回额外）。

## Background / 背景

①: If this card is Synchro Summoned, look at the opponent's Extra Deck and banish 1 card from it face-up until the End Phase. Then you may increase this card's ATK by that monster's ATK.

②: If this Synchro Summoned card is sent to the GY: Special Summon it, then you may look at the Extra Deck and banish 2 cards face-up until the End Phase.

①：这张卡同调召唤的场合才能发动。把对方的额外卡组确认，那之内的1张直到结束阶段表侧除外。那之后，可以让这张卡的攻击力上升除外的怪兽的攻击力数值。

②：同调召唤的这张卡被送去墓地的场合才能发动。这张卡特殊召唤。那之后，可以把对方的额外卡组确认，那之内的2张直到结束阶段表侧除外。

Database ruling (2026-01-23):

- (A) Banishing a **face-up** Extra Pendulum (including Fusion/Synchro/Xyz Pendulum) → End Phase returns it **face-up** to the Extra Deck.
- (B) Banishing a **face-down** Extra copy → End Phase returns it **face-down** to the Extra Deck.

数据库裁定（2026-01-23）：

- （A）除外额外卡组**表侧**灵摆（含融合/同调/超量灵摆）→ 结束阶段**表侧**回到额外卡组。
- （B）除外额外卡组**里侧**的卡 → 结束阶段**里侧**回到额外卡组。

## Problem / 问题

Official script `retop` / `retop2`:

```lua
Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
```

`SendtoDeck` sends a **Main Deck Pendulum** that was face-up in Extra to the **Main Deck**. Extra Deck Pendulums that were face-up are redirected to Extra **face-down**. Both contradict the ruling.

`SendtoDeck` 会把原本在额外表侧的**主卡组灵摆**送回**主卡组**；表侧的额外卡组灵摆则会被重定向成额外**里侧**。两种情况都与裁定不符。

## Fix / 修正

If the card was previously Extra **face-up**, return it with `Duel.SendtoExtraP`. Otherwise keep `SendtoDeck` (Fusion/Synchro/Xyz/Link and face-down Extra copies go back Extra face-down).

先前在额外**表侧**的卡用 `Duel.SendtoExtraP` 表侧回额外；其余仍用 `SendtoDeck`（融合/同调/超量/连接以及里侧额外会里侧回额外）。

```lua
function s.retexfilter(c)
	return c:IsPreviousLocation(LOCATION_EXTRA) and c:IsPreviousPosition(POS_FACEUP)
end
function s.returnremoved(g)
	local pg=g:Filter(s.retexfilter,nil)
	local dg=g:Filter(aux.NOT(s.retexfilter),nil)
	if #pg>0 then
		Duel.SendtoExtraP(pg,nil,REASON_EFFECT)
	end
	if #dg>0 then
		Duel.SendtoDeck(dg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
	end
end
```

`IsPreviousPosition(POS_FACEUP)` is the Extra position **before** the temporary banish. `Duel.Remove(..., POS_FACEUP, ...)` only sets the current banished position.

`IsPreviousPosition(POS_FACEUP)` 记录的是暂时除外**之前**在额外的表示；`Duel.Remove(..., POS_FACEUP, ...)` 只改变当前除外区表示。