### PR TITLE
Add Auxiliary.swapzonecheck

### DIFF
--- a/c13597785.lua
+++ b/c13597785.lua
@@ -65,7 +65,11 @@ function s.chfilter(c)
 	return c:GetSequence()==2
 end
 function s.chtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.chfilter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	if chk==0 then
+		local c=e:GetHandler()
+		local tc=Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE,0,c):GetFirst()
+		return tc~=nil and aux.swapzonecheck(c,tc)
+	end
 end
 function s.rthfilter(c)
 	return c:IsFaceup() and c:IsAbleToHand() and c:IsLevelBelow(6)
@@ -77,6 +81,7 @@ function s.chop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE,0,nil)
 	if g:GetCount()==1 then
 		local tc=g:GetFirst()
+		if not aux.swapzonecheck(c,tc) then return end
 		Duel.SwapSequence(c,tc)
 		if c:GetSequence()==cs then return end
 		if Duel.IsExistingMatchingCard(s.rthfilter,tp,0,LOCATION_MZONE,1,nil)

--- a/c22198672.lua
+++ b/c22198672.lua
@@ -51,25 +51,24 @@ function c22198672.seqop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.MoveSequence(tc,nseq)
 	end
 end
-function c22198672.chfilter1(c)
+function c22198672.chfilter(c)
 	return c:IsType(TYPE_LINK) and c:GetSequence()<5
-		and Duel.IsExistingMatchingCard(c22198672.chfilter2,c:GetControler(),LOCATION_MZONE,0,1,c)
 end
-function c22198672.chfilter2(c)
-	return c:IsType(TYPE_LINK) and c:GetSequence()<5
+function c22198672.gcheck(g)
+	if g:GetClassCount(Card.GetControler)~=1 then return false end
+	return aux.swapzonecheck(g:GetFirst(),g:GetNext())
 end
 function c22198672.chtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c22198672.chfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c22198672.chfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	if chk==0 then return g:CheckSubGroup(c22198672.gcheck,2,2) end
 end
 function c22198672.chop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
-	local g1=Duel.SelectMatchingCard(tp,c22198672.chfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	local tc1=g1:GetFirst()
-	if not tc1 then return end
-	Duel.HintSelection(g1)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
-	local g2=Duel.SelectMatchingCard(tp,c22198672.chfilter2,tc1:GetControler(),LOCATION_MZONE,0,1,1,tc1)
-	Duel.HintSelection(g2)
-	local tc2=g2:GetFirst()
+	local g=Duel.GetMatchingGroup(c22198672.chfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_OPERATECARD)
+	local sg=g:SelectSubGroup(tp,c22198672.gcheck,false,2,2)
+	if not sg or sg:GetCount()~=2 then return end
+	local tc1=sg:GetFirst()
+	local tc2=sg:GetNext()
+	Duel.HintSelection(sg)
 	Duel.SwapSequence(tc1,tc2)
 end

--- a/c25163979.lua
+++ b/c25163979.lua
@@ -31,17 +31,16 @@ end
 function c25163979.mvfilter1(c)
 	return c:IsFaceup() and c:IsSetCard(0x112)
 end
-function c25163979.mvfilter2(c,tp)
+function c25163979.chfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x112) and c:GetSequence()<5
-		and Duel.IsExistingMatchingCard(c25163979.mvfilter3,tp,LOCATION_MZONE,0,1,c)
 end
-function c25163979.mvfilter3(c)
-	return c:IsFaceup() and c:IsSetCard(0x112) and c:GetSequence()<5
+function c25163979.gcheck(g)
+	return aux.swapzonecheck(g:GetFirst(),g:GetNext())
 end
 function c25163979.mvtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local b1=Duel.IsExistingMatchingCard(c25163979.mvfilter1,tp,LOCATION_MZONE,0,1,nil)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE,PLAYER_NONE,0)>0
-	local b2=Duel.IsExistingMatchingCard(c25163979.mvfilter2,tp,LOCATION_MZONE,0,1,nil,tp)
+	local b2=Duel.GetMatchingGroup(c25163979.chfilter,tp,LOCATION_MZONE,0,nil):CheckSubGroup(c25163979.gcheck,2,2)
 	if chk==0 then return b1 or b2 end
 	local op=0
 	if b1 and b2 then op=Duel.SelectOption(tp,aux.Stringid(25163979,1),aux.Stringid(25163979,2))
@@ -61,15 +60,13 @@ function c25163979.mvop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.MoveSequence(g:GetFirst(),nseq)
 		end
 	else
+		local g=Duel.GetMatchingGroup(c25163979.chfilter,tp,LOCATION_MZONE,0,nil)
 		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(25163979,3))
