### PR TITLE
Fix 救いの架け橋

### DIFF
--- a/c5611760.lua
+++ b/c5611760.lua
@@ -31,9 +31,10 @@ function c5611760.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFlagEffect(tp,5611760)==0 and g:GetClassCount(Card.GetRace)>=2
 end
 function c5611760.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,5) and Duel.IsPlayerCanDraw(1-tp,5) end
 	local g=Duel.GetMatchingGroup(aux.NOT(Card.IsStatus),tp,0x1e,0x1e,nil,STATUS_BATTLE_DESTROYED)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0x1e)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,PLAYER_ALL,5)
 end
 function c5611760.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetFlagEffect(tp,5611760)~=0 then return end


### PR DESCRIPTION
## Summary / 摘要

- **EN:** Fix Bridge of Salvation (5611760) ① so it **cannot activate** if either player has fewer than 5 cards in the Deck, or if drawing is forbidden (Droll & Lock Bird).
- **ZH:** 修正「拯救的桥梁」(5611760) 的①效果：任一方卡组不足 5 张，或已被「小丑与锁鸟」封锁抽卡时，**不能发动**。

## Background / 背景

Bridge of Salvation ①: If there are 2 or more Types among face-up Level 10 or higher monsters on the field: Shuffle all other cards from both players' hands, fields, and GYs into the Deck, then both players draw 5 cards.

拯救的桥梁①：场上的 10 星以上的怪兽的种族是 2 种类以上的场合才能发动。这张卡以外的双方的手卡·场上·墓地的卡全部回到持有者卡组。那之后，双方从卡组抽 5 张。

The draw 5 is mandatory for both players. Official similar text such as 「死なばもろとも」(`14057297`) checks `Duel.IsPlayerCanDraw` for both players at activation.

抽 5 张是双方必须执行的处理。同类官方文本「同归于尽」( `14057297` ) 在发动时用 `Duel.IsPlayerCanDraw` 检查双方。

## Problem / 问题

Official script `target`:

```lua
function c5611760.target(e,tp,eg,ep,ev,re,r,rp,chk)
	if chk==0 then return true end
```

`chk==0` always returns true. That allows activation when:

官方脚本的 `chk==0` 恒为 true，因此下列情况仍能发动：

- Either player's Deck has fewer than 5 cards (`IsPlayerCanDraw(p,5)` is false because `list_main.size() < 5`).
- Droll & Lock Bird has applied `EFFECT_CANNOT_DRAW` (`is_player_can_draw` is false).

- 任一方卡组不足 5 张（`IsPlayerCanDraw(p,5)` 因卡组张数不足而为 false）。
- 「小丑与锁鸟」已经施加 `EFFECT_CANNOT_DRAW`（`is_player_can_draw` 为 false）。

## Fix / 修正

Match 「死なばもろとも」: require both players to be able to draw 5, and register `CATEGORY_DRAW` operation info.

对齐「同归于尽」：发动时要求双方都能抽 5 张，并补上抽卡的 `SetOperationInfo`。

```lua
function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
	if chk==0 then return Duel.IsPlayerCanDraw(tp,5) and Duel.IsPlayerCanDraw(1-tp,5) end
	local g=Duel.GetMatchingGroup(aux.NOT(Card.IsStatus),tp,0x1e,0x1e,nil,STATUS_BATTLE_DESTROYED)
	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0x1e)
	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,PLAYER_ALL,5)
end
```

`Duel.IsPlayerCanDraw(p,5)` covers both Deck count and `EFFECT_CANNOT_DRAW`.

`Duel.IsPlayerCanDraw(p,5)` 同时覆盖卡组张数和 `EFFECT_CANNOT_DRAW`。