### PR TITLE
Fix Priestess with Eyes of Blue

### DIFF
--- a/c36734924.lua
+++ b/c36734924.lua
@@ -68,7 +68,7 @@ end
 function c36734924.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) and tc:IsLocation(LOCATION_DECK) then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/c36734924.lua
+++ b/c36734924.lua
@@ -68,7 +68,7 @@ end
 function c36734924.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) and tc:IsLocation(LOCATION_DECK) then
+	if tc:IsRelateToEffect(e) and Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) and tc:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
Fix effect to only allow summoning if the target is shuffled into the deck. Previously, if the monster would be banished by "EFFECT_LEAVE_FIELD_REDIRECT", Priestess would still summon itself.