-		local g1=Duel.SelectMatchingCard(tp,c25163979.mvfilter2,tp,LOCATION_MZONE,0,1,1,nil,tp)
-		local tc1=g1:GetFirst()
-		if not tc1 then return end
-		Duel.HintSelection(g1)
-		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(25163979,3))
-		local g2=Duel.SelectMatchingCard(tp,c25163979.mvfilter3,tp,LOCATION_MZONE,0,1,1,tc1)
-		Duel.HintSelection(g2)
-		local tc2=g2:GetFirst()
+		local sg=g:SelectSubGroup(tp,c25163979.gcheck,false,2,2)
+		if not sg or sg:GetCount()~=2 then return end
+		local tc1=sg:GetFirst()
+		local tc2=sg:GetNext()
+		Duel.HintSelection(sg)
 		Duel.SwapSequence(tc1,tc2)
 	end
 end

--- a/c3507053.lua
+++ b/c3507053.lua
@@ -56,7 +56,8 @@ function c3507053.chfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x14b) and c:GetSequence()<5
 end
 function c3507053.fselect(g,c)
-	return g:IsContains(c)
+	if not g:IsContains(c) then return false end
+	return aux.swapzonecheck(g:GetFirst(),g:GetNext())
 end
 function c3507053.chtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(c3507053.chfilter,tp,LOCATION_MZONE,0,nil)
@@ -69,9 +70,9 @@ function c3507053.chop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_OPERATECARD)
 	local sg=g:SelectSubGroup(tp,c3507053.fselect,false,2,2,c)
 	if sg and sg:GetCount()==2 then
-		Duel.HintSelection(sg)
 		local tc1=sg:GetFirst()
 		local tc2=sg:GetNext()
+		Duel.HintSelection(sg)
 		Duel.SwapSequence(tc1,tc2)
 		local tc=tc1
 		if tc==c then tc=tc2 end

--- a/c50687050.lua
+++ b/c50687050.lua
@@ -117,7 +117,8 @@ function s.chfilter(c)
 	return c:GetSequence()<5
 end
 function s.gcheck(g)
-	return g:GetClassCount(Card.GetControler)==1
+	if g:GetClassCount(Card.GetControler)~=1 then return false end
+	return aux.swapzonecheck(g:GetFirst(),g:GetNext())
 end
 function s.chtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
@@ -129,9 +130,9 @@ function s.chop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_OPERATECARD)
 	local sg=g:SelectSubGroup(tp,s.gcheck,false,2,2)
 	if sg then
-		Duel.HintSelection(sg)
 		local tc1=sg:GetFirst()
 		local tc2=sg:GetNext()
+		Duel.HintSelection(sg)
 		Duel.SwapSequence(tc1,tc2)
 	end
 end

--- a/c59581480.lua
+++ b/c59581480.lua
@@ -63,7 +63,11 @@ function s.chfilter(c)
 	return c:GetSequence()==2
 end
 function s.chtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.chfilter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	if chk==0 then
+		local c=e:GetHandler()
+		local tc=Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE,0,c):GetFirst()
+		return tc~=nil and aux.swapzonecheck(c,tc)
+	end
 end
 function s.chop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -72,6 +76,7 @@ function s.chop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE,0,nil)
 	if g:GetCount()==1 then
 		local tc=g:GetFirst()
+		if not aux.swapzonecheck(c,tc) then return end
 		Duel.SwapSequence(c,tc)
 		if c:GetSequence()==cs then return end
 		if Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil)

--- a/c85976588.lua
+++ b/c85976588.lua
@@ -63,7 +63,11 @@ function s.chfilter(c)
 	return c:GetSequence()==2
 end
 function s.chtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.chfilter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	if chk==0 then
+		local c=e:GetHandler()
+		local tc=Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE,0,c):GetFirst()
+		return tc~=nil and aux.swapzonecheck(c,tc)
+	end
 end
 function s.rthfilter(c)
 	return c:IsFaceup() and c:IsAbleToHand() and c:IsType(TYPE_SPELL+TYPE_TRAP)
@@ -75,6 +79,7 @@ function s.chop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(s.chfilter,tp,LOCATION_MZONE,0,nil)
 	if g:GetCount()==1 then
 		local tc=g:GetFirst()
+		if not aux.swapzonecheck(c,tc) then return end
 		Duel.SwapSequence(c,tc)
 		if c:GetSequence()==cs then return end
 		if Duel.IsExistingMatchingCard(s.rthfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)

--- a/utility.lua
+++ b/utility.lua
@@ -2072,3 +2072,19 @@ function Auxiliary.covcheck(c)
 	local se=c:GetSpecialSummonInfo(SUMMON_INFO_REASON_EFFECT)
 	return se and se:GetHandler()==c
 end
+---Check if two monsters can swap Main Monster Zone positions.
+---Both cards must be the same controller, in MMZ sequences 0-4.
+---GetMZoneCount's second return is the unusable-zone bitmask after treating c1 and c2 as leaving.
+---PLAYER_NONE, 0: zone lock only, ignore EFFECT_MAX_MZONE / EFFECT_MUST_USE_MZONE.
+---@param c1 Card
+---@param c2 Card
+---@return boolean
+function Auxiliary.swapzonecheck(c1,c2)
+	if not c1 or not c2 then return false end
+	local p=c1:GetControler()
+	if p~=c2:GetControler() then return false end
+	local seq1,seq2=c1:GetSequence(),c2:GetSequence()
+	if seq1>4 or seq2>4 then return false end
+	local _,flag=Duel.GetMZoneCount(p,Group.FromCards(c1,c2),PLAYER_NONE,0)
+	return flag&(1<<seq1)==0 and flag&(1<<seq2)==0
+end


### PR DESCRIPTION
## Summary / 摘要

- **EN:** Swap-monster-position effects now check that **both occupied Main Monster Zones themselves are usable** (not disabled by `EFFECT_DISABLE_FIELD` etc.), not merely occupied. Seven official `Duel.SwapSequence` scripts were updated; `Duel.CheckLocation` is **not** used, because occupancy would make it return false.
- **ZH:** 交换怪兽位置的效果现在会检查**两只怪兽所在的主要怪兽区格子本身是否可用**（未被 `EFFECT_DISABLE_FIELD` 等封锁），而不是只看格子上有没有怪兽。七张使用 `Duel.SwapSequence` 的官方脚本已修正；**不能**用 `Duel.CheckLocation` 查自己脚下的格，因为占用也会返回 false。

## Background / 背景

Ruling: when an effect swaps two monsters' positions, the two zones those monsters sit in must themselves be usable. A zone occupied by a monster can still be **disabled** (field lock). The kernel `Duel.SwapSequence` → `swap_card` does **not** call `is_location_useable` on the destinations, so Lua must check.

裁定：交换怪兽位置时，两只怪兽所在区域本身必须可用。格子上有怪兽时，该格仍可能被封锁。内核 `Duel.SwapSequence` → `swap_card` **不会**对目的地做 `is_location_useable`，必须在 Lua 里检查。

Official `ygopro/script` only uses `Duel.SwapSequence` on these seven cards; all seven swap two Main Monster Zone monsters of the **same controller**.

官方脚本里只有下面七张卡调用 `Duel.SwapSequence`；都是同一控制者的两只主怪兽区怪兽互换。

## Problem / 问题

Official scripts called `Duel.SwapSequence` whenever two on-field monsters were chosen. They did not treat a disabled-but-occupied zone as illegal, so the swap could still be activated and resolved.

官方脚本只要选出两只场上怪兽就会 `Duel.SwapSequence`，没有把「有怪兽但格子被封锁」当成不合法，效果仍能发动并处理。

`Duel.CheckLocation(tp, LOCATION_MZONE, seq)` is the wrong API here: an occupied zone already returns false.

这里不能用 `Duel.CheckLocation`：占用中的格子本来就会返回 false。

`Duel.GetDisableField` exists in C++ but is **not** registered to Lua.

`Duel.GetDisableField` 在 C++ 有实现，但**没有**注册到 Lua。

## Fix / 修正

Treat the two cards as leaving the field, then inspect `Duel.GetMZoneCount`'s second return (zone bitmask). `PLAYER_NONE, 0` looks only at zone lock, not `EFFECT_MAX_MZONE` / `EFFECT_MUST_USE_MZONE`.

把要交换的两只卡当作离场后再看 `Duel.GetMZoneCount` 的第二个返回值。`PLAYER_NONE, 0` 只看格子封锁，不掺最大怪兽数量 / 必须使用区域。

```lua
function Auxiliary.swapzonecheck(c1,c2)
	if not c1 or not c2 then return false end
	local p=c1:GetControler()
	if p~=c2:GetControler() then return false end
	local seq1,seq2=c1:GetSequence(),c2:GetSequence()
	if seq1>4 or seq2>4 then return false end
	local _,flag=Duel.GetMZoneCount(p,Group.FromCards(c1,c2),PLAYER_NONE,0)
	return flag&(1<<seq1)==0 and flag&(1<<seq2)==0
end
```

The check is used in `target` / subgroup filters (cannot activate or cannot choose that pair) and again in `operation` before `SwapSequence`.

发动时的 `target` / 小组筛选会挡住不合法的一对；`operation` 里 `SwapSequence` 前再查一次。

Castle Link and World Legacy Nightmare now use `CheckSubGroup` / `SelectSubGroup` for “select 2 monsters”, matching Drydra / Arktos and the card text. Hint for Castle Link swap is `HINTMSG_OPERATECARD`.

王车连接、诱向星遗物的噩梦的「选 2 只」改为 `CheckSubGroup` / `SelectSubGroup`，与烘干龙兽、阿耳克托斯一致，也更贴文本。王车连接交换提示改为 `HINTMSG_OPERATECARD`。

### Cards / 卡片

| code | EN | ZH |
|---|---|---|
| 22198672 | Castle Link | 王车连接 |
| 85976588 | Fortuna | 耀圣之月诗 福尔图娜 |
| 59581480 | Dina | 耀圣之波诗 狄娜 |
| 13597785 | Lucina | 耀圣之花诗 卢西娜 |
| 25163979 | World Legacy Nightmare | 诱向星遗物的噩梦 |
| 3507053 | Appliancer Drydra | 干燥机块 烘干龙兽 |
| 50687050 | Vaylantz Arktos XII | 针渊之群豪将士-阿耳克托斯12 |
